### PR TITLE
Changed reference conversion logic

### DIFF
--- a/common/script/resolveReferences.js
+++ b/common/script/resolveReferences.js
@@ -79,7 +79,10 @@ function updateReferences(base) {
         var content = $item.text();
         var ref = $item.attr("title");
         if (!ref) {
-            ref = content;
+            ref = $item.attr("data-lt");
+            if (!ref) {
+                ref = content;
+            }
         }
 
         // what sort of reference are we?

--- a/common/script/resolveReferences.js
+++ b/common/script/resolveReferences.js
@@ -77,12 +77,17 @@ function updateReferences(base) {
 
         // what are we referencing?
         var content = $item.text();
+        var usedTitle = false;
         var ref = $item.attr("title");
         if (!ref) {
             ref = $item.attr("data-lt");
             if (!ref) {
                 ref = content;
+            } else {
+                usedTitle = true;
             }
+        } else {
+            usedTitle = true;
         }
 
         // what sort of reference are we?
@@ -101,7 +106,11 @@ function updateReferences(base) {
         if (pID) {
             if (sectionMap[pID]) {
                 if (sectionMap[pID][ref]) {
-                    theElement = "code";
+                    if (usedTitle) {
+                        theElement = "span";
+                    } else {
+                        theElement = "code";
+                    }
                 } else {
                     sectionMap[pID][ref] = 1;
                 }

--- a/common/script/resolveReferences.js
+++ b/common/script/resolveReferences.js
@@ -106,10 +106,13 @@ function updateReferences(base) {
         if (pID) {
             if (sectionMap[pID]) {
                 if (sectionMap[pID][ref]) {
-                    if (usedTitle) {
-                        theElement = "span";
-                    } else {
-                        theElement = "code";
+                    // only change the element if we are in a paragraph.
+                    if ($item.parents("p").length != 0) {
+                        if (usedTitle) {
+                            theElement = "span";
+                        } else {
+                            theElement = "code";
+                        }
                     }
                 } else {
                     sectionMap[pID][ref] = 1;

--- a/common/script/resolveReferences.js
+++ b/common/script/resolveReferences.js
@@ -63,7 +63,8 @@ function updateReferences(base) {
     // update references to properties
     //
     // New logic:
-    //     1. for each item, find it's nearest 'section' ancestor
+    //     1. for each item, find it's nearest 'section' ancestor (or nearest div
+    //     with a class of role, property, or state)
     //     2. if we have not already seen this item in this section, it is a link using 'a'
     //     3. otherwise, it is just a styled reference to the item  using 'span'
 
@@ -92,7 +93,7 @@ function updateReferences(base) {
         var theElement = "a";
 
         // pSec is the nearest parent section element
-        var $pSec = $item.parents("section").first();
+        var $pSec = $item.parents("section,div.role,div.state,div.property").first();
         var pID = $pSec.attr("id");
         if (pID) {
             if (sectionMap[pID]) {

--- a/common/script/resolveReferences.js
+++ b/common/script/resolveReferences.js
@@ -66,7 +66,7 @@ function updateReferences(base) {
     //     1. for each item, find it's nearest 'section' ancestor (or nearest div
     //     with a class of role, property, or state)
     //     2. if we have not already seen this item in this section, it is a link using 'a'
-    //     3. otherwise, it is just a styled reference to the item  using 'span'
+    //     3. otherwise, it is just a styled reference to the item  using 'code'
 
     var baseURL = respecConfig.ariaSpecURLs[respecConfig.specStatus];
 
@@ -98,7 +98,7 @@ function updateReferences(base) {
         if (pID) {
             if (sectionMap[pID]) {
                 if (sectionMap[pID][ref]) {
-                    theElement = "span";
+                    theElement = "code";
                 } else {
                     sectionMap[pID][ref] = 1;
                 }


### PR DESCRIPTION
Now only the first [spr]ref in a section will be a link to the
base definition.  The others will just be spans with the same class
so that they style the same (except the link version will have an
underline of course).

This should support the feature requested in #106 