### PR TITLE
Shane 377

### DIFF
--- a/aria/aria.html
+++ b/aria/aria.html
@@ -6370,7 +6370,7 @@
 		<div class="role" id="status">
 			<rdef>status</rdef>
 			<div class="role-description">
-				<p>A type of <a>live region</a> whose content is advisory information for the user but is not important enough to justify an <rref>alert</rref>, often but not necessarily presented as a status bar. See related <rref>alert</rref>.</p>
+				<p>A type of <a>live region</a> whose content is advisory information for the user but is not important enough to justify an <rref>alert</rref>, often but not necessarily presented as a status bar.</p>
 				<p>Authors SHOULD ensure an element with role <code>status</code> does not receive focus as a result of change in status.</p>
 				<p>Status is a form of <a>live region</a>. If another part of the page controls what appears in the status, authors SHOULD make the <a>relationship</a> explicit with the <pref>aria-controls</pref> <a>attribute</a>.</p>
 				<p><a>Assistive technologies</a> MAY reserve some cells of a Braille display to render the status.</p>
@@ -8160,7 +8160,7 @@
 		<div class="property" id="aria-atomic">
 			<pdef>aria-atomic</pdef>
 			<div class="property-description">
-				<p>Indicates whether <a>assistive technologies</a> will present all, or only parts of, the changed region based on the change notifications defined by the <pref>aria-relevant</pref> attribute. See related <pref>aria-relevant</pref>.</p>
+				<p>Indicates whether <a>assistive technologies</a> will present all, or only parts of, the changed region based on the change notifications defined by the <pref>aria-relevant</pref> attribute.</p>
 				<p>Both <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a> and the <cite><a href="https://www.w3.org/TR/dom/">Document Object Model</a></cite> [[DOM4]] provide events to allow the assistive technologies to determine changed areas of the document.</p>
 				<p>When the content of a <a>live region</a> changes, user agents SHOULD examine the changed <a>element</a> and traverse the ancestors to find the first element with <pref>aria-atomic</pref> set, and apply the appropriate behavior for the cases below.</p>
 				<ol>

--- a/common/script/resolveReferences.js
+++ b/common/script/resolveReferences.js
@@ -1,4 +1,8 @@
+/* globals respecConfig, $, localRoleInfo, roleInfo, respecEvents */
+/* exported linkCrossReferences, restrictReferences, fixIncludes */
+
 function linkCrossReferences() {
+  "use strict";
 
   var specBaseURL = ( respecConfig.ariaSpecURLs ?
     respecConfig.ariaSpecURLs[respecConfig.specStatus] : null
@@ -103,6 +107,8 @@ function updateReferences(base) {
     //     2. if we have not already seen this item in this section, it is a link using 'a'
     //     3. otherwise, it is just a styled reference to the item  using 'code'
 
+    "use strict";
+
     var baseURL = respecConfig.ariaSpecURLs[respecConfig.specStatus];
 
     var sectionMap = {} ;
@@ -141,8 +147,8 @@ function updateReferences(base) {
         if (pID) {
             if (sectionMap[pID]) {
                 if (sectionMap[pID][ref]) {
-                    // only change the element if we are in a paragraph.
-                    if ($item.parents("p").length != 0) {
+                    // only change the element if we not in a table or a dl
+                    if ($item.parents("table,dl").length === 0) {
                         if (usedTitle) {
                             theElement = "span";
                         } else {
@@ -158,7 +164,7 @@ function updateReferences(base) {
             }
         }
 
-        if (theElement == "a" && $item.is('rref') ) {
+        if (theElement === "a" && $item.is('rref') ) {
             if (typeof localRoleInfo !== 'undefined' && localRoleInfo[ref]) {
                 ref = localRoleInfo[ref].fragID;
             } else if (baseURL && roleInfo[ref]) {
@@ -170,8 +176,11 @@ function updateReferences(base) {
             }
         }
         var sp = document.createElement(theElement);
-        sp.href = URL + ref;
-        sp.className = theClass;
+        if (theElement === "a") {
+            sp.href = URL + ref;
+            sp.className = theClass;
+            content = "<code>" + content + "</code>";
+        }
         sp.innerHTML=content;
         $item.replaceWith(sp);
     });
@@ -182,6 +191,7 @@ function updateReferences(base) {
 var termNames = [] ;
 
 function restrictReferences(utils, content) {
+    "use strict";
     var base = document.createElement("div");
     base.innerHTML = content;
     updateReferences(base);
@@ -204,7 +214,7 @@ function restrictReferences(utils, content) {
     // consider it an internal reference and ignore it.
 
     respecEvents.sub('end', function(message) {
-        if (message == 'core/link-to-dfn') {
+        if (message === 'core/link-to-dfn') {
             // all definitions are linked
             $("a.internalDFN").each(function () {
                 var $item = $(this) ;
@@ -243,6 +253,7 @@ function restrictReferences(utils, content) {
 // of content then call the updateReferences method above on it.  Return
 // the transformed content
 function fixIncludes(utils, content) {
+    "use strict";
     var base = document.createElement("div");
     base.innerHTML = content;
     updateReferences(base);
@@ -251,6 +262,7 @@ function fixIncludes(utils, content) {
 
 // Fix the scroll-to-fragID problem:
 (function () {
+    "use strict";
     respecEvents.sub("end-all", function () {
         if(window.location.hash) {
             window.location = window.location.hash;


### PR DESCRIPTION
This PR removes TWO See related items from aria.html - one on the status role definition and one on the aria-atomic property definition.

It also updates link handling as per the commit comment:

Previously subsequent links in paragraphs would be suppressed.  As per
issue #377 this meant that links in lists were not being handled
correctly.  In addition, links in the master indices were being
suppressed when they really should not be.

New rule is that if references to roles, states, or properties are in a
table or a dl (definition list), then they are left as links.
Otherwise, only the first reference to a role, state, or property in a
section will be a link.  Subsequent ones will be just be terms that are
not linked.

Also cleaned up some JS warnings to make the code cleaner (no effect on
execution) and wrapped the links to roles, states, and properties in
code elements so that they are visually the same as their non-linked
counterparts.It also updates the 