### PR TITLE
Added data-lt aliases for all terms referenced.

### DIFF
--- a/aria/aria.html
+++ b/aria/aria.html
@@ -148,9 +148,9 @@
 		<li>providing for interoperability with <a>assistive technologies</a>.</li>
 	</ul>
 	<p>WAI-ARIA is a technical specification that provides a framework to improve the accessibility and interoperability of web content and applications. This document is primarily for developers creating custom widgets and other web application components. Please see the <a href="http://www.w3.org/WAI/intro/aria">WAI-ARIA Overview</a> for links to related documents for other audiences, such as the WAI-ARIA Primer that introduces developers to the accessibility problems that WAI-ARIA is intended to solve, the fundamental concepts, and the technical approach of WAI-ARIA.</p>
-	<p>This draft currently handles two aspects of <a title="role">roles</a>: user interface functionality and structural <a title="relationship">relationships</a>. For more information and use cases, see the [[WAI-ARIA-PRIMER]] for the use of roles in making interactive content accessible.</p>
-	<p>The role <a>taxonomy</a> is designed in part to support the common roles found in platform <a title="accessibility api">accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a>. Reference to roles found in this taxonomy by dynamic web content may be used to support interoperability with assistive technologies.</p>
-	<p>The schema to support this standard has been designed to be extensible so that custom roles can be created by extending base roles. This allows <a title="user agent">user agents</a> to support at least the base role, and user agents that support the custom role can provide enhanced access. Note that much of this could be formalized in [[XMLSCHEMA-2]]. However, being able to define similarities between roles, such as <a href="#baseConcept">baseConcepts</a> and more descriptive definitions, would not be available in <abbr title="Extensible Markup Language Schema Datatypes">XSD</abbr>.</p>
+	<p>This draft currently handles two aspects of <a>roles</a>: user interface functionality and structural <a>relationships</a>. For more information and use cases, see the [[WAI-ARIA-PRIMER]] for the use of roles in making interactive content accessible.</p>
+	<p>The role <a>taxonomy</a> is designed in part to support the common roles found in platform <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a>. Reference to roles found in this taxonomy by dynamic web content may be used to support interoperability with assistive technologies.</p>
+	<p>The schema to support this standard has been designed to be extensible so that custom roles can be created by extending base roles. This allows <a>user agents</a> to support at least the base role, and user agents that support the custom role can provide enhanced access. Note that much of this could be formalized in [[XMLSCHEMA-2]]. However, being able to define similarities between roles, such as <a href="#baseConcept">baseConcepts</a> and more descriptive definitions, would not be available in <abbr title="Extensible Markup Language Schema Datatypes">XSD</abbr>.</p>
 	<ul>
 		<li><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Primer [[WAI-ARIA-PRIMER]], a W3C Working Group Note, introduces developers to the accessibility problems that <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is intended to solve, the fundamental concepts, and the technical approach of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>.</li>
 		<li><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices [[WAI-ARIA-PRACTICES]], a planned W3C Working Group Note, describes how web content developers can develop accessible rich internet applications using <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>. It provides detailed advice and examples directed primarily to web application developers, yet also useful to user agent and developers of assistive technologies.</li>
@@ -160,10 +160,10 @@
 	<section class="section" id="intro_ria_accessibility">
 		<h2>Rich Internet Application Accessibility</h2>
 		<p>The domain of web accessibility defines how to make web content usable by persons with disabilities. Persons with certain types of disabilities use <a>assistive technologies</a> (<abbr title="Assistive Technologies">AT</abbr>) to interact with content. Assistive technologies can transform the presentation of content into a format more suitable to the user, and can allow the user to interact in different ways. For example, the user may need to, or choose to, interact with a slider widget via arrow keys, instead of dragging and dropping with a mouse. In order to accomplish this effectively, the software needs to understand the <a>semantics</a> of the content. Semantics is the science of meaning; in this case, used to assign roles, states, and properties that apply to user interface and content elements as a human would understand. For instance, if a paragraph is semantically identified as such, assistive technologies can interact with it as a unit separable from the rest of the content, knowing the exact boundaries of that paragraph. An adjustable range slider or collapsible list (a.k.a. a tree <a>widget</a>) are more complex examples, in which various parts of the widget have semantics that need to be properly identified for assistive technologies to support effective interaction.</p>
-		<p>New technologies often overlook semantics required for accessibility, and new authoring practices often misuse the intended semantics of those technologies. <a title="element">Elements</a> that have one defined meaning in the language are used with a different meaning intended to be understood by the user.</p>
+		<p>New technologies often overlook semantics required for accessibility, and new authoring practices often misuse the intended semantics of those technologies. <a>Elements</a> that have one defined meaning in the language are used with a different meaning intended to be understood by the user.</p>
 		<p>For example, web application developers create collapsible tree widgets in HTML using CSS and JavaScript even though HTML has no semantic <code>tree</code> element. To a non-disabled user, it may look and act like a collapsible tree widget, but without appropriate semantics, the tree widget may not be <a>perceivable</a> to, or <a>operable</a> by, a person with a disability because assistive technologies may not recognize the role.</p>
-		<p>The incorporation of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is a way for an author to provide proper semantics for custom widgets to make these widgets accessible, usable, and interoperable with assistive technologies. This specification identifies the types of widgets and structures that are commonly recognized by accessibility products, by providing an <a>ontology</a> of corresponding <a title="role">roles</a> that can be attached to content. This allows elements with a given role to be understood as a particular widget or structural type regardless of any semantic inherited from the implementing host language. Roles are a common property of platform <a title="accessibility api">accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a> which assistive technologies use to provide the user with effective presentation and interaction.</p>
-		<p>This role <a>taxonomy</a> includes interaction <a title="widget">widgets</a> and elements denoting document structure. The role taxonomy describes inheritance and details the <a title="attribute">attributes</a> each role supports. Information about mapping of roles to accessibility <abbr title="Application Programing Interfaces">APIs</abbr> is provided by the <cite><a href="http://www.w3.org/TR/wai-aria-implementation/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> User Agent Implementation Guide</a></cite> [[WAI-ARIA-IMPLEMENTATION]].</p>
+		<p>The incorporation of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is a way for an author to provide proper semantics for custom widgets to make these widgets accessible, usable, and interoperable with assistive technologies. This specification identifies the types of widgets and structures that are commonly recognized by accessibility products, by providing an <a>ontology</a> of corresponding <a>roles</a> that can be attached to content. This allows elements with a given role to be understood as a particular widget or structural type regardless of any semantic inherited from the implementing host language. Roles are a common property of platform <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a> which assistive technologies use to provide the user with effective presentation and interaction.</p>
+		<p>This role <a>taxonomy</a> includes interaction <a>widgets</a> and elements denoting document structure. The role taxonomy describes inheritance and details the <a>attributes</a> each role supports. Information about mapping of roles to accessibility <abbr title="Application Programing Interfaces">APIs</abbr> is provided by the <cite><a href="http://www.w3.org/TR/wai-aria-implementation/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> User Agent Implementation Guide</a></cite> [[WAI-ARIA-IMPLEMENTATION]].</p>
 		<p>Roles are element types and will not change with time or user actions. Role information is used by assistive technologies, through interaction with the user agent, to provide normal processing of the specified element type.</p>
 		<p>States and properties are used to declare important attributes of an element that affect and describe interaction. They enable the <a>user agent</a> and operating system to properly handle the element even when the attributes are dynamically changed by client-side scripts. For example, alternative input and output technology, such as screen readers and speech dictation software, need to be able to recognize and effectively manipulated and communicate various interaction states (e.g., disabled, checked) to the user.</p>
 		<p>While it is possible for assistive technologies to access these properties directly through the <cite><a href="http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/">Document Object Model</a></cite> [[DOM-Level-2-Core]], the preferred mechanism is for the user agent to map the states and properties to the accessibility <abbr title="Application Programing Interfaces">API</abbr> of the operating system. See the <cite><a href="http://www.w3.org/TR/wai-aria-implementation/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> User Agent Implementation Guide</a></cite> [[WAI-ARIA-IMPLEMENTATION]] for details.</p>
@@ -176,8 +176,8 @@
 		<p>In addition to the prose documentation, the role taxonomy is provided in <cite><a href="http://www.w3.org/TR/2004/REC-owl-features-20040210/">Web Ontology Language (OWL)</a></cite> [[OWL-FEATURES]], which is expressed in <cite><a href="http://www.w3.org/TR/2014/REC-rdf11-concepts-20140225/">Resource Description Framework (RDF)</a></cite> [[RDF-CONCEPTS]]. Tools can use these to validate the implementation of roles in a given content document. For example, instances of some roles are expected to be children of a specific parent role. Also, some roles may support a specific <a>state</a> or <a>property</a> that another role does not support.</p>
 		<p class="note">The use of <abbr title="Resource Description Framework">RDF</abbr>/OWL as a formal representation of roles may be used to support future extensibility. Standard RDF/OWL mechanisms can be used to define new roles that inherit from the roles defined in this specification. The mechanism to define and use role extensions in an interoperable manner, however, is not defined by this specification. A future version of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is expected to define how to extend roles.</p>
 		<p>Users of alternate input devices need <a>keyboard accessible</a> content. The new semantics, when combined with the recommended keyboard interactions provided in <cite><a href="http://www.w3.org/TR/wai-aria-practices/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> [[WAI-ARIA-PRACTICES]], will allow alternate input solutions to facilitate command and control via an alternate input solution.</p>
-		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> introduces navigational <a title="landmark">landmarks</a> through its taxonomy and the <abbr title="Extensible Hypertext Markup Language">XHTML</abbr> role landmarks, which can help persons with dexterity and vision impairments by providing for improved keyboard navigation. <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> may also be used to assist persons with cognitive learning disabilities. The additional semantics allow authors to restructure and substitute alternative content as needed.</p>
-		<p><a>Assistive technologies</a> need the ability to support alternative inputs by getting and setting the current value of <a>widget</a> states and properties. Assistive technologies also need to determine what <a title="object">objects</a> are selected and manage widgets that allow multiple selections, such as list boxes and grids.</p>
+		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> introduces navigational <a>landmarks</a> through its taxonomy and the <abbr title="Extensible Hypertext Markup Language">XHTML</abbr> role landmarks, which can help persons with dexterity and vision impairments by providing for improved keyboard navigation. <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> may also be used to assist persons with cognitive learning disabilities. The additional semantics allow authors to restructure and substitute alternative content as needed.</p>
+		<p><a>Assistive technologies</a> need the ability to support alternative inputs by getting and setting the current value of <a>widget</a> states and properties. Assistive technologies also need to determine what <a>objects</a> are selected and manage widgets that allow multiple selections, such as list boxes and grids.</p>
 		<p>Speech-based command and control systems can benefit from <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics like the <code>role</code> attribute to assist in conveying audio information to the user. For example, by determining that an element has a role of <rref>menuitem</rref> each containing text content representing a different flavor, a speech system might state to the user that, "Select one of three choices: chocolate, strawberry, or vanilla."</p>
 		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is intended to be used as a supplement for native language semantics, not a replacement. When the host language provides a feature that provides equivalent accessibility to the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> feature, use the host language feature. <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> should only be used in cases where the host language lacks the needed <a>role</a>, <a>state</a>, and <a>property</a> indicators. Use a host language feature that is as similar as possible to the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> feature, then refine the meaning by adding <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>. For instance, a multi-selectable grid could be implemented as a table, and then <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> used to clarify that it is an interactive grid, not just a static data table. This allows for the best possible fallback for user agents that do not support <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> and preserves the integrity of the host language semantics.</p>
 	</section>
@@ -185,7 +185,7 @@
 		<h2>Target Audience</h2>
 		<p>This specification defines the basic model for <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>, including roles, states, properties, and values. It impacts several audiences:</p>
 		<ul>
-			<li><a title="user agent">User agents</a> that process content containing <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> features;</li>
+			<li><a>User agents</a> that process content containing <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> features;</li>
 			<li><a>Assistive technologies</a> that present content in special ways to user with disabilities;</li>
 			<li>Authors who create content;</li>
 			<li>Authoring tools that help authors create conforming content; and</li>
@@ -202,7 +202,7 @@
 		<h2>User Agent Support</h2>
 		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> relies on user agent support for its features in two ways:</p>
 		<ul>
-			<li>Mainstream <a title="user agent">user agents</a> use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> to alter how host language features are exposed to <a title="accessibility api">accessibility APIs</a> in order to improve accessibility. The mechanism for this is defined in the <cite><a href="http://www.w3.org/TR/wai-aria-implementation/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> User Agent Implementation Guide</a></cite> [[WAI-ARIA-IMPLEMENTATION]].</li>
+			<li>Mainstream <a>user agents</a> use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> to alter how host language features are exposed to <a>accessibility APIs</a> in order to improve accessibility. The mechanism for this is defined in the <cite><a href="http://www.w3.org/TR/wai-aria-implementation/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> User Agent Implementation Guide</a></cite> [[WAI-ARIA-IMPLEMENTATION]].</li>
 			<li><a>Assistive technologies</a> use the enhanced information available in an accessibility API, or uses the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> markup directly via the <abbr title="Document Object Model">DOM</abbr>, to convey semantic and interaction information to the user.</li>
 		</ul>
 		<p>Aside from using <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> markup to improve what is exposed to accessibility APIs, user agents behave as they would natively. Assistive technologies react to the extra information in the accessibility API as they already do for the same information on non-web content. User agents that are not assistive technologies, however, need do nothing beyond providing appropriate updates to the accessibility API.</p>
@@ -221,12 +221,12 @@
 		<h2>Authoring Practices</h2>
 		<section id="authoring_tools">
 			<h3>Authoring Tools</h3>
-			<p>Many of the requirements in the definitions of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a title="role">roles</a>, <a title="state">state</a>, and <a title="property">properties</a> can be checked automatically during the development process, similar to other quality control processes used for validating code. To assist authors who are creating custom widgets, authoring tools may compare widget roles, states, and properties to those supported in <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> as well as those supported in related and cross-referenced roles, states, and properties. Authoring tools may notify authors of errors in widget design patterns, and may also prompt developers for information that cannot be determined from context alone. For example, a scripting library can determine the labels for the tree items in a tree view, but would need to prompt the author to label the entire tree. To help authors visualize a logical accessibility structure, an authoring environment might provide an outline view of a web resource based on the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> markup.</p>
+			<p>Many of the requirements in the definitions of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>roles</a>, <a>state</a>, and <a>properties</a> can be checked automatically during the development process, similar to other quality control processes used for validating code. To assist authors who are creating custom widgets, authoring tools may compare widget roles, states, and properties to those supported in <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> as well as those supported in related and cross-referenced roles, states, and properties. Authoring tools may notify authors of errors in widget design patterns, and may also prompt developers for information that cannot be determined from context alone. For example, a scripting library can determine the labels for the tree items in a tree view, but would need to prompt the author to label the entire tree. To help authors visualize a logical accessibility structure, an authoring environment might provide an outline view of a web resource based on the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> markup.</p>
 			<p>In HTML, <code>tabindex</code> is an important way browsers support keyboard <a href="#host_general_focus">focus navigation</a> for implementations of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>; authoring and debugging tools may check to make sure <code>tabindex</code> values are properly set. For example, error conditions may include cases where more than one treeitem in a tree has a <code>tabindex</code> value greater than or equal to 0, where <code>tabindex</code> is not set on any treeitem, or where <pref>aria-activedescendant</pref> is not defined when the element with the role tree has a <code>tabindex</code> value of greater than or equal to 0.</p>
 		</section>
 		<section id="authoring_testing">
 			<h3>Testing Practices and Tools</h3>
-			<p>The accessibility of interactive content cannot be confirmed by static checks alone. Developers of interactive content should test for device-independent access to <a title="widget">widgets</a> and applications, and should verify accessibility <abbr title="application programing interface">API</abbr> access to all content and changes during user interaction.</p>
+			<p>The accessibility of interactive content cannot be confirmed by static checks alone. Developers of interactive content should test for device-independent access to <a>widgets</a> and applications, and should verify accessibility <abbr title="application programing interface">API</abbr> access to all content and changes during user interaction.</p>
 		</section>
 	</section>
 	<section id="at_support">
@@ -238,8 +238,8 @@
 </section>
 <section class="informative" id="usage">
 	<h1>Using <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr></h1>
-	<p>Complex web applications become inaccessible when <a>assistive technologies</a> cannot determine the <a>semantics</a> behind portions of a document or when the user is unable to effectively navigate to all parts of it in a usable way (see the <cite><a href="http://www.w3.org/TR/wai-aria-primer/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Primer</a></cite> [[WAI-ARIA-PRIMER]]). <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> divides the semantics into <a title="role">roles</a> (the type defining a user interface element) and <a title="state">state</a> and <a title="property">properties</a> supported by the roles.</p>
-	<p>Authors need to associate <a title="element">elements</a> in the document to a WAI-ARIA role and the appropriate states and properties (aria-* <a title="attribute">attributes</a>) during its life-cycle, unless the elements already have the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantics</a> for states and properties. In these instances the equivalent host language states and properties take precedence to avoid a conflict while the role attribute will take precedence over the implicit role of the host language element.</p>
+	<p>Complex web applications become inaccessible when <a>assistive technologies</a> cannot determine the <a>semantics</a> behind portions of a document or when the user is unable to effectively navigate to all parts of it in a usable way (see the <cite><a href="http://www.w3.org/TR/wai-aria-primer/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Primer</a></cite> [[WAI-ARIA-PRIMER]]). <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> divides the semantics into <a>roles</a> (the type defining a user interface element) and <a>state</a> and <a>properties</a> supported by the roles.</p>
+	<p>Authors need to associate <a>elements</a> in the document to a WAI-ARIA role and the appropriate states and properties (aria-* <a>attributes</a>) during its life-cycle, unless the elements already have the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantics</a> for states and properties. In these instances the equivalent host language states and properties take precedence to avoid a conflict while the role attribute will take precedence over the implicit role of the host language element.</p>
 	<section id="usage_intro">
 		<h2><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Roles</h2>
 		<p>A <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>role</a> is set on an <a>element</a> using a <code>role</code> <a>attribute</a>, similar to the <code>role</code> attribute defined in the <cite><a href="http://www.w3.org/TR/role-attribute/">Role Attribute</a></cite> [[ROLE-ATTRIBUTE]].</p>
@@ -251,17 +251,17 @@
 			<li>hierarchical information about related roles (e.g., a <rref>directory</rref> is a type of <rref>list</rref>);</li>
 			<li>context of the role (e.g., a <rref>listitem</rref> is contained inside a <rref>list</rref>);</li>
 			<li>references to related concepts in other specifications;</li>
-			<li>use of <abbr title="Web Ontology Language">OWL</abbr> to provide a type hierarchy allowing for <a title="semantics">semantic</a> inheritance (similar to a <a>class</a> hierarchy); and</li>
-			<li>supported <a title="state">state</a> and <a title="property">properties</a> for each role (e.g., a <rref>checkbox</rref> supports being checked via <sref>aria-checked</sref>).</li>
+			<li>use of <abbr title="Web Ontology Language">OWL</abbr> to provide a type hierarchy allowing for <a>semantic</a> inheritance (similar to a <a>class</a> hierarchy); and</li>
+			<li>supported <a>state</a> and <a>properties</a> for each role (e.g., a <rref>checkbox</rref> supports being checked via <sref>aria-checked</sref>).</li>
 		</ul>
 		<p>Attaching a role gives <a>assistive technologies</a> information about how to handle each element.</p>
 	</section>
 	<section id="introstates">
 		<h2><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> States and Properties</h2>
-		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> provides a collection of accessibility <a title="state">state</a> and <a title="property">properties</a> which are used to support platform <a title="accessibility api">accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a> on various operating system platforms. <a>Assistive technologies</a> may access this information through an exposed <a>user agent</a> DOM or through a mapping to the platform accessibility <abbr title="Application Programing Interfaces">API</abbr>. When combined with <a title="role">roles</a>, the user agent can supply the assistive technologies with user interface information to convey to the user at any time. Changes in states or properties will result in a notification to assistive technologies, which could alert the user that a change has occurred.</p>
-		<p>In the following example, a list item (<code>html:li</code>) has been used to create a checkable menu item, and JavaScript <a title="event">events</a> will capture mouse and keyboard events to toggle value of <sref>aria-checked</sref>. A role is used to make the behavior of this simple <a>widget</a> known to the user agent. <a title="attribute">Attributes</a> that change with user actions (such as <sref>aria-checked</sref>) are defined in the <a href="#states_and_properties">states and properties</a> section.</p>
+		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> provides a collection of accessibility <a>state</a> and <a>properties</a> which are used to support platform <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a> on various operating system platforms. <a>Assistive technologies</a> may access this information through an exposed <a>user agent</a> DOM or through a mapping to the platform accessibility <abbr title="Application Programing Interfaces">API</abbr>. When combined with <a>roles</a>, the user agent can supply the assistive technologies with user interface information to convey to the user at any time. Changes in states or properties will result in a notification to assistive technologies, which could alert the user that a change has occurred.</p>
+		<p>In the following example, a list item (<code>html:li</code>) has been used to create a checkable menu item, and JavaScript <a>events</a> will capture mouse and keyboard events to toggle value of <sref>aria-checked</sref>. A role is used to make the behavior of this simple <a>widget</a> known to the user agent. <a>Attributes</a> that change with user actions (such as <sref>aria-checked</sref>) are defined in the <a href="#states_and_properties">states and properties</a> section.</p>
 		<pre class="example highlight">&lt;li role=&quot;menuitemcheckbox&quot; aria-checked=&quot;true&quot;&gt;Sort by Last Modified&lt;/li&gt;</pre>
-		<p>Some accessibility states, called <em><a title="managed state">managed states</a></em>, are controlled by the user agent. Examples of managed state include keyboard focus and selection. Managed states often have corresponding <abbr title="Cascading Style Sheets">CSS</abbr> pseudo-classes (such as <code>:focus</code> and <code>::selection</code>) to define style changes. In contrast, the states in this specification are typically controlled by the author and are called <em>unmanaged states.</em> Some states are managed by the user agent, such as <pref>aria-posinset</pref> and <pref>aria-setsize</pref>, but the author can override them if the <abbr title="Document Object Model">DOM</abbr> is incomplete and would cause the user agent calculation to be incorrect. User agents map both managed and unmanaged states to the platform accessibility <abbr title="Application Programing Interfaces">APIs</abbr>.</p>
+		<p>Some accessibility states, called <em><a>managed states</a></em>, are controlled by the user agent. Examples of managed state include keyboard focus and selection. Managed states often have corresponding <abbr title="Cascading Style Sheets">CSS</abbr> pseudo-classes (such as <code>:focus</code> and <code>::selection</code>) to define style changes. In contrast, the states in this specification are typically controlled by the author and are called <em>unmanaged states.</em> Some states are managed by the user agent, such as <pref>aria-posinset</pref> and <pref>aria-setsize</pref>, but the author can override them if the <abbr title="Document Object Model">DOM</abbr> is incomplete and would cause the user agent calculation to be incorrect. User agents map both managed and unmanaged states to the platform accessibility <abbr title="Application Programing Interfaces">APIs</abbr>.</p>
 		<p>Most modern user agents support <cite><a href="http://www.w3.org/TR/CSS2/selector.html#attribute-selectors"><abbr title="Cascading Style Sheets">CSS</abbr> attribute selectors</a></cite> ([[CSS2]]), and can allow the author to create <abbr title="User Interface">UI</abbr> changes based on <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attribute information, reducing the amount of scripts necessary to achieve equivalent functionality. In the following example, a <abbr title="Cascading Style Sheets">CSS</abbr> selector is used to determine whether or not the text is bold and an image of a check mark is shown, based on the value of the <sref>aria-checked</sref> attribute.</p>
 		<pre class="example highlight lang-css">[aria-checked=&quot;true&quot;] { font-weight: bold; }
 [aria-checked=&quot;true&quot;]::before { background-image: url(checked.gif); }</pre>
@@ -274,8 +274,8 @@
 	</section>
 	<section id="managingfocus">
 		<h2>Managing Focus</h2>
-		<p>An <rref>application</rref> should always have an <a>element</a> with focus when in use, as applications require users to have a place to provide user input. Authors are advised to <em>not</em> destroy the element with focus or scroll it off-screen unless through user intervention. All interactive <a  title="object">objects</a> should be focusable. All parts of composite interactive controls need to be focusable or have a documented alternative method to achieve their function, such as a keyboard shortcut. Authors are advised to maintain an obvious, discoverable way, either through tabbing or other standard navigation techniques, for keyboard users to move the focus to any interactive element. See <a href="http://www.w3.org/TR/2002/REC-UAAG10-20021217/guidelines.html#gl-navigation">User Agent Accessibility Guidelines, Guideline 9</a> ([[UAAG10]], Guideline 9).</p>
-		<p>When using standard <abbr title="Hypertext Markup Language">HTML</abbr> and basic <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a title="widget">widgets</a>, application developers can simply manipulate the tab order or use a script to create keyboard shortcuts to elements in the document. Use of more complex widgets requires the author to manage focus within them. SVG Tiny provides a similar navigation "ring" mechanism that by default follows document order and which should be implemented using system dependent input facilities (the TAB key on most desktop computers). SVG authors may place elements in the navigation order by manipulating the <a href="http://www.w3.org/TR/SVGTiny12/interact.html#FocusableAttribute">focusable</a> attribute and they may dynamically <a href="http://www.w3.org/TR/SVGTiny12/interact.html#specifyingnavigation">specify the navigation order</a> by modifying elements <a href="http://www.w3.org/TR/SVGTiny12/intro.html#TermNavigationAttribute">navigation attributes</a>.</p>
+		<p>An <rref>application</rref> should always have an <a>element</a> with focus when in use, as applications require users to have a place to provide user input. Authors are advised to <em>not</em> destroy the element with focus or scroll it off-screen unless through user intervention. All interactive <a>objects</a> should be focusable. All parts of composite interactive controls need to be focusable or have a documented alternative method to achieve their function, such as a keyboard shortcut. Authors are advised to maintain an obvious, discoverable way, either through tabbing or other standard navigation techniques, for keyboard users to move the focus to any interactive element. See <a href="http://www.w3.org/TR/2002/REC-UAAG10-20021217/guidelines.html#gl-navigation">User Agent Accessibility Guidelines, Guideline 9</a> ([[UAAG10]], Guideline 9).</p>
+		<p>When using standard <abbr title="Hypertext Markup Language">HTML</abbr> and basic <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>widgets</a>, application developers can simply manipulate the tab order or use a script to create keyboard shortcuts to elements in the document. Use of more complex widgets requires the author to manage focus within them. SVG Tiny provides a similar navigation "ring" mechanism that by default follows document order and which should be implemented using system dependent input facilities (the TAB key on most desktop computers). SVG authors may place elements in the navigation order by manipulating the <a href="http://www.w3.org/TR/SVGTiny12/interact.html#FocusableAttribute">focusable</a> attribute and they may dynamically <a href="http://www.w3.org/TR/SVGTiny12/interact.html#specifyingnavigation">specify the navigation order</a> by modifying elements <a href="http://www.w3.org/TR/SVGTiny12/intro.html#TermNavigationAttribute">navigation attributes</a>.</p>
 		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> includes a number of &quot;managing container&quot; widgets, also known as &quot;composite&quot; widgets. When appropriate, the container is responsible for tracking the last descendant which was active (the default is usually the first item in the container). It is essential that a container maintain a usable and consistent strategy when focus leaves a container and is then later refocused. While there may be exceptions, it is recommended that when a previously focused container is refocused, the active descendant be the same element as the active descendant when the container was last focused. Exceptions include cases where the contents of a container widget have changed, and widgets like a menubar where the user expects to always return to the first item when focus leaves the menu bar. For example, if the second item of a tree group was the active descendant when the user tabbed out of the tree group, then the second item of the tree group remains the active descendant when the tree group gets focus again. The user may also activate the container by clicking on one of the descendants within it.</p>
 		<p>When the container or its active descendant has focus, the user may navigate through the container by pressing additional keys, such as the arrow keys, to change the currently active descendant. Any additional press of the main navigation key (generally the <kbd>TAB</kbd> key) will move out of the container to the next widget.</p>
 		<p>For example, a <rref>grid</rref> may be used as a spreadsheet with thousands of <rref>gridcell</rref> elements, all of which may not be present in the document at one time. This requires focus to be managed by the container using the <pref>aria-activedescendant</pref> <a>attribute</a> on the managing container element, or by the container managing the <code>tabindex</code> of its child elements and setting focus on the appropriate child. For more information, see <cite><a href="http://www.w3.org/TR/wai-aria-practices/#kbd_focus">Providing Keyboard Focus in <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> ([[WAI-ARIA-PRACTICES]]).</p>
@@ -309,7 +309,7 @@
 	</section>
 	<section id="ua_domchanges">
 		<h2>Assistive Technology Notifications Communicated to Web Applications</h2>
-		<p><a>Assistive technologies</a>, such as voice recognition systems and alternate input devices for users with mobility impairments, require the ability to control a web application in a device-independent way. <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a title="state">state</a> and <a title="property">properties</a> reflect the current state of rich internet application components. The ability for assistive technologies to notify web application of necessary changes is essential because it allows these alternative input solutions to control an application without being dependent on the standard input device which the user is unable to effectively control directly.</p>
+		<p><a>Assistive technologies</a>, such as voice recognition systems and alternate input devices for users with mobility impairments, require the ability to control a web application in a device-independent way. <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>state</a> and <a>properties</a> reflect the current state of rich internet application components. The ability for assistive technologies to notify web application of necessary changes is essential because it allows these alternative input solutions to control an application without being dependent on the standard input device which the user is unable to effectively control directly.</p>
 		<p>User agents MUST provide a method to notify the web application when a change occurs to states or properties in the system accessibility API. Likewise, web application authors SHOULD update the web application accordingly when notified of a change request from the user agent or assistive technology.</p>
 		<p class="note">Many state and properties can be changed by assistive technologies through existing accessibility APIs by responding to a default action event. For example, the <sref>aria-selected</sref> state of a tab in a tabpanel can be changed by triggering the default action on the element.</p>
 	</section>
@@ -324,7 +324,7 @@
 </section>
 <section class="normative" id="roles">
 	<h1>The Roles Model</h1>
-	<p>This section defines the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>role</a> <a>taxonomy</a> and describes the characteristics and properties of all <a title="role">roles</a>. A formal <abbr title="Resource Description Framework">RDF</abbr>/<abbr title="Web Ontology Language">OWL</abbr> representation of all the information presented here is available in <a href="#a_schemata">Schemata Appendix</a>.</p>
+	<p>This section defines the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>role</a> <a>taxonomy</a> and describes the characteristics and properties of all <a>roles</a>. A formal <abbr title="Resource Description Framework">RDF</abbr>/<abbr title="Web Ontology Language">OWL</abbr> representation of all the information presented here is available in <a href="#a_schemata">Schemata Appendix</a>.</p>
 	<p>The roles, their characteristics, the states and properties they support, and specification of how they may be used in markup, shall be considered normative. The RDF/OWL representation used to model the taxonomy shall be considered informative. The RDF/OWL taxonomy may be used as a vehicle to extend <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> in the future or by tool manufacturers to validate states and properties applicable to roles per this specification.</p>
 	<p>Roles are element types and authors MUST NOT change role values over time or with user actions. Authors wishing to change a role MUST do so by deleting the associated element and its children and replacing it with a new element with the appropriate role. Typically, platform accessibility APIs do not provide a vehicle to notify assistive technologies of a role value change, and consequently, assistive technologies may not update their cache with the new role attribute value. </p>
 	<p>In order to reflect the content in the DOM, user agents SHOULD map the role attribute to the appropriate value in the implemented accessibility API, and user agents SHOULD update the mapping when the role attribute changes.</p>
@@ -338,7 +338,7 @@
 				<dt><abbr title="Resource Description Framework">RDF</abbr> Property</dt>
 				<dd>rdfs:subClassOf</dd>
 			</dl>
-			<p>The <a>role</a> that the current subclassed role extends in the <a>taxonomy</a>. This extension causes all the properties and constraints of the superclass role to propagate to the subclass role. Other than well known stable specifications, inheritance may be restricted to items defined inside this specification, so that external items cannot be changed and affect inherited <a title="class">classes</a>.</p>
+			<p>The <a>role</a> that the current subclassed role extends in the <a>taxonomy</a>. This extension causes all the properties and constraints of the superclass role to propagate to the subclass role. Other than well known stable specifications, inheritance may be restricted to items defined inside this specification, so that external items cannot be changed and affect inherited <a>classes</a>.</p>
 		</section>
 		<section id="subclassroles">
 			<h3>Subclass Roles</h3>
@@ -346,7 +346,7 @@
 				<dt><abbr title="Resource Description Framework">RDF</abbr> Property</dt>
 				<dd>&lt;none&gt;</dd>
 			</dl>
-			<p>Informative list of <a title="role">roles</a> for which this role is the superclass. This is provided to facilitate reading of the specification but adds no new information.</p>
+			<p>Informative list of <a>roles</a> for which this role is the superclass. This is provided to facilitate reading of the specification but adds no new information.</p>
 		</section>
 		<section id="relatedConcept">
 			<h3>Related Concepts</h3>
@@ -363,14 +363,14 @@
 				<dt><abbr title="Resource Description Framework">RDF</abbr> Property</dt>
 				<dd>role:baseConcept</dd>
 			</dl>
-			<p>Informative data about <a title="object">objects</a> that are considered prototypes for the <a>role</a>. Base concept is similar to type, but without inheritance of limitations and properties. Base concepts are designed as a substitute for inheritance for external concepts. A base concept is like a <a href="#relatedConcept">related concept</a> except that the base concept is almost identical to the role definition.</p>
+			<p>Informative data about <a>objects</a> that are considered prototypes for the <a>role</a>. Base concept is similar to type, but without inheritance of limitations and properties. Base concepts are designed as a substitute for inheritance for external concepts. A base concept is like a <a href="#relatedConcept">related concept</a> except that the base concept is almost identical to the role definition.</p>
 			<p>For example, the <rref>checkbox</rref> defined in this document has similar functionality and anticipated behavior to a <a href="http://www.w3.org/TR/html4/interact/forms.html#checkbox">checkbox defined in <abbr title="Hypertext Markup Language">HTML</abbr></a>. Therefore, a <rref>checkbox</rref> has an <abbr title="Hypertext Markup Language">HTML</abbr> <code>checkbox</code> as a <code>baseConcept</code>. However, if the original <abbr title="Hypertext Markup Language">HTML</abbr> checkbox baseConcept definition is modified, the definition of a <rref>checkbox</rref> in this document will not be affected, because there is no actual inheritance of the respective type.</p>
 		</section>
 	</section>
 	<section id="Properties">
 		<h2>Characteristics of Roles</h2>
-		<p>Roles are defined and described by their characteristics. Characteristics define the structural function of a role, such as what a role is, concepts behind it, and what instances the role can or must contain. In the case of <a title="widget">widgets</a> this also includes how it interacts with the <a>user agent</a> based on mapping to <abbr title="Hypertext Markup Language">HTML</abbr> forms and XForms. States and properties from <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> that are supported by the role are also indicated.</p>
-		<p>The roles <a>taxonomy</a> defines the following characteristics. These characteristics are implemented in <abbr title="Resource Description Framework">RDF</abbr> as properties of the OWL <a title="class">classes</a> that describe the roles.</p>
+		<p>Roles are defined and described by their characteristics. Characteristics define the structural function of a role, such as what a role is, concepts behind it, and what instances the role can or must contain. In the case of <a>widgets</a> this also includes how it interacts with the <a>user agent</a> based on mapping to <abbr title="Hypertext Markup Language">HTML</abbr> forms and XForms. States and properties from <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> that are supported by the role are also indicated.</p>
+		<p>The roles <a>taxonomy</a> defines the following characteristics. These characteristics are implemented in <abbr title="Resource Description Framework">RDF</abbr> as properties of the OWL <a>classes</a> that describe the roles.</p>
 		<section id="isAbstract">
 			<h3>Abstract Roles</h3>
 			<dl class="runin">
@@ -379,7 +379,7 @@
 				<dt>Values</dt>
 				<dd>Boolean</dd>
 			</dl>
-			<p>Abstract <a title="role">roles</a> are the foundation upon which all other <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles are built. Content authors MUST NOT use abstract roles because they are not implemented in the <abbr title="application programing interface">API</abbr> binding. User agents MUST NOT map abstract roles to the standard role mechanism of the accessibility API. Abstract roles are provided to help with the following:</p>
+			<p>Abstract <a>roles</a> are the foundation upon which all other <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles are built. Content authors MUST NOT use abstract roles because they are not implemented in the <abbr title="application programing interface">API</abbr> binding. User agents MUST NOT map abstract roles to the standard role mechanism of the accessibility API. Abstract roles are provided to help with the following:</p>
 			<ol>
 				<li>Organize the role <a>taxonomy</a> and provide roles with a meaning in the context of known concepts.</li>
 				<li>Streamline the addition of roles that include necessary features.</li>
@@ -393,7 +393,7 @@
 				<dt>Values</dt>
 				<dd>Any valid <abbr title="Resource Description Framework">RDF</abbr> object reference, such as a <abbr title="Uniform Resource Identifier">URI</abbr>.</dd>
 			</dl>
-			<p><a title="state">States</a> and <a title="property">properties</a> specifically required for the <a>role</a> and subclass roles. Content authors MUST provide a non-empty <span>value</span> for required states and properties. Content authors MUST NOT use the value "undefined" for required states and properties.</p>
+			<p><a>States</a> and <a>properties</a> specifically required for the <a>role</a> and subclass roles. Content authors MUST provide a non-empty <span>value</span> for required states and properties. Content authors MUST NOT use the value "undefined" for required states and properties.</p>
 			<p>When an <a>object</a> inherits from multiple ancestors and one ancestor indicates that property is supported while another ancestor indicates that it is required, the property is required in the inheriting object.</p>
 			<p class="note">A host language attribute with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> fulfills this requirement.</p>
 		</section>
@@ -405,12 +405,12 @@
 				<dt>Values</dt>
 				<dd>Any valid <abbr title="Resource Description Framework">RDF</abbr> object reference, such as a <abbr title="Uniform Resource Identifier">URI</abbr>.</dd>
 			</dl>
-			<p><a title="state">States</a> and <a title="property">properties</a> specifically applicable to the <a>role</a> and child roles. <a title="user agent">User agents</a> MUST map all supported states and properties for the role to an accessibility API. Content authors MAY provide <span>values</span> for supported states and properties, but need not in some cases where default values are sufficient.</p>
+			<p><a>States</a> and <a>properties</a> specifically applicable to the <a>role</a> and child roles. <a>User agents</a> MUST map all supported states and properties for the role to an accessibility API. Content authors MAY provide <span>values</span> for supported states and properties, but need not in some cases where default values are sufficient.</p>
 			<p class="note">A host language attribute with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> fulfills this requirement.</p>
 		</section>
 		<section id="inheritedattributes">
 			<h3>Inherited States and Properties</h3>
-			<p>Informative list of properties that are inherited onto a <a>role</a> from superclass roles. <a title="state">States</a> and <a title="property">properties</a> are inherited from superclass roles in the role <a>taxonomy</a>, not from ancestor <a title="element">elements</a> in the <abbr title="Document Object Model">DOM</abbr> tree. These properties are not explicitly defined on the role, as the inheritance of properties is automatic. This information is provided to facilitate reading of the specification. The set of supported states and properties combined with inherited states and properties forms the full set of states and properties supported by the role.</p>
+			<p>Informative list of properties that are inherited onto a <a>role</a> from superclass roles. <a>States</a> and <a>properties</a> are inherited from superclass roles in the role <a>taxonomy</a>, not from ancestor <a>elements</a> in the <abbr title="Document Object Model">DOM</abbr> tree. These properties are not explicitly defined on the role, as the inheritance of properties is automatic. This information is provided to facilitate reading of the specification. The set of supported states and properties combined with inherited states and properties forms the full set of states and properties supported by the role.</p>
 		</section>
 		<section id="mustContain">
 			<h3>Required Owned Elements</h3>
@@ -420,7 +420,7 @@
 				<dt>Values</dt>
 				<dd>Any valid <abbr title="Resource Description Framework">RDF</abbr> object reference, such as a <abbr title="Uniform Resource Identifier">URI</abbr>.</dd>
 			</dl>
-			<p>Any <a>element</a> that will be <a title="owned element">owned</a> by the element with this <a>role</a>. For example, an element with the role <rref>list</rref> will own at least one element with the role <rref>group</rref> or <rref>listitem</rref>.</p>
+			<p>Any <a>element</a> that will be <a>owned</a> by the element with this <a>role</a>. For example, an element with the role <rref>list</rref> will own at least one element with the role <rref>group</rref> or <rref>listitem</rref>.</p>
 			<p>When multiple roles are specified as <em>required owned elements</em> for a role, at least one instance of one required owned element is expected. This specification does <em>not</em> require an instance of each of the listed owned roles. For example, a <code>menu</code> should have at least one instance of a <code>menuitem</code>, <code>menuitemcheckbox</code>, <em>or</em> <code>menuitemradio</code>. The <code>menu</code> role does not require one instance of each. </p>
 			<p>There may be times that required owned elements are missing, for example, while editing or while loading a data set. When a widget is missing <em>required owned elements</em> due to script execution or loading, authors MUST mark a containing element with <sref>aria-busy</sref> equal to <code>true</code>. For example, until a page is fully initialized and complete, an author could mark the document element as busy.</p>
 			<p class="note">A role that has 'required owned elements' does not imply the reverse relationship. While processing of a role may be incomplete without elements of given roles present as descendants, elements with roles in this list do not always have to be found within elements of the given role. See <a href="#scope">required context role</a> for requirements about the context where elements of a given role will be contained.</p>
@@ -435,7 +435,7 @@
 				<dt>Values</dt>
 				<dd>Any valid <abbr title="Resource Description Framework">RDF</abbr> object reference, such as a <abbr title="Uniform Resource Identifier">URI</abbr>.</dd>
 			</dl>
-			<p>The required context role defines the owning container where this <a>role</a> is allowed. If a role has a required context, authors MUST ensure that an element with the role is contained inside (or <a title="owned element">owned</a> by) an element with the required context role. For example, an element with role <code>listitem</code> is only meaningful when contained inside (or owned by) an element with role <code>list</code>.</p>
+			<p>The required context role defines the owning container where this <a>role</a> is allowed. If a role has a required context, authors MUST ensure that an element with the role is contained inside (or <a>owned</a> by) an element with the required context role. For example, an element with role <code>listitem</code> is only meaningful when contained inside (or owned by) an element with role <code>list</code>.</p>
 			<p class="note">A role that has 'required context role' does not imply the reverse relationship. While an element with the given role needs to appear within an element of the listed role(s) in order to be meaningful, elements of the listed roles do not always need descendant elements of the given role in order to be meaningful. See <a href="#mustContain">required owned elements</a> for requirements about elements that require presence of a given descendant to be processed properly.</p>
 			<p class="note">An element with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> fulfills this requirement.</p>
 		</section>
@@ -464,7 +464,7 @@
 					<p>Boolean (true | false)</p>
 				</dd>
 			</dl>
-			<p>The <abbr title="Document Object Model">DOM</abbr> descendants are presentational. <a title="user agent">User agents</a> SHOULD NOT expose descendants of this <a>element</a> through the platform <a>accessibility <abbr title="Application Programing Interface">API</abbr></a>. If <a title="user agent">user agents</a> do not hide the descendant nodes, some information may be read twice.</p>
+			<p>The <abbr title="Document Object Model">DOM</abbr> descendants are presentational. <a>User agents</a> SHOULD NOT expose descendants of this <a>element</a> through the platform <a>accessibility <abbr title="Application Programing Interface">API</abbr></a>. If <a>user agents</a> do not hide the descendant nodes, some information may be read twice.</p>
 		</section>
 		<section id="implictValueForRole">
 			<h3>Implicit Value for Role</h3>
@@ -473,7 +473,7 @@
 	</section>
 	<section id="roles_categorization">
 		<h2>Categorization of Roles</h2>
-		<p>To support the current user scenario, this specification categorizes <a title="role">roles</a> that define user interface <a title="widget">widgets</a> (sliders, tree controls, etc.) and those that define page structure (sections, navigation, etc.). Note that some assistive technologies provide special modes of interaction for regions marked with role <code>application</code> or <code>document</code>.</p>
+		<p>To support the current user scenario, this specification categorizes <a>roles</a> that define user interface <a>widgets</a> (sliders, tree controls, etc.) and those that define page structure (sections, navigation, etc.). Note that some assistive technologies provide special modes of interaction for regions marked with role <code>application</code> or <code>document</code>.</p>
 		<div class="img" id="rdf_model"><a href="img/rdf_model"><img alt="Class diagram of the relationships described in the role data model" src="img/rdf_model_sm.png" longdesc="img/rdf_model.html" width="600" height="256" /></a>
 			<p>Class diagram of the relationships described in the role data model.</p>
 			<p><a href="img/rdf_model.svg"><abbr title="Scalable Vector Graphics">SVG</abbr> class diagram</a> | <a href="img/rdf_model.png"><abbr title="Portable Network Graphics">PNG</abbr> class diagram</a> | <a href="img/rdf_model.html">Class diagram description</a></p>
@@ -488,7 +488,7 @@
 		</ol>
 		<section id="abstract_roles">
 			<h3>Abstract Roles</h3>
-			<p>The following <a title="role">roles</a> are used to support the WAI-ARIA role <a>taxonomy</a> for the purpose of defining general role concepts.</p>
+			<p>The following <a>roles</a> are used to support the WAI-ARIA role <a>taxonomy</a> for the purpose of defining general role concepts.</p>
 			<p>Abstract roles are used for the ontology. Authors MUST NOT use abstract roles in content.</p>
 			<ul>
 				<li><rref>command</rref></li>
@@ -552,7 +552,7 @@
 		</section>
 		<section id="document_structure_roles">
 			<h3>Document Structure</h3>
-			<p>The following <a title="role">roles</a> describe structures that organize content in a page. Document structures are not usually interactive.</p>
+			<p>The following <a>roles</a> describe structures that organize content in a page. Document structures are not usually interactive.</p>
 			<ul>
 				<li><rref>article</rref></li>
 				<li><rref>cell</rref></li>
@@ -582,7 +582,7 @@
 		</section>
 		<section id="landmark_roles">
 			<h3>Landmark Roles</h3>
-			<p>The following <a title="role">roles</a> are regions of the page intended as navigational <a title="landmark">landmarks</a>. All of these roles inherit from the <code>landmark</code> base type and, with the exception of <code>application</code>, all are imported from the <cite><a href="http://www.w3.org/TR/role-attribute/#s_role_module_attributes">Role Attribute</a></cite> [[ROLE-ATTRIBUTE]]. The roles are included here in order to make them clearly part of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Role <a>taxonomy</a>.</p>
+			<p>The following <a>roles</a> are regions of the page intended as navigational <a>landmarks</a>. All of these roles inherit from the <code>landmark</code> base type and, with the exception of <code>application</code>, all are imported from the <cite><a href="http://www.w3.org/TR/role-attribute/#s_role_module_attributes">Role Attribute</a></cite> [[ROLE-ATTRIBUTE]]. The roles are included here in order to make them clearly part of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Role <a>taxonomy</a>.</p>
 			<ul>
 				<li><rref>application</rref></li>
 				<li><rref>banner</rref></li>
@@ -597,7 +597,7 @@
 		</section>
 		<section id="live_region_roles">
 			<h3>Live Region Roles</h3>
-			<p>The following widget <a title="role">roles</a> are also <a title="live region">live regions</a> and may be modified by <a href="#attrs_liveregions">live region attributes</a>.</p>
+			<p>The following widget <a>roles</a> are also <a>live regions</a> and may be modified by <a href="#attrs_liveregions">live region attributes</a>.</p>
 			<ul>
 				<li><rref>alert</rref></li>
 				<li><rref>log</rref></li>
@@ -609,7 +609,7 @@
 	</section>
 	<section id="role_definitions">
 		<h2>Definition of Roles</h2>
-		<p>Below is an alphabetical list of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a title="role">roles</a> to be used by rich internet application authors.</p>
+		<p>Below is an alphabetical list of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>roles</a> to be used by rich internet application authors.</p>
 		<p>Abstract roles are used for the ontology. Authors MUST NOT use abstract roles in content.</p>
 		<p id="index_role">Placeholder for compact list of roles</p>
 		<hr/>
@@ -707,7 +707,7 @@
 				<p>A type of dialog that contains an alert message, where initial focus goes to an <a>element</a> within the dialog. See related <rref>alert</rref> and <rref>dialog</rref>.</p>
 				<p>Alert dialogs are used to convey messages to alert the user. The <code>alertdialog</code> <a>role</a> goes on the node containing both the alert message and the rest of the dialog. Content authors SHOULD make alert dialogs modal by ensuring that, while the <code>alertdialog</code> is shown, keyboard and mouse interactions only operate within the dialog. See <pref>aria-modal</pref> [ARIA 1.1].</p>
 				<p>Unlike <rref>alert</rref>, <code>alertdialog</code> can receive a response from the user. For example, to confirm that the user understands the alert being generated. When the alert dialog is displayed, authors SHOULD set focus to an active element within the alert dialog, such as a form edit field or an OK button. The <a>user agent</a> SHOULD fire a system alert <a>event</a> through the accessibility API when the alert is created, provided one is specified by the intended <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a>.</p>
-				<p>Authors SHOULD use <pref>aria-describedby</pref> on an <code>alertdialog</code> to reference the alert message element in the dialog. If they do not, an <a title="assistive technologies">assistive technology</a> can resort to its internal recovery mechanism to determine the contents of the alert message.</p>
+				<p>Authors SHOULD use <pref>aria-describedby</pref> on an <code>alertdialog</code> to reference the alert message element in the dialog. If they do not, an <a>assistive technology</a> can resort to its internal recovery mechanism to determine the contents of the alert message.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -791,7 +791,7 @@
 			<rdef>application</rdef>
 			<div class="role-description">
 				<p>A region declared as a web application, as opposed to a web <rref>document</rref>.</p>
-				<p>When the user navigates an element assigned the role of <rref>application</rref>, <a>assistive technologies</a> that typically intercept standard keyboard events SHOULD switch to an application browsing mode, and pass keyboard events through to the web application. The intent is to hint to certain <a>assistive technologies</a> to switch from normal browsing mode into a mode more appropriate for interacting with a web application; some <a title="user agent">user agents</a> have a browse navigation mode where keys, such as up and down arrows, are used to browse the document, and this native behavior prevents the use of these keys by a web application.</p>
+				<p>When the user navigates an element assigned the role of <rref>application</rref>, <a>assistive technologies</a> that typically intercept standard keyboard events SHOULD switch to an application browsing mode, and pass keyboard events through to the web application. The intent is to hint to certain <a>assistive technologies</a> to switch from normal browsing mode into a mode more appropriate for interacting with a web application; some <a>user agents</a> have a browse navigation mode where keys, such as up and down arrows, are used to browse the document, and this native behavior prevents the use of these keys by a web application.</p>
 				<p class="note">Where appropriate, assistive technologies that typically intercept other standard device input events, such as touch screen input, could switch to an application browsing mode that passes some or all of those events through to the web application.</p>
 				<!-- note: keep the following paragraphs synced with their counterparts in #document -->
 				<p>Authors SHOULD set the <a>role</a> of <code>application</code> on the <a>element</a> that encompasses the entire application. If the application role applies to the entire web page, authors SHOULD set the role of <code>application</code> on the root node for content, such as the <code>body</code> element in <abbr title="Hypertext Markup Language">HTML</abbr> or <code>svg</code> element in SVG.</p>
@@ -803,7 +803,7 @@
 					<li>Otherwise, provide a visible label referenced by the application using <pref>aria-labelledby</pref>.</li>
 					<!-- note: keep the previous paragraphs synced with their counterparts in #document -->
 				</ul>
-				<p>User agents SHOULD treat elements with the role of <code>application</code> as navigational <a title="landmark">landmarks</a>.</p>
+				<p>User agents SHOULD treat elements with the role of <code>application</code> as navigational <a>landmarks</a>.</p>
 				<p>Authors MAY use the <code>application</code> role on the <a>primary content element</a> of the host language (such as the <code>body</code> element in HTML) to define an entire page as an application. However, if the <a>primary content element</a> is defined as having a role of <code>application</code>, user agents MUST NOT use the element as a navigational landmark. If assistive technologies use an interaction mode that intercepts standard keyboard events, when encountering the <code>application</code> role, those assistive technologies SHOULD switch to an interaction mode that passes keyboard events through to the web application.</p>
 				</div>
 			<table class="role-features">
@@ -964,7 +964,7 @@
 			<div class="role-description">
 				<p>A region that contains mostly site-oriented content, rather than page-specific content.</p>
 				<p>Site-oriented content typically includes things such as the logo or identity of the site sponsor, and site-specific search tool. A banner usually appears at the top of the page and typically spans the full width.</p>
-				<p>User agents SHOULD treat elements with the role of <code>banner</code> as navigational <a title="landmark">landmarks</a>.</p>
+				<p>User agents SHOULD treat elements with the role of <code>banner</code> as navigational <a>landmarks</a>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #main and #contentinfo-->
 				<p>Within any <rref>document</rref> or <rref>application</rref>, the author SHOULD mark no more than one <a>element</a> with the <code>banner</code> <a>role</a>.</p>
 				<p class="note">Because <code>document</code> and <code>application</code> elements can be nested in the <abbr title="Document Object Model">DOM</abbr>, they may have multiple <code>banner</code> elements as <abbr title="Document Object Model">DOM</abbr> descendants, assuming each of those is associated with different document nodes, either by a DOM nesting (e.g., <rref>document</rref> within <rref>document</rref>) or by use of the <pref>aria-owns</pref> <a>attribute</a>.</p>
@@ -1046,7 +1046,7 @@
 			<rdef>button</rdef>
 			<div class="role-description">
 				<p>An input that allows for user-triggered actions when clicked or pressed. See related <rref>link</rref>.</p>
-				<p>Buttons are mostly used for discrete actions. Standardizing the appearance of buttons enhances the user's recognition of the <a title="widget">widgets</a> as buttons and allows for a more compact display in toolbars.</p>
+				<p>Buttons are mostly used for discrete actions. Standardizing the appearance of buttons enhances the user's recognition of the <a>widgets</a> as buttons and allows for a more compact display in toolbars.</p>
 				<p>Buttons support the optional <a>attribute</a> <sref>aria-pressed</sref>. Buttons with a non-empty <sref>aria-pressed</sref> attribute are toggle buttons. When <sref>aria-pressed</sref> is <code>true</code> the button is in a "pressed" <a>state</a>, when <sref>aria-pressed</sref> is <code>false</code> it is not pressed. If the attribute is not present, the button is a simple command button.</p>
 			</div>
 			<table class="role-features">
@@ -1141,7 +1141,7 @@
 			<rdef>cell</rdef>
 			<div class="role-description">
 				<p>[ARIA 1.1] A cell in a tabular container.</p>
-				<p>Authors MUST ensure <a title="element">elements</a> with <a>role</a> cell are contained in, or owned by, an element with the <a>role</a> <rref>row</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with <a>role</a> cell are contained in, or owned by, an element with the <a>role</a> <rref>row</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -1232,7 +1232,7 @@
 			<rdef>checkbox</rdef>
 			<div class="role-description">
 				<p>A checkable input that has three possible <span>values</span>: true, false, or mixed.</p>
-				<p>The <sref>aria-checked</sref> <a>attribute</a> of a <code>checkbox</code> indicates whether the input is checked (<code>true</code>), unchecked (<code>false</code>), or represents a group of <a title="element">elements</a> that have a mixture of checked and unchecked values (<code>mixed</code>). Many checkboxes do not use the <code>mixed</code> value, and thus are effectively boolean checkboxes.</p>
+				<p>The <sref>aria-checked</sref> <a>attribute</a> of a <code>checkbox</code> indicates whether the input is checked (<code>true</code>), unchecked (<code>false</code>), or represents a group of <a>elements</a> that have a mixture of checked and unchecked values (<code>mixed</code>). Many checkboxes do not use the <code>mixed</code> value, and thus are effectively boolean checkboxes.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -1336,7 +1336,7 @@
 				<p>A cell containing header information for a column.</p>
 				<p><code>columnheader</code> can be used as a column header in a table or grid. It could also be used in a pie chart to show a similar <a>relationship</a> in the data.</p>
 				<p>The <code>columnheader</code> establishes a relationship between it and all cells in the corresponding column. It is the structural equivalent to an <abbr title="Hypertext Markup Language">HTML</abbr> <code>th</code> <a>element</a> with a column scope.</p>
-				<p>Authors MUST ensure <a title="element">elements</a> with <a>role</a>  <rref>columnheader</rref> are contained in, or owned by, an element with the role <rref>row</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with <a>role</a>  <rref>columnheader</rref> are contained in, or owned by, an element with the role <rref>row</rref>.</p>
 				<p>Applying the <pref>aria-selected</pref> state on a columnheader MUST not cause the user agent to automatically propagate the <pref>aria-selected</pref> state to all the cells in the corresponding column. An author MAY choose to propagate selection in this manner depending on the specific application.</p>
 				<p>While the <code>columnheader</code> role can be used in both interactive grids and non-interactive tables, the use of <pref>aria-readonly</pref> and <pref>aria-required</pref> is only applicable to interactive elements. Therefore, authors SHOULD NOT use <pref>aria-required</pref> or <pref>aria-readonly</pref> in a <code>columnheader</code> that descends from a <rref>table</rref>, and user agents SHOULD NOT expose either property to <a>assistive technologies</a> unless the <code>columnheader</code> descends from a <rref>grid</rref>.</p>
 				<p class="note">Because cells are organized into rows, there is not a single container element for the column. The column is the set of <rref>gridcell</rref> elements in a particular position within their respective <rref>row</rref> containers.</p>
@@ -1633,7 +1633,7 @@
 			<div class="role-description">
 				<p>A supporting section of the document, designed to be complementary to the main content at a similar level in the DOM hierarchy, but remains meaningful when separated from the main content.</p>
 				<p>There are various types of content that would appropriately have this <a>role</a>. For example, in the case of a portal, this may include but not be limited to show times, current weather, related articles, or stocks to watch. The complementary role indicates that contained content is relevant to the main content. If the complementary content is completely separable main content, it may be appropriate to use a more general role.</p>
-				<p>User agents SHOULD treat elements with the role of <code>complementary</code> as navigational <a title="landmark">landmarks</a>.</p>
+				<p>User agents SHOULD treat elements with the role of <code>complementary</code> as navigational <a>landmarks</a>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -1712,7 +1712,7 @@
 			<rdef>composite</rdef>
 			<div class="role-description">
 				<p>A <a>widget</a> that may contain navigable descendants or owned children.</p>
-				<p>Authors SHOULD ensure that a composite widget exist as a single navigation stop within the larger navigation system of the web page. Once the composite widget has focus, authors SHOULD provide a separate navigation mechanism for users to navigate to <a title="element">elements</a> that are descendants or owned children of the composite element.</p>
+				<p>Authors SHOULD ensure that a composite widget exist as a single navigation stop within the larger navigation system of the web page. Once the composite widget has focus, authors SHOULD provide a separate navigation mechanism for users to navigate to <a>elements</a> that are descendants or owned children of the composite element.</p>
 				<p class="note"><code>composite</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
 			</div>
 			<table class="role-features">
@@ -1785,7 +1785,7 @@
 			<div class="role-description">
 				<p>A large perceivable region that contains information about the parent document.</p>
 				<p>Examples of information included in this region of the page are copyrights and links to privacy statements.</p>
-				<p>User agents SHOULD treat elements with the role of <code>contentinfo</code> as navigational <a title="landmark">landmarks</a>.</p>
+				<p>User agents SHOULD treat elements with the role of <code>contentinfo</code> as navigational <a>landmarks</a>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #banner and #main -->
 				<p>Within any <rref>document</rref> or <rref>application</rref>, the author SHOULD mark no more than one <a>element</a> with the <code>contentinfo</code> role.</p>
 				<p class="note">Because <code>document</code> and <code>application</code> elements can be nested in the <abbr title="Document Object Model">DOM</abbr>, they may have multiple <code>contentinfo</code> elements as <abbr title="Document Object Model">DOM</abbr> descendants, assuming each of those is associated with different document nodes, either by a DOM nesting (e.g., <rref>document</rref> within <rref>document</rref>) or by use of the <pref>aria-owns</pref> attribute.</p>
@@ -2112,7 +2112,7 @@
 			<rdef>document</rdef>
 			<div class="role-description">
 				<p>A region containing related information that is declared as document content, as opposed to a web <rref>application</rref>.</p>
-				<p>When the user navigates an element assigned the role of <rref>document</rref>, <a>assistive technologies</a> that typically intercept standard keyboard events SHOULD switch to document browsing mode, as opposed to passing keyboard events through to the web application. The <code>document</code> <a>role</a> informs <a title="user agent">user agents</a> of the need to augment browser keyboard support in order to allow users to visit and read any content within the document region. In contrast, additional commands are not necessary for screen reader users to read text within a region with the <rref>application</rref> role, where if coded in an accessible manner, all text will be <a title="semantics">semantically</a> associated with focusable <a title="element">elements</a>. An important trait of documents is that they have text which is not associated with <a title="widget">widgets</a> or groups thereof.</p>
+				<p>When the user navigates an element assigned the role of <rref>document</rref>, <a>assistive technologies</a> that typically intercept standard keyboard events SHOULD switch to document browsing mode, as opposed to passing keyboard events through to the web application. The <code>document</code> <a>role</a> informs <a>user agents</a> of the need to augment browser keyboard support in order to allow users to visit and read any content within the document region. In contrast, additional commands are not necessary for screen reader users to read text within a region with the <rref>application</rref> role, where if coded in an accessible manner, all text will be <a>semantically</a> associated with focusable <a>elements</a>. An important trait of documents is that they have text which is not associated with <a>widgets</a> or groups thereof.</p>
 				<!-- note: keep the following paragraphs synced with their counterparts in #application -->
 				<p>Authors SHOULD set the role of <code>document</code> on the element that encompasses the entire document. If the document role applies to the entire web page, authors SHOULD set the role of <code>document</code> on the root node for content, such as the <code>body</code> element in <abbr title="Hypertext Markup Language">HTML</abbr> or <code>svg</code> element in <abbr title="Scalable Vector Graphics">SVG</abbr>.</p>
 				<p>For example, an email application has a document and an application in it. The author would want to use typical application navigation mode to cycle through the list of emails, and much of this navigation would be defined by the application author. However, when reading an email message, the content will appear in a region with a <rref>document</rref> role in order to use browsing navigation.</p>
@@ -2201,7 +2201,7 @@
 			<div class="role-description">
 				<p>A <rref>landmark</rref> region that contains a collection of items and objects that, as a whole, combine to create a form. See related <rref>search</rref>.</p>
 				<p>A form may be a mix of host language form controls, scripted controls, and hyperlinks. Authors are reminded to use native host language semantics to create form controls, whenever possible. For search facilities, authors SHOULD use the <rref>search</rref> role and not the generic <code>form</code> role. Authors SHOULD provide a visible label for the form referenced with <pref>aria-labelledby</pref>. If an author uses a script to submit a form based on a user action that would otherwise not trigger an <code>onsubmit</code> event (for example, a form submission triggered by the user changing a form element's value), the author SHOULD provide the user with advance notification of the behavior. Authors are reminded to use native host language semantics to create form controls, whenever possible.</p>
-				<p>User agents SHOULD treat elements with the role of <code>form</code> as navigational <a title="landmark">landmarks</a>.</p>
+				<p>User agents SHOULD treat elements with the role of <code>form</code> as navigational <a>landmarks</a>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -2281,8 +2281,8 @@
 			<div class="role-description">
 				<p>An interactive control which contains cells of tabular data arranged in rows and columns, like a table.</p>
 				<p class="ednote">JC 2014-06-03. Now that 1.1 will include a table role, we need to differentiate the short description more sufficiently. Emphasize that grids are "interactive" tables that maintain a selection state.</p>
-				<p>Grids do not necessarily imply presentation. The <code>grid</code> construct describes <a title="relationship">relationships</a> between data such that it may be used for different presentations. Grids allow the user to move focus between cells using two dimensional navigation.</p>
-				<p>Authors MUST ensure that elements with role <rref>treegrid</rref> are <a title="owned element">owned</a> by elements with role <rref>row</rref>, which are in turn owned by an element with role <rref>rowgroup</rref>, <rref>grid</rref>, or <rref>treegrid</rref>. If the author applies any non-global WAI-ARIA states or properties to a native markup element that is acting as a row (such as the <code>tr</code> element in HTML), the author MUST also apply the role of <rref>row</rref>, as stated in the section on <a href="#host_languages">Implementation in Host Languages</a>. Authors MAY make cells focusable. Authors MAY provide row and column headers for grids, by using <rref>rowheader</rref> and <rref>columnheader</rref> roles.</p>
+				<p>Grids do not necessarily imply presentation. The <code>grid</code> construct describes <a>relationships</a> between data such that it may be used for different presentations. Grids allow the user to move focus between cells using two dimensional navigation.</p>
+				<p>Authors MUST ensure that elements with role <rref>treegrid</rref> are <a>owned</a> by elements with role <rref>row</rref>, which are in turn owned by an element with role <rref>rowgroup</rref>, <rref>grid</rref>, or <rref>treegrid</rref>. If the author applies any non-global WAI-ARIA states or properties to a native markup element that is acting as a row (such as the <code>tr</code> element in HTML), the author MUST also apply the role of <rref>row</rref>, as stated in the section on <a href="#host_languages">Implementation in Host Languages</a>. Authors MAY make cells focusable. Authors MAY provide row and column headers for grids, by using <rref>rowheader</rref> and <rref>columnheader</rref> roles.</p>
 				<p>Since WAI-ARIA can augment an element in the host language, grids can reuse existing functionality of native table grids. When <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> grid or gridcell roles overlay host language table elements they reuse the host language <a>semantics</a> for that table. For instance, <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not specify general attributes for <rref>gridcell</rref> elements that span multiple rows or columns. When the author needs a <rref>gridcell</rref> to span multiple rows or columns, use the host language markup, such as the <code>colspan</code> and <code>rowspan</code> attributes in HTML.</p>
 				<p>Authors MAY determine the contents of a <rref>gridcell</rref> through calculation of a mathematical formula. Authors MAY make a cell's formula editable by the user. In a spreadsheet application for example, the text alternative of a cell may be the calculated value of a formula. However, when the cell is being edited, the text alternative may be the formula itself.</p>
 				<p><rref>gridcell</rref> elements with the <sref>aria-selected</sref> attribute set can be selected for user interaction, and if the <pref>aria-multiselectable</pref> attribute of the <code>grid</code> is set to <code>true</code>, multiple cells in the grid may be selected. Grids may be used for spreadsheets like those in desktop spreadsheet applications.</p>
@@ -2383,10 +2383,10 @@
 			<rdef>gridcell</rdef>
 			<div class="role-description">
 				<p>A cell in a grid or treegrid.</p>
-				<p>Cells may be active, editable, and selectable. Cells may have <a title="relationship">relationships</a> such as <pref>aria-controls</pref> to address the application of functional relationships.</p>
-				<p>If relevant headers cannot be determined from the <abbr title="Document Object Model">DOM</abbr> structure, authors SHOULD explicitly indicate which header cells are relevant to the cell by referencing <a title="element">elements</a> with <a>role</a> <rref>rowheader</rref> or <rref>columnheader</rref> using the <pref>aria-describedby</pref> <a>attribute</a>.</p>
+				<p>Cells may be active, editable, and selectable. Cells may have <a>relationships</a> such as <pref>aria-controls</pref> to address the application of functional relationships.</p>
+				<p>If relevant headers cannot be determined from the <abbr title="Document Object Model">DOM</abbr> structure, authors SHOULD explicitly indicate which header cells are relevant to the cell by referencing <a>elements</a> with <a>role</a> <rref>rowheader</rref> or <rref>columnheader</rref> using the <pref>aria-describedby</pref> <a>attribute</a>.</p>
 				<p>In a <rref>treegrid</rref>, authors MAY define cells as expandable by using the <sref>aria-expanded</sref> attribute. If the <sref>aria-expanded</sref> attribute is provided, it applies only to the individual cell. It is not a proxy for the container row, which also can be expanded. The main use case for providing this attribute on a cell is pivot table behavior.</p>
-				<p>Authors MUST ensure <a title="element">elements</a> with <a>role</a> gridcell are contained in, or owned by, an element with the <a>role</a> <rref>row</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with <a>role</a> gridcell are contained in, or owned by, an element with the <a>role</a> <rref>row</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -2481,7 +2481,7 @@
 		<div class="role" id="group">
 			<rdef>group</rdef>
 			<div class="role-description">
-				<p>A set of user interface <a title="object">objects</a> which are not intended to be included in a page summary or table of contents by <a>assistive technologies</a>.</p>
+				<p>A set of user interface <a>objects</a> which are not intended to be included in a page summary or table of contents by <a>assistive technologies</a>.</p>
 				<p>Contrast with <rref>region</rref> which is a grouping of user interface objects that will be included in a page summary or table of contents.</p>
 				<p>Authors SHOULD use a <rref>group</rref> to form logical collection of items in a <a>widget</a> such as children in a tree widget forming a collection of siblings in a hierarchy, or a collection of items having the same container in a directory. However, when a <rref>group</rref> is used in the context of list, authors MUST limit its children to <rref>listitem</rref> elements. Therefore, proper handling of <rref>group</rref> by authors and assistive technologies is determined by the context in which it is provided.</p>
 				<p>Authors MAY nest <code>group</code> elements. If a section is significant enough to warrant inclusion in the web page's table of contents, the author SHOULD assign the section a <a>role</a> of <rref>region</rref> or a <a href="#landmark_roles">standard landmark role</a>.</p>
@@ -2660,8 +2660,8 @@
 		<div class="role" id="img">
 			<rdef>img</rdef>
 			<div class="role-description">
-				<p>A container for a collection of <a title="element">elements</a> that form an image.</p>
-				<p>An <code>img</code> can contain captions and descriptive text, as well as multiple image files that when viewed together give the impression of a single image. An <code>img</code> represents a single graphic within a document, whether or not it is formed by a collection of drawing <a title="object">objects</a>. In order for elements with a <a>role</a> of <code>img</code> be <a>perceivable</a>, authors MUST provide alternative text or a label determined by the <a href="#namecalculation">accessible name calculation</a>.</p>
+				<p>A container for a collection of <a>elements</a> that form an image.</p>
+				<p>An <code>img</code> can contain captions and descriptive text, as well as multiple image files that when viewed together give the impression of a single image. An <code>img</code> represents a single graphic within a document, whether or not it is formed by a collection of drawing <a>objects</a>. In order for elements with a <a>role</a> of <code>img</code> be <a>perceivable</a>, authors MUST provide alternative text or a label determined by the <a href="#namecalculation">accessible name calculation</a>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -2817,7 +2817,7 @@
 				<p>A perceivable <rref>section</rref> containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.</p>
 				 <p>Authors designate the purpose of the content by assigning a role that is a subclass of the landmark role and, when needed, by providing a brief, descriptive label.</p>
 <p>Elements with a role that is a subclass of the landmark role are known as landmark regions or navigational landmark regions.
-<a>Assistive technologies</a> SHOULD enable users to quickly navigate to landmark regions. Mainstream <a title="user agent">user agents</a> MAY enable users to quickly navigate to landmark regions.</p>
+<a>Assistive technologies</a> SHOULD enable users to quickly navigate to landmark regions. Mainstream <a>user agents</a> MAY enable users to quickly navigate to landmark regions.</p>
 				<p class="note"><code>landmark</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
 			</div>
 			<table class="role-features">
@@ -3075,7 +3075,7 @@
 			<rdef>listbox</rdef>
 			<div class="role-description">
 				<p>A <a>widget</a> that allows the user to select one or more items from a list of choices. See related <rref>combobox</rref> and <rref>list</rref>.</p>
-				<p>Items within the list are static and, unlike standard <abbr title="Hypertext Markup Language">HTML</abbr> <code>select</code> <a title="element">elements</a>, may contain images. List boxes contain children whose <a>role</a> is <rref>option</rref>.</p>
+				<p>Items within the list are static and, unlike standard <abbr title="Hypertext Markup Language">HTML</abbr> <code>select</code> <a>elements</a>, may contain images. List boxes contain children whose <a>role</a> is <rref>option</rref>.</p>
 				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
 				<p class="note">Elements with the role <rref>listbox</rref> have an implicit <pref>aria-orientation</pref> value of <code>vertical</code>.</p>
 			</div>
@@ -3176,7 +3176,7 @@
 			<rdef>listitem</rdef>
 			<div class="role-description">
 				<p>A single item in a list or directory.</p>
-				<p>Authors MUST ensure <a title="element">elements</a> with <a>role</a>  <rref>listitem</rref> are contained in, or owned by, an <a>element</a> with the <a>role</a> <rref>list</rref> or <rref>group</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with <a>role</a>  <rref>listitem</rref> are contained in, or owned by, an <a>element</a> with the <a>role</a> <rref>list</rref> or <rref>group</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -3350,7 +3350,7 @@
 			<rdef>main</rdef>
 			<div class="role-description">
 				<p>The main content of a document.</p>
-				<p>This marks the content that is directly related to or expands upon the central topic of the document. The <code>main</code> <a>role</a> is a non-obtrusive alternative for "skip to main content" links, where the navigation option to go to the main content (or other <a title="landmark">landmarks</a>) is provided by the <a>user agent</a> through a dialog or by <a>assistive technologies</a>.</p>
+				<p>This marks the content that is directly related to or expands upon the central topic of the document. The <code>main</code> <a>role</a> is a non-obtrusive alternative for "skip to main content" links, where the navigation option to go to the main content (or other <a>landmarks</a>) is provided by the <a>user agent</a> through a dialog or by <a>assistive technologies</a>.</p>
 				<p>User agents SHOULD treat elements with the role of <code>main</code> as navigational landmarks.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #banner and #contentinfo -->
 				<p>Within any <rref>document</rref> or <rref>application</rref>, the author SHOULD mark no more than one <a>element</a> with the <code>main</code> role.</p>
@@ -3844,7 +3844,7 @@
 			<div class="role-description">
 				<p>An option in a set of choices contained by a <rref>menu</rref> or <rref>menubar</rref>.</p>
 				<p>Authors MAY disable a menu item with the <sref>aria-disabled</sref> attribute. If the menu item has its <pref>aria-haspopup</pref> attribute set to <code>true</code>, it indicates that the menu item may be used to launch a sub-level menu, and authors SHOULD display a new sub-level menu when the menu item is activated.</p>
-				<p>Authors MUST ensure that menu items are <a title="owned element">owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref> in order to identify that they are related <a title="widget">widgets</a>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
+				<p>Authors MUST ensure that menu items are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref> in order to identify that they are related <a>widgets</a>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -3946,7 +3946,7 @@
 			<div class="role-description">
 				<p>A <rref>menuitem</rref> with a checkable state whose possible <span>values</span> are true, false, or mixed.</p>
 				<p>The <sref>aria-checked</sref> <a>attribute</a> of a <code>menuitemcheckbox</code> indicates whether the menu item is checked (<code>true</code>), unchecked (<code>false</code>), or represents a sub-level menu of other menu items that have a mixture of checked and unchecked values (<code>mixed</code>).</p>
-				<p>Authors MUST ensure that menu item checkboxes are <a title="owned element">owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref> in order to identify that they are related widgets. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
+				<p>Authors MUST ensure that menu item checkboxes are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref> in order to identify that they are related widgets. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4046,7 +4046,7 @@
 				<p>A checkable <rref>menuitem</rref> in a set of elements with the same role, only one of which can be checked at a time.</p>
 				<p>Authors SHOULD enforce that only one <code>menuitemradio</code> in a group can be checked at the same time. When one item in the group is checked, the previously checked item becomes unchecked (its <sref>aria-checked</sref> <a>attribute</a> becomes <code>false</code>).</p>
 				<!-- keep previous sentence synced with radiogroup, etc. -->
-				<p>Authors MUST ensure that menu item radios are <a title="owned element">owned</a> by an element with role <rref>group</rref>, <rref>menu</rref>, or <rref>menubar</rref> in order to identify that they are related widgets. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
+				<p>Authors MUST ensure that menu item radios are <a>owned</a> by an element with role <rref>group</rref>, <rref>menu</rref>, or <rref>menubar</rref> in order to identify that they are related widgets. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
                 <p>If a <rref>menu</rref> or <rref>menubar</rref> contains more than one group of <rref>menuitemradio</rref> elements, or if the menu contains one group and other, unrelated menu items, authors SHOULD nest each set of related <rref>menuitemradio</rref> elements in an element using the <rref>group</rref> role, and authors SHOULD delimit the group from other menu items with an element using the <rref>separator</rref> role.</p>
 			</div>
 			<table class="role-features">
@@ -4141,8 +4141,8 @@
 		<div class="role" id="navigation">
 			<rdef>navigation</rdef>
 			<div class="role-description">
-				<p>A collection of navigational <a title="element">elements</a> (usually links) for navigating the document or related documents.</p>
-				<p>User agents SHOULD treat elements with the role of <code>navigation</code> as navigational <a title="landmark">landmarks</a>.</p>
+				<p>A collection of navigational <a>elements</a> (usually links) for navigating the document or related documents.</p>
+				<p>User agents SHOULD treat elements with the role of <code>navigation</code> as navigational <a>landmarks</a>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4311,7 +4311,7 @@
 			<rdef>option</rdef>
 			<div class="role-description">
 				<p>A selectable item in a <rref>select</rref> list.</p>
-				<p>Authors MUST ensure <a title="element">elements</a> with <a>role</a> <rref>option</rref> are contained in, or owned by, an element with the <a>role</a>  <rref>listbox</rref>. Options not associated with a <rref>listbox</rref> might not be correctly mapped to an <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a>.</p>
+				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <rref>option</rref> are contained in, or owned by, an element with the <a>role</a>  <rref>listbox</rref>. Options not associated with a <rref>listbox</rref> might not be correctly mapped to an <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a>.</p>
 				<p class="note">Elements with the role <rref>option</rref> have an implicit <sref>aria-selected</sref> value of <code>false</code>.</p>
 			</div>
 			<table class="role-features">
@@ -4444,7 +4444,7 @@
 <span class="comment">&lt;!-- &lt;&gt; --&gt;</span> Sample Content <span class="comment">&lt;!-- &lt;/&gt; --&gt;</span>
 </pre>
 				<p>The <code>presentation</code> role is used on an element that has implicit native semantics, meaning that there is a default accessibility <abbr title="Application Programing Interface">API</abbr> role for the element. Some elements are only complete when additional descendant elements are provided. For example, in <abbr title="Hypertext Markup Language">HTML</abbr>, table elements (matching the <rref>grid</rref> role) require <code>tr</code> descendants (the <rref>row</rref> <a>role</a>), which in turn require <code>th</code> or <code>td</code> children (the <rref>gridcell</rref>, <rref>columnheader</rref>, <rref>rowheader</rref> roles). Similarly, lists require list item children. The descendant elements that complete the semantics of an element are described in <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> as <a href="#mustContain">required owned elements</a>.</p>
-				<p>When an explicit or inherited role of <code>presentation</code> is applied to an element with the implicit semantic of a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role that has <a href="#mustContain">required owned elements</a>, in addition to the element with the explicit role of <code>presentation</code>, the user agent MUST apply an inherited role of presentation to any owned elements that do not have an explicit role defined. Also, when an explicit or inherited role of presentation is applied to a host language element which has required children as defined by the host language specification, in addition to the element with the explicit role of presentation, the user agent MUST apply an inherited role of presentation to any required children that do not have an explicit role defined. For any element with an explicit or inherited role of presentation and which is not focusable, user agents MUST ignore role-specific <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties for that element. For example, in <abbr title="Hypertext Markup Language">HTML</abbr>, a <code>ul</code> or <code>ol</code> element with a role of <rref>presentation</rref> will have the implicit native semantics of its <code>li</code> elements removed because the <rref>list</rref> role to which the <code>ul</code> or <code>ol</code> corresponds has a <a href="#mustContain">required owned element</a> of <rref>listitem</rref>. Likewise, although an <abbr title="Hypertext Markup Language">HTML</abbr> <code>table</code> element does not have an implicit native semantic role corresponding directly to a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role, the implicit native semantics of its <code>thead</code>/<code>tbody</code>/<code>tfoot</code>/<code>tr</code>/<code>th</code>/<code>td</code> descendants will also be removed, because the <abbr title="Hypertext Markup Language">HTML</abbr> specification indicates that these are required structural descendants of the <code>table</code> element. Explicit roles on a descendant or <a title="owned element">owned</a> element override the inherited role of <rref>presentation</rref>, and cause the owned element to behave as any other element with an explicit role. If the action of exposing the implicit role causes the accessibility tree to be malformed, the expected results are undefined and the user agent MAY resort to an internal recovery mechanism to repair the accessibility tree.</p>
+				<p>When an explicit or inherited role of <code>presentation</code> is applied to an element with the implicit semantic of a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role that has <a href="#mustContain">required owned elements</a>, in addition to the element with the explicit role of <code>presentation</code>, the user agent MUST apply an inherited role of presentation to any owned elements that do not have an explicit role defined. Also, when an explicit or inherited role of presentation is applied to a host language element which has required children as defined by the host language specification, in addition to the element with the explicit role of presentation, the user agent MUST apply an inherited role of presentation to any required children that do not have an explicit role defined. For any element with an explicit or inherited role of presentation and which is not focusable, user agents MUST ignore role-specific <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties for that element. For example, in <abbr title="Hypertext Markup Language">HTML</abbr>, a <code>ul</code> or <code>ol</code> element with a role of <rref>presentation</rref> will have the implicit native semantics of its <code>li</code> elements removed because the <rref>list</rref> role to which the <code>ul</code> or <code>ol</code> corresponds has a <a href="#mustContain">required owned element</a> of <rref>listitem</rref>. Likewise, although an <abbr title="Hypertext Markup Language">HTML</abbr> <code>table</code> element does not have an implicit native semantic role corresponding directly to a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role, the implicit native semantics of its <code>thead</code>/<code>tbody</code>/<code>tfoot</code>/<code>tr</code>/<code>th</code>/<code>td</code> descendants will also be removed, because the <abbr title="Hypertext Markup Language">HTML</abbr> specification indicates that these are required structural descendants of the <code>table</code> element. Explicit roles on a descendant or <a>owned</a> element override the inherited role of <rref>presentation</rref>, and cause the owned element to behave as any other element with an explicit role. If the action of exposing the implicit role causes the accessibility tree to be malformed, the expected results are undefined and the user agent MAY resort to an internal recovery mechanism to repair the accessibility tree.</p>
 				<p class="note">Only the implicit native semantics of elements that correspond to <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a href="#mustContain">required owned elements</a> are removed. All other content remains intact, including nested tables or lists, unless those elements also have a explicit role of <code>presentation</code> applied.</p>
 				<p>For example, according to an accessibility <abbr title="Application Programing Interface">API</abbr>, the following markup elements would appear to have identical role semantics (no roles) and identical content.</p>
 				<pre class="example highlight"><span class="comment">&lt;!-- 1. [role="presentation"] negates the implicit 'list' and 'listitem' role semantics but does not affect the contents. --&gt;</span>
@@ -4643,7 +4643,7 @@
 			<rdef>radio</rdef>
 			<div class="role-description">
 				<p>A checkable input in a group of elements with the same role, only one of which can be checked at a time.</p>
-				<p>Authors SHOULD ensure that <a title="element">elements</a> with role <code>radio</code> are explicitly grouped in order to indicate which ones affect the same value. This is achieved by enclosing the radio elements in an element with role <rref>radiogroup</rref>. If it is not possible to make the radio buttons <abbr title="Document Object Model">DOM</abbr> children of the <rref>radiogroup</rref>, authors SHOULD use the <pref>aria-owns</pref> <a>attribute</a> on the <rref>radiogroup</rref> element to indicate the <a>relationship</a> to its children.</p>
+				<p>Authors SHOULD ensure that <a>elements</a> with role <code>radio</code> are explicitly grouped in order to indicate which ones affect the same value. This is achieved by enclosing the radio elements in an element with role <rref>radiogroup</rref>. If it is not possible to make the radio buttons <abbr title="Document Object Model">DOM</abbr> children of the <rref>radiogroup</rref>, authors SHOULD use the <pref>aria-owns</pref> <a>attribute</a> on the <rref>radiogroup</rref> element to indicate the <a>relationship</a> to its children.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4908,7 +4908,7 @@
 				<p>A perceivable <rref>section</rref> containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.</p>
 				<p>Authors SHOULD limit use of the region role to sections containing content with a purpose that is not accurately described by one of the other <rref>landmark</rref> roles, such as <rref>main</rref>, <rref>complementary</rref>, or <rref>navigation</rref>.</p>
 				<p>Authors MUST give each element with role region a brief label that describes the purpose of the content in the region. Authors SHOULD reference a visible label with <pref>aria-labelledby</pref> if a visible label is present. Authors SHOULD include the label inside of a heading whenever possible. The heading MAY be an instance of the standard host language heading element or an instance of an element with role <rref>heading</rref>.</p>
-				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role region. Mainstream <a title="User Agent">user agents</a> MAY enable users to quickly navigate to elements with role region.</p>
+				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role region. Mainstream <a>user agents</a> MAY enable users to quickly navigate to elements with role region.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4993,7 +4993,7 @@
 			<rdef>roletype</rdef>
 			<div class="role-description">
 				<p>The base <a>role</a> from which all other roles in this <a>taxonomy</a> inherit.</p>
-				<p>Properties of this role describe the structural and functional purpose of <a title="object">objects</a> that are assigned this role (known in <abbr title="Resource Description Framework">RDF</abbr> terms as "instances"). A role is a concept that can be used to understand and operate instances.</p>
+				<p>Properties of this role describe the structural and functional purpose of <a>objects</a> that are assigned this role (known in <abbr title="Resource Description Framework">RDF</abbr> terms as "instances"). A role is a concept that can be used to understand and operate instances.</p>
 				<p class="note"><code>roletype</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
 			</div>
 			<table class="role-features">
@@ -5075,9 +5075,9 @@
 			<rdef>row</rdef>
 			<div class="role-description">
 				<p>A row of cells in a tabular container.</p>
-				<p>Rows contain <rref>cell</rref> or <rref>gridcell</rref> <a title="element">elements</a>, and thus serve to organize the <rref>table</rref> or <rref>grid</rref>.</p>
+				<p>Rows contain <rref>cell</rref> or <rref>gridcell</rref> <a>elements</a>, and thus serve to organize the <rref>table</rref> or <rref>grid</rref>.</p>
 				<p>In a <rref>treegrid</rref>, authors MAY mark rows as expandable, using the <sref>aria-expanded</sref> <a>attribute</a> to indicate the present status. This is not the case for an ordinary <rref>table</rref> or <rref>grid</rref>, in which the <sref>aria-expanded</sref> attribute is not present.</p>
-				<p>Authors MUST ensure <a title="element">elements</a> with <a>role</a> <rref>row</rref> are contained in, or <a title="owned element">owned</a> by, an element with the role <rref>table</rref>, <rref>grid</rref>, <rref>rowgroup</rref>, or <rref>treegrid</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <rref>row</rref> are contained in, or <a>owned</a> by, an element with the role <rref>table</rref>, <rref>grid</rref>, <rref>rowgroup</rref>, or <rref>treegrid</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -5187,8 +5187,8 @@
 			<rdef>rowgroup</rdef>
 			<div class="role-description">
 				<p>A structure containing one or more row elements in a tabular container.</p>
-				<p>The <rref>rowgroup</rref> role establishes a <a>relationship</a> between <a title="owned element">owned</a> <rref>row</rref> elements. It is a structural equivalent to the <code>thead</code>, <code>tfoot</code>, and <code>tbody</code> elements in an <abbr title="Hypertext Markup Language">HTML</abbr> <code>table</code> <a>element</a>.</p>
-				<p>Authors MUST ensure <a title="element">elements</a> with <a>role</a> <code>rowgroup</code> are contained in, or <a title="owned element">owned</a> by, an element with the role <rref>table</rref> or <rref>grid</rref>.</p>
+				<p>The <rref>rowgroup</rref> role establishes a <a>relationship</a> between <a>owned</a> <rref>row</rref> elements. It is a structural equivalent to the <code>thead</code>, <code>tfoot</code>, and <code>tbody</code> elements in an <abbr title="Hypertext Markup Language">HTML</abbr> <code>table</code> <a>element</a>.</p>
+				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>rowgroup</code> are contained in, or <a>owned</a> by, an element with the role <rref>table</rref> or <rref>grid</rref>.</p>
 				<p class="note">The <code>rowgroup</code> role exists, in part, to support role symmetry in HTML, and allows for the propagation of presentation inheritance on HTML <code>table</code> elements with an explicit <code>presentation</code> role applied.</p>
 				<p class="note">This role does not differentiate between types of row groups (e.g., <code>thead</code> vs. <code>tbody</code>), but an issue has been raised for <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 2.0.</p>
 			</div>
@@ -5281,7 +5281,7 @@
 			<div class="role-description">
 				<p>A cell containing header information for a row in a grid.</p>
 				<p>Rowheader can be used as a row header in a table or grid. The rowheader establishes a <a>relationship</a> between it and all cells in the corresponding row. It is a structural equivalent to setting <code>scope="row"</code> on an <abbr title="Hypertext Markup Language">HTML</abbr> <code>th</code> <a>element</a>.</p>
-				<p>Authors MUST ensure <a title="element">elements</a> with <a>role</a> <rref>rowheader</rref> are contained in, or <a title="owned element">owned</a> by, an element with the role <rref>grid</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <rref>rowheader</rref> are contained in, or <a>owned</a> by, an element with the role <rref>grid</rref>.</p>
 				<p>Applying the <pref>aria-selected</pref> state on a rowheader MUST not cause the user agent to automatically propagate the <pref>aria-selected</pref> state to all the cells in the corresponding row. An author MAY choose to propagate selection in this manner depending on the specific application.</p>
 				<p>While the <code>rowheader</code> role can be used in both interactive grids and non-interactive tables, the use of <pref>aria-readonly</pref> and <pref>aria-required</pref> is only applicable to interactive elements. Therefore, authors SHOULD NOT use <pref>aria-required</pref> or <pref>aria-readonly</pref> in a <code>rowheader</code> that descends from a <rref>table</rref>, and user agents SHOULD NOT expose either property to <a>assistive technologies</a> unless the <code>rowheader</code> descends from a <rref>grid</rref>.</p>
 			</div>
@@ -5374,7 +5374,7 @@
 			<div class="role-description">
 				<p>A <rref>landmark</rref> region that contains a collection of items and objects that, as a whole, combine to create a search facility. See related <rref>form</rref> and <rref>searchbox</rref>.</p>
 				<p>A search region may be a mix of host language form controls, scripted controls, and hyperlinks.</p>
-				<p>User agents SHOULD treat elements with the role of <code>search</code> as navigational <a title="landmark">landmarks</a>.</p>
+				<p>User agents SHOULD treat elements with the role of <code>search</code> as navigational <a>landmarks</a>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -6264,7 +6264,7 @@
 			<rdef>structure</rdef>
 			<div class="role-description">
 				<p>A document structural <a>element</a>.</p>
-				<p><a title="role">Roles</a> for document structure support the accessibility of dynamic web content by helping <a>assistive technologies</a> determine active content versus static document content. Structural roles by themselves do not all map to <a title="accessibility api">accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a>, but are used to create <a>widget</a> roles or assist content adaptation for assistive technologies.</p>
+				<p><a>Roles</a> for document structure support the accessibility of dynamic web content by helping <a>assistive technologies</a> determine active content versus static document content. Structural roles by themselves do not all map to <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a>, but are used to create <a>widget</a> roles or assist content adaptation for assistive technologies.</p>
 				<p class="note"><code>structure</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
 			</div>
 			<table class="role-features">
@@ -6434,13 +6434,13 @@
 			<div class="role-description">
 				<p>A grouping label providing a mechanism for selecting the tab content that is to be rendered to the user.</p>
 				<p>If a  <rref>tabpanel</rref> or item in a <rref>tabpanel</rref> has focus, the associated <rref>tab</rref> is the currently active tab in the <rref>tablist</rref>, as defined in <a href="#managingfocus">Managing Focus</a>. <rref>tablist</rref> elements, which contain a set of associated <rref>tab</rref> elements, are typically placed near a series of <rref>tabpanel</rref> elements, usually preceding it. See the <cite><a href="http://www.w3.org/TR/wai-aria-practices/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices Guide</a></cite> [[WAI-ARIA-PRACTICES]] for details on implementing a tab set design pattern.</p>
-				<p>Authors MUST ensure <a title="element">elements</a> with <a>role</a> <rref>tab</rref> are contained in, or <a title="owned element">owned</a> by, an element with the role <rref>tablist</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <rref>tab</rref> are contained in, or <a>owned</a> by, an element with the role <rref>tablist</rref>.</p>
 				<p>Authors SHOULD ensure the <rref>tabpanel</rref> associated with the currently active tab is <a>perceivable</a> to the user.</p>
 
 				<!-- keep following para synced with its counterpart in #tablist -->
-				<p>For a single-selectable <rref>tablist</rref>, authors SHOULD hide other <code>tabpanel</code> <a title="element">elements</a> from the user until the user selects the tab associated with that tabpanel. For a multi-selectable <rref>tablist</rref>, authors SHOULD ensure each visible <rref>tabpanel</rref> has its <sref>aria-expanded</sref> <a>attribute</a> set to <code>true</code>, and that the remaining hidden <code>tabpanel</code> elements have their <sref>aria-expanded</sref> attributes set to <code>false</code>.</p>
+				<p>For a single-selectable <rref>tablist</rref>, authors SHOULD hide other <code>tabpanel</code> <a>elements</a> from the user until the user selects the tab associated with that tabpanel. For a multi-selectable <rref>tablist</rref>, authors SHOULD ensure each visible <rref>tabpanel</rref> has its <sref>aria-expanded</sref> <a>attribute</a> set to <code>true</code>, and that the remaining hidden <code>tabpanel</code> elements have their <sref>aria-expanded</sref> attributes set to <code>false</code>.</p>
 
-				<p>In either case, authors SHOULD ensure that a selected tab has its <sref>aria-selected</sref> attribute set to <code>true</code>, that inactive tab elements have their <sref>aria-selected</sref> attribute set to <code>false</code>, and that the currently selected tab provides a visual indication that it is selected. In the absence of an <sref>aria-selected</sref> attribute on the current tab, <a title="user agent">user agents</a> SHOULD indicate to <a>assistive technologies</a> through the platform <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> that the currently focused tab is selected.</p>
+				<p>In either case, authors SHOULD ensure that a selected tab has its <sref>aria-selected</sref> attribute set to <code>true</code>, that inactive tab elements have their <sref>aria-selected</sref> attribute set to <code>false</code>, and that the currently selected tab provides a visual indication that it is selected. In the absence of an <sref>aria-selected</sref> attribute on the current tab, <a>user agents</a> SHOULD indicate to <a>assistive technologies</a> through the platform <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> that the currently focused tab is selected.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -6628,11 +6628,11 @@
 		<div class="role" id="tablist">
 			<rdef>tablist</rdef>
 			<div class="role-description">
-				<p>A list of <rref>tab</rref> <a title="element">elements</a>, which are references to <rref>tabpanel</rref> elements.</p>
+				<p>A list of <rref>tab</rref> <a>elements</a>, which are references to <rref>tabpanel</rref> elements.</p>
 				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
 
 				<!-- keep following para synced with its counterpart in #tab -->
-				<p>For a single-selectable <rref>tablist</rref>, authors SHOULD hide other <code>tabpanel</code> <a title="element">elements</a> from the user until the user selects the tab associated with that tabpanel. For a multi-selectable <rref>tablist</rref>, authors SHOULD ensure each visible <rref>tabpanel</rref> has its <sref>aria-expanded</sref> <a>attribute</a> set to <code>true</code>, and that the remaining hidden <code>tabpanel</code> elements have their <sref>aria-expanded</sref> attributes set to <code>false</code>.</p>
+				<p>For a single-selectable <rref>tablist</rref>, authors SHOULD hide other <code>tabpanel</code> <a>elements</a> from the user until the user selects the tab associated with that tabpanel. For a multi-selectable <rref>tablist</rref>, authors SHOULD ensure each visible <rref>tabpanel</rref> has its <sref>aria-expanded</sref> <a>attribute</a> set to <code>true</code>, and that the remaining hidden <code>tabpanel</code> elements have their <sref>aria-expanded</sref> attributes set to <code>false</code>.</p>
 
 				<!-- keep following para synced with its counterpart in #tabpanel -->
 				<p><rref>tablist</rref> elements are typically placed near usually preceding, a series of <rref>tabpanel</rref> elements. See the <cite><a href="http://www.w3.org/TR/wai-aria-practices/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices Guide</a></cite> [[WAI-ARIA-PRACTICES]] for details on implementing a tab set design pattern.</p>
@@ -7545,7 +7545,7 @@
 			<div class="role-description">
 				<p>An option item of a <rref>tree</rref>. This is an <a>element</a> within a tree that may be expanded or collapsed if it contains a sub-level group of tree item elements.</p>
 				<p>A collection of <code>treeitem</code> elements to be expanded and collapsed are enclosed in an element with the <rref>group</rref> <a>role</a>.</p>
-				<p>Authors MUST ensure <a title="element">elements</a> with <a>role</a> <code>treeitem</code> are contained in, or <a title="owned element">owned</a> by, an element with the role <rref>group</rref> or <rref>tree</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>treeitem</code> are contained in, or <a>owned</a> by, an element with the role <rref>group</rref> or <rref>tree</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -7639,7 +7639,7 @@
 			<rdef>widget</rdef>
 			<div class="role-description">
 				<p>An interactive component of a graphical user interface (<abbr title="Graphical User Interface">GUI</abbr>).</p>
-				<p>Widgets are discrete user interface objects with which the user can interact. Widget <a title="role">roles</a> map to standard features in <a title="accessibility api">accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a>. When the user navigates an element assigned any of the non-abstract subclass roles of <code>widget</code>, <a>assistive technologies</a> that typically intercept standard keyboard events SHOULD switch to an application browsing mode, and pass keyboard events through to the web application. The intent is to hint to certain <a>assistive technologies</a> to switch from normal browsing mode into a mode more appropriate for interacting with a web application; some <a title="user agent">user agents</a> have a browse navigation mode where keys, such as up and down arrows, are used to browse the document, and this native behavior prevents the use of these keys by a web application.</p>
+				<p>Widgets are discrete user interface objects with which the user can interact. Widget <a>roles</a> map to standard features in <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a>. When the user navigates an element assigned any of the non-abstract subclass roles of <code>widget</code>, <a>assistive technologies</a> that typically intercept standard keyboard events SHOULD switch to an application browsing mode, and pass keyboard events through to the web application. The intent is to hint to certain <a>assistive technologies</a> to switch from normal browsing mode into a mode more appropriate for interacting with a web application; some <a>user agents</a> have a browse navigation mode where keys, such as up and down arrows, are used to browse the document, and this native behavior prevents the use of these keys by a web application.</p>
 				<p class="note"><code>widget</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
 			</div>
 			<table class="role-features">
@@ -7715,7 +7715,7 @@
 			<rdef>window</rdef>
 			<div class="role-description">
 				<p>A browser or application window.</p>
-				<p><a title="element">Elements</a> with this <a>role</a> have a window-like behavior in a graphical user interface (<abbr title="Graphical User Interface">GUI</abbr>) context, regardless of whether they are implemented as a native window in the operating system, or merely as a section of the document styled to look like a window.</p>
+				<p><a>Elements</a> with this <a>role</a> have a window-like behavior in a graphical user interface (<abbr title="Graphical User Interface">GUI</abbr>) context, regardless of whether they are implemented as a native window in the operating system, or merely as a section of the document styled to look like a window.</p>
 				<p class="note">In the description of this role, the term "application" does not refer to the <rref>application</rref> role, which specifies specific assistive technology behaviors.</p>
 				<p class="note"><code>window</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
 			</div>
@@ -7795,7 +7795,7 @@
 	<h1>Supported States and Properties</h1>
 	<section id="statevsprop">
 		<h2>Clarification of States versus Properties</h2>
-		<p>The terms "states" and "properties" refer to similar features. Both provide specific information about an <a>object</a>, and both form part of the definition of the nature of <a title="role">roles</a>. In this document, states and properties are both treated as aria-prefixed markup <a title="attribute">attributes</a>. However, they are maintained conceptually distinct to clarify subtle differences in their meaning. One major difference is that the <span>values</span> of properties (such as <pref>aria-labelledby</pref>) are often less likely to change throughout the application life-cycle than the values of states (such as <sref>aria-checked</sref>) which may change frequently due to user interaction. Note that the frequency of change difference is not a rule; a few properties, such as <pref>aria-valuetext</pref> are expected to change often. Because the distinction between states and properties is of little consequence to most web content authors, this specification refers to both "states" and "properties" simply as "attributes" whenever possible. See the definitions of <a class="termref" href="#dfn-state">state</a> and <a class="termref" href="#dfn-property">property</a> for more information.</p>
+		<p>The terms "states" and "properties" refer to similar features. Both provide specific information about an <a>object</a>, and both form part of the definition of the nature of <a>roles</a>. In this document, states and properties are both treated as aria-prefixed markup <a>attributes</a>. However, they are maintained conceptually distinct to clarify subtle differences in their meaning. One major difference is that the <span>values</span> of properties (such as <pref>aria-labelledby</pref>) are often less likely to change throughout the application life-cycle than the values of states (such as <sref>aria-checked</sref>) which may change frequently due to user interaction. Note that the frequency of change difference is not a rule; a few properties, such as <pref>aria-valuetext</pref> are expected to change often. Because the distinction between states and properties is of little consequence to most web content authors, this specification refers to both "states" and "properties" simply as "attributes" whenever possible. See the definitions of <a class="termref" href="#dfn-state">state</a> and <a class="termref" href="#dfn-property">property</a> for more information.</p>
 	</section>
 	<section id="state_prop_att">
 		<h2>Characteristics of States and Properties</h2>
@@ -7846,11 +7846,11 @@
 	</section>
 	<section id="state_prop_values">
 		<h2>Values for States and Properties</h2>
-		<p>Many <a title="state">state</a> and <a title="property">properties</a> accept a specific set of tokens as <span>values</span>. The allowed values and explanation of their meaning is shown after the table of characteristics. The default value, if defined, is shown in <strong>strong</strong> type, followed by the parenthetical term 'default'. When a value is indicated as the default, the user agent MUST follow the behavior prescribed by this value when the state or property is empty or undefined. Some <a title="role">roles</a> also define what behavior to use when certain states or properties, that do not have default values, are not provided.</p>
+		<p>Many <a>state</a> and <a>properties</a> accept a specific set of tokens as <span>values</span>. The allowed values and explanation of their meaning is shown after the table of characteristics. The default value, if defined, is shown in <strong>strong</strong> type, followed by the parenthetical term 'default'. When a value is indicated as the default, the user agent MUST follow the behavior prescribed by this value when the state or property is empty or undefined. Some <a>roles</a> also define what behavior to use when certain states or properties, that do not have default values, are not provided.</p>
 	</section>
 	<section id="global_states">
 		<h2>Global States and Properties</h2>
-		<p>Some <a title="state">state</a> and <a title="property">properties</a> are applicable to all host language <a title="element">elements</a> regardless of whether a <a>role</a> is applied. The following global states and properties are supported by all roles and by all base markup elements.</p>
+		<p>Some <a>state</a> and <a>properties</a> are applicable to all host language <a>elements</a> regardless of whether a <a>role</a> is applied. The following global states and properties are supported by all roles and by all base markup elements.</p>
 		<p class="placeholder">Placeholder for global states and properties</p>
 		<p>Global states and properties are applied to the role <rref>roletype</rref>, which is the base role, and therefore inherit into all roles. To facilitate reading, they are not explicitly identified as either supported or inherited states and properties in the specification. Instead, the inheritance is indicated by a link to this section.</p>
 	</section>
@@ -7865,7 +7865,7 @@
 		</ol>
 		<section id="attrs_widgets">
 			<h3>Widget Attributes</h3>
-			<p>This section contains <a title="attribute">attributes</a> specific to common user interface <a title="element">elements</a> found on <abbr title="Graphical User Interface">GUI</abbr> systems or in rich internet applications which receive user input and process user actions. These attributes are used to support the <a href="#widget_roles">widget roles</a>.</p>
+			<p>This section contains <a>attributes</a> specific to common user interface <a>elements</a> found on <abbr title="Graphical User Interface">GUI</abbr> systems or in rich internet applications which receive user input and process user actions. These attributes are used to support the <a href="#widget_roles">widget roles</a>.</p>
 			<ul>
 				<li><pref>aria-autocomplete</pref></li>
 				<li><sref>aria-checked</sref></li>
@@ -7892,11 +7892,11 @@
 				<li><pref>aria-valuenow</pref></li>
 				<li><pref>aria-valuetext</pref></li>
 			</ul>
-			<p>Widget attributes might be mapped by a <a>user agent</a> to platform <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> <a title="state">state</a>, for access by <a>assistive technologies</a>, or they might be accessed directly from the <abbr title="Document Object Model">DOM</abbr>. User agents MUST provide a way for assistive technologies to be notified when states change, either through <abbr title="Document Object Model">DOM</abbr> attribute change <a title="event">events</a> or platform accessibility <abbr title="Application Programing Interfaces">API</abbr> events.</p>
+			<p>Widget attributes might be mapped by a <a>user agent</a> to platform <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> <a>state</a>, for access by <a>assistive technologies</a>, or they might be accessed directly from the <abbr title="Document Object Model">DOM</abbr>. User agents MUST provide a way for assistive technologies to be notified when states change, either through <abbr title="Document Object Model">DOM</abbr> attribute change <a>events</a> or platform accessibility <abbr title="Application Programing Interfaces">API</abbr> events.</p>
 		</section>
 		<section id="attrs_liveregions">
 			<h3>Live Region Attributes</h3>
-			<p>This section contains <a title="attribute">attributes</a> specific to <a title="live region">live regions</a> in rich internet applications. These attributes may be applied to any <a>element</a>. The purpose of these attributes is to indicate that content changes may occur without the element having focus, and to provide <a>assistive technologies</a> with information on how to process those content updates. Some <a title="role">roles</a> specify a default value for the <pref>aria-live</pref> attribute specific to that role. An example of a live region is a ticker section that lists updating stock quotes.</p>
+			<p>This section contains <a>attributes</a> specific to <a>live regions</a> in rich internet applications. These attributes may be applied to any <a>element</a>. The purpose of these attributes is to indicate that content changes may occur without the element having focus, and to provide <a>assistive technologies</a> with information on how to process those content updates. Some <a>roles</a> specify a default value for the <pref>aria-live</pref> attribute specific to that role. An example of a live region is a ticker section that lists updating stock quotes.</p>
 			<ul>
 				<li><pref>aria-atomic</pref></li>
 				<li><sref>aria-busy</sref></li>
@@ -7906,7 +7906,7 @@
 		</section>
 		<section id="attrs_dragdrop">
 			<h3>Drag-and-Drop Attributes</h3>
-			<p>This section lists <a title="attribute">attributes</a> which indicate information about drag-and-drop interface <a title="element">elements</a>, such as draggable elements and their drop targets. Drop target information will be rendered visually by the author and provided to <a>assistive technologies</a> through an alternate modality.</p>
+			<p>This section lists <a>attributes</a> which indicate information about drag-and-drop interface <a>elements</a>, such as draggable elements and their drop targets. Drop target information will be rendered visually by the author and provided to <a>assistive technologies</a> through an alternate modality.</p>
 			<ul>
 				<li><pref>aria-dropeffect</pref></li>
 				<li><sref>aria-grabbed</sref></li>
@@ -7915,7 +7915,7 @@
 		</section>
 		<section id="attrs_relationships">
 			<h3>Relationship Attributes</h3>
-			<p>This section lists <a title="attribute">attributes</a> that indicate <a title="relationship">relationships</a> or associations between <a title="element">elements</a> which cannot be readily determined from the document structure.</p>
+			<p>This section lists <a>attributes</a> that indicate <a>relationships</a> or associations between <a>elements</a> which cannot be readily determined from the document structure.</p>
 			<ul>
 				<li><pref>aria-activedescendant</pref></li>
 				<li><pref>aria-colcount</pref></li>
@@ -7937,7 +7937,7 @@
 	</section>
 	<section id="state_prop_def">
 		<h2>Definitions of States and Properties (all aria-* attributes)</h2>
-		<p>Below is an alphabetical list of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a title="state">state</a> and <a title="property">properties</a> to be used by rich internet application authors. A detailed definition of each <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> state and <a>property</a> follows this compact list.</p>
+		<p>Below is an alphabetical list of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>state</a> and <a>properties</a> to be used by rich internet application authors. A detailed definition of each <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> state and <a>property</a> follows this compact list.</p>
 		<p id="index_state_prop" class="placeholder">Placeholder for index of states and properties</p>
 		<hr/>
 		<div class="property" id="aria-activedescendant">
@@ -7980,7 +7980,7 @@
 			<pdef>aria-atomic</pdef>
 			<div class="property-description">
 				<p>Indicates whether <a>assistive technologies</a> will present all, or only parts of, the changed region based on the change notifications defined by the <pref>aria-relevant</pref> attribute. See related <pref>aria-relevant</pref>.</p>
-				<p>Both <a title="accessibility api">accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a> and the <cite><a href="http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/">Document Object Model</a></cite> [[DOM-Level-2-Core]] provide events to allow the assistive technologies to determine changed areas of the document.</p>
+				<p>Both <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a> and the <cite><a href="http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/">Document Object Model</a></cite> [[DOM-Level-2-Core]] provide events to allow the assistive technologies to determine changed areas of the document.</p>
 				<p>When the content of a <a>live region</a> changes, user agents SHOULD examine the changed <a>element</a> and traverse the ancestors to find the first element with <pref>aria-atomic</pref> set, and apply the appropriate behavior for the cases below.</p>
 				<ol>
 					<li>If none of the ancestors have explicitly set <pref>aria-atomic</pref>, the default is that <pref>aria-atomic</pref> is <code>false</code>, and assistive technologies will only present the changed node to the user.</li>
@@ -8156,9 +8156,9 @@
 		<div class="state" id="aria-checked">
 			<sdef>aria-checked</sdef>
 			<div class="state-description">
-				<p>Indicates the current "checked" <a>state</a> of checkboxes, radio buttons, and other <a title="widget">widgets</a>. See related <sref>aria-pressed</sref> and <sref>aria-selected</sref>.</p>
+				<p>Indicates the current "checked" <a>state</a> of checkboxes, radio buttons, and other <a>widgets</a>. See related <sref>aria-pressed</sref> and <sref>aria-selected</sref>.</p>
 				<p>The <sref>aria-checked</sref> <a>attribute</a> indicates whether the <a>element</a> is checked (<code>true</code>), unchecked (<code>false</code>), or represents a group of other elements that have a mixture of checked and unchecked <span>values</span> (<code>mixed</code>). Most inputs only support values of <code>true</code> and <code>false</code>, but the <code>mixed</code> value is supported by certain tri-state inputs such as a <rref>checkbox</rref> or <rref>menuitemcheckbox</rref>.</p>
-				<p>The <code>mixed</code> value is <em>not</em> supported on <rref>radio</rref>, <rref>menuitemradio</rref>, <rref>switch</rref> or any element that inherits from these in the <a>taxonomy</a>, and <a title="user agent">user agents</a> MUST treat a <code>mixed</code> value as equivalent to <code>false</code> for those <a title="role">roles</a>.</p>
+				<p>The <code>mixed</code> value is <em>not</em> supported on <rref>radio</rref>, <rref>menuitemradio</rref>, <rref>switch</rref> or any element that inherits from these in the <a>taxonomy</a>, and <a>user agents</a> MUST treat a <code>mixed</code> value as equivalent to <code>false</code> for those <a>roles</a>.</p>
 				<p>Examples using the <code>mixed</code> value of tri-state inputs are covered in <cite><a href="http://www.w3.org/TR/wai-aria-practices/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> [[WAI-ARIA-PRACTICES]]</p>
 			</div>
 			<table class="state-features">
@@ -8284,10 +8284,10 @@
 		<div class="property" id="aria-colindex">
 			<pdef>aria-colindex</pdef>
 			<div class="property-description">
-				<p>[ARIA 1.1] Defines an <a title="element">element's</a> column index or position with respect to the total number of columns within a table, <rref>grid</rref>, or <rref>treegrid</rref>. See related <pref>aria-colcount</pref> and <pref>aria-colspan</pref>.</p>
+				<p>[ARIA 1.1] Defines an <a>element's</a> column index or position with respect to the total number of columns within a table, <rref>grid</rref>, or <rref>treegrid</rref>. See related <pref>aria-colcount</pref> and <pref>aria-colspan</pref>.</p>
 				<p>If all of the columns are present in the <abbr title="Document Object Model">DOM</abbr>, it is not necessary to set this <a>attribute</a> as the <a>user agent</a> can automatically calculate the column index of each cell or <rref>gridcell</rref>. However, if only a portion of the columns is present in the <abbr title="Document Object Model">DOM</abbr> at a given moment, this attribute is needed to provide an explicit indication of the column of each cell or gridcell with respect to the full table.</p>
 				<p>Authors MUST set the <span>value</span> for <pref>aria-colindex</pref> to an integer greater than or equal to 1, greater than the <pref>aria-colindex</pref> value of any previous elements within the same row, and less than or equal to the number of columns in the full table. For a cell or gridcell which spans multiple columns, authors MUST set the value of <pref>aria-colindex</pref> to the start of the span.</p>
-				<p>If the set of columns which is present in the <abbr title="Document Object Model">DOM</abbr> is contiguous, and if there are no cells which span more than one row or column in that set, then authors MAY place <pref>aria-colindex</pref> on each row, setting the value to the index of the first column of the set. Otherwise, authors SHOULD place <pref>aria-colindex</pref> on all of the children or <a title="owned element">owned</a> elements of each row.</p>
+				<p>If the set of columns which is present in the <abbr title="Document Object Model">DOM</abbr> is contiguous, and if there are no cells which span more than one row or column in that set, then authors MAY place <pref>aria-colindex</pref> on each row, setting the value to the index of the first column of the set. Otherwise, authors SHOULD place <pref>aria-colindex</pref> on all of the children or <a>owned</a> elements of each row.</p>
 				<p>The following example shows a grid with 16 columns, of which columns 2 through 5 are displayed to the user. Because the set of columns is contiguous, <pref>aria-colindex</pref> can be placed on each row.</p>
 				<pre class="example highlight">
 &lt;div role="grid" aria-colcount="16"&gt;
@@ -8401,7 +8401,7 @@
 			<pdef>aria-colspan</pdef>
 			<div class="property-description">
 				<p>[ARIA 1.1] Defines the number of columns spanned by a cell or gridcell within a table, <rref>grid</rref>, or <rref>treegrid</rref>. See related <pref>aria-colindex</pref> and <pref>aria-rowspan</pref>.</p>
-				<p>This <a>attribute</a> is intended for cells and gridcells which are not contained in a native table. When defining the column span of cells or gridcells in a native table, authors SHOULD use the host language's attribute instead of <pref>aria-colspan</pref>. If <pref>aria-colspan</pref> is used on an element for which the host language provides an equivalent attribute, <a title="user agent">user agents</a> MUST ignore the value of <pref>aria-colspan</pref> and instead expose the value of the host language's attribute to <a>assistive technologies</a>.</p>
+				<p>This <a>attribute</a> is intended for cells and gridcells which are not contained in a native table. When defining the column span of cells or gridcells in a native table, authors SHOULD use the host language's attribute instead of <pref>aria-colspan</pref>. If <pref>aria-colspan</pref> is used on an element for which the host language provides an equivalent attribute, <a>user agents</a> MUST ignore the value of <pref>aria-colspan</pref> and instead expose the value of the host language's attribute to <a>assistive technologies</a>.</p>
 				<p>Authors MUST set the <span>value</span> of <pref>aria-colspan</pref> to an integer greater than or equal to 1 and less than the value which would cause the cell or gridcell to overlap the next cell or gridcell in the same row.</p>
 			</div>
 			<table class="property-features">
@@ -8478,7 +8478,7 @@
 		<div class="state" id="aria-current">
 			<sdef>aria-current</sdef>
 			<div class="state-description">
-				<p>[ARIA 1.1] Indicates the <a title="element">element</a> that represents the current item within a container or set of related elements.</p>
+				<p>[ARIA 1.1] Indicates the <a>element</a> that represents the current item within a container or set of related elements.</p>
 				<p>The <sref>aria-current</sref> <a>attribute</a> is an enumerated type. Any <span>value</span> not included in the list of allowed values SHOULD be treated by <a>assistive technologies</a> as if the value <code>true</code> had been provided. If the attribute is not present or its value is an empty string, the default value of <code>false</code> applies and the <sref>aria-current</sref> <a>state</a> MUST NOT be exposed by user agents or assistive technologies.</p>
 				<p>The <sref>aria-current</sref> attribute is used when an element within a set of related elements is visually styled to indicate it is the current item in the set. For example:</p>
 				<ul>
@@ -8935,7 +8935,7 @@
 			<div class="property-description">
 				<p>Identifies the next <a>element</a> (or elements) in an alternate reading order of content which, at the user's discretion, allows assistive technology to override the general default of reading in document source order.</p>
 				<p>When <pref>aria-flowto</pref> has a single IDREF, it allows <a>assistive technologies</a> to, at the user's request, forego normal document reading order and go to the targeted <a>object</a>. <!-- [No longer ref XHTML2] <pref>aria-flowto</pref> in subsequent elements would follow a process similar to <cite><a href="http://www.w3.org/TR/2006/WD-xhtml2-20060726/mod-hyperAttributes.html#adef_hyperAttributes_nextfocus">next focus in <abbr title="Extensible Hypertext Markup Language">XHTML</abbr>2</a></cite> ([[XHTML2]]). --> However, when <pref>aria-flowto</pref> is provided with multiple IDREFS, assistive technologies SHOULD present the referenced elements as path choices.</p>
-				<p>In the case of one or more IDREFS, <a title="user agent">user agents</a> or assistive technologies SHOULD give the user the option of navigating to any of the targeted elements. The name of the path can be determined by the name of the target element of the <pref>aria-flowto</pref> <a>attribute</a>. <a title="accessibility api">Accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a> can provide named path <a title="relationship">relationships</a>.</p>
+				<p>In the case of one or more IDREFS, <a>user agents</a> or assistive technologies SHOULD give the user the option of navigating to any of the targeted elements. The name of the path can be determined by the name of the target element of the <pref>aria-flowto</pref> <a>attribute</a>. <a>Accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a> can provide named path <a>relationships</a>.</p>
 			</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>
@@ -9155,8 +9155,8 @@
 			<sdef>aria-invalid</sdef>
 			<div class="state-description">
 				<p>Indicates the entered value does not conform to the format expected by the application. See related <pref>aria-errormessage</pref>.</p>
-				<p>If the value is computed to be invalid or out-of-range, the application author SHOULD set this <a>attribute</a> to <code>true</code>. <a title="user agent">User agents</a> SHOULD inform the user of the error. Application authors SHOULD provide suggestions for corrections if they are known.</p>
-				<p>When the user attempts to submit data involving a field for which <pref>aria-required</pref> is <code>true</code>, authors MAY use the <sref>aria-invalid</sref> attribute to signal there is an error. However, if the user has not attempted to submit the form, authors SHOULD NOT set the <sref>aria-invalid</sref> attribute on required <a title="widget">widgets</a> simply because the user has not yet entered data.</p>
+				<p>If the value is computed to be invalid or out-of-range, the application author SHOULD set this <a>attribute</a> to <code>true</code>. <a>User agents</a> SHOULD inform the user of the error. Application authors SHOULD provide suggestions for corrections if they are known.</p>
+				<p>When the user attempts to submit data involving a field for which <pref>aria-required</pref> is <code>true</code>, authors MAY use the <sref>aria-invalid</sref> attribute to signal there is an error. However, if the user has not attempted to submit the form, authors SHOULD NOT set the <sref>aria-invalid</sref> attribute on required <a>widgets</a> simply because the user has not yet entered data.</p>
 				<p>For future expansion, the <sref>aria-invalid</sref> attribute is an enumerated type. Any value not recognized in the list of allowed <span>values</span> MUST be treated by user agents as if the value <code>true</code> had been provided. If the attribute is not present, or its value is <code>false</code>, or its value is an empty string, the default value of <code>false</code> applies.</p>
 			</div>
 			<table class="state-features">
@@ -9354,7 +9354,7 @@
 				<p>This can be applied inside trees to tree items, to headings inside a document, to nested grids, nested tablists and to other structural items that may appear inside a container or participate in an ownership hierarchy. The value for <pref>aria-level</pref> is an integer greater than or equal to 1.</p>
 				<p>Levels increase with depth. If the <abbr title="Document Object Model">DOM</abbr> ancestry does not accurately represent the level, authors SHOULD explicitly define the <pref>aria-level</pref> <a>attribute</a>.</p>
 				<p>This attribute is applied to elements that act as leaf nodes within the orientation of the set, for example, on elements with role <rref>treeitem</rref> rather than elements with role <rref>group</rref>. This means that multiple elements in a set may have the same value for this attribute. Although it would be less repetitive to provide a single value on the container, restricting this to leaf nodes ensures that there is a single way for <a>assistive technologies</a> to use the attribute.</p>
-				<p>If the <abbr title="Document Object Model">DOM</abbr> ancestry accurately represents the level, the <a>user agent</a> can calculate the level of an item from the document structure. This attribute can be used to provide an explicit indication of the level when that is not possible to calculate from the document structure or the <pref>aria-owns</pref> attribute. User agent support for automatic calculation of level may vary; authors SHOULD test with <a title="user agent">user agents</a> and assistive technologies to determine whether this attribute is needed. If the author intends for the user agent to calculate the level, the author SHOULD omit this attribute.</p>
+				<p>If the <abbr title="Document Object Model">DOM</abbr> ancestry accurately represents the level, the <a>user agent</a> can calculate the level of an item from the document structure. This attribute can be used to provide an explicit indication of the level when that is not possible to calculate from the document structure or the <pref>aria-owns</pref> attribute. User agent support for automatic calculation of level may vary; authors SHOULD test with <a>user agents</a> and assistive technologies to determine whether this attribute is needed. If the author intends for the user agent to calculate the level, the author SHOULD omit this attribute.</p>
                 <p class="note"> In the case of a <rref>treegrid</rref>, <pref>aria-level</pref> is supported on elements with the role <rref>row</rref>, not elements with role <rref>gridcell</rref>. At first glance, this may seem inconsistent with the application of <pref>aria-level</pref> on <rref>treeitem</rref> elements, but it is consistent in that the <rref>row</rref> acts as the leaf node within the vertical orientation of the <rref>grid</rref>, whereas the <rref>gridcell</rref> is a leaf node within the horizontal orientation of each <rref>row</rref>. Level is not supported on sets of cells within rows, so the <pref>aria-level</pref> attribute is applied to the element with the role <rref>row</rref>.</p>
 			</div>
 			<table class="property-features">
@@ -9389,7 +9389,7 @@
 		<div class="property" id="aria-live">
 			<pdef>aria-live</pdef>
 			<div class="property-description">
-				<p>Indicates that an <a>element</a> will be updated, and describes the types of updates the <a title="user agent">user agents</a>, <a>assistive technologies</a>, and user can expect from the <a>live region</a>.</p>
+				<p>Indicates that an <a>element</a> will be updated, and describes the types of updates the <a>user agents</a>, <a>assistive technologies</a>, and user can expect from the <a>live region</a>.</p>
 				<p>The <span>values</span> of this <a>attribute</a> are expressed in degrees of importance. When regions are specified as <code>polite</code>, assistive technologies will notify users of updates but generally do not interrupt the current task, and updates take low priority. When regions are specified as <code>assertive</code>, assistive technologies will immediately notify the user, and could potentially clear the speech queue of previous updates. Please refer to <cite><a href="http://www.w3.org/WAI/PF/aria-practices/#liveprops">Live Region Properties and How to Use Them</a></cite> ([[WAI-ARIA-PRACTICES]], Section 5.2.1).</p>
 				<p>Politeness levels are essentially an ordering mechanism for updates and serve as a strong suggestion to user agents or assistive technologies. The value may be overridden by user agents, assistive technologies, or the user. For example, if assistive technologies can determine that a change occurred in response to a key press or a mouse click, the assistive technologies may present that change immediately even if the value of the <pref>aria-live</pref> attribute states otherwise.</p>
 				<p>Since different users have different needs, it is up to the user to tweak his or her assistive technologies' response to a live region with a certain politeness level from the commonly defined baseline. Assistive technologies may choose to implement increasing and decreasing levels of granularity so that the user can exercise control over queues and interruptions.</p>
@@ -9929,7 +9929,7 @@
 			<div class="property-description">
 				<p>Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. See related <pref>aria-atomic</pref>.</p>
 				<p>The <a>attribute</a> is represented as a space delimited list of the following <span>values</span>: <code>additions</code>, <code>removals</code>, <code>text</code>; or a single catch-all value <code>all</code>.</p>
-				<p>This is used to describe <a title="semantics">semantically</a> meaningful changes, as opposed to merely presentational ones. For example, nodes that are removed from the top of a log are merely removed for purposes of creating room for other entries, and the removal of them does not have meaning. However, in the case of a buddy list, removal of a buddy name indicates that they are no longer online, and this is a meaningful <a>event</a>. In that case <pref>aria-relevant</pref> will be set to <code>all</code>. When the <pref>aria-relevant</pref> attribute is not provided, the default value, <code>additions text</code>, indicates that text modifications and node additions are relevant, but that node removals are irrelevant.</p>
+				<p>This is used to describe <a>semantically</a> meaningful changes, as opposed to merely presentational ones. For example, nodes that are removed from the top of a log are merely removed for purposes of creating room for other entries, and the removal of them does not have meaning. However, in the case of a buddy list, removal of a buddy name indicates that they are no longer online, and this is a meaningful <a>event</a>. In that case <pref>aria-relevant</pref> will be set to <code>all</code>. When the <pref>aria-relevant</pref> attribute is not provided, the default value, <code>additions text</code>, indicates that text modifications and node additions are relevant, but that node removals are irrelevant.</p>
 				<p class="note"><pref>aria-relevant</pref> values of removals or all are to be used sparingly. Assistive technologies only need to be informed of content removal when its removal represents an important change, such as a buddy leaving a chat room.</p>
 				<p class="note">Text removals should only be considered relevant if one of the specified values is 'removals' or 'all'. For example, for a text change from 'foo' to 'bar' in a live region with a default <pref>aria-relevant</pref> value, the text addition ('bar') would be spoken, but the text removal ('foo') would not.</p>
 				<p><pref>aria-relevant</pref> is an optional attribute of live regions. This is a suggestion to <a>assistive technologies</a>, but assistive technologies are not required to present changes of all the relevant types.</p>
@@ -10056,7 +10056,7 @@
 			<pdef>aria-roledescription</pdef>
 			<div class="property-description">
 			  <p>[ARIA 1.1] Defines a human-readable, author-localized description for the <a>role</a> of an <a>element</a>.</p>
-			  <p>Authors SHOULD only use <code>aria-roledescription</code> on elements that equate to a valid <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role (have an implicit WAI-ARIA role semantic) or have a valid WAI-ARIA role applied. If neither condition is met, then <a title="user agent">user agents</a> MUST NOT expose the <code>aria-roledescription</code>.</p>
+			  <p>Authors SHOULD only use <code>aria-roledescription</code> on elements that equate to a valid <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role (have an implicit WAI-ARIA role semantic) or have a valid WAI-ARIA role applied. If neither condition is met, then <a>user agents</a> MUST NOT expose the <code>aria-roledescription</code>.</p>
 			  <p class="note">Users of <a>assistive technologies</a> learn interaction patterns based on localized role descriptions such as "button" or "slider." When authors change the role description, users may no longer understand the purpose of the control or how to interact with it. Thus custom role descriptions are only recommended for use on non-interactive container roles like <rref>group</rref> or <rref>region</rref> or to provide a <em>more specific</em> description of a <rref>widget</rref>.</p>
 			  <p>The following two examples show the use of <code>aria-roledescription</code> to indicate that a non-interactive container is a "slide" in web-based presentation application.</p>
 			  <pre class="example highlight">&lt;div role="region" aria-roledescription="slide" id="slide42" aria-labelledby="slide42heading"&gt;
@@ -10173,10 +10173,10 @@
 		<div class="property" id="aria-rowindex">
 			<pdef>aria-rowindex</pdef>
 			<div class="property-description">
-				<p>[ARIA 1.1] Defines an <a title="element">element's</a> row index or position with respect to the total number of rows within a table, <rref>grid</rref>, or <rref>treegrid</rref>. See related <pref>aria-rowcount</pref> and <pref>aria-rowspan</pref>.</p>
+				<p>[ARIA 1.1] Defines an <a>element's</a> row index or position with respect to the total number of rows within a table, <rref>grid</rref>, or <rref>treegrid</rref>. See related <pref>aria-rowcount</pref> and <pref>aria-rowspan</pref>.</p>
 				<p>If all of the rows are present in the <abbr title="Document Object Model">DOM</abbr>, it is not necessary to set this <a>attribute</a> as the <a>user agent</a> can automatically calculate the index of each row. However, if only a portion of the rows is present in the <abbr title="Document Object Model">DOM</abbr> at a given moment, this attribute is needed to provide an explicit indication of each row's position with respect to the full table.</p>
 				<p>Authors MUST set the <span>value</span> for <pref>aria-rowindex</pref> to an integer greater than or equal to 1, greater than the <pref>aria-rowindex</pref> value of any previous rows, and less than or equal to the number of rows in the full table. For a cell or gridcell which spans multiple rows, authors MUST set the value of <pref>aria-rowindex</pref> to the start of the span.</p>
-				<p>Authors SHOULD place <pref>aria-rowindex</pref> on each row. Authors MAY also place <pref>aria-rowindex</pref> on all of the children or <a title="owned element">owned elements</a> of each row.</p>
+				<p>Authors SHOULD place <pref>aria-rowindex</pref> on each row. Authors MAY also place <pref>aria-rowindex</pref> on all of the children or <a>owned elements</a> of each row.</p>
 				<p>The following example shows a grid with 2000 rows, of which the first row and rows 100 through 102 are displayed to the user.</p>
 				<pre class="example highlight">
 &lt;div role="grid" aria-rowcount="2000"&gt;
@@ -10275,7 +10275,7 @@
 			<pdef>aria-rowspan</pdef>
 			<div class="property-description">
 				<p>[ARIA 1.1] Defines the number of rows spanned by a cell or gridcell within a table, <rref>grid</rref>, or <rref>treegrid</rref>. See related <pref>aria-rowindex</pref> and <pref>aria-colspan</pref>.</p>
-				<p>This <a>attribute</a> is intended for cells and gridcells which are not contained in a native table. When defining the row span of cells or gridcells in a native table, authors SHOULD use the host language's attribute instead of <pref>aria-rowspan</pref>. If <pref>aria-rowspan</pref> is used on an element for which the host language provides an equivalent attribute, <a title="user agent">user agents</a> MUST ignore the value of <pref>aria-rowspan</pref> and instead expose the value of the host language's attribute to <a>assistive technologies</a>.</p>
+				<p>This <a>attribute</a> is intended for cells and gridcells which are not contained in a native table. When defining the row span of cells or gridcells in a native table, authors SHOULD use the host language's attribute instead of <pref>aria-rowspan</pref>. If <pref>aria-rowspan</pref> is used on an element for which the host language provides an equivalent attribute, <a>user agents</a> MUST ignore the value of <pref>aria-rowspan</pref> and instead expose the value of the host language's attribute to <a>assistive technologies</a>.</p>
 				<p>Authors MUST set the <span>value</span> of <pref>aria-rowspan</pref> to an integer greater than or equal to 0 and less than the value which would cause the cell or gridcell to overlap the next cell or gridcell in the same column. Setting the value to 0 indicates that the cell or gridcell is to span all the remaining rows in the row group.</p>
 			</div>
 			<table class="property-features">
@@ -10310,7 +10310,7 @@
 		<div class="state" id="aria-selected">
 			<sdef>aria-selected</sdef>
 			<div class="state-description">
-				<p>Indicates the current "selected" <a>state</a> of various <a title="widget">widgets</a>. See related <sref>aria-checked</sref> and <sref>aria-pressed</sref>.</p>
+				<p>Indicates the current "selected" <a>state</a> of various <a>widgets</a>. See related <sref>aria-checked</sref> and <sref>aria-pressed</sref>.</p>
 				<p>This <a>attribute</a> is used with single-selection and multiple-selection widgets:</p>
 				<ol>
 					<li>Single-selection containers where the currently focused item is not selected. The selection normally follows the focus, and is managed by the <a>user agent</a>.</li>
@@ -10640,9 +10640,9 @@
 </section>
 <section class="normative" id="host_languages">
 	<h1>Implementation in Host Languages</h1>
-	<p>The <a title="role">roles</a>, <a title="state">state</a>, and <a title="property">properties</a> defined in this specification do not form a complete web language or format. They are intended to be used in the context of a host language. This section discusses how host languages are to implement <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>, to ensure that the markup specified here will integrate smoothly and effectively with the host language markup.</p>
+	<p>The <a>roles</a>, <a>state</a>, and <a>properties</a> defined in this specification do not form a complete web language or format. They are intended to be used in the context of a host language. This section discusses how host languages are to implement <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>, to ensure that the markup specified here will integrate smoothly and effectively with the host language markup.</p>
 	<p>Although markup languages look alike superficially, they do not share language definition infrastructure. To accommodate differences in language-building approaches, the requirements are both general and modularization-specific. While allowing for differences in how the specifications are written, the intent is to maintain consistency in how the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> information looks to authors and how it is manipulated in the <abbr title="Document Object Model">DOM</abbr> by scripts.</p>
-	<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles, states, and properties are implemented as <a title="attribute">attributes</a> of <a title="element">elements</a>. Roles are applied by placing their names among the tokens appearing in the value of a host-language-provided <code>role</code> attribute. States and properties each get their own attribute, with values as defined for each particular state or property in this specification. The name of the attribute is the aria-prefixed name of the state or property.</p>
+	<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles, states, and properties are implemented as <a>attributes</a> of <a>elements</a>. Roles are applied by placing their names among the tokens appearing in the value of a host-language-provided <code>role</code> attribute. States and properties each get their own attribute, with values as defined for each particular state or property in this specification. The name of the attribute is the aria-prefixed name of the state or property.</p>
 	<section id="host_general_role">
 		<h2>Role Attribute</h2>
 		<p>An implementing host language will provide an <a>attribute</a> with the following characteristics:</p>
@@ -10655,7 +10655,7 @@
 	</section>
 	<section id="host_general_attrs">
 		<h3>State and Property Attributes</h3>
-		<p>An implementing host language MUST allow <a title="attribute">attributes</a> with the following characteristics:</p>
+		<p>An implementing host language MUST allow <a>attributes</a> with the following characteristics:</p>
 		<ul>
 			<li>The attribute name is the name of any state or property identified in the <a href="#states_and_properties">Supported States and Properties</a> section, such as <sref>aria-busy</sref>, <sref>aria-selected</sref>, <pref>aria-activedescendant</pref>, <pref>aria-valuetext</pref>;</li>
 			<li>The syntax does <strong>NOT</strong> prevent the attribute from appearing anywhere that it is applicable, as specified in this specification;</li>
@@ -10672,14 +10672,14 @@
 	</section>
 	<section id="implicit_semantics">
 		<h2>Implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Semantics</h2>
-		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is designed to provide <a title="semantics">semantic</a> information about objects when host languages lack native semantics for the object. <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is designed, however, to provide additional semantics for many host languages. Furthermore, host languages over time can evolve and provide new native features that correspond to WAI-ARIA features. Therefore, there are many situations in which <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics are redundant with host language semantics. </p>
+		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is designed to provide <a>semantic</a> information about objects when host languages lack native semantics for the object. <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is designed, however, to provide additional semantics for many host languages. Furthermore, host languages over time can evolve and provide new native features that correspond to WAI-ARIA features. Therefore, there are many situations in which <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics are redundant with host language semantics. </p>
 		<p>These host language features can be viewed as having &quot;implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics&quot;. User agent processing of features with implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics would be similar to the processing for the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> feature. The processing might not be identical because of lexical differences between the host language feature and the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> feature, but generally the user agent would expose the same information to the accessibility API. Features with implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics satisfy <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> structural requirements such as required owned elements, required states and properties, etc. and do not require explicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics to be provided.</p>
 		<p>For example, if an element with the functionality already exists, such as a checkbox or radio button, use the native semantics of the host language. <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> markup is only intended to be used to enhance the native semantics (e.g., indicating that the element is required with <pref>aria-required</pref>), or to change the semantics to a different purpose form the standard functionality of the element.</p>
 		<p>Implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics affect the conflict resolution procedures in the following section, Conflicts with Host Language Semantics. Therefore, implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics need to be defined in a normative specification, such as the host language specification or the <cite><a href="http://www.w3.org/TR/wai-aria-implementation/">WAI-ARIA User Agent Implementation Guide</a></cite> [[WAI-ARIA-IMPLEMENTATION]].</p>
 	</section>
 	<section id="host_general_conflict">
 		<h2>Conflicts with Host Language Semantics</h2>
-		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles, states, and properties are intended to add <a title="semantics">semantic</a> information when native host language elements with these semantics are not available, and are generally used on elements that have no native semantics of their own. They can also be used on elements that have similar but non-identical semantics (for example, a nested list could be used to represent a tree structure). This method can be part of a fallback strategy for older browsers that have no <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> implementation, or because native presentation of the repurposed element reduces the amount of style and/or script needed. Except for the cases outlined below, user agents MUST always use the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics to define how it exposes the element to accessibility APIs, rather than using the host language semantics.</p>
+		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles, states, and properties are intended to add <a>semantic</a> information when native host language elements with these semantics are not available, and are generally used on elements that have no native semantics of their own. They can also be used on elements that have similar but non-identical semantics (for example, a nested list could be used to represent a tree structure). This method can be part of a fallback strategy for older browsers that have no <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> implementation, or because native presentation of the repurposed element reduces the amount of style and/or script needed. Except for the cases outlined below, user agents MUST always use the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics to define how it exposes the element to accessibility APIs, rather than using the host language semantics.</p>
 		<p>In addition to these normal situations in which <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is expected to override native semantics, there are elements that are inappropriate to override with <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>. This could be because identical host language semantics exist, so <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is not needed, or because semantics from <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> directly conflict with host language semantics. When a feature in the host language with identical role semantics and values is available, and the author has no compelling reason to avoid using the host language feature, authors SHOULD use the host language features rather than repurpose other elements with <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>.</p>
 		<p>Host languages can have features that have implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics corresponding to roles. When a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role is provided, user agents MUST use the semantic of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role for processing, not the native semantic, unless the role requires <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties whose attributes are explicitly forbidden on the native element by the host language. Values for roles do not conflict in the same way as values for states and properties (for example, the HTML 'checked' attribute and the 'aria-checked' attribute could have conflicting values), and authors are expected to have valid reason to provide a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role even on elements that would not normally be repurposed.</p>
 		<p>When <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties correspond to host language features that have the same <a href="#implicit_semantics">implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantic</a>, it can be particularly problematic to use the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> feature. If the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> feature and the host language feature are both provided but their values are not kept in sync, user agents and assistive technologies cannot know which value to use. Therefore, to prevent providing conflicting states and properties to assistive technologies, host languages MUST explicitly declare where the use of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attributes on each host language element conflicts with native attributes for that element. When a host language declares a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attribute to be in direct semantic conflict with a native attribute for a given element, user agents MUST ignore the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attribute and instead use the host language attribute with the same implicit semantic.</p>
@@ -10687,7 +10687,7 @@
 
 		<!-- previous 'Conflicts with Host Language Semantics' section -->
 		<!--
-		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is intended to add <a title="semantics">semantic</a> information to objects when native host language elements are not available with these semantics. It is generally used on elements that have no native semantics of their own with respect to user interface objects. At times, however, it is used on elements that have similar but not identical semantics to the intended object (for instance, nested list elements might be used to represent a tree structure). This is usually done as part of a fallback strategy, or because native presentation of the repurposed element reduces the amount of style and script the author needs to use. In these cases, the user agent MUST use the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics to define how it exposes the element to accessibility APIs, not the native semantics.</p>
+		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is intended to add <a>semantic</a> information to objects when native host language elements are not available with these semantics. It is generally used on elements that have no native semantics of their own with respect to user interface objects. At times, however, it is used on elements that have similar but not identical semantics to the intended object (for instance, nested list elements might be used to represent a tree structure). This is usually done as part of a fallback strategy, or because native presentation of the repurposed element reduces the amount of style and script the author needs to use. In these cases, the user agent MUST use the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics to define how it exposes the element to accessibility APIs, not the native semantics.</p>
 		<p>Notwithstanding these normal situations in which <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is expected to override native semantics, there are elements that are inappropriate to override with <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>. This may be because native semantics already exist so <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is not needed, or because semantics from <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> directly conflict with host language semantics. When features in the host language are available for a given type of object, authors SHOULD use those features rather than repurpose other elements with <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>. </p>
 		<p>When <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties correspond to host language features that have the same <a href="#implicit_semantics">implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantic</a>, it can be particularly problematic to use the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> feature. If the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> feature and the host language feature are both provided but their values are not kept in sync, it is uncertain which one is correct. Therefore, user agents MUST ignore <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties when a host language feature with the same implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantic is provided on the same object. </p>
 		<p>Although host languages can also have features that have implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics corresponding to roles, the above rule does not apply to roles. When a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role is provided, user agents MUST use the semantic of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role for processing, not the native semantic. This is because values for roles do not conflict in the same way as values for states and properties, and because authors are expected to have good reason to provide a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role even on elements that would not normally be repurposed.</p>
@@ -10717,12 +10717,12 @@
 	</section>
 	<section id="xhtml_mod">
 		<h3><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Attributes Module</h3>
-		<p>This module declares the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a title="attribute">attributes</a> as a module that can be included in a modularized <abbr title="Document Type Definition">DTD</abbr>. A sample XHTML DTD using this module follows. Note the WAI-ARIA attributes are in no namespace, and the attribute name begins with "aria-" to reduce the likelihood of collision with existing attributes.</p>
+		<p>This module declares the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>attributes</a> as a module that can be included in a modularized <abbr title="Document Type Definition">DTD</abbr>. A sample XHTML DTD using this module follows. Note the WAI-ARIA attributes are in no namespace, and the attribute name begins with "aria-" to reduce the likelihood of collision with existing attributes.</p>
 		<p>This module is available from <a href="http://www.w3.org/MarkUp/DTD/aria-attributes-1.mod">http://www.w3.org/MarkUp/DTD/aria-attributes-1.mod</a>.</p>
 	</section>
 	<section id="xhtml_dtd">
 		<h3><abbr title="Extensible Hypertext Markup Language">XHTML</abbr> plus <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <abbr title="Document Type Definition">DTD</abbr></h3>
-		<p>This <abbr title="Document Type Definition">DTD</abbr> extends <abbr title="Extensible Hypertext Markup Language">XHTML</abbr> 1.1 and adds the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>state</a> and <a>property</a> <a title="attribute">attributes</a> to all its <a title="element">elements</a>. In order to provide broader keyboard support and conform with the Focus Navigation section above, it also adds the <code>tabindex</code> attribute to a wider set of elements. </p>
+		<p>This <abbr title="Document Type Definition">DTD</abbr> extends <abbr title="Extensible Hypertext Markup Language">XHTML</abbr> 1.1 and adds the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>state</a> and <a>property</a> <a>attributes</a> to all its <a>elements</a>. In order to provide broader keyboard support and conform with the Focus Navigation section above, it also adds the <code>tabindex</code> attribute to a wider set of elements. </p>
 		<p>This is not a formal document type and may be obsoleted by future formal XHTML DTDs that support WAI-ARIA.</p>
 		<p>The XHTML 1.1 plus WAI-ARIA DTD is available from <a href="http://www.w3.org/WAI/ARIA/schemata/xhtml-aria-1.dtd">http://www.w3.org/WAI/ARIA/schemata/xhtml-aria-1.dtd</a>.</p>
 		<p>Documents written using this XHTML Family markup language can be validated using the above DTD. If a document author wants to facilitate such validation, they can include the following declaration at the top of their document: </p>
@@ -10775,12 +10775,12 @@ PUBLIC "-//W3C//ENTITIES XHTML ARIA Attributes 1.0//EN" "aria-attributes-1.mod"
 	</section>
 	<section id="xhtml_schema_mod">
 		<h3><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Attributes <abbr title="Extensible Markup Language">XML</abbr> Schema Module</h3>
-		<p>This module declares the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a title="attribute">attributes</a> as an <abbr title="Extensible Markup Language">XML</abbr> Schema module that can be included in a modularized schema. Note the WAI-ARIA attributes are in no namespace, and the attribute name begins with "aria-" to reduce the likelihood of collision with existing attributes.</p>
+		<p>This module declares the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>attributes</a> as an <abbr title="Extensible Markup Language">XML</abbr> Schema module that can be included in a modularized schema. Note the WAI-ARIA attributes are in no namespace, and the attribute name begins with "aria-" to reduce the likelihood of collision with existing attributes.</p>
 		<p>This module is available from <a href="http://www.w3.org/MarkUp/SCHEMA/aria-attributes-1.xsd">http://www.w3.org/MarkUp/SCHEMA/aria-attributes-1.xsd</a>.</p>
 	</section>
 	<section id="html_dtd">
 		<h3><abbr title="Accessible Rich Internet Applications">HTML 4.01 plus WAI-ARIA DTD</abbr></h3>
-		<p>This standalone DTD adds WAI-ARIA <a>state</a> and <a>property</a> <a title="attribute">attributes</a> to all <a title="element">elements</a> in HTML 4.01, as well as a <code>role</code> attribute. In order to provide broader keyboard support, it also adds the <code>tabindex</code> attribute to a wider set of elements. </p>
+		<p>This standalone DTD adds WAI-ARIA <a>state</a> and <a>property</a> <a>attributes</a> to all <a>elements</a> in HTML 4.01, as well as a <code>role</code> attribute. In order to provide broader keyboard support, it also adds the <code>tabindex</code> attribute to a wider set of elements. </p>
 		<p>The DTD is based on the HTML 4.01 Transitional DTD, and includes all entity references needed to make it a standalone file. <em>This is not an official W3C DTD</em> and should be considered a derivative work of HTML 4.01.</p>
 		<p>Documents written using this markup language can be validated using the above DTD. If a document author wants to facilitate such validation, they can include the following declaration at the top of their document: </p>
 		<pre>&lt;!DOCTYPE html PUBLIC &quot;-//W3C//DTD HTML+ARIA 1.0//EN&quot;

--- a/common/terms.html
+++ b/common/terms.html
@@ -1,6 +1,6 @@
 <p>While some terms are defined in place, the following definitions are used throughout this document. </p>
   <dl class="termlist">
-    <dt><dfn>Accessibility <abbr title="Application Programming Interface">API</abbr></dfn></dt>
+    <dt><dfn data-lt="accessibility api|accessibility apis">Accessibility <abbr title="Application Programming Interface">API</abbr></dfn></dt>
     <dd>
       <p>Operating systems and other platforms provide a set of interfaces that expose information about <a class="termref" data-lt="object">objects</a> and <a class="termref" data-lt="event">events</a> to <a>assistive technologies</a>. Assistive technologies use these interfaces to get information about and interact with those <a class="termref" data-lt="widget">widgets</a>. Examples of accessibility APIs are <a href="https://msdn.microsoft.com/en-us/library/ms697270(VS.85).aspx">Microsoft Active Accessibility</a> [[MSAA]], <a href="https://msdn.microsoft.com/en-us/library/ee684013%28VS.85%29.aspx">Microsoft User Interface Automation</a> [[UI-AUTOMATION]], <abbr title="Microsoft Active Accessibility">MSAA</abbr> with <cite><a href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd561898(v=vs.85).aspx"><abbr title="User Interface Automation">UIA</abbr> Express</a></cite> [[UIA-EXPRESS]], the
       	<a href="https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Protocols/NSAccessibility_Protocol/index.html">Mac <abbr title="OS Ten">OS X</abbr> Accessibility Protocol</a> [[AXAPI]], the <cite><a href="https://developer.gnome.org/atk/unstable/">Linux/Unix Accessibility Toolkit</a></cite> [[ATK]] and <cite><a href="https://developer.gnome.org/libatspi/stable/">Assistive Technology Service Provider Interface</a></cite> [[AT-SPI]], and <a href="http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2">IAccessible2</a> [[IAccessible2]].</p>
@@ -17,12 +17,12 @@
     <dd>
       <p>An accessible description provides additional information, related to an interface element, that complements the <a>accessible name</a>. The accessible description might or might not be visually perceivable. </p>
     </dd>
-    <dt><dfn>Accessible Name</dfn></dt>
+    <dt><dfn data-lt="accessible names">Accessible Name</dfn></dt>
     <dd>
       <p>The accessible name is the name of a user interface element. Each platform <a>accessibility <abbr title="application programming interface">API</abbr></a> provides the accessible name property. The value of the accessible name may be derived from a visible (e.g., the visible text on a button) or invisible (e.g., the text alternative that describes an icon) property of the user interface element.  See related <a>accessible description</a>.</p>
       <p>A simple use for the accessible name property may be illustrated by an &quot;OK&quot; button. The text &quot;OK&quot; is the accessible name. When the button receives focus, assistive technologies may concatenate the platform's role description with the accessible name. For example, a screen reader may speak &quot;push-button OK&quot; or &quot;OK button&quot;. The order of concatenation and specifics of the role description (e.g., &quot;button&quot;, &quot;push-button&quot;, &quot;clickable button&quot;) are determined by platform <a class="termref" data-lt="accessibility api">accessibility API</a>s or <a>assistive technologies</a>.</p>
     </dd>
-    <dt><dfn>Accessible object</dfn></dt>
+    <dt><dfn data-lt="accessible objects">Accessible object</dfn></dt>
     <dd>
       <p>A <a>node</a> in the <a>accessibility tree</a> of a platform <a>accessibility <abbr title="application programming interface">API</abbr></a>. Accessible objects expose various <a class="termref" data-lt="state">states</a>, <a class="termref" data-lt="property">properties</a>, and <a class="termref" data-lt="event">events</a> for use by <a>assistive technologies</a>.  In the context of markup languages (e.g., HTML and SVG) in general, and of WAI-ARIA in particular, markup <a class="termref" data-lt="element">elements</a> and their <a class="termref" data-lt="attribute">attributes</a> are represented as accessible objects.  </p>
     </dd>
@@ -30,7 +30,7 @@
     <dd>
       <p>The action taken when an <a>event</a>, typically initiated by users through an input device, causes an element to fulfill a defined role. The role may be defined for that element by the host language, or by author-defined variables, or both. The role for any given element may be a generic action, or may be unique to that element. For example, the activation behavior of an <abbr title="Hypertext Markup Language">HTML</abbr> or <abbr title="Scalable Vector Graphics">SVG</abbr> <code>&lt;a&gt;</code> element shall be to cause the user agent to traverse the link specified in the <code>href</code> attribute, with the further optional parameter of specifying the browsing context for the traversal (such as the current window or tab, a named window, or a new window); the activation behavior of an <abbr title="Hypertext Markup Language">HTML</abbr> <code>&lt;input&gt;</code> element with the <code>type</code> attribute value <code>submit</code> shall be to send the values of the form elements to an author-defined <abbr title="Internationalized Resource Identifiers">IRI</abbr> by the author-defined <abbr title="Hypertext Transfer Protocol">HTTP</abbr> method.</p>
     </dd>
-    <dt><dfn>Assistive Technologies</dfn></dt>
+    <dt><dfn data-lt="assistive technology">Assistive Technologies</dfn></dt>
     <dd><p>Hardware and/or software that:</p>
 			<ul>
 				<li>relies on services provided by a <a>user agent</a> to retrieve and render Web content </li>
@@ -49,11 +49,11 @@
       <li>alternate pointing devices, which are used to simulate mouse pointing and clicking.</li>
     </ul>
     </dd>
-    <dt><dfn>Attribute</dfn></dt>
+    <dt><dfn data-lt="attributes">Attribute</dfn></dt>
     <dd>
       <p>In this specification, attribute is used as it is in markup languages. Attributes are structural features added to <a class="termref" href="#dfn-element">elements</a> to provide information about the <a class="termref" href="#dfn-state">states</a> and <a class="termref" href="#dfn-property">properties</a> of the <a class="termref" href="#dfn-object">object</a> represented by the element.</p>
     </dd>
-    <dt><dfn>Class</dfn></dt>
+    <dt><dfn data-lt="classes">Class</dfn></dt>
     <dd>
       <p>A set of instance <a class="termref" href="#dfn-object">objects</a> that share similar characteristics.</p>
     </dd>
@@ -61,11 +61,11 @@
     <dd>
       <p>Event from/to the host operating system via the accessibility <abbr title="application programming interface">API</abbr>, notifying of a change of input focus.</p>
     </dd>
-    <dt><dfn>Element</dfn></dt>
+    <dt><dfn data-lt="elements|element's">Element</dfn></dt>
     <dd>
       <p>In this specification, element is used as it is in markup languages. Elements are the structural elements in markup language that contains the data profile for <a class="termref" data-lt="object">objects</a>.</p>
     </dd>
-    <dt><dfn>Event</dfn></dt>
+    <dt><dfn data-lt="events">Event</dfn></dt>
     <dd>
       <p>A programmatic message used to communicate discrete changes in the <a>state</a> of an <a>object</a> to other objects in a computational system. User input to a web page is commonly mediated through abstract events that describe the interaction and can provide notice of changes to the state of a document object. In some programming languages, events are more commonly known as notifications.</p>
     </dd>
@@ -85,11 +85,11 @@
     <dd>
       <p>Accessible to the user using a keyboard or <a>assistive technologies</a> that mimic keyboard input, such as a sip and puff tube. References in this document relate to <cite><a href="http://www.w3.org/TR/WCAG20/#keyboard-operation"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.0 Guideline 2.1: Make all functionality available from a keyboard</a></cite> [[WCAG20]].</p>
     </dd>
-    <dt><dfn>Landmark</dfn></dt>
+    <dt><dfn data-lt="landmarks">Landmark</dfn></dt>
     <dd>
       <p>A type of region on a page to which the user may want quick access. Content in such a region is different from that of other regions on the page and relevant to a specific user purpose, such as navigating, searching, perusing the primary content, etc.</p>
     </dd>
-    <dt><dfn>Live Region</dfn></dt>
+    <dt><dfn data-lt="live regions">Live Region</dfn></dt>
     <dd>
       <p>Live regions are perceivable regions of a web page that are typically updated as a result of an external event when user focus may be elsewhere. These regions are not always updated as result of a user interaction. This practice has become commonplace with the growing use of Ajax. Examples of live regions include a chat log, stock ticker, or a sport scoring section that updates periodically to reflect game statistics. Since these asynchronous areas are expected to update outside the user's area of focus, assistive technologies such as screen readers have either been unaware of their existence or unable to process them for the user. WAI-ARIA has provided a collection of properties that allow the author to identify these live regions and how to process them: aria-live, aria-relevant, aria-atomic, and aria-busy. Pre-defined live region roles are listed in the <cite><a href="http://www.w3.org/TR/wai-aria-practices/#chobet">Choosing Between Special Case Live Regions</a></cite> ([[WAI-ARIA-PRACTICES]], Section 5.3).</p>
     </dd>
@@ -97,7 +97,7 @@
     <dd>
       <p>An implementing host language's primary content element, such as the <code>body</code> element in HTML.</p>
     </dd>
-    <dt><dfn>Managed State</dfn></dt>
+    <dt><dfn data-lt="managed states">Managed State</dfn></dt>
     <dd>
       <p><a>Accessibility API</a> <a>state</a> that is controlled by the user agent, such as focus and selection. These are contrasted with &quot;unmanaged states&quot; that are typically controlled by the author. Nevertheless, authors can override some managed states, such as aria-posinset and aria-setsize. Many managed states have corresponding CSS pseudo-classes, such as :focus, and pseudo-elements, such as ::selection, that are also updated by the user agent.</p>
     </dd>
@@ -113,7 +113,7 @@
     <dd>
       <p>Required for conformance. By contrast, content identified as <a>informative</a> or &quot;non-normative&quot; is not required for conformance.</p>
     </dd>
-    <dt><dfn>Object</dfn></dt>
+    <dt><dfn data-lt="objects">Object</dfn></dt>
     <dd>
       <p>In the context of user interfaces,  an item in the   perceptual user experience, represented in markup languages by one or   more <a class="termref" data-lt="element">elements</a>, and rendered by <a class="termref" data-lt="user agent">user agents</a>.</p>
     In the context of programming, the instantiation of one or more <a class="termref" data-lt="class">classes</a> and interfaces which define the general characteristics of similar objects. An object in an <a>accessibility <abbr title="Application Programming Interfaces">API</abbr></a> may represent one or more DOM objects. <a class="termref" data-lt="accessibility api">Accessibility APIs</a> have defined interfaces that are distinct from DOM interfaces.</dd>
@@ -126,11 +126,11 @@
     <dd>
       <p>Usable by users in ways they can control. References in this document relate to <cite><a href="http://www.w3.org/TR/WCAG20/#operable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.0 Principle 2: Content must be operable</a></cite> [[WCAG20]]. See <a>Keyboard Accessible</a>.</p>
     </dd>
-    <dt><dfn>Owned Element</dfn></dt>
+    <dt><dfn data-lt="owned|owned element's|owned elements">Owned Element</dfn></dt>
     <dd>
       <p>An 'owned element' is any <abbr title="Document Object Model">DOM</abbr> descendant of the <a>element</a>, any element specified as a child via <pref>aria-owns</pref>, or any <abbr title="Document Object Model">DOM</abbr> descendant of the owned child.</p>
     </dd>
-    <dt><dfn>Owning Element</dfn></dt>
+    <dt><dfn data-lt="owning">Owning Element</dfn></dt>
     <dd>
       <p>An 'owning element' is any <abbr title="Document Object Model">DOM</abbr> ancestor of the <a>element</a>, or any element with an <pref>aria-owns</pref> attribute which references the ID of the   element. </p>
     </dd>
@@ -138,15 +138,15 @@
     <dd>
       <p>Presentable to users in ways they can sense. References in this document relate to <cite><a href="http://www.w3.org/TR/WCAG20/#perceivable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.0 Principle 1: Content must be perceivable</a></cite> [[WCAG20]].</p>
     </dd>
-    <dt><dfn>Property</dfn></dt>
+    <dt><dfn data-lt="properties">Property</dfn></dt>
     <dd>
       <p><a class="termref" data-lt="attribute">Attributes</a> that are essential to the nature of a given <a>object</a>, or that represent a data value associated with the object. A change of a property may significantly impact the meaning or presentation of an object. Certain properties (for example, <pref>aria-multiline</pref>) are less likely to change than <a class="termref" href="#dfn-state">states</a>, but note that the frequency of change difference is not a rule. A few properties, such as <pref>aria-activedescendant</pref>, <pref>aria-valuenow</pref>, and <pref>aria-valuetext</pref> are expected to change often. See <a href="http://www.w3.org/TR/wai-aria/states_and_properties#statevsprop">clarification of states versus properties</a>.</p>
     </dd>
-    <dt><dfn>Relationship</dfn></dt>
+    <dt><dfn data-lt="relationships">Relationship</dfn></dt>
     <dd>
       <p>A connection between two distinct things. Relationships may be of various types to indicate which <a>object</a> labels another, controls another, etc.</p>
     </dd>
-    <dt><dfn>Role</dfn></dt>
+    <dt><dfn data-lt="roles">Role</dfn></dt>
     <dd>
       <p>Main indicator of type. <!-- (removing, vague) The object's role is the class of <a class="termref" data-lt="object">objects</a> of which it is a member. --> This <a class="termref" data-lt="semantics">semantic</a> association allows tools to present and support interaction with the object in a manner that is consistent with user expectations about other objects of that type.</p>
     </dd>
@@ -154,11 +154,11 @@
     <dd>
       <p> The primary element containing non-metadata content. In many languages, this is  the document element but in <abbr title="Hypertext Markup Language">HTML</abbr>, it is the <code>&lt;body&gt;</code>.</p>
     </dd>
-    <dt><dfn>Semantics</dfn></dt>
+    <dt><dfn data-lt="semantic|semantically">Semantics</dfn></dt>
     <dd>
       <p>The meaning of something as understood by a human, defined in a way that computers can process a representation of an <a>object</a>, such as <a class="termref" data-lt="element">elements</a> and <a class="termref" data-lt="attribute">attributes</a>, and reliably represent the object in a way that various humans will achieve a mutually consistent understanding of the object.</p>
     </dd>
-    <dt><dfn>State</dfn></dt>
+    <dt><dfn data-lt="states">State</dfn></dt>
     <dd>
       <p>A state is a dynamic <a class="termref" href="#dfn-property">property</a> expressing characteristics of an <a>object</a> that may change in response to user action or automated processes. States do not affect the essential nature of the object, but represent data associated with the object or user interaction possibilities. See <a href="http://www.w3.org/TR/wai-aria/states_and_properties#statevsprop">clarification of states versus properties</a>.</p>
     </dd>
@@ -182,7 +182,7 @@
     <dd>
       <p>Presentable to users in ways they can construct an appropriate meaning. References in this document relate to <cite><a href="http://www.w3.org/TR/WCAG20/#understandable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.0 Principle 3: Information and the operation of user interface must be understandable</a></cite> [[WCAG20]].</p>
     </dd>
-    <dt><dfn>User Agent</dfn></dt>
+    <dt><dfn data-lt="user agents">User Agent</dfn></dt>
     <dd>
       <p>Any software that retrieves, renders and facilitates end user interaction with Web content. This definition may differ from that used in other documents.</p>
     </dd>
@@ -190,7 +190,7 @@
     <dd>
       <p>A reference to a target element in the same document that has a matching ID</p>
     </dd>
-    <dt><dfn>Widget</dfn></dt>
+    <dt><dfn data-lt="widgets">Widget</dfn></dt>
     <dd>
       <p>Discrete user interface <a class="termref" href="#dfn-object">object</a> with which the user can interact. Widgets range from simple objects that have one value or operation (e.g., check boxes and menu items), to complex objects that contain many managed sub-objects (e.g., trees and grids).</p>
     </dd>


### PR DESCRIPTION
Changed aria source to never use @title.

This resolves all the warnings in the ARIA spec that showed up as a result of fixing #90 in PR #91.