### PR TITLE
remove msaa+uiaexpress columns from html-aam

### DIFF
--- a/html-aam/html-aam.html
+++ b/html-aam/html-aam.html
@@ -191,7 +191,6 @@
         			<tr>
         				<th>Element</th>
         				<th><a href="http://www.w3.org/WAI/PF/aria/">WAI-ARIA</a></th>
-        				<th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd561898%28v=vs.85%29.aspx">UIA Express</a></th>
         				<th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
                 <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
         				<th><a href="https://developer.gnome.org/atk/stable/">ATK</a></th>
@@ -202,7 +201,6 @@
               <tr tabindex="-1" id="el-a">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-a-element"><code>a</code></a> <span class="el-context">(represents a <a href="http://www.w3.org/TR/html51/semantics.html#hyperlink">hyperlink</a>)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-link"><code>link</code></a> role </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -211,7 +209,6 @@
               <tr tabindex="-1" id="el-a-parentmenu">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-a-element"><code>a</code></a> <span class="el-context">(represents a <a href="http://www.w3.org/TR/html51/semantics.html#hyperlink">hyperlink</a> and parent is a menu)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-menuitem"><code>menuitem</code></a> role </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -220,16 +217,9 @@
               <tr tabindex="-1" id="el-a-nohref">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-a-element"><code>a</code></a> <span class="el-context">(no <a href="http://www.w3.org/TR/html51/semantics.html#attr-hyperlink-href"><code>href</code></a> attribute)</span></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_TEXT</code>
-                      </div>
-                      <div class="general">Use MSAA or UIA guidance</div>
-                    </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_TEXT_FRAME</code>
+                      <span class="type">Roles: </span><code>ROLE_SYSTEM_TEXT</code>; <code>IA2_ROLE_TEXT_FRAME</code>
                     </div>
                     <div class="ifaces">
                       <span class="type">Interfaces: </span>
@@ -266,16 +256,9 @@
               <tr tabindex="-1" id="el-abbr">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-abbr-element"><code>abbr</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_TEXT</code>
-                      </div>
-                      <div class="general">Use MSAA or UIA guidance</div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_TEXT_FRAME</code>
+                      <span class="type">Roles: </span><code>ROLE_SYSTEM_TEXT</code>; <code>IA2_ROLE_TEXT_FRAME</code>
                     </div>
                     <div class="objattrs">
                       <span class="type">Object attributes: </span>
@@ -322,16 +305,9 @@
               <tr tabindex="-1" id="el-address">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-address-element"><code>address</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_TEXT</code>
-                      </div>
-                      <div class="general">Use MSAA or UIA guidance</div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_TEXT_FRAME</code>
+                      <span class="type">Roles: </span><code>ROLE_SYSTEM_TEXT</code>; <code>IA2_ROLE_TEXT_FRAME</code>
                     </div>
                     <div class="ifaces">
                       <span class="type">Interfaces: </span>
@@ -369,7 +345,6 @@
               <tr tabindex="-1" id="el-area">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-area-element"><code>area</code></a> <span class="el-context">(represents a <a href="http://www.w3.org/TR/html51/semantics.html#hyperlink">hyperlink</a>)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-link"><code>link</code></a> role </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -378,16 +353,9 @@
               <tr tabindex="-1" id="el-area-nohref">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-area-element"><code>area</code></a> <span class="el-context">(no <a href="http://www.w3.org/TR/html51/semantics.html#attr-hyperlink-href"><code>href</code></a> attribute)</span></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_TEXT</code>
-                      </div>
-                      <div class="general">Use MSAA or UIA guidance</div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_SHAPE</code>
+                      <span class="type">Roles: </span><code>ROLE_SYSTEM_TEXT</code>; <code>IA2_ROLE_SHAPE</code>
                     </div>
                   </td>
                   <td class="uia">
@@ -408,7 +376,6 @@
               <tr tabindex="-1" id="el-article">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-article-element"><code>article</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-article"><code>article</code></a> role </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -417,7 +384,6 @@
               <tr tabindex="-1" id="el-aside">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-aside-element"><code>aside</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-complementary"><code>complementary</code></a> role </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia">
                     <div class="ctrltype"><span class="type">Control Type: </span><code>Group</code></div>
@@ -431,14 +397,6 @@
               <tr tabindex="-1" id="el-audio">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-audio-element"><code>audio</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="ctrltype">
-                          <span class="type">Control Type: </span><code>Group</code>
-                      </div>
-                      <div class="ctrltype"><span class="type">Localized Control Type:</span> <code>"audio"</code></div>
-                      <div class="general">If the <a href="https://www.w3.org/TR/html51/semantics.html#attr-media-controls"><code>controls</code></a> attribute is present, each control is a child in the UIA tree, and mapped as <a class="core-mapping" href="#role-map-button"><code>button</code></a>, <a class="core-mapping" href="#role-map-slider"><code>slider</code></a>, etc. as appropriate for the type of control.</div>
-                      <div class="general">Loading and error text objects, along with any control not currently displayed, MAY be present in the UIA and marked as hidden or off-screen.</div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
                       <span class="type">Role: </span>
@@ -475,10 +433,6 @@
               <tr tabindex="-1" id="el-b">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-b-element"><code>b</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">No accessible object. Exposed by <code>UIA_FontWeightAttributeId</code> of the <code>TextRange</code> control pattern implemented on a parent accessible object.
-                      </div>
-                    </td>
                   <td class="ia2">
                     <div class="general">No accessible object. Exposed as
                       "font-weight" text attribute on the text container.
@@ -510,9 +464,6 @@
               <tr tabindex="-1" id="el-base">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-base-element"><code>base</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">Not mapped</div>
-                  </td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -529,7 +480,6 @@
               <tr tabindex="-1" id="el-bdi">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-bdi-element"><code>bdi</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">?</td>
                   <td class="ia2">
                     <div class="general">
                       No accessible object. May affect on
@@ -548,16 +498,12 @@
               <tr tabindex="-1" id="el-bdo">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-bdo-element"><code>bdo</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_TEXT</code>
-                      </div>
-                    <div class="general">Use MSAA or UIA guidance</div>
-                  </td>
                   <td class="ia2">
-                    <div class="general">
-                      No accessible object.
-                      Exposed as "writing-mode" text attribute on its text container.
+                    <div class="role">
+                        <span class="type">Role: </span><code>ROLE_SYSTEM_TEXT</code>
+                    </div>
+                    <div class="properties">
+                          <span class="type">Text attributes: </span><code>writing-mode</code> on the text container
                     </div>
                   </td>
                   <td class="uia">
@@ -586,16 +532,9 @@
               <tr tabindex="-1" id="el-blockquote">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-blockquote-element"><code>blockquote</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code>
-                      </div>
-                      <div class="general">Use MSAA or UIA guidance</div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_SECTION</code>
+                      <span class="type">Roles: </span><code>ROLE_SYSTEM_GROUPING</code>; <code>IA2_ROLE_SECTION</code>
                     </div>
                     <div class="ifaces">
                       <span class="type">Interfaces: </span>
@@ -633,7 +572,6 @@
               <tr tabindex="-1" id="el-body">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-body-element"><code>body</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-document"><code>document</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -642,11 +580,6 @@
               <tr tabindex="-1" id="el-br">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-br-element"><code>br</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_WHITESPACE</code>
-                      </div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
                       <span class="type">Role: </span>
@@ -666,7 +599,6 @@
               <tr tabindex="-1" id="el-button">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-button-element"><code>button</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-button"><code>button</code></a> role </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -675,16 +607,9 @@
               <tr tabindex="-1" id="el-canvas">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-canvas-element"><code>canvas</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_GRAPHIC</code>
-                      </div>
-                      <div class="general">Use MSAA or UIA guidance</div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_CANVAS</code>
+                      <span class="type">Roles: </span><code>ROLE_SYSTEM_GRAPHIC</code>; <code>IA2_ROLE_CANVAS</code>
                     </div>
                   </td>
                   <td class="uia">
@@ -716,19 +641,12 @@
               <tr tabindex="-1" id="el-caption">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-caption-element"><code>caption</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_TEXT</code>
-                      </div>
-                      <div class="states">
-                          <span class="type">States: </span><code>STATE_SYSTEM_READONLY</code>
-                      </div>
-                    <div class="general">Use MSAA or UIA guidance</div>
-                    </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_CAPTION</code>
+                      <span class="type">Roles: </span><code>ROLE_SYSTEM_TEXT</code>; <code>IA2_ROLE_CAPTION</code>
+                    </div>
+                    <div class="states">
+                      <span class="type">States: </span><code>STATE_SYSTEM_READONLY</code>
                     </div>
                     <div class="relations">
                       <span class="type">Relations: </span>
@@ -776,15 +694,9 @@
               <tr tabindex="-1" id="el-cite">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-cite-element"><code>cite</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                    <div class="general">No accessible object. Styles used are exposed by UIA text attributes of the <code>TextRange</code> 
-                      Control Pattern implemented on a parent accessible object.
-                    </div>
-                  </td>
                   <td class="ia2">
                     <div class="general">
-                      No accessible object. Styles used are
-                      mapped into text attributes on its text container.
+                      No accessible object. Styles used are mapped into text attributes on its text container.
                     </div>
                   </td>
                   <td class="uia">
@@ -813,15 +725,9 @@
               <tr tabindex="-1" id="el-code">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-code-element"><code>code</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">No accessible object. Styles used are exposed by UIA text attributes of the <code>TextRange</code> 
-                      Control Pattern implemented on a parent accessible object.
-                    </div>
-                  </td>
                   <td class="ia2">
                     <div class="general">
-                      No accessible object. Styles used are
-                      mapped into text attributes on its text container.
+                      No accessible object. Styles used are mapped into text attributes on its text container.
                     </div>
                   </td>
                   <td class="uia">
@@ -850,9 +756,6 @@
               <tr tabindex="-1" id="el-col">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-col-element"><code>col</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">Not mapped</div>
-                  </td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -869,14 +772,10 @@
               <tr tabindex="-1" id="el-colgroup">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-colgroup-element"><code>colgroup</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code>
-                      </div>
-                      <div class="general">TODO:&#160; look in more detail at UIA table implemenation</div>
-                  </td>
                   <td class="ia2">
-                    <div class="general">Not mapped</div>
+                    <div class="role">
+                      <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code>
+                    </div>
                   </td>
                   <td class="uia">
                       <div class="general">
@@ -893,7 +792,6 @@
               <tr tabindex="-1" id="el-command-checkbox">
                   <th>Command: <span class="el-context">an element that <a href="http://www.w3.org/TR/html51/semantics.html#commands">defines a command</a>, whose <a href="http://www.w3.org/TR/html51/semantics.html#command-facet-type">Type</a> facet is "checkbox", and that is a descendant of a <a href="http://www.w3.org/TR/html51/semantics.html#the-menu-element"><code>menu</code></a> element whose <a href="http://www.w3.org/TR/html51/semantics.html#attr-menu-type"><code>type</code></a> attribute is in the <a href="http://www.w3.org/TR/html51/semantics.html#toolbar-state">toolbar</a> state</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-menuitemcheckbox"><code>menuitemcheckbox</code></a> role, with the <a class="core-mapping" href="#ariaCheckedTrue"><code>aria-checked</code></a> state set to "true" if the command's <a href="http://www.w3.org/TR/html51/semantics.html#command-facet-checkedstate">Checked State</a> facet is true, and "false" otherwise </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -902,7 +800,6 @@
               <tr tabindex="-1" id="el-command-command">
                   <th>Command: <span class="el-context">an element that <a href="http://www.w3.org/TR/html51/semantics.html#commands">defines a command</a>, whose <a href="http://www.w3.org/TR/html51/semantics.html#command-facet-type">Type</a> facet is "command", and that is a descendant of a <a href="http://www.w3.org/TR/html51/semantics.html#the-menu-element"><code>menu</code></a> element whose <a href="http://www.w3.org/TR/html51/semantics.html#attr-menu-type"><code>type</code></a> attribute is in the <a href="http://www.w3.org/TR/html51/semantics.html#toolbar-state">toolbar</a> state</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-menuitem"><code>menuitem</code></a> role </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -911,7 +808,6 @@
               <tr tabindex="-1" id="el-command-radio">
                   <th>Command: <span class="el-context">an element that <a href="http://www.w3.org/TR/html51/semantics.html#commands">defines a command</a>, whose <a href="http://www.w3.org/TR/html51/semantics.html#command-facet-type">Type</a> facet is "radio", and that is a descendant of a <a href="http://www.w3.org/TR/html51/semantics.html#the-menu-element"><code>menu</code></a> element whose <a href="http://www.w3.org/TR/html51/semantics.html#attr-menu-type"><code>type</code></a> attribute is in the <a href="http://www.w3.org/TR/html51/semantics.html#toolbar-state">toolbar</a> state</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-menuitemradio"><code>menuitemradio</code></a> role, with the <a class="core-mapping" href="#ariaCheckedTrue"><code>aria-checked</code></a> state set to "true" if the command's <a href="http://www.w3.org/TR/html51/semantics.html#command-facet-checkedstate">Checked State</a> facet is true, and "false" otherwise </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -920,9 +816,6 @@
               <tr tabindex="-1" id="el-data">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-data-element"><code>data</code></a></th>
                   <td class="aria"></td>
-                  <td class="uia-express">
-                      <div class="general">Not mapped</div>
-                  </td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -939,7 +832,6 @@
               <tr tabindex="-1" id="el-datalist">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-datalist-element"><code>datalist</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-listbox"><code>listbox</code></a> role, with the <a class="core-mapping" href="#ariaMultiselectableFalse"><code>aria-multiselectable</code></a> property set to "false" </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -948,7 +840,6 @@
               <tr tabindex="-1" id="el-dd">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-dd-element"><code>dd</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-definition"><code>definition</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -957,11 +848,6 @@
               <tr tabindex="-1" id="el-del">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-del-element"><code>del</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">No accessible object. Styles used are exposed by UIA text attributes of the <code>TextRange</code> 
-                      Control Pattern implemented on a parent accessible object.
-                    </div>
-                  </td>
                   <td class="ia2">
                     <div class="general">
                       No accessible object. Styles used are mapped
@@ -993,16 +879,10 @@
               </tr>
               <tr tabindex="-1" id="el-details">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-details-element"><code>details</code></a></th>
-                  <td class="aria">None<br /></td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code>
-                      </div>
-                  </td>
+                  <td class="aria">None</td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>ROLE_SYSTEM_GROUPING</code>
+                      <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code>
                     </div>
                   </td>
                   <td class="uia">
@@ -1029,15 +909,9 @@
               <tr tabindex="-1" id="el-dfn">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-dfn-element"><code>dfn</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">No accessible object. Styles used are exposed by UIA text attributes of the <code>TextRange</code> 
-                      Control Pattern implemented on a parent accessible object.
-                    </div>
-                  </td>
                   <td class="ia2">
                     <div class="general">
-                      No accessible object. Styles used are
-                      exposed by text attributes on its text container.
+                      No accessible object. Styles used are exposed by text attributes on its text container.
                     </div>
                   </td>
                   <td class="uia">
@@ -1068,7 +942,6 @@
               <tr tabindex="-1" id="el-dialog">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-dialog-element"><code>dialog</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-dialog"><code>dialog</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -1077,20 +950,14 @@
              <tr tabindex="-1" id="el-div">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-div-element"><code>div</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code>
-                      </div>
-                  </td>
                   <td class="ia2">
                     <div class="general">
-                      May not have an accessible object if has no semantic meaning. Otherwise
+                      May not have an accessible object if has no semantic meaning. Otherwise,
                     </div>
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_SECTION</code>
-                     </div>
-                     <div class="ifaces">
+                      <span class="type">Roles: </span><code>ROLE_SYSTEM_GROUPING</code>; <code>IA2_ROLE_SECTION</code>
+                    </div>
+                    <div class="ifaces">
                       <span class="type">Interfaces: </span>
                       <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>;
                     </div>
@@ -1107,8 +974,7 @@
                       <code>ATK_ROLE_SECTION</code>
                      </div>
                      <div class="ifaces">
-                      <span class="type">Interfaces: </span>
-                      <code>AtkText</code>; <code>AtkHypertext</code>
+                      <span class="type">Interfaces: </span><code>AtkText</code>; <code>AtkHypertext</code>
                     </div>
                   </td>
                   <td class="ax">
@@ -1126,23 +992,12 @@
               <tr tabindex="-1" id="el-dl">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-dl-element"><code>dl</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_LIST</code>
-                      </div>
-                      <div class="states">
-                          <span class="type">States: </span><code>STATE_SYSTEM_READONLY</code>
-                      </div>
-                      <div class="general">Use MSAA or UIA guidance</div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>ROLE_SYSTEM_LIST</code>
+                      <span class="type">Role: </span><code>ROLE_SYSTEM_LIST</code>
                     </div>
                     <div class="states">
-                      <span class="type">States: </span>
-                      <code>STATE_SYSTEM_READONLY</code>
+                      <span class="type">States: </span><code>STATE_SYSTEM_READONLY</code>
                     </div>
                   </td>
                   <td class="uia">
@@ -1171,26 +1026,15 @@
               <tr tabindex="-1" id="el-dt">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-dt-element"><code>dt</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_LISTITEM</code>
-                      </div>
-                      <div class="states">
-                          <span class="type">States: </span><code>STATE_SYSTEM_READONLY</code>
-                      </div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>ROLE_SYSTEM_LISTITEM</code>
+                      <span class="type">Role: </span><code>ROLE_SYSTEM_LISTITEM</code>
                     </div>
                     <div class="states">
-                      <span class="type">States: </span>
-                      <code>STATE_SYSTEM_READONLY</code>
+                      <span class="type">States: </span><code>STATE_SYSTEM_READONLY</code>
                     </div>
                     <div class="ifaces">
-                      <span class="type">Interfaces: </span>
-                      <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>;
+                      <span class="type">Interfaces: </span><code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>;
                     </div>
                   </td>
                   <td class="uia">
@@ -1223,15 +1067,9 @@
               <tr tabindex="-1" id="el-em">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-em-element"><code>em</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">No accessible object. Styles used are exposed by UIA text attributes of the <code>TextRange</code> 
-                      Control Pattern implemented on a parent accessible object.
-                    </div>
-                  </td>
                   <td class="ia2">
                     <div class="general">
-                      No accessible object. Styles used are mapped
-                      into text attributes on its text container
+                      No accessible object. Styles used are mapped into text attributes on its text container.
                     </div>
                   </td>
                   <td class="uia">
@@ -1259,19 +1097,12 @@
               <tr tabindex="-1" id="el-embed">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-embed-element"><code>embed</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_CLIENT</code>
-                      </div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_EMBEDDED_OBJECT</code>
+                      <span class="type">Roles: </span><code>ROLE_SYSTEM_CLIENT</code>; <code>IA2_ROLE_EMBEDDED_OBJECT</code>
                     </div>
                     <div class="states">
-                      <span class="type">States:</span>
-                        <code>STATE_SYSTEM_UNAVAILABLE</code> for windowless plugin
+                      <span class="type">States: </span><code>STATE_SYSTEM_UNAVAILABLE</code> for windowless plugin
                     </div>
                   </td>
                   <td class="uia">
@@ -1290,20 +1121,12 @@
               <tr tabindex="-1" id="el-fieldset">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-fieldset-element"><code>fieldset</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code>
-                      </div>
-                      <div class="general">Use MSAA or UIA guidance</div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>ROLE_SYSTEM_GROUPING</code>
+                      <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code>
                     </div>
                     <div class="relations">
-                      <span class="type">Relations:</span>
-                      <code>IA2_RELATION_LABELLED_BY</code> with child <a href="#el-legend"><code>legend</code></a> element
+                      <span class="type">Relations:</span><code>IA2_RELATION_LABELLED_BY</code> with child <a href="#el-legend"><code>legend</code></a> element
                     </div>
                   </td>
                   <td class="uia">
@@ -1337,20 +1160,12 @@
               <tr tabindex="-1" id="el-figcaption">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-figcaption-element"><code>figcaption</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_TEXT</code>
-                      </div>
-                      <div class="general">Use MSAA or UIA guidance</div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_CAPTION</code>
+                      <span class="type">Roles: </span><code>ROLE_SYSTEM_TEXT</code>; <code>IA2_ROLE_CAPTION</code>
                     </div>
                     <div class="relations">
-                      <span class="type">Relations: </span>
-                      <code>IA2_RELATION_LABEL_FOR</code> with parent <a href="#el-figure"><code>figure</code></a> element
+                      <span class="type">Relations: </span><code>IA2_RELATION_LABEL_FOR</code> with parent <a href="#el-figure"><code>figure</code></a> element
                     </div>
                     <div class="ifaces">
                       <span class="type">Interfaces: </span>
@@ -1391,27 +1206,15 @@
               <tr tabindex="-1" id="el-figure">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-figure-element"><code>figure</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code>
-                      </div>
-                      <div class="general">Use MSAA or UIA guidance</div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
                       <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code>
                     </div>
                     <div class="objattrs">
-                      <span class="type">Object attributes: </span>
-                      <code>xml-roles:figure</code>
-                    </div>
-                    <div class="name">
-                      <span class="type">Name: </span>
-                      related <a href="#el-figcaption"><code>figcaption</code></a> content
+                      <span class="type">Object attributes: </span><code>xml-roles:figure</code>
                     </div>
                     <div class="relations">
-                      <span class="type">Relations: </span>
-                      <code>IA2_RELATION_LABELLED_BY</code> with child <a href="#el-figcaption"><code>figcaption</code></a> element
+                      <span class="type">Relations: </span><code>IA2_RELATION_LABELLED_BY</code> with child <a href="#el-figcaption"><code>figcaption</code></a> element
                     </div>
                   </td>
                   <td class="uia">
@@ -1448,15 +1251,9 @@
               <tr tabindex="-1" id="el-footer">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-footer-element"><code>footer</code></a> (nearest ancestor <a href="http://www.w3.org/TR/html51/dom.html#sectioning-content-2">sectioning content</a> or <a href="http://www.w3.org/TR/html51/semantics.html#sectioning-root">sectioning root</a> element is <em>not</em> <a href="http://www.w3.org/TR/html51/dom.html#the-body-element-2"><code>body</code></a>, or parent is <a href="https://www.w3.org/TR/html51/semantics.html#the-main-element"><code>main</code></a>)</th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code>
-                      </div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_SECTION</code>
+                      <span class="type">Roles: </span><code>ROLE_SYSTEM_GROUPING</code>; <code>IA2_ROLE_SECTION</code>
                     </div>
                     <div class="ifaces">
                       <span class="type">Interfaces: </span>
@@ -1494,24 +1291,15 @@
               <tr tabindex="-1" id="el-footer-ancestorbody">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-footer-element"><code>footer</code></a> (nearest ancestor <a href="http://www.w3.org/TR/html51/dom.html#sectioning-content-2">sectioning content</a> or <a href="http://www.w3.org/TR/html51/semantics.html#sectioning-root">sectioning root</a> element is <a href="http://www.w3.org/TR/html51/dom.html#the-body-element-2"><code>body</code></a>)</th>
                   <td class="aria"><a class="core-mapping" href="#role-map-contentinfo"><code>contentinfo</code></a> role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code>
-                      </div>
-                      <div class="general">Expose "contentinfo" as text string in <code>AriaRole</code></div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_FOOTER</code>
+                      <span class="type">Roles: </span><code>ROLE_SYSTEM_GROUPING</code>; <code>IA2_ROLE_FOOTER</code>
                     </div>
                     <div class="objattrs">
-                      <span class="type">Object attributes: </span>
-                      <code>xml-roles:contentinfo</code>
+                      <span class="type">Object attributes: </span><code>xml-roles:contentinfo</code>
                     </div>
                     <div class="ifaces">
-                      <span class="type">Interfaces: </span>
-                      <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>;
+                      <span class="type">Interfaces: </span><code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>;
                     </div>
                   </td>
                   <td class="uia">
@@ -1556,7 +1344,6 @@
               <tr tabindex="-1" id="el-form">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-form-element"><code>form</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-form "><code>form </code></a>role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -1565,7 +1352,6 @@
               <tr tabindex="-1" id="el-h1-h6">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements"><code>h1</code></a>, <a href="http://www.w3.org/TR/html51/semantics.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements"><code>h2</code></a>, <a href="http://www.w3.org/TR/html51/semantics.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements"><code>h3</code></a>, <a href="http://www.w3.org/TR/html51/semantics.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements"><code>h4</code></a>, <a href="http://www.w3.org/TR/html51/semantics.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements"><code>h5</code></a>, <a href="http://www.w3.org/TR/html51/semantics.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements"><code>h6</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-heading"><code>heading</code></a> role, with the <a class="core-mapping" href="#ariaLevel"><code>aria-level</code></a> property set to the element's <a href="http://www.w3.org/TR/html51/semantics.html#outline-depth">outline depth</a></td>
-<td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -1574,9 +1360,6 @@
               <tr tabindex="-1" id="el-head">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-head-element"><code>head</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">Not mapped</div>
-                  </td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -1593,19 +1376,12 @@
               <tr tabindex="-1" id="el-header">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-header-element"><code>header</code></a> (nearest ancestor <a href="http://www.w3.org/TR/html51/dom.html#sectioning-content-2">sectioning content</a> or <a href="http://www.w3.org/TR/html51/semantics.html#sectioning-root">sectioning root</a>  element is <em>not</em> <a href="http://www.w3.org/TR/html51/dom.html#the-body-element-2"><code>body</code></a>, or parent is <a href="https://www.w3.org/TR/html51/semantics.html#the-main-element"><code>main</code></a>)</th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code>
-                      </div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_SECTION</code>
+                      <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code>; <code>IA2_ROLE_SECTION</code>
                     </div>
                     <div class="ifaces">
-                      <span class="type">Interfaces: </span>
-                      <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>;
+                      <span class="type">Interfaces: </span><code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>;
                     </div>
                   </td>
                   <td class="uia">
@@ -1641,31 +1417,15 @@
               <tr tabindex="-1" id="el-header-ancestorbody">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-header-element"><code>header</code></a> (nearest ancestor <a href="http://www.w3.org/TR/html51/dom.html#sectioning-content-2">sectioning content</a> or <a href="http://www.w3.org/TR/html51/semantics.html#sectioning-root">sectioning root</a> element is <a href="http://www.w3.org/TR/html51/dom.html#the-body-element-2"><code>body</code></a>)</th>
                   <td class="aria"><a class="core-mapping" href="#role-map-banner"><code>banner</code></a> role</td>
-                  <td class="uia-express">
-                      <div class="ctrltype">
-                          <span class="type">Control Type: </span><code>Group</code>
-                      </div>
-                      <div class="properties">
-                          <span class="type">Localized Control Type: </span><code>"header"</code>
-                      </div>
-                      <div class="properties">
-                          <span class="type">Landmark Type: </span><code>Custom</code>
-                      </div>
-                      <div class="properties">
-                          <span class="type">Localized Landmark Type: </span><code>"banner"</code>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_HEADER</code>
+                      <span class="type">Role: </span><code>IA2_ROLE_HEADER</code>
                     </div>
                     <div class="objattrs">
-                      <span class="type">Object attributes: </span>
-                      <code>xml-roles:banner</code>
+                      <span class="type">Object attributes: </span><code>xml-roles:banner</code>
                     </div>
                     <div class="ifaces">
-                      <span class="type">Interfaces: </span>
-                      <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>;
+                      <span class="type">Interfaces: </span><code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>;
                     </div>
                   </td>
                   <td class="uia">
@@ -1712,7 +1472,6 @@
               <tr tabindex="-1" id="el-hr">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-hr-element"><code>hr</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-separator"><code>separator</code></a> role </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -1721,9 +1480,6 @@
               <tr tabindex="-1" id="el-html">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-html-element"><code>html</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">Not mapped</div>
-                  </td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -1740,13 +1496,10 @@
               <tr tabindex="-1" id="el-i">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-i-element"><code>i</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                    <div class="general">No accessible object. Exposed by the <code>IsItalic</code> attribute of the <code>TextRange</code> Control Pattern implemented on a parent accessible object.
-                      </div>
-                  </td>
                   <td class="ia2">
-                    <div class="general">No accessible object. Exposed as
-                      "font-style:italic" text attribute on its text container.
+                    <div class="general">No accessible object.</div>
+                    <div class="properties">
+                      <span class="type">Text attributes: </span><code>font-style:italic</code> on the text container
                     </div>
                   </td>
                   <td class="uia">
@@ -1773,22 +1526,13 @@
               <tr tabindex="-1" id="el-iframe">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-iframe-element"><code>iframe</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_DOCUMENT</code> ??pane??
-                      </div>
-                      <div class="states">
-                          <span class="type">States: </span><code>STATE_SYSTEM_READONLY</code>
-                      </div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_INTERNAL_FRAME</code>
+                      <span class="type">Role: </span><code>IA2_ROLE_INTERNAL_FRAME</code>
                     </div>
                     <div class="children">
                       <span class="type">Child: </span>
-                      <code>ROLE_SYSTEM_DOCUMENT</code> having <code>STATE_SYSTEM_READONLY</code>
+                      <code>ROLE_SYSTEM_DOCUMENT</code> with <code>STATE_SYSTEM_READONLY</code>
                     </div>
                   </td>
                   <td class="uia">
@@ -1821,7 +1565,6 @@
               <tr tabindex="-1" id="el-img">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-img-element"><code>img</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-img"><code>img</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -1833,7 +1576,6 @@
                     <div class="role"><a class="core-mapping" href="#role-map-presentation"><code>presentation</code></a></div>
                     <div class="general">See also the Note under <a href="#img-element-accessible-name-calculation"><code>img</code> element Accessible Name Calculation</a>.</div>
                   </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -1842,7 +1584,6 @@
               <tr tabindex="-1" id="el-input-button">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#button-state-(type=button)">Button</a> state)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-button"><code>button</code></a> role </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -1851,7 +1592,6 @@
               <tr tabindex="-1" id="el-input-button-parentmenu">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#button-state-(type=button)">Button</a> state and parent is a menu)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-menuitem"><code>menuitem</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -1860,16 +1600,9 @@
               <tr tabindex="-1" id="el-input-color">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#color-state-(type=color)">Color</a> state)</span></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span>If implemented as a textbox, <code>ROLE_SYSTEM_TEXT</code>
-                      </div>
-                      <div class="general">Use UIA guidance</div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_COLOR_CHOOSER</code>
+                      <span class="type">Roles: </span><code>ROLE_SYSTEM_TEXT</code> if implemented as a textbox; <code>IA2_ROLE_COLOR_CHOOSER</code> if implemented as a color picker
                     </div>
                   </td>
                   <td class="uia">
@@ -1912,7 +1645,6 @@
               <tr tabindex="-1" id="el-input-checkbox">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#checkbox-state-(type=checkbox)">Checkbox</a> state)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-checkbox"><code>checkbox</code></a> role, with the <a class="core-mapping" href="#ariaCheckedMixed"><code>aria-checked</code></a> state set to "mixed" if the element's <a href="http://www.w3.org/TR/html51/semantics.html#dom-input-indeterminate"><code>indeterminate</code></a> IDL attribute is true, or "true" if the element's <a href="http://www.w3.org/TR/html51/semantics.html#concept-fe-checked">checkedness</a> is true, or "false" otherwise </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -1921,7 +1653,6 @@
               <tr tabindex="-1" id="el-input-checkbox-parentmenu">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#checkbox-state-(type=checkbox)">Checkbox</a> state and parent is a menu)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-menuitemcheckbox"><code>menuitemcheckbox</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -1930,15 +1661,9 @@
               <tr tabindex="-1" id="el-input-date">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#date-state-(type=date)">Date</a> state)</span></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">
-                          Depends on UI design of implementation. The UI in Windows 10 Edge, for Example, is a composit of multiple spinners.
-                      </div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_DATE_EDITOR</code>
+                      <span class="type">Role: </span><code>IA2_ROLE_DATE_EDITOR</code>
                     </div>
                   </td>
                   <td class="uia">
@@ -1967,15 +1692,9 @@
               <tr tabindex="-1" id="el-input-dateandtime">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#date-and-time-state-(type=datetime)">Date and Time</a> state)</span></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">
-                          Depends on UI design of implementation. The UI in Windows 10 Edge, for Example, is a composit of multiple spinners.
-                      </div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_DATE_EDITOR</code>
+                      <span class="type">Role: </span><code>IA2_ROLE_DATE_EDITOR</code>
                     </div>
                   </td>
                   <td class="uia">
@@ -2004,8 +1723,8 @@
               <tr tabindex="-1" id="el-input-email">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#e-mail-state-(type=email)">E-mail</a> state with no <a href="http://www.w3.org/TR/html51/semantics.html#concept-input-list">suggestions source element</a>)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-textbox"><code>textbox</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
-                  <td class="ia2"><div class="general">Use WAI-ARIA mapping</div> +
+                  <td class="ia2">
+                    <div class="general">Use WAI-ARIA mapping</div>
                     <div class="objattrs"> <span class="type">Object attributes: </span> <code>text-input-type:email</code> </div>
                   </td>
                   <td class="uia">
@@ -2022,19 +1741,12 @@
               <tr tabindex="-1" id="el-input-file">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#file-upload-state-(type=file)">File Upload</a> state)</span></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_PUSHBUTTON</code>
-                      </div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_TEXT_FRAME</code>
+                      <span class="type">Roles: </span><code>ROLE_SYSTEM_PUSHBUTTON</code>; <code>IA2_ROLE_TEXT_FRAME</code>
                     </div>
                     <div class="children">
-                      <span class="type">Children: </span>
-                      A button and label (implementation specific)
+                      <span class="type">Children: </span>A button and label (implementation specific)
                     </div>
                   </td>
                   <td class="uia">
@@ -2074,24 +1786,22 @@
               <tr tabindex="-1" id="el-input-hidden">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#hidden-state-(type=hidden)">Hidden</a> state)</span></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">Do not expose this object</div>
-                      </td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
                   <td class="uia">
-                      <div class="general">Do not expose this object</div>
+                      <div class="general">Not mapped</div>
                   </td>
                   <td class="atk">
                     <div class="general">Not mapped</div>
                   </td>
-                  <td>Do not expose this object</td>
+                  <td class="ax">
+                    <div class="general">Not mapped</div>
+                  </td>
               </tr>
               <tr tabindex="-1" id="el-input-image">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#image-button-state-(type=image)">Image Button</a> state)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-button"><code>button</code></a> role </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2100,7 +1810,6 @@
               <tr tabindex="-1" id="el-input-image-parentmenu">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#image-button-state-(type=image)">Image Button</a> state and parent is a menu)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-menuitem"><code>menuitem</code></a> role </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2109,15 +1818,9 @@
               <tr tabindex="-1" id="el-input-localdateandtime">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="https://www.w3.org/TR/html51/sec-forms.html#local-date-and-time-state-typedatetimelocal">Local Date and Time</a> state)</span></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">
-                          Depends on UI design of implementation. The UI in Windows 10 Edge, for Example, is a composit of multiple spinners.
-                      </div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_DATE_EDITOR</code>
+                      <span class="type">Role: </span><code>IA2_ROLE_DATE_EDITOR</code>
                     </div>
                   </td>
                   <td class="uia">
@@ -2146,15 +1849,9 @@
               <tr tabindex="-1" id="el-input-input-month">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#month-state-(type=month)">Month</a> state)</span></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">
-                          Depends on UI design of implementation. The UI in Windows 10 Edge, for Example, is a composit of multiple spinners.
-                      </div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_DATE_EDITOR</code>
+                      <span class="type">Role: </span><code>IA2_ROLE_DATE_EDITOR</code>
                     </div>
                   </td>
                   <td class="uia">
@@ -2183,7 +1880,6 @@
               <tr tabindex="-1" id="el-input-number">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#number-state-(type=number)">Number</a> state)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-spinbutton"><code>spinbutton</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia">
                       <div class="general">If implemented as a spin control, use WAI-ARIA mapping.</div>
@@ -2201,11 +1897,6 @@
               <tr tabindex="-1" id="el-input-password">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#password-state-(type=password)">Password</a> state)</span></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                    <div class="role"><span class="type">Role: </span><code>ROLE_SYSTEM_TEXT</code></div>
-                    <div class="states"><span class="type">States:</span><code>STATE_SYSTEM_PROTECTED</code></div>
-                    <div class="general">Use UIA guidance</div>
-                  </td>
                   <td class="ia2">
                     <div class="role"><span class="type">Role: </span><code>ROLE_SYSTEM_TEXT</code>
                     <div class="states"><span class="type">States: </span><code>STATE_SYSTEM_PROTECTED</code>; <code>IA2_STATE_SINGLE_LINE</code>; <code>STATE_SYSTEM_READONLY</code> if readonly, otherwise <code>IA2_STATE_EDITABLE</code></div>
@@ -2235,7 +1926,6 @@
               <tr tabindex="-1" id="el-input-radio">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#radio-button-state-(type=radio)">Radio Button</a> state)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-radio"><code>radio</code></a> role, with the <a class="core-mapping" href="#ariaCheckedTrue"><code>aria-checked</code></a> state set to "true" if the element's <a href="http://www.w3.org/TR/html51/semantics.html#concept-fe-checked">checkedness</a> is true, or "false" otherwise. With <a href="http://www.w3.org/TR/core-aam-1.1/#ariaSetsize"><code>aria-setsize</code></a> value reflecting number of <code>type=radio input</code> elements within the <a href="http://www.w3.org/TR/html51/semantics.html#radio-button-group">radio button group</a>  and <a href="http://www.w3.org/TR/core-aam-1.1/#ariaPosinset"><code>aria-posinset</code></a> value reflecting the<code> </code>elements position within the <a href="http://www.w3.org/TR/html51/semantics.html#radio-button-group">radio button group</a>. </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2244,7 +1934,6 @@
               <tr tabindex="-1" id="el-input-radio-menuparent">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#radio-button-state-(type=radio)">Radio Button</a> state and parent is a menu)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-menuitemradio"><code>menuitemradio</code></a> role, with the <a class="core-mapping" href="#ariaCheckedTrue"><code>aria-checked</code></a> state set to "true" if the element's <a href="http://www.w3.org/TR/html51/semantics.html#concept-fe-checked">checkedness</a> is true, or "false" otherwise</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2253,7 +1942,6 @@
               <tr tabindex="-1" id="el-input-range">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#range-state-(type=range)">Range</a> state)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-slider"><code>slider</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2262,7 +1950,6 @@
               <tr tabindex="-1" id="el-input-reset">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#reset-button-state-(type=reset)">Reset Button</a> state)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-button"><code>button</code></a> role </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2271,7 +1958,6 @@
               <tr tabindex="-1" id="el-input-search">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#text-(type=text)-state-and-search-state-(type=search)">Search</a> state with no <a href="http://www.w3.org/TR/html51/semantics.html#concept-input-list" title="concept-input-list">suggestions source element</a>)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-searchbox"><code>searchbox</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2280,7 +1966,6 @@
               <tr tabindex="-1" id="el-input_submit">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#submit-button-state-(type=submit)">Submit Button</a> state)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-button"><code>button</code></a> role </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2289,7 +1974,6 @@
               <tr tabindex="-1" id="el-input-tel">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#telephone-state-(type=tel)">Telephone</a> state with no <a href="http://www.w3.org/TR/html51/semantics.html#concept-input-list">suggestions source element</a>)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-textbox"><code>textbox</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div>
                   <p>+ </p>
                   <div class="objattrs"> <span class="type">Object attributes: </span> <code>text-input-type:telephone</code></div></td>
@@ -2306,7 +1990,6 @@
               <tr tabindex="-1" id="el-input-text">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#text-(type=text)-state-and-search-state-(type=search)">Text</a> state with no <a href="http://www.w3.org/TR/html51/semantics.html#concept-input-list">suggestions source element</a>)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-textbox"><code>textbox</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2315,7 +1998,6 @@
               <tr tabindex="-1" id="el-input-textetc-autocomplete">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#text-(type=text)-state-and-search-state-(type=search)">Text</a>, <a href="http://www.w3.org/TR/html51/semantics.html#text-(type=text)-state-and-search-state-(type=search)">Search</a>, <a href="http://www.w3.org/TR/html51/semantics.html#telephone-state-(type=tel)">Telephone</a>, <a href="http://www.w3.org/TR/html51/semantics.html#url-state-(type=url)">URL</a>, or <a href="http://www.w3.org/TR/html51/semantics.html#e-mail-state-(type=email)">E-mail</a> states with a <a href="http://www.w3.org/TR/html51/semantics.html#concept-input-list">suggestions source element</a>)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-combobox"><code>combobox</code></a> role, with the <a class="core-mapping" href="#ariaOwns"><code>aria-owns</code></a> property set to the same value as the <a href="http://www.w3.org/TR/html51/semantics.html#attr-input-list"><code>list</code></a> attribute</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div>
                   <p>+ </p>
                   <div class="objattrs"> <span class="type">Object attributes: </span> <code>text-input-type:<em>as per input type</em></code></div></td>
@@ -2331,23 +2013,13 @@
               <tr tabindex="-1" id="el-input-time">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#time-state-(type=time)">Time</a> state)</span></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <p><span class="type">Role: </span><code>ROLE_SYSTEM_SPINBUTTON</code>
-                      if implemented as a simple <a>widget</a>. 
-                      <br />If implemented as a complex <a>widget</a> use: <br />
-                      <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code> and map child controls as appropriate</p>
-                      </div>
-                  </td>
                   <td class="ia2">
-                     <div class="role">
-                          <p><span class="type">Role: </span><code>ROLE_SYSTEM_SPINBUTTON</code>
-                      if implemented as a simple <a>widget</a>. <br />If implemented as a complex <a>widget</a> use: <br />
-                      <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code> and map child controls as appropriate                      </p>
-                      
-                     </div>
-                     <p>+ </p>
-                     <div class="objattrs"> <span class="type">Object attributes: </span> <code>text-input-type:time</code></div>
+                    <div class="role">
+                      <span class="type">Role: </span><code>ROLE_SYSTEM_SPINBUTTON</code> if implemented as a simple <a>widget</a>; <code>ROLE_SYSTEM_GROUPING</code> with child controls mapped as appropriate if implemented as a complex <a>widget</a>
+                    </div>
+                     <div class="objattrs">
+                      <span class="type">Object attributes: </span><code>text-input-type:time</code>
+                    </div>
                   </td>
                   <td class="uia">
                       <div class="general">
@@ -2376,10 +2048,12 @@
               <tr tabindex="-1" id="el-input-url">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#url-state-(type=url)">URL</a> state with no <a href="http://www.w3.org/TR/html51/semantics.html#concept-input-list" title="concept-input-list">suggestions source element</a>)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-textbox"><code>textbox</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
-                  <td class="ia2"><div class="general">Use WAI-ARIA mapping</div>
-                  <p>+ </p>
-                  <div class="objattrs"> <span class="type">Object attributes: </span> <code>text-input-type:url</code></div></td>
+                  <td class="ia2">
+                    <div class="general">Use WAI-ARIA mapping</div>
+                    <div class="objattrs">
+                      <span class="type">Object attributes: </span><code>text-input-type:url</code>
+                    </div>
+                  </td>
                   <td class="uia">
                       <div class="ctrltype">
                           <span class="type">Control Type:</span> <code>Edit</code>
@@ -2394,18 +2068,13 @@
               <tr tabindex="-1" id="el-input-week">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#week-state-(type=week)">Week</a> state)</span></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">
-                          Depends on UI design of implementation. The UI in Windows 10 Edge, for Example, is a composit of multiple spinners.
-                      </div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_DATE_EDITOR</code>
+                      <span class="type">Role: </span><code>IA2_ROLE_DATE_EDITOR</code>
                     </div>
-                    <p>+ </p>
-                    <div class="objattrs"> <span class="type">Object attributes: </span> <code>text-input-type:week</code></div>
+                    <div class="objattrs">
+                      <span class="type">Object attributes: </span><code>text-input-type:week</code>
+                    </div>
                   </td>
                   <td class="uia">
                       <div class="general">
@@ -2433,14 +2102,9 @@
               <tr tabindex="-1" id="el-ins">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-ins-element"><code>ins</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                    <div class="general">No accessible object. Styles used are exposed by UIA text attributes of the <code>TextRange</code> Control Pattern implemented on a parent accessible object.
-                      </div>
-                  </td>
                   <td class="ia2">
                     <div class="general">
-                      No accessible object. Styles used are mapped
-                      into text attributes on its text container.
+                      No accessible object. Styles used are mapped into text attributes on its text container.
                     </div>
                   </td>
                   <td class="uia">
@@ -2468,15 +2132,10 @@
               <tr tabindex="-1" id="el-kbd">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-kbd-element"><code>kbd</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                    <div class="general">No accessible object. Styles used are exposed by UIA text attribute identifiers of the <code>TextRange</code> control pattern implemented on a parent accessible object.
-                    </div>
-                  </td>
                   <td class="ia2">
-                    <div class="general">
-                      No accessible object. Mapped into 
-                      "font-family:monospace" text attribute on its text
-                      container.
+                    <div class="general">No accessible object.</div>
+                    <div class="properties">
+                      <span class="type">Text attributes: </span><code>font-family:monospace</code> on the text container
                     </div>
                   </td>
                   <td class="uia">
@@ -2505,7 +2164,6 @@
               <tr tabindex="-1" id="el-keygen">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-keygen-element"><code>keygen</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-listbox"><code>listbox</code></a> role, with the <a class="core-mapping" href="#ariaMultiselectableFalse"><code>aria-multiselectable</code></a> property set to "false" </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2514,26 +2172,15 @@
               <tr tabindex="-1" id="el-label">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-label-element"><code>label</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_TEXT</code>
-                      </div>
-                      <div class="general">Use UIA guidance</div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>ROLE_SYSTEM_STATICTEXT</code> and <code>IA2_ROLE_LABEL</code>
+                      <span class="type">Roles: </span><code>ROLE_SYSTEM_STATICTEXT</code>; <code>IA2_ROLE_LABEL</code>
                     </div>
                     <div class="relations">
-                      <span class="type">Relations: </span>
-                      <code>IA2_RELATION_LABEL_FOR</code> for a child form element or form element
-                      referred by <a href="#att-for-label"><code>for</code></a> attribute. Note,
-                      related form element provides <code>IA2_RELATION_LABELLED_BY</code> pointing to the label.
+                      <span class="type">Relations: </span><code>IA2_RELATION_LABEL_FOR</code> with a form control that is child to the <code>label</code> or referred to by the <code>label</code> element's <a href="#att-for-label"><code>for</code></a> attribute. The associated form element has <code>IA2_RELATION_LABELLED_BY</code> pointing to the <code>label</code>.
                     </div>
                     <div class="ifaces">
-                      <span class="type">Interfaces: </span>
-                      <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>
+                      <span class="type">Interfaces: </span><code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>
                     </div>
                   </td>
                   <td class="uia">
@@ -2577,24 +2224,12 @@
                   <tr tabindex="-1" id="el-legend">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-legend-element"><code>legend</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="ctrltype">
-                          <span class="type">Control Type: </span><code>Text</code>
-                      </div>
-                    <div class="properties">
-                      <span class="type">Properties: </span>
-                      The parent <a href="#el-fieldset"><code>fieldset</code></a> has a <code>UIA_LabeledByPropertyId</code>
-                      pointing to the UIA element for the <code>legend</code> element.
-                    </div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role :</span>
-                      <code>ROLE_SYSTEM_STATICTEXT</code> and <code>IA2_ROLE_LABEL</code>
+                      <span class="type">Roles: </span><code>ROLE_SYSTEM_STATICTEXT</code>; <code>IA2_ROLE_LABEL</code>
                     </div>
                     <div class="relations">
-                      <span class="type">Relations: </span>
-                      <code>IA2_RELATION_LABEL_FOR</code> with parent <a href="#el-fieldset"><code>fieldset</code></a> element
+                      <span class="type">Relations: </span><code>IA2_RELATION_LABEL_FOR</code> with the parent <a href="#el-fieldset"><code>fieldset</code></a>
                     </div>
                     <div class="ifaces">
                       <span class="type">Interfaces: </span>
@@ -2638,7 +2273,6 @@
               <tr tabindex="-1" id="el-li">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-li-element"><code>li</code></a> <span class="el-context">(parent is an <a href="http://www.w3.org/TR/html51/semantics.html#the-ol-element"><code>ol</code></a> or <a href="http://www.w3.org/TR/html51/semantics.html#the-ul-element"><code>ul</code></a>)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-listitem"><code>listitem</code></a> role  with <a href="http://www.w3.org/TR/core-aam-1.1/#ariaSetsize"><code>aria-setsize</code></a> value reflecting number of <code>li</code> elements within the parent <code>ol</code> or <code>ul</code> and <a href="http://www.w3.org/TR/core-aam-1.1/#ariaPosinset"><code>aria-posinset</code></a> value reflecting the <code>li</code> elements position within the set. </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2647,7 +2281,6 @@
               <tr tabindex="-1" id="el-li-parentmenu">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-li-element"><code>li</code></a> <span class="el-context">(parent is a <a href="http://www.w3.org/TR/html51/semantics.html#the-menu-element"><code>menu</code></a>)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-listitem"><code>listitem</code></a> role  with <a href="http://www.w3.org/TR/core-aam-1.1/#ariaSetsize"><code>aria-setsize</code></a> value reflecting number of <code>li</code> elements within the parent <code>menu</code><code></code> and <a href="http://www.w3.org/TR/core-aam-1.1/#ariaPosinset"><code>aria-posinset</code></a> value reflecting the <code>li</code> elements position within the set. </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2656,9 +2289,6 @@
               <tr tabindex="-1" id="el-link">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-link-element"><code>link</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                    <div class="general">Not mapped</div>
-                  </td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -2675,7 +2305,6 @@
               <tr tabindex="-1" id="el-main">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-main-element"><code>main</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-main"><code>main</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2684,16 +2313,12 @@
               <tr tabindex="-1" id="el-map">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-map-element"><code>map</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">Not mapped</div>
-                  </td>
                   <td class="ia2">
                     <div class="general">
-                      Not mapped if used as an image map, otherwise:
+                      Not mapped if used as an image map. Otherwise,
                     </div>
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_TEXT_FRAME</code>
+                      <span class="type">Role: </span><code>IA2_ROLE_TEXT_FRAME</code>
                     </div>
                   </td>
                   <td class="uia">
@@ -2715,10 +2340,6 @@
               <tr tabindex="-1" id="el-mark">
                 <th><a href="http://www.w3.org/TR/html51/semantics.html#the-mark-element"><code>mark</code></a></th>
                 <td class="aria">No corresponding role</td>
-                <td class="uia-express">
-                    <div class="ctrltype"> <span class="type">Control Type: </span><code>Text</code> </div>
-                    <div class="ctrltype"> <span class="type">Localized Control Type: </span><code>"mark"</code> </div>
-                </td>
                 <td class="ia2"><div class="general"><span class="role"><span class="type">Role: </span> <code>IA2_ROLE_TEXT_FRAME</code></span></div>
                   <p><span class="objattrs"><span class="type">Object attributes: </span></span><code>xml-roles:mark</code></p>
                   <p><span class="general">Styles used are mapped to text attributes on the accessible object.</span></p>
@@ -2741,7 +2362,6 @@
               <tr tabindex="-1" id="el-math">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#mathml"><code>math</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-math"><code>math</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2750,7 +2370,6 @@
               <tr tabindex="-1" id="el-menu">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-menu-element"><code>menu</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-menu-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#popup-menu-state">popup menu</a> state)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-menu"><code>menu</code></a> role </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2759,7 +2378,6 @@
               <tr tabindex="-1" id="el-menu-toolbar">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-menu-element"><code>menu</code></a> <span class="el-context">(<a href="http://www.w3.org/TR/html51/semantics.html#attr-menu-type"><code>type</code></a> attribute in the <a href="http://www.w3.org/TR/html51/semantics.html#toolbar-state">toolbar</a> state)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-toolbar"><code>toolbar</code></a> role </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2768,7 +2386,6 @@
               <tr tabindex="-1" id="el-menuitem-checkbox">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-menuitem-element"><code>menuitem</code></a> <span class="el-context">(<code>type</code> attribute in the Checkbox state)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-menuitemcheckbox"><code>menuitemcheckbox</code></a> role, with the <a class="core-mapping" href="#ariaCheckedTrue"><code>aria-checked</code></a> state set to "true" if the <code>checked</code> attribute is present, and "false" otherwise</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2777,7 +2394,6 @@
               <tr tabindex="-1" id="el-menuitem-command">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-menuitem-element"><code>menuitem</code></a> <span class="el-context">(<code>type</code> attribute in the Command state)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-menuitem"><code>menuitem</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2786,7 +2402,6 @@
               <tr tabindex="-1" id="el-menuitem-radio">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-menuitem-element"><code>menuitem</code></a> <span class="el-context">(<code>type</code> attribute in the Radio state)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-menuitemradio"><code>menuitemradio</code></a> role, with the <a class="core-mapping" href="#ariaCheckedTrue"><code>aria-checked</code></a> state set to "true" if the <code>checked</code> attribute is present, and "false" otherwise</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2795,9 +2410,6 @@
               <tr tabindex="-1" id="el-meta">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-meta-element"><code>meta</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">Not mapped</div>
-                  </td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -2814,31 +2426,12 @@
               <tr tabindex="-1" id="el-meter">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-meter-element"><code>meter</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="ctrltype">
-                          <span class="type">Control Type: </span><code>Progressbar</code>
-                      </div>
-                      <div class="ctrltype">
-                          <span class="type">Localized Control Type: </span><code>"meter"</code>
-                      </div>
-                      
-                      <div class="ctrlpattern">
-                          <span class="type">Control Pattern: </span><code>RangeValue</code>; <code>Value</code>
-                      </div>
-                      <div class="properties">
-                          <span class="type">Other properties: </span> With the <code>RangeValue</code> Control Pattern, set the <code>IsReadOnly</code> property to <code>true</code>.
-                          <p>With the <code>Value</code> Control Pattern, set the <code>Value</code> property to a localized string expressing relative value as the result of optimal calculation. For example, Edge uses "Good" when the meter would be colored green, "Fair" when it would be colored yellow, and "Poor" when it would be colored red.</p>
- 
-                      </div>  
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>ROLE_SYSTEM_PROGRESSBAR</code>
+                      <span class="type">Role: </span><code>ROLE_SYSTEM_PROGRESSBAR</code>
                     </div>
                     <div class="ifaces">
-                      <span class="type">Interfaces: </span>
-                      <code>IAccessibleValue</code>
+                      <span class="type">Interfaces: </span><code>IAccessibleValue</code>
                     </div>
                   </td>
                   <td class="uia">
@@ -2860,8 +2453,7 @@
                           <span class="type">Control Pattern: </span><code>Value</code>
                       </div>
                       <div class="properties">
-                          <span class="type">Properties: </span> <code>Value.Value</code> is the result of optimal calculation, expressed as a localized string denoting relative levels of goodness. For example, Edge uses "Good" when the meter would be colored green, "Fair" when it would be colored yellow, and "Poor" when it would be colored red.
- 
+                          <span class="type">Properties: </span><code>Value.Value</code> is the result of optimal calculation, expressed as a localized string denoting relative levels of goodness. For example, Edge uses "Good" when the meter would be colored green, "Fair" when it would be colored yellow, and "Poor" when it would be colored red.
                       </div>                      
                   </td>
                   <td class="atk">
@@ -2888,7 +2480,6 @@
               <tr tabindex="-1" id="el-nav">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-nav-element"><code>nav</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-navigation"><code>navigation</code></a> role </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2897,9 +2488,6 @@
               <tr tabindex="-1" id="el-noscript">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-noscript-element"><code>noscript</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">Not mapped</div>
-                  </td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -2916,20 +2504,13 @@
               <tr tabindex="-1" id="el-object">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-object-element"><code>object</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">?? would pane or window work??<br /><br />depends on format of data file. examples include document, client, graphic and unknown.<br /><br />
-                    <div class="general">Use MSAA or UIA guidance</div>
-                  </td>
                   <td class="ia2">
-                    <div class="general">
-                      Depends on format of data file. If contains a plugin then
-                    </div>
+                    <div class="general">Depends on format of data file. If it contains a plugin then,</div>
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_EMBEDDED_OBJECT</code>
+                      <span class="type">Role: </span><code>IA2_ROLE_EMBEDDED_OBJECT</code>
                     </div>
                     <div class="states">
-                      <span class="type">States:</span>
-                        <code>STATE_SYSTEM_UNAVAILABLE</code> for windowless plugin
+                      <span class="type">States:</span><code>STATE_SYSTEM_UNAVAILABLE</code> for windowless plugin
                     </div>
                   </td>
                   <td class="uia">
@@ -2949,7 +2530,6 @@
               <tr tabindex="-1" id="el-ol">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-ol-element"><code>ol</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-list"><code>list</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2958,7 +2538,6 @@
               <tr tabindex="-1" id="el-optgroup">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-optgroup-element"><code>optgroup</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-group"><code>group</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2967,7 +2546,6 @@
               <tr tabindex="-1" id="el-option">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-option-element"><code>option</code></a> <span class="el-context">(in a <a href="http://www.w3.org/TR/html51/semantics.html#concept-select-option-list">list of options</a> or represents a suggestion in a <a href="http://www.w3.org/TR/html51/semantics.html#the-datalist-element"><code>datalist</code></a>)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-option"><code>option</code></a> role, with the <a class="core-mapping" href="#ariaSelectedTrue"><code>aria-selected</code></a> state set to "true" if the element's <a href="http://www.w3.org/TR/html51/semantics.html#concept-option-selectedness">selectedness</a> is true, or "false" otherwise. </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2976,11 +2554,6 @@
               <tr tabindex="-1" id="el-output">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-output-element"><code>output</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-status"><code>status</code></a> role</td>
-                  <td class="uia-express">
-                  <div class="ctrltype"> <span class="type">Control Type: </span><code>"output"</code> </div>
-                  <div class="ctrltype"> <span class="type">LiveSetting:</span> <code>Polite</code> </div>
-                  <div class="ctrltype"> <span class="type">ControllerFor:</span> points to elements referenced by the <code>for</code> attribute </div>
-                  </td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="ctrltype"> <span class="type">Control Type: </span><code>Group</code> </div>
                   <div class="ctrltype"> <span class="type">Control Type: </span><code>"output"</code> </div>
@@ -2993,20 +2566,12 @@
               <tr tabindex="-1" id="el-p">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-p-element"><code>p</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_TEXT</code>
-                      </div>
-                      <div class="general">Use MSAA or UIA guidance</div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_PARAGRAPH</code>
+                      <span class="type">Roles: </span><code>ROLE_SYSTEM_TEXT</code>; <code>IA2_ROLE_PARAGRAPH</code>
                     </div>
                     <div class="ifaces">
-                      <span class="type">Interfaces: </span>
-                      <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>
+                      <span class="type">Interfaces: </span><code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>
                     </div>
                   </td>
                   <td class="uia">
@@ -3039,9 +2604,6 @@
               <tr tabindex="-1" id="el-param">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-param-element"><code>param</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">Not mapped</div>
-                  </td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -3058,7 +2620,6 @@
               <tr id="el-picture" tabindex="-1">
                 <th><a href="http://www.w3.org/TR/html51/semantics.html#the-picture-element"><code>picture</code></a></th>
                 <td class="aria">No corresponding role</td>
-                <td class="uia-express"><div class="general">Not mapped</div></td>
                 <td class="ia2"><div class="general">Not mapped</div></td>
                 <td class="uia"><div class="general">Not mapped</div></td>
                 <td class="atk"><div class="general">Not mapped</div></td>
@@ -3067,19 +2628,12 @@
               <tr tabindex="-1" id="el-pre">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-pre-element"><code>pre</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_TEXT</code> ??group?
-                      </div>
-                      <div class="general">Use MSAA or UIA guidance</div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_TEXT_FRAME</code>
+                      <span class="type">Roles: </span><code>ROLE_SYSTEM_TEXT</code> (??group??); <code>IA2_ROLE_TEXT_FRAME</code>
                     </div>
                     <div class="general">
-                      Styles used are mapped to text attributes on the accessible object.
+                      Styles used are mapped to text attributes on the parent accessible object.
                     </div>
                     <div class="ifaces">
                       <span class="type">Interfaces: </span>
@@ -3119,7 +2673,6 @@
               <tr tabindex="-1" id="el-progress">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-progress-element"><code>progress</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-progressbar"><code>progressbar</code></a> role, with, if the progress bar is determinate, the <a class="core-mapping" href="#ariaValueMax"><code>aria-valuemax</code></a> property set to the maximum value of the progress bar, the <a class="core-mapping" href="#ariaValueMin"><code>aria-valuemin</code></a> property set to zero, and the <a class="core-mapping" href="#ariaValueNow"><code>aria-valuenow</code></a> property set to the current value of the progress bar </td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3128,24 +2681,15 @@
               <tr tabindex="-1" id="el-q">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-q-element"><code>q</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_TEXT</code> ??group??
-                      </div>
-                      <div class="general">Use MSAA or UIA guidance</div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_TEXT_FRAME</code>
+                      <span class="type">Roles: </span><code>ROLE_SYSTEM_TEXT</code> (??group??); <code>IA2_ROLE_TEXT_FRAME</code>
                     </div>
                     <div class="children">
-                      <span class="type">Children: </span>
-                      <code>ROLE_SYSTEM_TEXT</code> wrapped by <code>ROLE_SYSTEM_STATICTEXT</code> created for quote marks
+                      <span class="type">Children: </span><code>ROLE_SYSTEM_TEXT</code> wrapped by quote marks using <code>ROLE_SYSTEM_STATICTEXT</code>
                     </div>
                     <div class="ifaces">
-                      <span class="type">Interfaces: </span>
-                      <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>
+                      <span class="type">Interfaces: </span><code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>
                     </div>
                   </td>
                   <td class="uia">
@@ -3178,16 +2722,9 @@
               <tr tabindex="-1" id="el-rp">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-rp-element"><code>rp</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_TEXT</code> ??group??
-                      </div>
-                      <div class="general">Use MSAA or UIA guidance</div>
-                  </td>
                   <td class="ia2">
                     <div class="general">
-                      No accessible object. No child elements are
-                      exposed if <a href="#el-ruby"><code>ruby</code></a> is supported by the browser.
+                      No accessible object. No child elements are exposed if <a href="#el-ruby"><code>ruby</code></a> is supported by the browser.
                     </div>
                   </td>
                   <td class="uia">
@@ -3206,15 +2743,9 @@
               <tr tabindex="-1" id="el-rt">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-rt-element"><code>rt</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_TEXT</code>
-                      </div>
-                      <div class="general">Use MSAA or UIA guidance</div>
-                  </td>
                   <td class="ia2">
                     <div class="general">
-                      No accessible object.
+                      No accessible object. No child elements are exposed if <a href="#el-ruby"><code>ruby</code></a> is supported by the browser.
                     </div>
                   </td>
                   <td class="uia">
@@ -3232,16 +2763,9 @@
               <tr tabindex="-1" id="el-ruby">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-ruby-element"><code>ruby</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_TEXT</code> ??group??
-                      </div>
-                      <div class="general">Use MSAA or UIA guidance</div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>IA2_ROLE_TEXT_FRAME</code>
+                      <span class="type">Role: </span><code>ROLE_SYSTEM_TEXT</code> (??group??); <code>IA2_ROLE_TEXT_FRAME</code>
                     </div>
                   </td>
                   <td class="uia">
@@ -3260,13 +2784,10 @@
               <tr tabindex="-1" id="el-s">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-s-element"><code>s</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                    <div class="general">No accessible object. Styles used are exposed by UIA text attribute identifiers of the <code>TextRange</code> control pattern implemented on a parent accessible object.
-                    </div>
-                  </td>
                   <td class="ia2">
-                    <div class="general">No accessible object. Exposed as
-                      "text-line-through-style:solid" text attribute on the text container.
+                    <div class="general">No accessible object.</div>
+                    <div class="properties">
+                          <span class="type">Text attributes: </span><code>text-line-through-style:solid</code> on the text container
                     </div>
                   </td>
                   <td class="uia">
@@ -3293,14 +2814,9 @@
               <tr tabindex="-1" id="el-samp">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-samp-element"><code>samp</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                    <div class="general">No accessible object. Styles used are exposed by UIA text attribute identifiers of the <code>TextRange</code> control pattern implemented on a parent accessible object.
-                    </div>
-                  </td>
                   <td class="ia2">
                     <div class="general">
-                      No accessible object. Styles are mapped into
-                      text attributes on its text container.
+                      No accessible object. Styles are mapped into text attributes on its text container.
                     </div>
                   </td>
                   <td class="uia">
@@ -3328,9 +2844,6 @@
               <tr tabindex="-1" id="el-script">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-script-element"><code>script</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">Not mapped</div>
-                  </td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -3348,7 +2861,6 @@
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-section-element"><code>section</code></a></th>
                   <td class="aria"><p><a class="core-mapping" href="#role-map-region"><code>region</code></a> role </p>
                   <p><strong>Note:</strong>It is strongly recommended that user agents such as screen readers only convey the presence of, and provide navigation for <a href="http://www.w3.org/TR/html5/sections.html#the-section-element">section</a> elements, when the <a href="http://www.w3.org/TR/html5/sections.html#the-section-element">section</a> element has an <a class="termref">accessible name</a>.</p></td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia">
                       <div class="ctrltype">
@@ -3375,7 +2887,6 @@
                     </span>
                   </th>
                   <td class="aria"><a class="core-mapping" href="#role-map-listbox"><code>listbox</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3390,7 +2901,6 @@
                     </span>
                   </th>
                   <td class="aria"><a class="core-mapping" href="#role-map-combobox"><code>combobox</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3399,14 +2909,10 @@
               <tr tabindex="-1" id="el-small">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-small-element"><code>small</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                    <div class="general">No accessible object. Exposed by <code>UIA_FontSizeAttributeId</code> of the <code>TextRange</code> control pattern implemented on a parent accessible object.
-                    </div>
-                  </td>
                   <td class="ia2">
-                    <div class="general">
-                      No accessible object. Exposed as "font-size"
-                      text attribute on the text container.
+                    <div class="general">No accessible object.</div>
+                    <div class="properties">
+                      <span class="type">Text attributes: </span><code>font-size</code> on the text container
                     </div>
                   </td>
                   <td class="uia">
@@ -3434,31 +2940,22 @@
               <tr tabindex="-1" id="el-source">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-source-element"><code>source</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">Do not expose this object</div>
-                  </td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
                   <td class="uia">
-                      <div class="general">Do not expose this object</div>
+                      <div class="general">Not mapped</div>
                   </td>
                   <td class="atk">
                     <div class="general">Not mapped</div>
                   </td>
                   <td class="ax">
-                      <div class="general">Do not expose this object</div>
+                      <div class="general">Not mapped</div>
                   </td>
               </tr>
               <tr tabindex="-1" id="el-span">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-span-element"><code>span</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code>
-                      </div>
-                      <div class="general">Use MSAA or UIA guidance</div>
-                    </td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -3485,14 +2982,9 @@
               <tr tabindex="-1" id="el-strong">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-strong-element"><code>strong</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                     <div class="general">No accessible object. Styles used are exposed by UIA text attribute identifiers of the <code>TextRange</code> control pattern implemented on a parent accessible object.
-                    </div>
-                  </td>
                   <td class="ia2">
                     <div class="general">
-                      No accessible object. Styles used are mapped
-                      into text attributes on its text container.
+                      No accessible object. Styles used are mapped into text attributes on its text container.
                     </div>
                   </td>
                   <td class="uia">
@@ -3520,33 +3012,26 @@
               <tr tabindex="-1" id="el-style">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-style-element"><code>style</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">Do not expose this object</div>
-                  </td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
                   <td class="uia">
-                      <div class="general">Do not expose this object</div>
+                      <div class="general">Not mapped</div>
                   </td>
                   <td class="atk">
                     <div class="general">Not mapped</div>
                   </td>
                   <td class="ax">
-                      <div class="general">Do not expose this object</div>
+                      <div class="general">Not mapped</div>
                   </td>
               </tr>
               <tr tabindex="-1" id="el-sub">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-sub-and-sup-elements"><code>sub</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                    <div class="general">No accessible object. Exposed by <code>UIA_IsSubscriptAttributeId</code> of the <code>TextRange</code> control pattern implemented on a parent accessible object.
-                    </div>
-                  </td>
                   <td class="ia2">
-                    <div class="general">
-                      No accessible object. Exposed as "text-position:sub"
-                      text attribute on its text container.
+                    <div class="general">No accessible object.</div>
+                    <div class="properties">
+                      <span class="type">Text attributes: </span><code>text-position:sub</code> on the text container
                     </div>
                   </td>
                   <td class="uia">
@@ -3574,15 +3059,6 @@
               <tr tabindex="-1" id="el-summary">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-summary-element"><code>summary</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_PUSHBUTTON</code>
-                      </div>
-                      <div class="states">
-                          <span class="type">States: </span>??has popup??
-                      </div>
-                      <div class="general">Use MSAA or UIA guidance</div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
                       <span class="type">Role: </span><code>ROLE_SYSTEM_PUSHBUTTON</code>
@@ -3617,14 +3093,10 @@
               <tr tabindex="-1" id="el-sup">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-sub-and-sup-elements"><code>sup</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                    <div class="general">No accessible object. Exposed by <code>UIA_IsSuperscriptAttributeId</code> of the <code>TextRange</code> control pattern implemented on a parent accessible object.
-                    </div>
-                  </td>
                   <td class="ia2">
-                    <div class="general">
-                      No accessible object. Exposed as "text-position:super"
-                      text attribute on its text container.
+                    <div class="general">No accessible object.</div>
+                    <div class="properties">
+                      <span class="type">Text attributes: </span><code>text-position:super</code> on the text container
                     </div>
                   </td>
                   <td class="uia">
@@ -3652,11 +3124,6 @@
               <tr tabindex="-1" id="el-svg">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#svg"><code>svg</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="role">
-                          <span class="type">Role: </span><code>ROLE_SYSTEM_GRAPHIC</code>
-                      </div>
-                  </td>
                   <td class="ia2">
                     <div class="role">
                       <span class="type">Role: </span><code>ROLE_SYSTEM_GRAPHIC</code>
@@ -3688,7 +3155,6 @@
               <tr tabindex="-1" id="el-table">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-table-element"><code>table</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-table"><code>table</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3697,7 +3163,6 @@
               <tr tabindex="-1" id="el-tbody">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-tbody-element"><code>tbody</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-rowgroup"><code>rowgroup</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3706,7 +3171,6 @@
               <tr tabindex="-1" id="el-td">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-td-element"><code>td</code></a> (ancestor <a href="http://www.w3.org/TR/html51/semantics.html#the-table-element"><code>table</code></a> element has <a class="core-mapping" href="#role-map-table"><code>table</code></a> role)</th>
                   <td class="aria"><a class="core-mapping" href="#role-map-cell"><code>cell</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3715,7 +3179,6 @@
               <tr tabindex="-1" id="el-td-gridcell">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-td-element"><code>td</code></a> (ancestor <a href="http://www.w3.org/TR/html51/semantics.html#the-table-element"><code>table</code></a> element has <a class="core-mapping" href="#role-map-grid"><code>grid</code></a> role)</th>
                   <td class="aria"><a class="core-mapping" href="#role-map-gridcell"><code>gridcell</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3724,20 +3187,14 @@
               <tr tabindex="-1" id="el-template">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-template-element"><code>template</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express"> <div class="general">Not mapped</div></td>
-                  <td class="ia2">
-                    <div class="general">Not mapped</div>
-                  </td>
-                  <td class="uia"> <div class="general">Not mapped</div></td>
-                  <td class="atk">
-                    <div class="general">Not mapped</div>
-                  </td>
-                  <td class="ax"> <div class="general">Not mapped</div></td>
+                  <td class="ia2"><div class="general">Not mapped</div></td>
+                  <td class="uia"><div class="general">Not mapped</div></td>
+                  <td class="atk"><div class="general">Not mapped</div></td>
+                  <td class="ax"><div class="general">Not mapped</div></td>
               </tr>
               <tr tabindex="-1" id="el-textarea">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-textarea-element"><code>textarea</code></a></th>
                   <td class="aria">textbox role, with the <a class="core-mapping" href="#ariaMultilineTrue"><code>aria-multiline</code></a> property set to "true"</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3746,7 +3203,6 @@
               <tr tabindex="-1" id="el-tfoot">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-tfoot-element"><code>tfoot</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-rowgroup"><code>rowgroup</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3755,7 +3211,6 @@
               <tr tabindex="-1" id="el-th">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-th-element"><code>th</code></a> <span class="el-context">(is neither column header nor row header, and ancestor <a href="http://www.w3.org/TR/html51/semantics.html#the-table-element"><code>table</code></a> element has <a class="core-mapping" href="#role-map-table"><code>table</code></a> role)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-cell"><code>cell</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3764,7 +3219,6 @@
               <tr tabindex="-1" id="el-th-gridcell">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-th-element"><code>th</code></a> <span class="el-context">(is neither column header nor row header, and ancestor <a href="http://www.w3.org/TR/html51/semantics.html#the-table-element"><code>table</code></a> element has <a class="core-mapping" href="#role-map-grid"><code>grid</code></a> role)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-gridcell"><code>gridcell</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3773,7 +3227,6 @@
               <tr tabindex="-1" id="el-th-columnheader">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-th-element"><code>th</code></a> <span class="el-context">(is a column header)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-columnheader"><code>columnheader</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3782,7 +3235,6 @@
               <tr tabindex="-1" id="el-th-rowheader">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-th-element"><code>th</code></a> <span class="el-context">(is a row header)</span></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-rowheader"><code>rowheader</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3791,7 +3243,6 @@
               <tr tabindex="-1" id="el-thead">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-thead-element"><code>thead</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-rowgroup"><code>rowgroup</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia">
                     <div class="ctrltype">
@@ -3804,19 +3255,16 @@
               <tr tabindex="-1" id="el-time">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-time-element"><code>time</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                    <div class="ctrltype">
-                      <span class="type">Control Type: </span><code>Text</code>
-                    </div>
-                    <div class="ctrltype">
-                      <span class="type">Localized Control Type: </span><code>"time"</code>
-                    </div>
-                  </td>
                   <td class="ia2">
-                    <div class="general"><span class="role"><span class="type">Role: </span> <code>IA2_ROLE_TEXT_FRAME</code> </span></div>
-                    <p><span class="objattrs"><span class="type">Object attributes: </span></span><code>xml-roles:time</code></p>
-                    <p><span class="objattrs">"datetime" attribute on the containing <a href="http://www.w3.org/TR/html51/semantics.html#the-time-element"><code>time</code></a>, text content used as a value </span></p>
-                    <p><span class="ifaces"><span class="type">Interfaces: </span> <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>;</span></p>
+                    <div class="role">
+                      <span class="type">Role: </span><code>IA2_ROLE_TEXT_FRAME</code>
+                    </div>
+                    <div class="objattrs">
+                      <span class="type">Object attributes: </span><code>xml-roles:time</code>; <code>datetime</code> on the containing <a href="http://www.w3.org/TR/html51/semantics.html#the-time-element"><code>time</code></a> element, with its text content used as the value
+                    </div>
+                    <div class="ifaces">
+                      <span class="type">Interfaces: </span><code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>
+                    </div>
                   </td>
                   <td class="uia">
                     <div class="ctrltype">
@@ -3853,26 +3301,14 @@
               <tr tabindex="-1" id="el-title">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-title-element"><code>title</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">Not mapped</div>
-                  </td>
-                  <td class="ia2">
-                    <div class="general">Not mapped</div>
-                  </td>
-                  <td class="uia">
-                      <div class="general">Not mapped</div>
-                  </td>
-                  <td class="atk">
-                    <div class="general">Not mapped</div>
-                  </td>
-                  <td class="ax">
-                      <div class="general">Not mapped</div>
-                  </td>
+                  <td class="ia2"><div class="general">Not mapped</div></td>
+                  <td class="uia"><div class="general">Not mapped</div></td>
+                  <td class="atk"><div class="general">Not mapped</div></td>
+                  <td class="ax"><div class="general">Not mapped</div></td>
               </tr>
               <tr tabindex="-1" id="el-tr">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-tr-element"><code>tr</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-row"><code>row</code></a> role</td>
-                  <td class="uia-express"><div class="general">Generally not mapped. If the element must be included per Core-AAM Section 5.1.2, map as <code>Group</code>.</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Generally not mapped. If the element must be included per Core-AAM Section 5.1.2, map as <code>Group</code>.</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3881,23 +3317,14 @@
               <tr tabindex="-1" id="el-track">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-track-element"><code>track</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express"> <div class="general">Not mapped</div></td>
-                  <td class="ia2">
-                    <div class="general">Not mapped</div>
-                  </td>
+                  <td class="ia2"><div class="general">Not mapped</div></td>
                   <td class="uia"> <div class="general">Not mapped</div></td>
-                  <td class="atk">
-                    <div class="general">Not mapped</div>
-                  </td>
+                  <td class="atk"><div class="general">Not mapped</div></td>
                   <td class="ax"> <div class="general">Not mapped</div></td>
               </tr>
               <tr tabindex="-1" id="el-u">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-u-element"><code>u</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                    <div class="general">No accessible object. Exposed by <code>UIA_UnderlineStyleAttributeId</code> of the <code>TextRange</code> control pattern implemented on a parent accessible object. 
-                    </div>
-                  </td>
                   <td class="ia2">
                     <div class="general">No accessible object. Exposed as "text-underline-style:solid" text attribute on its text container.
                     </div>
@@ -3916,7 +3343,6 @@
               <tr tabindex="-1" id="el-ul">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-ul-element"><code>ul</code></a></th>
                   <td class="aria"><a class="core-mapping" href="#role-map-list"><code>list</code></a> role</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3925,10 +3351,6 @@
               <tr tabindex="-1" id="el-var">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-var-element"><code>var</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                    <div class="general">No accessible object. Styles used are exposed by UIA text attribute identifiers of the <code>TextRange</code> control pattern implemented on a parent accessible object. 
-                    </div>
-                  </td>
                   <td class="ia2">
                     <div class="general">No accessible object. Styles used are mapped to text attributes on its text container.</div>
                   </td>
@@ -3954,18 +3376,9 @@
               <tr tabindex="-1" id="el-video">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-video-element"><code>video</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express"> 
-                    <div class="ctrltype">
-                      <span class="type">Control Type: </span><code>Group</code>
-                    </div>
-                    <div class="general">If the controls attribute is present, each control is a child in the UIA tree, and mapped as button, slider, etc. as appropriate for the type of control.</div>
-                    <div class="general">Loading and error text objects, along with any control not currently displayed, MAY be present in the UIA and marked as hidden or off-screen.</div>
-
-                  </td>
                   <td class="ia2">
                     <div class="role">
-                      <span class="type">Role: </span>
-                      <code>ROLE_SYSTEM_GROUPING</code>
+                      <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code>
                     </div>
                   </td>
                   <td class="uia">
@@ -3997,12 +3410,9 @@
               <tr tabindex="-1" id="el-wbr">
                   <th><a href="http://www.w3.org/TR/html51/semantics.html#the-wbr-element"><code>wbr</code></a></th>
                   <td class="aria">No corresponding role</td>
-                  <td class="uia-express">
-                      <div class="general">Not mapped</div>
-                  </td>
                   <td class="ia2">
                     <div class="general">
-                      A line break if added is exposed via <code>IAccessibleText</code> on its text container
+                      If a line break is added, expose it with <code>IAccessibleText</code> on the text container
                     </div>
                   </td>
                   <td class="uia">Not mapped</td>
@@ -4045,7 +3455,6 @@
                 <th>Attribute</th>
                 <th>Element(s)</th>
                 <th><a href="http://www.w3.org/WAI/PF/aria/">WAI-ARIA</a></th>
-                <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd561898%28v=vs.85%29.aspx">UIA Express</a></th>
                 <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
                 <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
                 <th><a href="https://developer.gnome.org/atk/stable/">ATK</a></th>
@@ -4058,7 +3467,6 @@
                   <th><code>abbr</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-th-abbr"><code>th</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="objattrs">
                       <span class="type">Object attributes: </span>
@@ -4079,7 +3487,6 @@
                   <th><code>accept</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-input-accept"><code>input</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4098,7 +3505,6 @@
                   <th><code>accept-charset</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-form-accept-charset"><code>form</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4117,7 +3523,6 @@
                   <th><code>accesskey</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/editing.html#the-accesskey-attribute"><code>HTML elements</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express"><a href="https://msdn.microsoft.com/en-us/library/accessibility.iaccessible.acckeyboardshortcut.aspx"><code>accKeyboardShortcut</code></a></td>
                   <td class="ia2">
                     <div class="general">
                       a key binding accessible by
@@ -4142,7 +3547,6 @@
                   <th><code>action</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-fs-action"><code>form</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4161,7 +3565,6 @@
                   <th><code>allowfullscreen</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-iframe-allowfullscreen"><code>iframe</code></a></td>
                   <td class="aria"></td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4180,7 +3583,6 @@
                   <th><code>alt</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-area-alt"><code>area</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-img-alt"><code>img</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-input-alt"><code>input</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express"><a href="https://msdn.microsoft.com/en-us/library/accessibility.iaccessible.accname.aspx"><code>accName</code></a></td>
                   <td class="ia2">
                     Used for <a class="termref">accessible name</a>, exposed via <a href="https://msdn.microsoft.com/en-us/library/system.windows.automation.automationelement.automationelementinformation.name.aspx"><code>accName</code></a>
                   </td>
@@ -4202,7 +3604,6 @@
                   <th><code>async</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-script-async"><code>script</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4222,7 +3623,6 @@
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-form-autocomplete"><code>form</code></a></td>
                   <td class="aria"><p><a class="core-mapping" href="#ariaAutocompleteInlineListBoth"><code>aria-autocomplete</code></a></p>
                 <p><strong>Note:</strong> the ARIA attribute and the HTML attribute have disparate features.</p></td>
-                  <td class="uia-express">Not mapped</td>
                   <td class="ia2">
                     <div class="states">
                       <span class="type">States: </span>
@@ -4245,7 +3645,6 @@
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-fe-autocomplete"><code>input</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fe-autocomplete"><code>select</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fe-autocomplete"><code>textarea</code></a></td>
                   <td class="aria"><p><a class="core-mapping" href="#ariaAutocompleteInlineListBoth"><code>aria-autocomplete</code></a></p>
                 <p><strong>Note:</strong> the ARIA attribute and the HTML attribute have disparate features.</p></td>
-                  <td class="uia-express">Not mapped</td>
                   <td class="ia2">
                     <div class="states">
                       <span class="type">States: </span>
@@ -4266,7 +3665,6 @@
                   <th><code>autofocus</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-fe-autofocus"><code>button</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fe-autofocus"><code>input</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fe-autofocus"><code>keygen</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fe-autofocus"><code>select</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fe-autofocus"><code>textarea</code></a></td>
                   <td class="aria">Not mapped - <a class="core-mapping" href="#ariaFlowto"><code>aria-flowto</code></a>?</td>
-                  <td class="uia-express">N/A</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4285,7 +3683,6 @@
                   <th><code>autoplay</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-media-autoplay"><code>audio</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-media-autoplay"><code>video</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">N/A</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4304,7 +3701,6 @@
                   <th><code>border</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-table-border"><code>table</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4323,7 +3719,6 @@
                   <th><code>challenge</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-keygen-challenge"><code>keygen</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4342,7 +3737,6 @@
                   <th><code>charset</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-meta-charset"><code>meta</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4361,7 +3755,6 @@
                   <th><code>charset</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-script-charset"><code>script</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4380,7 +3773,6 @@
                   <th><code>checked</code> (if present)</th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-menuitem-checked"><code>menuitem</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-input-checked"><code>input</code></a></td>
                   <td class="aria"><a class="core-mapping" href="#ariaCheckedTrue"><code>aria-checked</code></a> (state)="true"</td>
-                  <td class="uia-express">Set the <code>STATE_SYSTEM_CHECKED</code> state</td>
                   <td class="ia2">
                     <div class="states">
                       <span class="type">States: </span><code>STATE_SYSTEM_CHECKED</code>
@@ -4400,7 +3792,6 @@
                   <th><code>checked</code> (if absent)</th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-menuitem-checked"><code>menuitem</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-input-checked"><code>input</code></a></td>
                   <td class="aria"><a class="core-mapping" href="#ariaCheckedFalse"><code>aria-checked</code></a> (state)="false"</td>
-                  <td class="uia-express">Clear the <code>STATE_SYSTEM_CHECKED</code> state</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4419,7 +3810,6 @@
                   <th><code>cite</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-blockquote-cite"><code>blockquote</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-mod-cite"><code>del</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-mod-cite"><code>ins</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-q-cite"><code>q</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4438,7 +3828,6 @@
                   <th><code>class</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/dom.html#classes">HTML elements</a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4457,7 +3846,6 @@
                   <th><code>cols</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-textarea-cols"><code>textarea</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4476,7 +3864,6 @@
                   <th><code>colspan</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-tdth-colspan"><code>td</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-tdth-colspan"><code>th</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       exposed via <code>IAccessibleTableCell::columnExtent</code>
@@ -4502,7 +3889,6 @@
                   <th><code>command</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-menuitem-command"><code>menuitem</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2"><div class="general">
                       Not mapped
                     </div>
@@ -4519,7 +3905,6 @@
                   <th><code>content</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-meta-content"><code>meta</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                   <div class="general">
                       Not mapped
@@ -4538,7 +3923,6 @@
                   <th><code>contenteditable</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/editing.html#attr-contenteditable">HTML elements</a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="states">
                       <span class="type">States: </span>
@@ -4567,7 +3951,6 @@
                   <th><code>contextmenu</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-contextmenu">HTML elements</a></td>
                   <td class="aria"><a class="core-mapping" href="#ariaHaspopupTrue"><code>aria-haspopup</code></a>="true"</td>
-                  <td class="uia-express">Expose as <code>STATE_SYSTEM_HASPOPUP</code>. If on  a push button, change the role to <code>ROLE_SYSTEM_BUTTONMENU</code>.</td>
                   <td class="ia2">
                     <div class="general">
                       Linked menu is available in browser's context menu on the element
@@ -4590,7 +3973,6 @@
                   <th><code>controls</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-media-controls"><code>audio</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-media-controls"><code>video</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4609,7 +3991,6 @@
                   <th><code>coords</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-area-coords"><code>area</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Defines an accessible object's dimensions (<code>IAccessible::accLocation</code>)
@@ -4629,7 +4010,6 @@
                   <th><code>crossorigin</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-media-crossorigin"><code>audio</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-img-crossorigin"><code>img</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-link-crossorigin"><code>link</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-script-crossorigin"><code>script</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-media-crossorigin"><code>video</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                   <div class="general">
                       Not mapped
@@ -4648,7 +4028,6 @@
                   <th><code>data</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-object-data"><code>object</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                   <div class="general">
                       Not mapped
@@ -4667,7 +4046,6 @@
                   <th><code>datetime</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-mod-datetime"><code>del</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-mod-datetime"><code>ins</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                   <div class="objattrs">
                       <span class="type">Object attributes:</span> 
@@ -4686,7 +4064,6 @@
                   <th><code>datetime</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-time-datetime"><code>time</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                    <div class="objattrs">
                       <span class="type">Object attributes:</span>  
@@ -4705,7 +4082,6 @@
                   <th><code>default</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-track-default"><code>track</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                   <div class="general">
                       Not mapped
@@ -4724,7 +4100,6 @@
                   <th><code>defer</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-script-defer"><code>script</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                   <div class="general">
                       Not mapped
@@ -4743,7 +4118,6 @@
                   <th><code>dir</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/dom.html#the-dir-attribute" title="attr-dir">HTML elements</a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Exposed as "writing-mode" text attribute on the text container.
@@ -4762,7 +4136,6 @@
                   <th><code>dirname</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#submitting-element-directionality:-the-dirname-attribute"><code>input</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#submitting-element-directionality:-the-dirname-attribute"><code>textarea</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                   <div class="general">
                       Not mapped
@@ -4781,7 +4154,6 @@
                   <th><code>disabled</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-fe-disabled"><code>button</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-menuitem-disabled"><code>menuitem</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fieldset-disabled"><code>fieldset</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fe-disabled"><code>input</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fe-disabled"><code>keygen</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-optgroup-disabled"><code>optgroup</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-option-disabled"><code>option</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fe-disabled"><code>select</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fe-disabled"><code>textarea</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="states">
                       <span class="type">States: </span>
@@ -4802,7 +4174,6 @@
                   <th><code>download</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-hyperlink-download"><code>a</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-hyperlink-download"><code>area</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4821,7 +4192,6 @@
                   <th><code>draggable</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/editing.html#the-draggable-attribute" title="attr-draggable">HTML elements</a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="objattrs">
                       <span class="objattrs">Object attributes: </span>
@@ -4842,7 +4212,6 @@
                   <th><code>dropzone</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/editing.html#the-dropzone-attribute" title="attr-dropzone">HTML elements</a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4861,7 +4230,6 @@
                   <th><code>enctype</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-fs-enctype"><code>form</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4880,7 +4248,6 @@
                   <th><code>for</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-label-for"><code>label</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="name">
                       Used for <a class="termref">accessible name</a>
@@ -4909,7 +4276,6 @@
                   <th><code>for</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-output-for"><code>output</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="relations">
                       <span class="type">Relations: </span>
@@ -4931,7 +4297,6 @@
                   <th><code>form</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-fae-form"><code>button</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fae-form"><code>fieldset</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fae-form"><code>input</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fae-form"><code>keygen</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fae-form"><code>label</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fae-form"><code>object</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fae-form"><code>output</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fae-form"><code>select</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fae-form"><code>textarea</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4950,7 +4315,6 @@
                   <th><code>formaction</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-fs-formaction"><code>button</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fs-formaction"><code>input</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4969,7 +4333,6 @@
                   <th><code>formenctype</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-fs-formenctype"><code>button</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fs-formenctype"><code>input</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -4988,7 +4351,6 @@
                   <th><code>formmethod</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-fs-formmethod"><code>button</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fs-formmethod"><code>input</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -5007,7 +4369,6 @@
                   <th><code>formnovalidate</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-fs-formnovalidate"><code>button</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fs-formnovalidate"><code>input</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -5026,7 +4387,6 @@
                   <th><code>formtarget</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-fs-formtarget"><code>button</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fs-formtarget"><code>input</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -5045,7 +4405,6 @@
                   <th><code>headers</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-tdth-headers"><code>td</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-tdth-headers"><code>th</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Links the cell to its header cells. Exposed via <code>IAccessibleTableCell::rowHeaderCells</code> and <code>IAccessibleTableCell::columnHeaderCells</code>.
@@ -5066,7 +4425,6 @@
                   <th><code>height</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-canvas-height"><code>canvas</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-dim-height"><code>embed</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-dim-height"><code>iframe</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-dim-height"><code>img</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-dim-height"><code>input</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-dim-height"><code>object</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-dim-height"><code>video</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Defines an accessible object's height (<code>IAccessible::accLocation</code>)
@@ -5113,7 +4471,6 @@
                   <th><code>high</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-meter-high"><code>meter</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express"><code>RangeValue.Maximum</code></td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -5183,7 +4540,6 @@
                   <th><code>hreflang</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-hyperlink-hreflang"><code>a</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-hyperlink-hreflang"><code>area</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-link-hreflang"><code>link</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -5202,7 +4558,6 @@
                   <th><code>http-equiv</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-meta-http-equiv"><code>meta</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -5221,7 +4576,6 @@
                   <th><code>icon</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-menuitem-icon"><code>menuitem</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -5240,7 +4594,6 @@
                   <th><code>id</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/dom.html#the-id-attribute">HTML elements</a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -5259,7 +4612,6 @@
                   <th><code>indeterminate [IDL]</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#dom-input-indeterminate">HTML elements</a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-menuitem-checked"><code>menuitem</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-input-checked"><code>input</code></a></td>
                   <td class="aria"><a class="core-mapping" href="#ariaCheckedTrue"><code>aria-checked</code></a> (state)="mixed"</td>
-                  <td class="uia-express"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -5270,7 +4622,6 @@
                   <th><code>ismap</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-img-ismap"><code>img</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -5289,7 +4640,6 @@
                   <th><code>keytype</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-keygen-keytype"><code>keygen</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -5308,7 +4658,6 @@
                   <th><code>kind</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-track-kind"><code>track</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -5327,7 +4676,6 @@
                   <th><code>label</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-menuitem-label"><code>menuitem</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-menu-label"><code>menu</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-optgroup-label"><code>optgroup</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-option-label"><code>option</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-track-label"><code>track</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="name">
                       Associates the <a class="termref">accessible name</a>
@@ -5346,7 +4694,6 @@
                   <th><code>lang</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/dom.html#attr-lang" title="attr-lang">HTML elements</a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">Unknown</td>
                   <td class="ia2">
                     <div class="textattrs">
                       Exposed as "language" text attribute on the text container
@@ -5397,7 +4744,6 @@
                 <th><code>longdesc</code></th>
                   <td class="elements"><code>img</code>, <a href="http://www.w3.org/TR/html4/present/frames.html#edef-FRAME"><code>frame</code></a>, <code>iframe</code></td>
                   <td class="aria">No</td>
-                  <td class="uia-express">accdescription (Internet Explorer only)</td>
                   <td class="ia2">
                     <div class="actions">
                       <span class="type">Actions: </span>
@@ -5422,7 +4768,6 @@
                   <th><code>loop</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-media-loop"><code>audio</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-media-loop"><code>video</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5437,7 +4782,6 @@
                   <th><code>low</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-meter-low"><code>meter</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5452,7 +4796,6 @@
                   <th><code>manifest</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-html-manifest"><code>html</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5467,7 +4810,6 @@
                   <th><code>max</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-input-max"><code>input</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Exposed as <code>IAccessibleValue::maximumValue</code> if the element
@@ -5488,7 +4830,6 @@
                   <th><code>max</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-meter-max"><code>meter</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-progress-max"><code>progress</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Exposed as <code>IAccessibleValue::maximumValue</code> if the element
@@ -5509,7 +4850,6 @@
                   <th><code>maxlength</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-input-maxlength"><code>input</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-textarea-maxlength"><code>textarea</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5524,7 +4864,6 @@
                   <th><code>media</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-link-media"><code>link</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-picture-source-media"><code>source</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-style-media"><code>style</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5540,7 +4879,6 @@
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-media-mediagroup"><code>audio</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-media-mediagroup"><code>video</code></a>
                   </td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5555,7 +4893,6 @@
                   <th><code>method</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-fs-method"><code>form</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5570,7 +4907,6 @@
                   <th><code>min</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-input-min"><code>input</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Exposed as <code>IAccessibleValue::minimumValue</code> if the element
@@ -5591,7 +4927,6 @@
                   <th><code>min</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-meter-min"><code>meter</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Exposed as <code>IAccessibleValue::minimumValue</code> if the element
@@ -5612,7 +4947,6 @@
                   <th><code>multiple</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-input-multiple"><code>input</code></a></td>
                   <td class="aria"><a class="core-mapping" href="#ariaMultiselectableTrue"><code>aria-multiselectable</code></a> property set to "true"</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -5631,7 +4965,6 @@
                 <th><code>multiple</code></th>
                 <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-select-multiple"><code>select</code></a></td>
                 <td class="aria">&#160;</td>
-                <td class="uia-express">&#160;</td>
                 <td class="ia2">
                   <div class="states">
                     <span class="type">States: </span>
@@ -5660,7 +4993,6 @@
                   <th><code>muted</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-media-muted"><code>audio</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-media-muted"><code>video</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5675,7 +5007,6 @@
                   <th><code>name</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-fe-name"><code>button</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fe-name"><code>fieldset</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fe-name"><code>input</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fe-name"><code>keygen</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fe-name"><code>output</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fe-name"><code>select</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-fe-name"><code>textarea</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5690,7 +5021,6 @@
                   <th><code>name</code></th>
                   <td class="elements"> <a href="http://www.w3.org/TR/html51/semantics.html#attr-form-name"><code>form</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5705,7 +5035,6 @@
                   <th><code>name</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#the-iframe-element"><code>iframe</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-object-name"><code>object</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5720,7 +5049,6 @@
                   <th><code>name</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-map-name"><code>map</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5735,7 +5063,6 @@
                   <th><code>name</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-meta-name"><code>meta</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5750,7 +5077,6 @@
                   <th><code>name</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-param-name"><code>param</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5765,7 +5091,6 @@
                   <th><code>novalidate</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-fs-novalidate"><code>form</code></a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5780,7 +5105,6 @@
                   <th><code>open</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-details-open"><code>details</code></a></td>
                   <td class="aria"><a class="core-mapping" href="#ariaExpandedTrue"><code>aria-expanded</code></a>="true | false"</td>
-                  <td class="uia-express"><code>STATE_SYSTEM_EXPANDED</code><br /><code>STATE_SYSTEM_COLLAPSED</code></td>
                   <td class="ia2"><code>STATE_SYSTEM_EXPANDED</code><br /><code>STATE_SYSTEM_COLLAPSED</code></td>
                   <td class="uia">
                     <a href="https://msdn.microsoft.com/en-us/library/system.windows.automation.expandcollapsepattern.aspx"><code>ExpandCollapsePattern</code></a>
@@ -5799,7 +5123,6 @@
                   <th><code>open</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-dialog-open"><code>dialog</code></a></td>
                   <td class="aria"><a class="core-mapping" href="#ariaExpandedTrue"><code>aria-expanded</code></a>="true | false"</td>
-                  <td class="uia-express"><code>STATE_SYSTEM_EXPANDED</code><br /><code>STATE_SYSTEM_COLLAPSED</code></td>
                   <td class="ia2"><code>STATE_SYSTEM_EXPANDED</code><br /><code>STATE_SYSTEM_COLLAPSED</code></td>
                   <td class="uia">
                     <a href="https://msdn.microsoft.com/en-us/library/system.windows.automation.expandcollapsepattern.aspx"><code>ExpandCollapsePattern</code></a>
@@ -5818,7 +5141,6 @@
                   <th><code>optimum</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-meter-optimum"><code>meter</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5833,7 +5155,6 @@
                   <th><code>pattern</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-input-pattern"><code>input</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="states">
                       <span class="type">States: </span>
@@ -5854,7 +5175,6 @@
                   <th><code>placeholder</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-input-placeholder"><code>input</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-textarea-placeholder"><code>textarea</code></a></td>
                   <td class="aria"><a class="core-mapping" href="#ariaPlaceholder"><code>aria-placeholder</code></a></td>
-                  <td class="uia-express"><div class="general">Not mapped to UIA tree. Participates in <a href="https://rawgit.com/w3c/aria/master/accname-aam/accname-aam.html">Accessible Name and Description Calculation</a></div></td>
                   <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                   <td class="uia"><div class="general">Not mapped to UIA tree. Participates in <a href="https://rawgit.com/w3c/aria/master/accname-aam/accname-aam.html">Accessible Name and Description Calculation</a></div></td>
                   <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -5865,7 +5185,6 @@
                   <th><code>poster</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-video-poster"><code>video</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5880,7 +5199,6 @@
                   <th><code>preload</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-media-preload"><code>audio</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-media-preload"><code>video</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5895,7 +5213,6 @@
                   <th><code>radiogroup</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-menuitem-radiogroup"><code>menuitem</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5910,7 +5227,6 @@
                   <th><code>readonly</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-input-readonly"><code>input</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-textarea-readonly"><code>textarea</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express"><code>STATE_SYSTEM_READONLY</code></td>
                   <td class="ia2">
                     <div class="states">
                       Adds <code>STATE_SYSTEM_READONLY</code> bit to
@@ -5933,7 +5249,6 @@
                   <th><code>rel</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-hyperlink-rel"><code>a</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-hyperlink-rel"><code>area</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-link-rel"><code>link</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5960,7 +5275,6 @@
                   <th><code>reversed</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-ol-reversed"><code>ol</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">Reverses the order of the child list items in the accessibility tree and reverses the numbering of the child list items.</td>
                   <td class="ia2">
                     <div class="general">
                       Reverses the numbering of the child list item accessible objects.
@@ -5979,7 +5293,6 @@
                   <th><code>rows</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-textarea-rows"><code>textarea</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -5994,7 +5307,6 @@
                   <th><code>rowspan</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-tdth-rowspan"><code>td</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-tdth-rowspan"><code>th</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       exposed via <code>IAccessibleTableCell::rowExtent</code>
@@ -6020,7 +5332,6 @@
                   <th><code>sandbox</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-iframe-sandbox"><code>iframe</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -6035,7 +5346,6 @@
                   <th><code>spellcheck</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/editing.html#attr-spellcheck">HTML elements</a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="textattrs">
                       Mapped to "invalid" text attribute on the text container
@@ -6054,7 +5364,6 @@
                   <th><code>scope</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-th-scope"><code>th</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Defines whether the element is a row or column header (refer to <a href="#el-th"><code>th</code></a> element)
@@ -6073,7 +5382,6 @@
                   <th><code>scoped</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-style-scoped"><code>style</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -6088,7 +5396,6 @@
                   <th><code>seamless</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-iframe-seamless"><code>iframe</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -6103,7 +5410,6 @@
                   <th><code>selected</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-option-selected"><code>option</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="states">
                       <span class="type">States: </span>
@@ -6126,7 +5432,6 @@
                   <th><code>shape</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-area-shape"><code>area</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -6141,7 +5446,6 @@
                   <th><code>size</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-input-size"><code>input</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-select-size"><code>select</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       If greater than 1, then creates a listbox accessible object. Refer to <a href="#el-select-listbox"><code>select</code></a> element for details.
@@ -6160,7 +5464,6 @@
                   <th><code>sizes</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-link-sizes"><code>link</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -6175,7 +5478,6 @@
                   <th><code>span</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-col-span"><code>col</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-colgroup-span"><code>colgroup</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       exposed as <code>IAccessibleTableCell::columnExtent</code> on
@@ -6195,7 +5497,6 @@
                   <th><code>src</code></th>
                   <td class="elements"> <a href="http://www.w3.org/TR/html51/semantics.html#attr-media-src"><code>audio</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-embed-src"><code>embed</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-iframe-src"><code>iframe</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-img-src"><code>img</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-input-src"><code>input</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-script-src"><code>script</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-source-src"><code>source</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-track-src"><code>track</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-media-src"><code>video</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="objattrs">
                       <span class="type">Object attributes: </span>
@@ -6216,7 +5517,6 @@
                   <th><code>srcdoc</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-iframe-srcdoc"><code>iframe</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -6231,7 +5531,6 @@
                   <th><code>srclang</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-track-srclang"><code>track</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -6246,7 +5545,6 @@
                   <th><code>start</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-ol-start"><code>ol</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Changes the first number of the child list item accessible objects to match the <code>start</code> attribute's value.
@@ -6265,7 +5563,6 @@
                   <th><code>step</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-input-step"><code>input</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">If the input is in the <a href="el-input-range"><code>Range</code></a> state, set both <code>RangeValue.SmallChange</code> and <code>RangeValue.LargeChange</code> to the value of <code>step</code></td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -6285,7 +5582,6 @@
                   <th><code>style</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/dom.html#the-style-attribute">HTML elements</a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Refer to CSS accessibility mapping
@@ -6317,7 +5613,6 @@
                   <th><code>tabindex</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/editing.html#attr-tabindex">HTML elements</a></td>
                   <td class="aria">Not mapped</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="states">
                       <span class="type">States: </span>
@@ -6338,7 +5633,6 @@
                   <th><code>target</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-hyperlink-target"><code>a</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-hyperlink-target"><code>area</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -6353,7 +5647,6 @@
                   <th><code>target</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-base-target"><code>base</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -6368,7 +5661,6 @@
                   <th><code>target</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-fs-target"><code>form</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -6383,7 +5675,6 @@
                   <th><code>title</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/dom.html#the-title-attribute" title="attr-title">HTML elements</a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="name">
                       Associates the <a class="termref">accessible name</a> or if it was provided otherwise then
@@ -6404,7 +5695,6 @@
                   <th><code>title</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-abbr-title"><code>abbr</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-dfn-title"><code>dfn</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="name">
                       Associates the <a class="termref">accessible name</a>
@@ -6423,7 +5713,6 @@
                   <th><code>title</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-menuitem-title"><code>menuitem</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="name">
                       Associates the <a class="termref">accessible name</a> or if it was provided otherwise then
@@ -6444,7 +5733,6 @@
                   <th><code>title</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-link-title"><code>link</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -6461,7 +5749,6 @@
                   <th><code>title</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-link-title"><code>link</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-style-title"><code>style</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -6478,7 +5765,6 @@
                   <th><code>translate</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/dom.html#attr-translate">HTML elements</a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -6493,7 +5779,6 @@
                   <th><code>type</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-hyperlink-type"><code>a</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-hyperlink-type"><code>area</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-link-type"><code>link</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -6508,7 +5793,6 @@
                   <th><code>type</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-button-type"><code>button</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       <a href="#el-input_submit"><code>submit</code></a> type may be a default button in the form
@@ -6527,7 +5811,6 @@
                   <th><code>type</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-button-type"><code>button</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-input-type"><code>input</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Defines the accessible role, states and other properties, refer to
@@ -6552,7 +5835,6 @@
                   <th><code>type</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-menuitem-type"><code>menuitem</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Defines the accessible role and states, refer to
@@ -6573,7 +5855,6 @@
                   <th><code>type</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-embed-type"><code>embed</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-object-type"><code>object</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-script-type"><code>script</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-source-type"><code>source</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-style-type"><code>style</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -6588,7 +5869,6 @@
                   <th><code>type</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-menu-type"><code>menu</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -6603,7 +5883,6 @@
                   <th><code>typemustmatch</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-object-typemustmatch"><code>object</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">Not mapped</div>
                   </td>
@@ -6618,7 +5897,6 @@
                   <th><code>usemap</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-hyperlink-usemap"><code>img</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-hyperlink-usemap"><code>object</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Responsible for image map creation, refer to <a href="#el-img"><code>img</code></a> element
@@ -6637,7 +5915,6 @@
                   <th><code>value</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-button-value"><code>button</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-option-value"><code>option</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped 
@@ -6656,7 +5933,6 @@
                   <th><code>value</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-input-value"><code>input</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="name">
                       Associates the accessible value for entry type input elements
@@ -6681,7 +5957,6 @@
                   <th><code>value</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-li-value"><code>li</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Exposed as first text node of <code>li</code>'s accessible object.
@@ -6711,7 +5986,6 @@
                   <th><code>value</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-meter-value"><code>meter</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-progress-value"><code>progress</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Exposed as <code>IAccessibleValue::currentValue</code>
@@ -6730,7 +6004,6 @@
                   <th><code>value</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-param-value"><code>param</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Not mapped
@@ -6749,7 +6022,6 @@
                   <th><code>width</code></th>
                   <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-canvas-width"><code>canvas</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-dim-width"><code>embed</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-dim-width"><code>iframe</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-dim-width"><code>img</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-dim-width"><code>input</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-dim-width"><code>object</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-dim-width"><code>video</code></a></td>
                   <td class="aria">&#160;</td>
-                  <td class="uia-express">&#160;</td>
                   <td class="ia2">
                     <div class="general">
                       Defines an accessible object's width (<code>IAccessible::accLocation</code>)
@@ -6768,7 +6040,6 @@
                 <th><code>wrap</code></th>
                 <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-textarea-wrap"><code>textarea</code></a></td>
                 <td class="aria">&#160;</td>
-                <td class="uia-express">&#160;</td>
                 <td class="ia2">
                   <div class="general">
                     Not mapped


### PR DESCRIPTION
moved relevant info from msaa+uiaexpress columns into msaa+ia2 columns,
and deleted msaa+uiaexpress columns from both tables. Included some
clean up of msaa+ia2 column.

There were too many changes so GH won't display the diff. It's also clear that we need to remove the msaa+uiaexpress column, so it makes sense to merge now, and then any review can compare the updated master branch with an earlier instance of the html-aam, as the msaa+uiaexpress column hasn't changed much in a while.
