### PR TITLE
ReSpec event handler to fix scrolling when loading.

### DIFF
--- a/common/script/resolveReferences.js
+++ b/common/script/resolveReferences.js
@@ -177,12 +177,10 @@ function fixIncludes(utils, content) {
 }
 
 // Fix the scroll-to-fragID problem:
-(function() {
-    respecEvents.sub("start", function (details) {
-        if (details === "core/location-hash") {
-            if(window.location.hash) {
-                window.location = window.location.hash;
-            }
+(function () {
+    respecEvents.sub("end-all", function () {
+        if(window.location.hash) {
+            window.location = window.location.hash;
         }
     });
 })();

--- a/common/script/resolveReferences.js
+++ b/common/script/resolveReferences.js
@@ -176,3 +176,13 @@ function fixIncludes(utils, content) {
     return (base.innerHTML);
 }
 
+// Fix the scroll-to-fragID problem:
+(function() {
+    respecEvents.sub("start", function (details) {
+        if (details === "core/location-hash") {
+            if(window.location.hash) {
+                window.location = window.location.hash;
+            }
+        }
+    });
+})();


### PR DESCRIPTION
@Joanmarie @mcking65 @richschwer @michael-n-cooper 
This is an attempt at fixing the failure to position an ARIA spec document when loading from an URL with a fragment ID when ReSpec is in play.  We run into this problem when using rawgit URLs.

I've spot checked a few of the documents with a couple of browsers, but my tests are not exhaustive.  Could you check with the documents you edit to see if this works for all of them?  Here are some sample URLs.

- APG:  http://rawgit.com/klown/aria/scrollToFragId/practices/aria-practices.html#relations_labeling
- ARIA: http://rawgit.com/klown/aria/scrollToFragId/aria/aria.html#aria-multiline
- DPUB: http://rawgit.com/klown/aria/scrollToFragId/aria/dpub.html#references
- SVG-AAM: http://rawgit.com/klown/aria/scrollToFragId/svg-aam/svg-aam.html#glossary

@halindrome I put the code in "resolveReferences.js" simply because it is a file that is loaded by all of our ARIA documents.  So while it has nothing to do with resolving references, it was convenient to add it there.