### PR TITLE
SVG-AAM: Update Editor's Draft status & link

### DIFF
--- a/svg-aam/svg-aam.html
+++ b/svg-aam/svg-aam.html
@@ -17,7 +17,7 @@
     includePermalinks: true,
     
     // specification status (e.g., WD, LC, NOTE, etc.). If in doubt use ED.
-    specStatus:           "FPWD",
+    specStatus:           "ED",
     //crEnd:                "2012-04-30",
     //perEnd:               "2013-07-23",
     //publishDate:           "2015-02-26",
@@ -38,7 +38,7 @@
     //previousDiffURI:      "http://www.w3.org/TR/2014/REC-wai-aria-implementation-20140320/",
 
     // if there a publicly available Editors Draft, this is the link
-    edDraftURI:           "http://w3c.github.io/aria/svg-aam/svg-aam.html",
+    edDraftURI:           "https://rawgit.com/w3c/aria/master/svg-aam/svg-aam.html",
 
     // if this is a LCWD, uncomment and set the end of its review period
     // lcEnd: "2012-02-21",


### PR DESCRIPTION
Referencing the RawGit URL as the Editor's Draft, since the GitHub pages version was not being updated.  Also make sure it is marked as an Editor's Draft, not a working draft.