### PR TITLE
DPUB-AAM: Add AXAPI role mappings

### DIFF
--- a/dpub-aam/dpub-aam.html
+++ b/dpub-aam/dpub-aam.html
@@ -315,7 +315,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LIST_ITEM</code> and object attribute <code>xml-roles:doc-bilioentry</code>.</p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                    AXSubrole: <code>AXDocumentBibliographEntry</code><br />
+                                                                    AXSubrole: <code>AXDocumentBibliographyEntry</code><br />
                                                                     AXRoleDescription: <code>'bibliography entry'</code>
                                                                 </td>
                                                         </tr>

--- a/dpub-aam/dpub-aam.html
+++ b/dpub-aam/dpub-aam.html
@@ -210,7 +210,6 @@ var mappingTableLabels = {
                 <p class="ednote">Translators: For label text associated with the following table and its toggle buttons, see the <code>mappingTableLabels</code> object in the <code>&lt;head&gt;</code> section of this document.</p>
 				<p> This section defines how roles in digital publishing map to platform accessibility APIs based on their native host language semantics and when WAI-ARIA roles are applied. This section refers directly to the Core Accessibility API Mappings specification. </p>
                                <p class="ednote">There are a number of roles mappings that are localized. The group needs to look into localizing for non-English languages.</p>
-                               <p class="ednote">There are a number of Mac OSX subroles that need to be addressed and they are currently marked as TBD. </p>
 				<div class="table-container">
 					<table class="map-table elements" id="role-mapping-table">
 						<caption>Table describing mapping of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles to accessibility <abbr title="application programming interfaces">APIs</abbr>.</caption>
@@ -235,7 +234,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-abstract</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentAbstract</code><br />
                                                                     AXRoleDescription: <code>'abstract'</code>
                                                                 </td>
                                                         </tr>
@@ -250,8 +249,8 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-acknowledgments</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
-                                                                    AXRoleDescription: <code>'acknolwedgements'</code>
+                                                                    AXSubrole: <code>AXDocumentAcknowledgments'</code><br />
+                                                                    AXRoleDescription: <code>'acknowledgments'</code>
                                                                 </td>
                                                         </tr>
 							<tr id="role-map-afterword">
@@ -265,7 +264,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-afterword</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentAfterword'</code><br />
                                                                     AXRoleDescription: <code>'afterword'</code>
                                                                 </td>
                                                         </tr>
@@ -280,7 +279,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-appendix</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentAppendix'</code><br />
                                                                     AXRoleDescription: <code>'appendix'</code>
                                                                 </td>
                                                         </tr>
@@ -299,7 +298,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LINK</code> and object attribute <code>xml-roles:doc-backlink</code>. </p></td>
                                                                 <td>AXRole: <code>AXLink</code><br />
-                                                                        AXSubrole: <code>nil</code><br />
+                                                                    AXSubrole: <code>&lt;nil&gt;</code><br />
                                                                     AXRoleDescription: <code>'backward reference'</code>
                                                                 </td>
 
@@ -316,7 +315,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LIST_ITEM</code> and object attribute <code>xml-roles:doc-bilioentry</code>.</p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentBibliographEntry</code><br />
                                                                     AXRoleDescription: <code>'bibliography entry'</code>
                                                                 </td>
                                                         </tr>
@@ -331,7 +330,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-bibliography</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentBibliography'</code><br />
                                                                     AXRoleDescription: <code>'bibliography'</code>
                                                                 </td>
                                                         </tr>
@@ -350,7 +349,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LINK</code> and object attribute <code>xml-roles:doc-biblioref</code>. </p></td>
                                                                 <td>AXRole: <code>AXLink</code><br />
-                                                                        AXSubrole: <code>nil</code><br />
+                                                                    AXSubrole: <code>&lt;nil&gt;</code><br />
                                                                     AXRoleDescription: <code>'bibliography reference'</code>
                                                                 </td>
                                                         </tr>
@@ -365,8 +364,8 @@ var mappingTableLabels = {
 								  </ul>
 								</td>
 								<td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:chapter</code>. </p></td>
-								<td>AXRole: <code>AXGroup</code><br />d
-									AXSubrole: ? <code>TBD</code><br />
+								<td>AXRole: <code>AXGroup</code><br />
+								    AXSubrole: <code>AXDocumentChapter</code><br />
 								    AXRoleDescription: <code>'chapter'</code>
 								</td>
 							</tr>
@@ -381,7 +380,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-colophon</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentColophon'</code><br />
                                                                     AXRoleDescription: <code>'colophon'</code>
                                                                 </td>
                                                         </tr>
@@ -396,7 +395,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-conclusion</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentConclusion'</code><br />
                                                                     AXRoleDescription: <code>'conclusion'</code>
                                                                 </td>
                                                         </tr>
@@ -411,7 +410,7 @@ var mappingTableLabels = {
 									object attribute <code>xml-roles:doc-cover</code>. </p> 
 								</td>
                                                                 <td>AXRole: <code>AXImage</code><br />
-                                                                        AXSubrole: <code>&lt;nil&gt;</code><br />
+                                                                    AXSubrole: <code>&lt;nil&gt;</code><br />
                                                                     AXRoleDescription: <code>'image'</code>
                                                                 </td>
                                                         </tr>
@@ -426,7 +425,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-credit</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentCredit'</code><br />
                                                                     AXRoleDescription: <code>'credit'</code>
                                                                 </td>
                                                         </tr>
@@ -441,7 +440,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-credits</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentCredits'</code><br />
                                                                     AXRoleDescription: <code>'credits'</code>
                                                                 </td>
                                                         </tr>
@@ -456,7 +455,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-dedication</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentDedication'</code><br />
                                                                     AXRoleDescription: <code>'dedication'</code>
                                                                 </td>
                                                         </tr>
@@ -471,7 +470,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LIST_ITEM</code> and object attribute <code>xml-roles:doc-endnote</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentEndnote'</code><br />
                                                                     AXRoleDescription: <code>'endnote'</code>
                                                                 </td>
                                                         </tr>
@@ -486,7 +485,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-endnotes</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentEndnotes'</code><br />
                                                                     AXRoleDescription: <code>'endnotes'</code>
                                                                 </td>
                                                         </tr>
@@ -502,7 +501,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-epigraph</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentEpigraph'</code><br />
                                                                     AXRoleDescription: <code>'epigraph'</code>
                                                                 </td>
                                                         </tr>
@@ -517,7 +516,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-epilogue</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentEpilogue'</code><br />
                                                                     AXRoleDescription: <code>'epilogue'</code>
                                                                 </td>
                                                         </tr>
@@ -532,7 +531,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-errata</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentErrata'</code><br />
                                                                     AXRoleDescription: <code>'errata'</code>
                                                                 </td>
                                                         </tr>
@@ -547,7 +546,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-example</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentExample'</code><br />
                                                                     AXRoleDescription: <code>'example'</code>
                                                                 </td>
                                                         </tr>
@@ -562,7 +561,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_FOOTNOTE</code> and object attribute <code>xml-roles:doc-footnote</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentFootnote'</code><br />
                                                                     AXRoleDescription: <code>'footnote'</code>
                                                                 </td>
                                                         </tr>
@@ -577,7 +576,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-foreword</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentForeword'</code><br />
                                                                     AXRoleDescription: <code>'foreword'</code>
                                                                 </td>
                                                         </tr>
@@ -592,7 +591,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-glossary</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentGlossary'</code><br />
                                                                     AXRoleDescription: <code>'glossary'</code>
                                                                 </td>
                                                         </tr>
@@ -611,7 +610,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LINK</code> and object attribute <code>xml-roles:doc-glossref</code>. </p></td>
                                                                 <td>AXRole: <code>AXLink</code><br />
-                                                                        AXSubrole: <code>nil</code><br />
+                                                                    AXSubrole: <code>&lt;nil&gt;</code><br />
                                                                     AXRoleDescription: <code>'glossary reference'</code>
                                                                 </td>
 
@@ -627,7 +626,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-index</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentIndex'</code><br />
                                                                     AXRoleDescription: <code>'index'</code>
                                                                 </td>
                                                         </tr>
@@ -642,7 +641,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-introduction</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentIntroduction'</code><br />
                                                                     AXRoleDescription: <code>'introduction'</code>
                                                                 </td>
                                                         </tr>
@@ -661,7 +660,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LINK</code> and object attribute <code>xml-roles:doc-noteref</code>. </p></td>
                                                                 <td>AXRole: <code>AXLink</code><br />
-                                                                        AXSubrole: <code>nil</code><br />
+                                                                        AXSubrole: <code>&lt;nil&gt;</code><br />
                                                                     AXRoleDescription: <code>'note reference'</code>
                                                                 </td>
 
@@ -677,7 +676,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_COMMENT</code> and object attribute <code>xml-roles:doc-notice</code>.</p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentNotice'</code><br />
                                                                     AXRoleDescription: <code>'notice'</code>
                                                                 </td>
                                                         </tr>
@@ -692,7 +691,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SEPARATOR</code> and object attribute <code>xml-roles:doc-pagebreak</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentPageBreak</code><br />
                                                                     AXRoleDescription: <code>'page break'</code>
                                                                 </td>
                                                         </tr>
@@ -707,7 +706,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-pagelist</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>AXLandmarkNavigation</code><br />
+                                                                    AXSubrole: <code>AXDocumentPageList</code><br />
                                                                     AXRoleDescription: <code>'page list'</code>
                                                                 </td>
                                                         </tr>
@@ -722,7 +721,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-part</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentPart'</code><br />
                                                                     AXRoleDescription: <code>'part'</code>
                                                                 </td>
                                                         </tr>
@@ -737,7 +736,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-pagebreak</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentPreface'</code><br />
                                                                     AXRoleDescription: <code>'preface'</code>
                                                                 </td>
                                                         </tr>
@@ -752,7 +751,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-prologue</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentPrologue'</code><br />
                                                                     AXRoleDescription: <code>'prologue'</code>
                                                                 </td>
                                                         </tr>
@@ -774,7 +773,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-qna</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentQuestionsAndAnswers</code><br />
                                                                     AXRoleDescription: <code>'questions and answers'</code>
                                                                 </td>
                                                         </tr>
@@ -789,7 +788,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_HEADING</code> and object attribute <code>xml-roles:doc-subtitle</code>. </p></td>
                                                                 <td>AXRole: <code>AXHeading</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentSubtitle'</code><br />
                                                                     AXRoleDescription: <code>'subtitle'</code>
                                                                 </td>
                                                         </tr>
@@ -804,7 +803,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-tip</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>TBD</code><br />
+                                                                    AXSubrole: <code>AXDocumentTip'</code><br />
                                                                     AXRoleDescription: <code>'tip'</code>
                                                                 </td>
                                                         </tr>
@@ -819,8 +818,8 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-toc</code>.</p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>AXLandmarkNavigation</code><br />
-                                                                    AXRoleDescription: <code>'doc toc'</code>
+                                                                    AXSubrole: <code>AXDocumentTableOfContents</code><br />
+                                                                    AXRoleDescription: <code>'table of contents'</code>
                                                                 </td>
 							</tr>
 						</tbody>


### PR DESCRIPTION
* Provide missing subrole values provided by Chris Fleizach via
  the ARIA mailing list
* Modify subroles for doc-toc and doc-pagelist to not be landmarks
* Remove now-obsolete editorial note regarding missing subroles
* Fix nits:
  - 'nil' -> '<nil>' (consistency within spec and with Core AAM)
  - spelling error in doc-acknowledgments AXRoleDescription
  - extra char ('d') and inconsistent indentation of AXSubrole