### PR TITLE
Removing "golden hammer" language

### DIFF
--- a/aria/graphics.html
+++ b/aria/graphics.html
@@ -229,19 +229,7 @@
 	 <p>
      Authors are given the ability to influence what is presented 
      to assistive technologies and to influence navigation through
-     the use of roles and properties. With graphics, there are many 
-     cases where presenting and navigating every element will make the 
-     graphic harder to understand and use. 
-     Authors may mark elements for exclusion 
-     from the semantic representation of the document 
-     (the accessibility tree) by assigning 
-     the role <rref>none</rref> or <rref>presentation</rref>.  
-     The element with this role should be treated transparently 
-     by assistive technologies, as if its children or text content 
-     were directly contained by its parent element.
-  </p>  
-   <p>
-     In addition, certain roles, 
+     the use of roles and properties. Certain roles, 
      such as <rref>img</rref> or <rref>graphics-symbol</rref>, 
      when assigned to a parent element, will cause all child 
      DOM structure to be omitted from the accessibility tree.


### PR DESCRIPTION
The 'golden hammer', removing elements with role="none" or "presentation" entirely from the accessibility tree, was rejected by the task force so I removed this text.

For stylistic reasons I removed "in addition" and added the sentence beginning "Certain roles" to the previous paragraph.