### PR TITLE
Notes to html role mappings

### DIFF
--- a/html-aam/html-aam.html
+++ b/html-aam/html-aam.html
@@ -166,8 +166,22 @@
       		<li>HTML elements with default WAI-ARIA role semantics <span class="rfc2119">must</span> be mapped to platform <a class="termref" data-lt="accessibility API">accessibility APIs</a> according to those WAI-ARIA roles' mappings as defined in the <a href="http://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings</a> [[!CORE-AAM]] specification.</li>
           <li>A '?' in a cell indicates the data has yet to be provided.</li>
       		<li>"Not mapped" (Not Applicable) means the element does not need to be exposed via an <a class="termref">accessibility API</a>. This is usually because the element is not displayed as part of the user interface.</li>
-      		<li>User agents should return a user-presentable, localized string value for the Mac Accessibility AXRoleDescription.</li>
-          <li>All elements having an accessible object in IAccessible2 mapping are supposed to implement IAccessible, IAccessible2 and IAccessible2_2 interfaces.</li>
+          <li><strong>IAccessible2:</strong>
+            <ul>
+              <li>All elements with accessible objects should implement the IAccessible, IAccessible2 and IAccessible2_2 interfaces.</li>
+            </ul>
+          </li>
+          <li><strong>UIA:</strong>
+            <ul>
+              <li>When a <a href="https://www.w3.org/TR/html51/sec-forms.html#labelable-element">labelable element</a> is referenced by a <code>label</code> element's <code>for</code> attribute, or a descendant of a <code>label</code> element, the labelable element's UIA <code>LabeledBy</code> property points to the UIA element for the <code>label</code> element.</li>
+              <li>Elements mapped to the <code>Text</code> Control Type are not generally represented as <a class="termref" data-lt="accessible object">accessible objects</a> in the <a class="termref">accessibility tree</a>, but are just part of the <code>Text</code> Control Pattern implemented for the whole HTML document. However, if they have any <code>aria-</code> attributes or an explict <code>tabindex</code> specified, elements mapped to the <code>Text</code> Control Type will be represented as <a class="termref" data-lt="accessible object">accessible objects</a> in the <a class="termref">accessibility tree</a>.</li>
+            </ul>
+          </li>
+      		<li><strong>AXAPI:</strong>
+            <ul>
+              <li>User agents should return a user-presentable, localized string value for the Mac Accessibility AXRoleDescription.</li>
+            </ul>
+          </li>
       	</ul>
       	<div class="table-container">
         	<table class="map-table elements" id="element-mapping-table">

--- a/html-aam/html-aam.html
+++ b/html-aam/html-aam.html
@@ -166,6 +166,7 @@
       		<li>HTML elements with default WAI-ARIA role semantics <span class="rfc2119">must</span> be mapped to platform <a class="termref" data-lt="accessibility API">accessibility APIs</a> according to those WAI-ARIA roles' mappings as defined in the <a href="http://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings</a> [[!CORE-AAM]] specification.</li>
           <li>A '?' in a cell indicates the data has yet to be provided.</li>
       		<li>"Not mapped" (Not Applicable) means the element does not need to be exposed via an <a class="termref">accessibility API</a>. This is usually because the element is not displayed as part of the user interface.</li>
+          <li>Where applicable, how an element participates in the computation of its own or another element's <a class="termref">accessible name</a> and/or <a class="termref">accessible description</a> is described in the <a href="#accessible-name-and-description-calculation">Accessible Name and Description Calculation</a> section below.</li> 
           <li><strong>IAccessible2:</strong>
             <ul>
               <li>All elements with accessible objects should implement the IAccessible, IAccessible2 and IAccessible2_2 interfaces.</li>


### PR DESCRIPTION
Reorganised Notes preface to role mapping table, added details about UIA LabeledBy property and Text Control Pattern, and added general note about elements participating in their or another element's accessible name computation. 

Addresses issues #159, #172, and #177 