### PR TITLE
Fixed a typo in Rich Text Editor example.

### DIFF
--- a/practices/aria-practices.html
+++ b/practices/aria-practices.html
@@ -1980,7 +1980,7 @@ This is because browser accessibility APIs do not support child elements contain
           <p class="note">Any examples referenced here that are hosted outside www.w3.org may have changed and may not accurately exemplify the guidance in this section. The APG task force is developing examples for APG version 1.1 that will be directly incorporated into the guide.</p>
             <ul>
               <li><a href="http://archive.dojotoolkit.org/nightly/dojotoolkit/dijit/tests/editor/test_Editor.html" title="Editor Test" target="_blank" rel="nofollow">Dojo nightly</a>.</li>
-              <li><a href="http://ckeditor.com/demo" title="CKEditor demo | CKEditor.com" target="_blank" rel="nofollow">CKEdtor</a>.</li>
+              <li><a href="http://ckeditor.com/demo" title="CKEditor demo | CKEditor.com" target="_blank" rel="nofollow">CKEditor</a>.</li>
               <li><a href="http://developer.yahoo.com/yui/examples/editor/switch_editor.html" title="YUI Library Examples: Rich Text Editor: Plain Text Switcher" target="_blank" rel="nofollow">YUI Rich Text Editor</a>.</li>
             </ul>
           </td>


### PR DESCRIPTION
While looking at some ARIA practices we found a typo in CKEditor's name.

With regards from the CKEditor team. :)