### PR TITLE
Shane save roles

### DIFF
--- a/aria/script/aria.js
+++ b/aria/script/aria.js
@@ -1,5 +1,119 @@
 var roleInfo = {};
 
+respecEvents.sub("end-all", function() {
+    var m = document.URL;
+    if (m.match(/\?saveRoles/)) {
+        window.alert("would have saved the serialized roles");
+        var $modal
+        ,   $overlay
+        ,   buttons = {}
+        ;
+        var conf, doc, msg;
+        var ui = {
+            closeModal: function () {
+                if ($overlay) $overlay.fadeOut(200, function () { $overlay.remove(); $overlay = null; });
+                if (!$modal) return;
+                $modal.remove();
+                $modal = null;
+            }
+        ,   freshModal: function (title, content) {
+                if ($modal) $modal.remove();
+                if ($overlay) $overlay.remove();
+                var width = 500;
+                $overlay = $("<div id='respec-overlay' class='removeOnSave'></div>").hide();
+                $modal = $("<div id='respec-modal' class='removeOnSave'><h3></h3><div class='inside'></div></div>").hide();
+                $modal.find("h3").text(title);
+                $modal.find(".inside").append(content);
+                $("body")
+                    .append($overlay)
+                    .append($modal);
+                $overlay
+                    .click(this.closeModal)
+                    .css({
+                        display:    "block"
+                    ,   opacity:    0
+                    ,   position:   "fixed"
+                    ,   zIndex:     10000
+                    ,   top:        "0px"
+                    ,   left:       "0px"
+                    ,   height:     "100%"
+                    ,   width:      "100%"
+                    ,   background: "#000"
+                    })
+                    .fadeTo(200, 0.5)
+                    ;
+                $modal
+                    .css({
+                        display:        "block"
+                    ,   position:       "fixed"
+                    ,   opacity:        0
+                    ,   zIndex:         11000
+                    ,   left:           "50%"
+                    ,   marginLeft:     -(width/2) + "px"
+                    ,   top:            "100px"
+                    ,   background:     "#fff"
+                    ,   border:         "5px solid #666"
+                    ,   borderRadius:   "5px"
+                    ,   width:          width + "px"
+                    ,   padding:        "0 20px 20px 20px"
+                    ,   maxHeight:      ($(window).height() - 150) + "px"
+                    ,   overflowY:      "auto"
+                    })
+                    .fadeTo(200, 1)
+                    ;
+            }
+        };
+        var supportsDownload = $("<a href='foo' download='x'>A</a>")[0].download === "x"
+        ;
+        var $div = $("<div></div>")
+        ,   buttonCSS = {
+                background:     "#eee"
+            ,   border:         "1px solid #000"
+            ,   borderRadius:   "5px"
+            ,   padding:        "5px"
+            ,   margin:         "5px"
+            ,   display:        "block"
+            ,   width:          "100%"
+            ,   color:          "#000"
+            ,   textDecoration: "none"
+            ,   textAlign:      "center"
+            ,   fontSize:       "inherit"
+            }
+        ,   addButton = function (title, content, fileName, popupContent) {
+                if (supportsDownload) {
+                    $("<a></a>")
+                        .appendTo($div)
+                        .text(title)
+                        .css(buttonCSS)
+                        .attr({
+                            href:   "data:text/html;charset=utf-8," + encodeURIComponent(content)
+                        ,   download:   fileName
+                        })
+                        .click(function () {
+                            ui.closeModal();
+                        })
+                        ;
+                }
+                else {
+                    $("<button></button>")
+                        .appendTo($div)
+                        .text(title)
+                        .css(buttonCSS)
+                        .click(function () {
+                            popupContent();
+                            ui.closeModal();
+                        })
+                        ;
+                }
+                
+            }
+        ;
+        var s = JSON.stringify(roleInfo, null, '\t') ;
+        addButton("Save Role Values", s, "roleInfo.js", s) ;
+        ui.freshModal("Save Roles, States, and Properties", $div);
+    }
+});
+
 function updateReferences(base) {
     // update references to properties
 

--- a/aria/script/aria.js
+++ b/aria/script/aria.js
@@ -3,7 +3,6 @@ var roleInfo = {};
 respecEvents.sub("end-all", function() {
     var m = document.URL;
     if (m.match(/\?saveRoles/)) {
-        window.alert("would have saved the serialized roles");
         var $modal
         ,   $overlay
         ,   buttons = {}

--- a/aria/script/roleInfo.js
+++ b/aria/script/roleInfo.js
@@ -1,0 +1,4135 @@
+{
+	"alert": {
+		"name": "alert",
+		"fragID": "alert",
+		"parentRoles": [
+			"section"
+		],
+		"localprops": [],
+		"allprops": [
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"alertdialog": {
+		"name": "alertdialog",
+		"fragID": "alertdialog",
+		"parentRoles": [
+			"alert",
+			"dialog"
+		],
+		"localprops": []
+	},
+	"application": {
+		"name": "application",
+		"fragID": "application",
+		"parentRoles": [
+			"landmark"
+		],
+		"localprops": []
+	},
+	"article": {
+		"name": "article",
+		"fragID": "article",
+		"parentRoles": [
+			"document"
+		],
+		"localprops": []
+	},
+	"banner": {
+		"name": "banner",
+		"fragID": "banner",
+		"parentRoles": [
+			"landmark"
+		],
+		"localprops": []
+	},
+	"button": {
+		"name": "button",
+		"fragID": "button",
+		"parentRoles": [
+			"command"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-pressed"
+			}
+		]
+	},
+	"checkbox": {
+		"name": "checkbox",
+		"fragID": "checkbox",
+		"parentRoles": [
+			"input"
+		],
+		"localprops": [],
+		"allprops": [
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"columnheader": {
+		"name": "columnheader",
+		"fragID": "columnheader",
+		"parentRoles": [
+			"gridcell",
+			"sectionhead",
+			"widget"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-sort"
+			}
+		]
+	},
+	"combobox": {
+		"name": "combobox",
+		"fragID": "combobox",
+		"parentRoles": [
+			"select"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-autocomplete"
+			},
+			{
+				"is": "property",
+				"name": "aria-required"
+			}
+		]
+	},
+	"command": {
+		"name": "command",
+		"fragID": "command",
+		"parentRoles": [
+			"widget"
+		],
+		"localprops": [],
+		"allprops": [
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"complementary": {
+		"name": "complementary",
+		"fragID": "complementary",
+		"parentRoles": [
+			"landmark"
+		],
+		"localprops": []
+	},
+	"composite": {
+		"name": "composite",
+		"fragID": "composite",
+		"parentRoles": [
+			"widget"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-activedescendant"
+			}
+		],
+		"allprops": [
+			{
+				"is": "property",
+				"name": "aria-activedescendant"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"contentinfo": {
+		"name": "contentinfo",
+		"fragID": "contentinfo",
+		"parentRoles": [
+			"landmark"
+		],
+		"localprops": []
+	},
+	"definition": {
+		"name": "definition",
+		"fragID": "definition",
+		"parentRoles": [
+			"section"
+		],
+		"localprops": []
+	},
+	"dialog": {
+		"name": "dialog",
+		"fragID": "dialog",
+		"parentRoles": [
+			"window"
+		],
+		"localprops": [],
+		"allprops": [
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-modal"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"directory": {
+		"name": "directory",
+		"fragID": "directory",
+		"parentRoles": [
+			"list"
+		],
+		"localprops": [],
+		"allprops": [
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"document": {
+		"name": "document",
+		"fragID": "document",
+		"parentRoles": [
+			"structure"
+		],
+		"localprops": [
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			}
+		],
+		"allprops": [
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"form": {
+		"name": "form",
+		"fragID": "form",
+		"parentRoles": [
+			"landmark"
+		],
+		"localprops": []
+	},
+	"grid": {
+		"name": "grid",
+		"fragID": "grid",
+		"parentRoles": [
+			"composite",
+			"section"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-level"
+			},
+			{
+				"is": "property",
+				"name": "aria-multiselectable"
+			},
+			{
+				"is": "property",
+				"name": "aria-readonly"
+			}
+		],
+		"allprops": [
+			{
+				"is": "property",
+				"name": "aria-level"
+			},
+			{
+				"is": "property",
+				"name": "aria-multiselectable"
+			},
+			{
+				"is": "property",
+				"name": "aria-readonly"
+			},
+			{
+				"is": "property",
+				"name": "aria-activedescendant"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			},
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"gridcell": {
+		"name": "gridcell",
+		"fragID": "gridcell",
+		"parentRoles": [
+			"section",
+			"widget"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-readonly"
+			},
+			{
+				"is": "property",
+				"name": "aria-required"
+			},
+			{
+				"is": "state",
+				"name": "aria-selected"
+			}
+		],
+		"allprops": [
+			{
+				"is": "property",
+				"name": "aria-readonly"
+			},
+			{
+				"is": "property",
+				"name": "aria-required"
+			},
+			{
+				"is": "state",
+				"name": "aria-selected"
+			},
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"group": {
+		"name": "group",
+		"fragID": "group",
+		"parentRoles": [
+			"section"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-activedescendant"
+			}
+		],
+		"allprops": [
+			{
+				"is": "property",
+				"name": "aria-activedescendant"
+			},
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"heading": {
+		"name": "heading",
+		"fragID": "heading",
+		"parentRoles": [
+			"sectionhead"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-level"
+			}
+		]
+	},
+	"img": {
+		"name": "img",
+		"fragID": "img",
+		"parentRoles": [
+			"section"
+		],
+		"localprops": []
+	},
+	"input": {
+		"name": "input",
+		"fragID": "input",
+		"parentRoles": [
+			"widget"
+		],
+		"localprops": [],
+		"allprops": [
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"landmark": {
+		"name": "landmark",
+		"fragID": "landmark",
+		"parentRoles": [
+			"section"
+		],
+		"localprops": [],
+		"allprops": [
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"link": {
+		"name": "link",
+		"fragID": "link",
+		"parentRoles": [
+			"command"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-expanded"
+			}
+		]
+	},
+	"list": {
+		"name": "list",
+		"fragID": "list",
+		"parentRoles": [
+			"section"
+		],
+		"localprops": [],
+		"allprops": [
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"listbox": {
+		"name": "listbox",
+		"fragID": "listbox",
+		"parentRoles": [
+			"list",
+			"select"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-multiselectable"
+			},
+			{
+				"is": "property",
+				"name": "aria-required"
+			}
+		]
+	},
+	"listitem": {
+		"name": "listitem",
+		"fragID": "listitem",
+		"parentRoles": [
+			"section"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-level"
+			},
+			{
+				"is": "property",
+				"name": "aria-posinset"
+			},
+			{
+				"is": "property",
+				"name": "aria-setsize"
+			}
+		],
+		"allprops": [
+			{
+				"is": "property",
+				"name": "aria-level"
+			},
+			{
+				"is": "property",
+				"name": "aria-posinset"
+			},
+			{
+				"is": "property",
+				"name": "aria-setsize"
+			},
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"log": {
+		"name": "log",
+		"fragID": "log",
+		"parentRoles": [
+			"section"
+		],
+		"localprops": []
+	},
+	"main": {
+		"name": "main",
+		"fragID": "main",
+		"parentRoles": [
+			"landmark"
+		],
+		"localprops": []
+	},
+	"marquee": {
+		"name": "marquee",
+		"fragID": "marquee",
+		"parentRoles": [
+			"section"
+		],
+		"localprops": []
+	},
+	"math": {
+		"name": "math",
+		"fragID": "math",
+		"parentRoles": [
+			"section"
+		],
+		"localprops": []
+	},
+	"menu": {
+		"name": "menu",
+		"fragID": "menu",
+		"parentRoles": [
+			"list",
+			"select"
+		],
+		"localprops": [],
+		"allprops": [
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			},
+			{
+				"is": "property",
+				"name": "aria-orientation"
+			},
+			{
+				"is": "property",
+				"name": "aria-activedescendant"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			},
+			{
+				"is": "property",
+				"name": "aria-activedescendant"
+			},
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"menubar": {
+		"name": "menubar",
+		"fragID": "menubar",
+		"parentRoles": [
+			"menu"
+		],
+		"localprops": []
+	},
+	"menuitem": {
+		"name": "menuitem",
+		"fragID": "menuitem",
+		"parentRoles": [
+			"command"
+		],
+		"localprops": [],
+		"allprops": [
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"menuitemcheckbox": {
+		"name": "menuitemcheckbox",
+		"fragID": "menuitemcheckbox",
+		"parentRoles": [
+			"checkbox",
+			"menuitem"
+		],
+		"localprops": [],
+		"allprops": [
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"menuitemradio": {
+		"name": "menuitemradio",
+		"fragID": "menuitemradio",
+		"parentRoles": [
+			"menuitemcheckbox",
+			"radio"
+		],
+		"localprops": []
+	},
+	"navigation": {
+		"name": "navigation",
+		"fragID": "navigation",
+		"parentRoles": [
+			"landmark"
+		],
+		"localprops": []
+	},
+	"none": {
+		"name": "none",
+		"fragID": "none",
+		"parentRoles": [],
+		"localprops": []
+	},
+	"note": {
+		"name": "note",
+		"fragID": "note",
+		"parentRoles": [
+			"section"
+		],
+		"localprops": []
+	},
+	"option": {
+		"name": "option",
+		"fragID": "option",
+		"parentRoles": [
+			"input"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-checked"
+			},
+			{
+				"is": "property",
+				"name": "aria-posinset"
+			},
+			{
+				"is": "property",
+				"name": "aria-setsize"
+			}
+		],
+		"allprops": [
+			{
+				"is": "property",
+				"name": "aria-checked"
+			},
+			{
+				"is": "property",
+				"name": "aria-posinset"
+			},
+			{
+				"is": "property",
+				"name": "aria-setsize"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"presentation": {
+		"name": "presentation",
+		"fragID": "presentation",
+		"parentRoles": [
+			"structure"
+		],
+		"localprops": []
+	},
+	"progressbar": {
+		"name": "progressbar",
+		"fragID": "progressbar",
+		"parentRoles": [
+			"range",
+			"status"
+		],
+		"localprops": []
+	},
+	"radio": {
+		"name": "radio",
+		"fragID": "radio",
+		"parentRoles": [
+			"checkbox"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-posinset"
+			},
+			{
+				"is": "property",
+				"name": "aria-setsize"
+			}
+		],
+		"allprops": [
+			{
+				"is": "property",
+				"name": "aria-posinset"
+			},
+			{
+				"is": "property",
+				"name": "aria-setsize"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"radiogroup": {
+		"name": "radiogroup",
+		"fragID": "radiogroup",
+		"parentRoles": [
+			"select"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-required"
+			}
+		]
+	},
+	"range": {
+		"name": "range",
+		"fragID": "range",
+		"parentRoles": [
+			"widget"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-valuemax"
+			},
+			{
+				"is": "property",
+				"name": "aria-valuemin"
+			},
+			{
+				"is": "property",
+				"name": "aria-valuenow"
+			},
+			{
+				"is": "property",
+				"name": "aria-valuetext"
+			}
+		],
+		"allprops": [
+			{
+				"is": "property",
+				"name": "aria-valuemax"
+			},
+			{
+				"is": "property",
+				"name": "aria-valuemin"
+			},
+			{
+				"is": "property",
+				"name": "aria-valuenow"
+			},
+			{
+				"is": "property",
+				"name": "aria-valuetext"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"region": {
+		"name": "region",
+		"fragID": "region",
+		"parentRoles": [
+			"landmark"
+		],
+		"localprops": []
+	},
+	"roletype": {
+		"name": "roletype",
+		"fragID": "roletype",
+		"parentRoles": [],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		],
+		"allprops": [
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"row": {
+		"name": "row",
+		"fragID": "row",
+		"parentRoles": [
+			"group",
+			"widget"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-level"
+			},
+			{
+				"is": "state",
+				"name": "aria-selected"
+			}
+		]
+	},
+	"rowgroup": {
+		"name": "rowgroup",
+		"fragID": "rowgroup",
+		"parentRoles": [
+			"structure"
+		],
+		"localprops": []
+	},
+	"rowheader": {
+		"name": "rowheader",
+		"fragID": "rowheader",
+		"parentRoles": [
+			"gridcell",
+			"sectionhead",
+			"widget"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-sort"
+			}
+		]
+	},
+	"search": {
+		"name": "search",
+		"fragID": "search",
+		"parentRoles": [
+			"landmark"
+		],
+		"localprops": []
+	},
+	"searchbox": {
+		"name": "searchbox",
+		"fragID": "searchbox",
+		"parentRoles": [
+			"textbox"
+		],
+		"localprops": []
+	},
+	"section": {
+		"name": "section",
+		"fragID": "section",
+		"parentRoles": [
+			"structure"
+		],
+		"localprops": [
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			}
+		],
+		"allprops": [
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"sectionhead": {
+		"name": "sectionhead",
+		"fragID": "sectionhead",
+		"parentRoles": [
+			"structure"
+		],
+		"localprops": [
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			}
+		],
+		"allprops": [
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"select": {
+		"name": "select",
+		"fragID": "select",
+		"parentRoles": [
+			"composite",
+			"group",
+			"input"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-orientation"
+			}
+		],
+		"allprops": [
+			{
+				"is": "property",
+				"name": "aria-orientation"
+			},
+			{
+				"is": "property",
+				"name": "aria-activedescendant"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			},
+			{
+				"is": "property",
+				"name": "aria-activedescendant"
+			},
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"separator": {
+		"name": "separator",
+		"fragID": "separator",
+		"parentRoles": [
+			"structure"
+		],
+		"localprops": [
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-orientation"
+			}
+		]
+	},
+	"scrollbar": {
+		"name": "scrollbar",
+		"fragID": "scrollbar",
+		"parentRoles": [
+			"input",
+			"range"
+		],
+		"localprops": []
+	},
+	"slider": {
+		"name": "slider",
+		"fragID": "slider",
+		"parentRoles": [
+			"input",
+			"range"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-orientation"
+			}
+		]
+	},
+	"spinbutton": {
+		"name": "spinbutton",
+		"fragID": "spinbutton",
+		"parentRoles": [
+			"input",
+			"range"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-required"
+			}
+		]
+	},
+	"status": {
+		"name": "status",
+		"fragID": "status",
+		"parentRoles": [
+			"section"
+		],
+		"localprops": [],
+		"allprops": [
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"structure": {
+		"name": "structure",
+		"fragID": "structure",
+		"parentRoles": [
+			"roletype"
+		],
+		"localprops": [],
+		"allprops": [
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"switch": {
+		"name": "switch",
+		"fragID": "switch",
+		"parentRoles": [
+			"checkbox"
+		],
+		"localprops": []
+	},
+	"tab": {
+		"name": "tab",
+		"fragID": "tab",
+		"parentRoles": [
+			"sectionhead",
+			"widget"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-posinset"
+			},
+			{
+				"is": "state",
+				"name": "aria-selected"
+			},
+			{
+				"is": "property",
+				"name": "aria-setsize"
+			}
+		]
+	},
+	"tablist": {
+		"name": "tablist",
+		"fragID": "tablist",
+		"parentRoles": [
+			"composite",
+			"directory"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-level"
+			},
+			{
+				"is": "property",
+				"name": "aria-multiselectable"
+			},
+			{
+				"is": "property",
+				"name": "aria-orientation"
+			}
+		]
+	},
+	"tabpanel": {
+		"name": "tabpanel",
+		"fragID": "tabpanel",
+		"parentRoles": [
+			"section"
+		],
+		"localprops": []
+	},
+	"text": {
+		"name": "text",
+		"fragID": "text",
+		"parentRoles": [
+			"structure"
+		],
+		"localprops": []
+	},
+	"textbox": {
+		"name": "textbox",
+		"fragID": "textbox",
+		"parentRoles": [
+			"input"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-activedescendant"
+			},
+			{
+				"is": "property",
+				"name": "aria-autocomplete"
+			},
+			{
+				"is": "property",
+				"name": "aria-multiline"
+			},
+			{
+				"is": "property",
+				"name": "aria-readonly"
+			},
+			{
+				"is": "property",
+				"name": "aria-required"
+			}
+		],
+		"allprops": [
+			{
+				"is": "property",
+				"name": "aria-activedescendant"
+			},
+			{
+				"is": "property",
+				"name": "aria-autocomplete"
+			},
+			{
+				"is": "property",
+				"name": "aria-multiline"
+			},
+			{
+				"is": "property",
+				"name": "aria-readonly"
+			},
+			{
+				"is": "property",
+				"name": "aria-required"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"timer": {
+		"name": "timer",
+		"fragID": "timer",
+		"parentRoles": [
+			"status"
+		],
+		"localprops": []
+	},
+	"toolbar": {
+		"name": "toolbar",
+		"fragID": "toolbar",
+		"parentRoles": [
+			"group"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-orientation"
+			}
+		]
+	},
+	"tooltip": {
+		"name": "tooltip",
+		"fragID": "tooltip",
+		"parentRoles": [
+			"section"
+		],
+		"localprops": []
+	},
+	"tree": {
+		"name": "tree",
+		"fragID": "tree",
+		"parentRoles": [
+			"select"
+		],
+		"localprops": [
+			{
+				"is": "property",
+				"name": "aria-multiselectable"
+			},
+			{
+				"is": "property",
+				"name": "aria-required"
+			}
+		],
+		"allprops": [
+			{
+				"is": "property",
+				"name": "aria-multiselectable"
+			},
+			{
+				"is": "property",
+				"name": "aria-required"
+			},
+			{
+				"is": "property",
+				"name": "aria-orientation"
+			},
+			{
+				"is": "property",
+				"name": "aria-activedescendant"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			},
+			{
+				"is": "property",
+				"name": "aria-activedescendant"
+			},
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"treegrid": {
+		"name": "treegrid",
+		"fragID": "treegrid",
+		"parentRoles": [
+			"grid",
+			"tree"
+		],
+		"localprops": []
+	},
+	"treeitem": {
+		"name": "treeitem",
+		"fragID": "treeitem",
+		"parentRoles": [
+			"listitem",
+			"option"
+		],
+		"localprops": []
+	},
+	"widget": {
+		"name": "widget",
+		"fragID": "widget",
+		"parentRoles": [
+			"roletype"
+		],
+		"localprops": [],
+		"allprops": [
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	},
+	"window": {
+		"name": "window",
+		"fragID": "window",
+		"parentRoles": [
+			"roletype"
+		],
+		"localprops": [
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-modal"
+			}
+		],
+		"allprops": [
+			{
+				"is": "state",
+				"name": "aria-expanded"
+			},
+			{
+				"is": "property",
+				"name": "aria-modal"
+			},
+			{
+				"is": "property",
+				"name": "aria-atomic"
+			},
+			{
+				"is": "state",
+				"name": "aria-busy"
+			},
+			{
+				"is": "property",
+				"name": "aria-controls"
+			},
+			{
+				"is": "state",
+				"name": "aria-current"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedat"
+			},
+			{
+				"is": "property",
+				"name": "aria-describedby"
+			},
+			{
+				"is": "state",
+				"name": "aria-disabled"
+			},
+			{
+				"is": "property",
+				"name": "aria-dropeffect"
+			},
+			{
+				"is": "property",
+				"name": "aria-flowto"
+			},
+			{
+				"is": "state",
+				"name": "aria-grabbed"
+			},
+			{
+				"is": "property",
+				"name": "aria-haspopup"
+			},
+			{
+				"is": "state",
+				"name": "aria-hidden"
+			},
+			{
+				"is": "state",
+				"name": "aria-invalid"
+			},
+			{
+				"is": "property",
+				"name": "aria-label"
+			},
+			{
+				"is": "property",
+				"name": "aria-labelledby"
+			},
+			{
+				"is": "property",
+				"name": "aria-live"
+			},
+			{
+				"is": "property",
+				"name": "aria-owns"
+			},
+			{
+				"is": "property",
+				"name": "aria-relevant"
+			}
+		]
+	}
+}


### PR DESCRIPTION
This is a simple change to the base aria.js script that will allow it to save a snapshot of the roles, states, and properties so that specs such as dpub can easily incorporate references.  

I am planning to merge it since the change is non-intrusive unless you use the special ?saveRoles parameter on the aria.html URL.