### PR TITLE
ISSUE-715: Removing unused glossary terms deletes only the term.

### DIFF
--- a/common/script/resolveReferences.js
+++ b/common/script/resolveReferences.js
@@ -115,7 +115,7 @@ function restrictReferences(utils, content) {
                 var $p = $("#"+term) ;
                 if ($p) {
                     var t = $p.dfnTitle();
-                    $p.next().remove();
+                    $p.parent().next().remove();
                     $p.remove() ;
                     if (respecConfig.definitionMap[t]) {
                         delete respecConfig.definitionMap[t];


### PR DESCRIPTION
@halindrome. @michael-n-cooper,

The function that removes unused glossary terms is only removing the term, the DT element and not the actual definition, DD element.  As a result, the DD text appears to be part of some other term.

You can see an example of this for the glossary entry for "State" here:
http://w3c.github.io/aria/aria/aria.html#dfn-state

The second paragraph of that definition is actually for "Sub-document", and the third for "Target Element".

I've found the bug, and made a simple fix.  Please review this pull request, thanks. 

Tracker ISSUE-715: https://www.w3.org/WAI/PF/Group/track/issues/715