### PR TITLE
Move scrollbar role section to correct position in alphabetical order…

### DIFF
--- a/aria/aria.html
+++ b/aria/aria.html
@@ -5490,6 +5490,114 @@
 				</tbody>
 			</table>
 		</div>
+		<div class="role" id="scrollbar">
+			<rdef>scrollbar</rdef>
+			<div class="role-description">
+				<p>A graphical object that controls the scrolling of content within a viewing area, regardless of whether the content is fully displayed within the viewing area.</p>
+				<p>A scrollbar represents the current value and range of possible values via the size of the scrollbar and position of the thumb with respect to the visible range of the orientation (horizontal or vertical) it controls. Its orientation represents the orientation of the scrollbar and the scrolling effect on the viewing area controlled by the scrollbar. It is typically possible to add or subtract to the current value by using directional keys such as arrow keys.</p>
+				<p>Authors MUST set the <pref>aria-controls</pref> attribute on the scrollbar element to reference the scrollable area it controls.</p>
+				<p>Authors MUST set the <pref>aria-valuemin</pref>, <pref>aria-valuemax</pref>, and <pref>aria-valuenow</pref> attributes.  If missing, their implicit values follow the same rules as the <a href="http://www.w3.org/TR/html5/forms.html#range-state-%28type=range%29" title="Range state">HTML range input type</a>:</p>
+				<ul>
+				    <li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero). </li>
+				    <li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100. </li>
+				    <li>If <code>aria-valuenow</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to the value half way between <code>aria-valuemin</code> and <code>aria-valuemax</code>. </li>
+				    <li>If <code>aria-valuenow</code> is present but less than <code>aria-valuemin</code>, it defaults to the value of <code>aria-valuemin</code>. </li>
+				    <li>If <code>aria-valuenow</code> is present but greater than <code>aria-valuemax</code>, it defaults to the value of <code>aria-valuemax</code>. </li>
+				</ul>
+				<p>Elements with the role <code>scrollbar</code> have an implicit <pref>aria-orientation</pref> value of <code>vertical</code>.</p>
+				<p class="note">Assistive technologies generally will render the value of <pref>aria-valuenow</pref> as a percent of a range between the value of <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref>, unless <pref>aria-valuetext</pref> is specified. It is best to set the values for <pref>aria-valuemin</pref>, <pref>aria-valuemax</pref>, and <pref>aria-valuenow</pref> in a manner that is appropriate for this calculation.</p>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent"><ul>
+							<li><rref>range</rref></li>
+						</ul></td>
+					</tr>
+					<tr>
+						<th class="role-children-head" scope="row">Subclass Roles:</th>
+						<td class="role-children">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"> </td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"> </td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Context Role:</th>
+						<td class="role-scope"> </td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties">
+							<ul>
+								<li><pref>aria-controls</pref></li>
+								<li><pref>aria-orientation</pref></li>
+								<li><pref>aria-valuemax</pref></li>
+								<li><pref>aria-valuemin</pref></li>
+								<li><pref>aria-valuenow</pref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">author</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired">False</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational">True</td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
+						<td class="implicit-values">
+							Default for <pref>aria-orientation</pref> is <code class="default">vertical</code>. <br/>
+							Default for <pref>aria-valuemin</pref> is <code class="default">0</code>. <br/>
+							Default for <pref>aria-valuemax</pref> is <code class="default">100</code>. <br/>
+							Default for <pref>aria-valuenow</pref> is half way between <code class="default">aria-valuemax</code> and <code class="default">aria-valuemin</code>.
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
 		<div class="role" id="search">
 			<rdef>search</rdef>
 			<div class="role-description">
@@ -5948,114 +6056,6 @@
 					<tr>
 						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
 						<td class="implicit-values">Default for <pref>aria-orientation</pref> is <code class="default">horizontal</code>.</td>
-					</tr>
-				</tbody>
-			</table>
-		</div>
-		<div class="role" id="scrollbar">
-			<rdef>scrollbar</rdef>
-			<div class="role-description">
-				<p>A graphical object that controls the scrolling of content within a viewing area, regardless of whether the content is fully displayed within the viewing area.</p>
-				<p>A scrollbar represents the current value and range of possible values via the size of the scrollbar and position of the thumb with respect to the visible range of the orientation (horizontal or vertical) it controls. Its orientation represents the orientation of the scrollbar and the scrolling effect on the viewing area controlled by the scrollbar. It is typically possible to add or subtract to the current value by using directional keys such as arrow keys.</p>
-				<p>Authors MUST set the <pref>aria-controls</pref> attribute on the scrollbar element to reference the scrollable area it controls.</p>
-				<p>Authors MUST set the <pref>aria-valuemin</pref>, <pref>aria-valuemax</pref>, and <pref>aria-valuenow</pref> attributes.  If missing, their implicit values follow the same rules as the <a href="http://www.w3.org/TR/html5/forms.html#range-state-%28type=range%29" title="Range state">HTML range input type</a>:</p>
-				<ul>
-				    <li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero). </li>
-				    <li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100. </li>
-				    <li>If <code>aria-valuenow</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to the value half way between <code>aria-valuemin</code> and <code>aria-valuemax</code>. </li>
-				    <li>If <code>aria-valuenow</code> is present but less than <code>aria-valuemin</code>, it defaults to the value of <code>aria-valuemin</code>. </li>
-				    <li>If <code>aria-valuenow</code> is present but greater than <code>aria-valuemax</code>, it defaults to the value of <code>aria-valuemax</code>. </li>
-				</ul>
-				<p>Elements with the role <code>scrollbar</code> have an implicit <pref>aria-orientation</pref> value of <code>vertical</code>.</p>
-				<p class="note">Assistive technologies generally will render the value of <pref>aria-valuenow</pref> as a percent of a range between the value of <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref>, unless <pref>aria-valuetext</pref> is specified. It is best to set the values for <pref>aria-valuemin</pref>, <pref>aria-valuemax</pref>, and <pref>aria-valuenow</pref> in a manner that is appropriate for this calculation.</p>
-			</div>
-			<table class="role-features">
-				<caption>Characteristics:</caption>
-				<thead>
-					<tr>
-						<th scope="col">Characteristic</th>
-						<th scope="col">Value</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<th class="role-abstract-head" scope="row">Is Abstract:</th>
-						<td class="role-abstract"> </td>
-					</tr>
-					<tr>
-						<th class="role-parent-head" scope="row">Superclass Role:</th>
-						<td class="role-parent"><ul>
-							<li><rref>range</rref></li>
-						</ul></td>
-					</tr>
-					<tr>
-						<th class="role-children-head" scope="row">Subclass Roles:</th>
-						<td class="role-children">Placeholder</td>
-					</tr>
-					<tr>
-						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"> </td>
-					</tr>
-					<tr>
-						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"> </td>
-					</tr>
-					<tr>
-						<th class="role-scope-head" scope="row">Required Context Role:</th>
-						<td class="role-scope"> </td>
-					</tr>
-					<tr>
-						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
-						<td class="role-mustcontain"> </td>
-					</tr>
-					<tr>
-						<th class="role-required-properties-head">Required States and Properties:</th>
-						<td class="role-required-properties">
-							<ul>
-								<li><pref>aria-controls</pref></li>
-								<li><pref>aria-orientation</pref></li>
-								<li><pref>aria-valuemax</pref></li>
-								<li><pref>aria-valuemin</pref></li>
-								<li><pref>aria-valuenow</pref></li>
-							</ul>
-						</td>
-					</tr>
-					<tr>
-						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"> </td>
-					</tr>
-					<tr>
-						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
-						<td class="role-inherited">Placeholder</td>
-					</tr>
-					<tr>
-						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
-					</tr>
-					<tr>
-						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-						<td class="role-namerequired">False</td>
-					</tr>
-					<tr>
-						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
-						<td class="role-namerequired-inherited"> </td>
-					</tr>
-					<tr>
-						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
-						<td class="role-childpresentational">True</td>
-					</tr>
-					<tr>
-						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
-						<td class="role-presentational-inherited"> </td>
-					</tr>
-					<tr>
-						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
-						<td class="implicit-values">
-							Default for <pref>aria-orientation</pref> is <code class="default">vertical</code>. <br/>
-							Default for <pref>aria-valuemin</pref> is <code class="default">0</code>. <br/>
-							Default for <pref>aria-valuemax</pref> is <code class="default">100</code>. <br/>
-							Default for <pref>aria-valuenow</pref> is half way between <code class="default">aria-valuemax</code> and <code class="default">aria-valuemin</code>.
-						</td>
 					</tr>
 				</tbody>
 			</table>


### PR DESCRIPTION
…. (This also fixes the order in the auto-generated section 5.4 Definition of Roles)

This is just 1 small change: cut scrollbar section out from between separator and slider, and paste it verbatim between rowheader and search.  :)