### PR TITLE
Addresses issue with subclass roles being dropped

### DIFF
--- a/aria/script/aria.js
+++ b/aria/script/aria.js
@@ -454,7 +454,7 @@ require(["core/pubsubhub"], function( respecEvents ) {
                         }
                         output += "</ul>\n";
                         // put it somewhere
-                        var subRolesContainer = document.querySelector("div#" + subRoles[i]);
+                        var subRolesContainer = document.querySelector("#" + subRoles[i]);
                         if (subRolesContainer) {
                             var subRolesListContainer = subRolesContainer.querySelector(".role-children");
                             if (subRolesListContainer) {

--- a/aria/script/ariaChild.js
+++ b/aria/script/ariaChild.js
@@ -291,7 +291,7 @@ require(["core/pubsubhub"], function( respecEvents ) {
                         }
                         output += "</ul>\n";
                         // put it somewhere
-                        var subRolesContainer = document.querySelector("div#" + subRoles[i]);
+                        var subRolesContainer = document.querySelector("#" + subRoles[i]);
                         if (subRolesContainer) {
                             var subRolesListContainer = subRolesContainer.querySelector(".role-children");
                             if (subRolesListContainer) {


### PR DESCRIPTION
As mentioned in issue #382, the subrole row of the role tables stopped
being populated when I wrapped the roles in section elements.

@Joanmarie if you agree please LMNK so I can merge this.