### PR TITLE
Fixed wrong escape char used for aria-kbdshortcuts

### DIFF
--- a/aria/aria.html
+++ b/aria/aria.html
@@ -9231,7 +9231,7 @@
 					<li>"A"</li>
 					<li>"Shift+Space"</li>
 					<li>"Control+Alt+."</li>
-					<li>"Ctrl+%quot;"</li>
+					<li>"Ctrl+&quot;"</li>
 				</ul>
 				<p>Examples of valid values for the aria-key attribute, which can include more than one space-delimited shortcut, include:</p>
 				<ul>


### PR DESCRIPTION
Seems like there's a wrong escape character used for `&quot;` entity.