### PR TITLE
Editorial: Fix typos

### DIFF
--- a/aria/dpub.html
+++ b/aria/dpub.html
@@ -171,7 +171,7 @@
 	
 	<section id="ua-support">
 		<h2>User Agent Support</h2>
-		<p>This module builds on the general <a href="http://www.w3.org/TR/wai-aria-1.1/#ua-support">User Agent support princinples</a> defined in [[WAI-ARIA]] by also providing the ability for user agents to enhance the general user interface presented to readers.</p> 
+		<p>This module builds on the general <a href="http://www.w3.org/TR/wai-aria-1.1/#ua-support">User Agent support principles</a> defined in [[WAI-ARIA]] by also providing the ability for user agents to enhance the general user interface presented to readers.</p> 
 	</section>
 	
 	<section id="co-evolution">
@@ -1689,7 +1689,7 @@
 		<div class="role">
 			<rdef>doc-example</rdef>
 			<div class="role-description">
-				<p>An illustratration of a key concept of the work, such as a code listing, case study or problem.</p>
+				<p>An illustration of a key concept of the work, such as a code listing, case study or problem.</p>
 				<pre class="example highlight">&lt;aside role="doc-example"&gt;
    &lt;h1&gt;Hello World!&lt;/h1&gt;
    &#8230;


### PR DESCRIPTION
Found some spelling mistakes - 
`princinples` > `principles`
`illustratration` > `illustration`