### PR TITLE
ACTION-2103: Provide uia mappings for roles feed, figure, and term; and aria-colcount, aria-colspan, aria-colindex, aria-rowcount, aria-rowindex, aria-rowspan, and aria-details.

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -734,10 +734,10 @@ var mappingTableLabels = {
                         <td>
 				<code>ROLE_SYSTEM_GROUPING</code> + object attribute <code>xml-roles:feed</code></td>
                         <td>
-                            Need to verify. 
-			    <ul><li>Control Type: <code>Group</code></li>
-                                <li>Localized Control Type: <code>"feed"</code></li>
-                            </ul>
+			                    <ul>
+                            <li>Control Type = <code>Group</code></li>
+                            <li>Localized Control Type = "<code>feed</code>"</li>
+                          </ul>
                         </td>
                         <td>
                                 <code>ROLE_PANEL</code> + object attribute <code>xml-roles:feed</code>
@@ -752,10 +752,12 @@ var mappingTableLabels = {
         	<tr id="role-map-figure">
                 	<th><a class="role-reference" href="#figure"><code>figure</code></a> [ARIA 1.1]</th>                
 			<td><code>ROLE_SYSTEM_GROUPING</code> + object attribute <code>xml-roles:figure</code></td>
-          		<td><ul><li>Control Type: <code>Group</code></li> 
-				<li>Localized Control Type: <code>"figure"</code></li>
-			    </ul>
-			</td>
+          		<td>
+                <ul>
+                  <li>Control Type = <code>Group</code></li> 
+				          <li>Localized Control Type = "<code>figure</code>"</li>
+              </ul>
+          </td>
           		<td>
               			<code>ROLE_PANEL</code> + object attribute <code>xml-roles:figure</code>
           		</td>                         
@@ -1246,7 +1248,7 @@ var mappingTableLabels = {
           <td><code>ROLE_SYSTEM_TEXT</code> + object attribute <code>text-input-type:search</code></td>
           <td>
             <ul>
-              <li>Control Type is <code>Edit</code></li>
+              <li>Control Type = <code>Edit</code></li>
               <li>Localized Control Type is "<code>search box</code>"</li>
             </ul>
           </td>
@@ -1422,14 +1424,13 @@ var mappingTableLabels = {
 					<li><code>STATE_SYSTEM_READONLY</code></li>
 				</ul>
 			</td>                        
-			<td>Control Type: <code>ListItem</code>
-                        </td>
-                        <td>
+			<td>Control Type = <code>ListItem</code></td>
+      <td>
 				<ul>
-                                	<li><code>ROLE_DESCRIPTION_TERM</code> </li>
+          <li><code>ROLE_DESCRIPTION_TERM</code> </li>
 					<li>Interfaces: <code>AtkText</code>; <code>AtkHypertext</code></li>
 				</ul>
-                        </td>          
+      </td>          
                         <td>    AXRole: <code>AXGroup</code><br />
                                 AXSubrole: <code>AXTerm</code><br />
                                 AXRoleDescription: <code>'term'</code></td>
@@ -1718,7 +1719,10 @@ var mappingTableLabels = {
 			</ul>
 		  </td>
                   <td>
-                    TBD.
+                    <ul>
+                      <li>Implement <code>Grid</code> Control Pattern</li>
+                      <li>Set <code>ColumnCount</code> property</li>
+                    </ul>
                   </td>
                   <td>
                         <ul>
@@ -1739,8 +1743,11 @@ var mappingTableLabels = {
 
 		  </td>
                   <td>
-                    <p><code>GridItem.Column</code></p>
-                    <p>Subtract 1 from the one-based <code>aria-colindex</code> since the UIA value is zero-based.</p>
+                    <ul>
+                      <li>Implement <code>GridItem</code> Control Pattern</li>
+                      <li>Set <code>Column</code> property</li>
+                      <li>Note: UIA values are zero-based</li>
+                    </ul>
                   </td>
                   <td>
                         <ul>
@@ -1766,7 +1773,10 @@ var mappingTableLabels = {
 			</ul>
 		  </td>
                   <td>
-                    Exposed via <code>ColumnSpan</code> in the <code>GridItem</code> pattern
+                    <ul>
+                      <li>Implement <code>GridItem</code> Control Pattern</li>
+                      <li>Set <code>ColumnSpan</code> property</li>
+                    </ul>
                   </td>
                   <td>
 			<ul>
@@ -1833,7 +1843,7 @@ var mappingTableLabels = {
 		   <p>IAccessible2: </p>
 		   <p>If the referenced object is in the accessibility tree, expose a pointer to the accessible object using <code>IA2_RELATION_DETAILS</code>, and expose reverse relations as described in <a href="#mapping_additional_relations">Relations</a>.</p>
 		  </td>
-                  <td>TBD.</td>
+                  <td><code>DescribedBy</code> property points to the referenced element</td>
                   <td>
                    <p>If the referenced object is in the accessibility tree, expose a pointer to the accessible object using <code>RELATION_DETAILS</code>, and expose reverse relations as described in <a href="#mapping_additional_relations">Relations</a>.</p>
 		  </td>
@@ -2420,7 +2430,10 @@ var mappingTableLabels = {
                         </ul>
                   </td>
                   <td>
-                    TBD.
+                    <ul>
+                      <li>Implement <code>Grid</code> Control Pattern</li>
+                      <li>Set <code>RowCount</code> property</li>
+                    </ul>
                   </td>
                   <td>
                         <ul>
@@ -2440,8 +2453,11 @@ var mappingTableLabels = {
                         </ul>
 		  </td>
                   <td>
-                    <p><code>GridItem.Row</code></p>
-                    <p>Subtract 1 from the one-based <code>aria-rowindex</code> since the UIA value is zero-based.</p>
+                    <ul>
+                      <li>Implement <code>GridItem</code> Control Pattern</li>
+                      <li>Set <code>Row</code> property</li>
+                      <li>Note: UIA values are zero-based</li>
+                    </ul>
                   </td>
  		  <td>
                         <ul>
@@ -2464,7 +2480,10 @@ var mappingTableLabels = {
                                 <li>Expose via <code>IAccessibleTableCell::rowExtent</code></li>
                         </ul>
                   <td>
-                    Expose via <code>RowSpan</code> in the <code>GridItem</code> pattern
+                    <ul>
+                      <li>Implement <code>GridItem</code> Control Pattern</li>
+                      <li>Set <code>RowSpan</code> property</li>
+                    </ul>
                   </td>
                   <td>
                         <ul>

--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -1208,7 +1208,12 @@ var mappingTableLabels = {
 				<tr id="role-map-scrollbar">
 					<th><a class="role-reference" href="#scrollbar"><code>scrollbar</code></a></th>
           <td><code>ROLE_SYSTEM_SCROLLBAR</code></td>
-          <td><code>scrollbar</code></td>
+          <td>
+            <ul>
+              <li>Control Type = <code>ScrollBar</code></li>
+              <li>Implement <code>Range</code> Control Pattern</li>
+            </ul>
+          </td>
           <td>
             <ul>
               <li><code>ROLE_SCROLLBAR</code></li>
@@ -1239,7 +1244,13 @@ var mappingTableLabels = {
         <tr id="role-map-searchbox">
 		  <th><a class="role-reference" href="#searchbox"><code>searchbox</code></a>  [ARIA 1.1]</th>
           <td><code>ROLE_SYSTEM_TEXT</code> + object attribute <code>text-input-type:search</code></td>
-          <td>Control Type is <code>Edit</code>.  Localized Control Type is "<code>search box</code>"</td>
+          <td>
+            <ul>
+              <li>Control Type is <code>Edit</code></li>
+              <li>Localized Control Type is "<code>search box</code>"</li>
+            </ul>
+          </td>
+          </td>
           <td>
             <ul>
               <li><code>ROLE_ENTRY</code> + <code>STATE_SINGLE_LINE</code> if <a class="property-reference" href="#aria-multiline"><code>aria-multiline</code></a> is not <code>&quot;true&quot;</code></li>
@@ -1289,7 +1300,10 @@ var mappingTableLabels = {
 				<tr id="role-map-slider">
 					<th><a class="role-reference" href="#slider"><code>slider</code></a></th>
 					<td><code>ROLE_SYSTEM_SLIDER</code></td>
-                    <td><code>Slider</code></td>
+          <td><ul>
+              <li>Control Type = <code>Slider</code></li>
+              <li>Implement <code>Range</code> Control Pattern</li>
+            </ul></td>
 					<td>
 					  <ul>
 					    <li><code>ROLE_SLIDER</code></li>
@@ -1304,7 +1318,10 @@ var mappingTableLabels = {
 				<tr id="role-map-spinbutton">
 					<th><a class="role-reference" href="#spinbutton"><code>spinbutton</code></a></th>
 					<td><code>ROLE_SYSTEM_SPINBUTTON</code></td>
-          <td><code>Spinner</code></td>
+          <td><ul>
+              <li>Control Type = <code>Spinner</code></li>
+              <li>Implement <code>Range</code> Control Pattern</li>
+            </ul></td>
 					<td>
 					  <ul>
 					    <li><code>ROLE_SPIN_BUTTON</code></li>


### PR DESCRIPTION
Map outstanding ARIA 1.1 roles and properties to relevant UIA values.
Fortunately for the defined roles I beleive the mapping is really clean
and straightforward. I would expect the only question might be raised
for aria-details. We map this to UIA DescribedBy property that achieves
the desired effect - the aria-details element would be referenced, not
it's value won't be used in Name or Description computation.