### PR TITLE
Provide UIA mappings for DPUB-AAM

### DIFF
--- a/dpub-aam/dpub-aam.html
+++ b/dpub-aam/dpub-aam.html
@@ -236,8 +236,8 @@ var mappingTableLabels = {
 								</td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-abstract' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'abstract'</code>.</li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>abstract</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-abstract</code>. </p></td>
@@ -257,8 +257,8 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-acknowledgments' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'acknowledgements'</code></li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>acknowledgements</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code><code>ROLE_LANDMARK</code></code> and object attribute <code>xml-roles:doc-acknowledgments</code>. </p></td>
@@ -279,8 +279,8 @@ var mappingTableLabels = {
 
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-afterword' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'afterword'</code>.</li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>afterword</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-afterword</code>. </p></td>
@@ -301,8 +301,8 @@ var mappingTableLabels = {
 
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-appendix' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'appendix'</code>.</li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>appendix</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-appendix</code>. </p></td>
@@ -327,8 +327,8 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-backlink' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'back HyperLink'</code>. </li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>backlink</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LINK</code> and object attribute <code>xml-roles:doc-backlink</code>. </p></td>
@@ -347,8 +347,8 @@ var mappingTableLabels = {
 									<p>IAccessible2:</p><p>Object attribute <code>xml-roles:doc-biblioentry</code>.</p></td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-biblioentry' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'bibliography entry'</code>.</li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>biblioentry</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LIST_ITEM</code> and object attribute <code>xml-roles:doc-bilioentry</code>.</p></td>
@@ -367,10 +367,9 @@ var mappingTableLabels = {
                                                                         </ul>
 
                                                                 <td>
-								  Expose IAccessible2:
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-bibliography' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'bibliography'</code>.</li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>bibliography</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-bibliography</code>. </p></td>
@@ -395,8 +394,8 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-biblioref' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'bibliography references'</code>.</li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>biblioref</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LINK</code> and object attribute <code>xml-roles:doc-biblioref</code>. </p></td>
@@ -417,8 +416,8 @@ var mappingTableLabels = {
                                                                 </td>
 								<td>
 								  <ul>
-							    <li>Expose as text string 'doc-chapter' in <code>AriaRole</code>. </li>
-								    <li>Control type/role is <code>'chapter'</code>.</li>
+                                                                    <li>Control Type is <code>Text</code></li>
+								    <li>Localized Control Type is '<code>chapter</code>'</li>
 								  </ul>
 								</td>
 								<td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:chapter</code>. </p></td>
@@ -432,8 +431,8 @@ var mappingTableLabels = {
                                                                 <td>Expose<p><code>IA2_ROLE_SECTION</code></p><p>IAccessible2: Object attribute <code>xml-roles:doc-colophon</code>. </p></td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-colophon' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'colophon'</code>.</li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>colophon</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-colophon</code>. </p></td>
@@ -454,8 +453,8 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-conclusion' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'conclusion'</code>.</li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>conclusion</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-conclusion</code>. </p></td>
@@ -469,7 +468,7 @@ var mappingTableLabels = {
                                                                 <td>Expose <p><code>ROLE_SYSTEM_GRAPHIC</code></p>  
 								<p>IAccessible2: </p>Object attribute <code>xml-roles:doc-cover</code>. </p>
 								</td>
-                                                                <td><code>Image</code>
+                                                                <td>Control Type is <code>Image</code>
                                                                 </td>
                                                                 <td> <p>expose <code>ROLE_IMAGE</code> and
 									object attribute <code>xml-roles:doc-cover</code>. </p> 
@@ -484,8 +483,8 @@ var mappingTableLabels = {
                                                                 <td>Expose<p><code>IA2_ROLE_SECTION</code></p><p>IAccessible2:</p> Object attribute <code>xml-roles:doc-credit</code></td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-credit' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'credit'</code>. </li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>credit</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-credit</code>. </p></td>
@@ -505,8 +504,8 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-credits' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'credits'</code>.</li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>credits</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-credits</code>. </p></td>
@@ -520,8 +519,8 @@ var mappingTableLabels = {
                                                                 <td>Expose<p><code>IA2_ROLE_SECTION</code></p><p>IAccessible2:</p> Object attribute <code>xml-roles:doc-dedication</code></td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-dedication' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'dedication'</code>. </li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>dedication</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-dedication</code>. </p></td>
@@ -538,8 +537,8 @@ var mappingTableLabels = {
                                                                         <p>IAccessible2:</p><p>Object attribute <code>xml-roles:doc-endnote</code>.</p></td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-endnote' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'endnote'</code>.</li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>endnote</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LIST_ITEM</code> and object attribute <code>xml-roles:doc-endnote</code>. </p></td>
@@ -560,8 +559,8 @@ var mappingTableLabels = {
 
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-endnotes' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'endnotes'</code>.</li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>endnotes</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-endnotes</code>. </p></td>
@@ -576,8 +575,8 @@ var mappingTableLabels = {
                                                                 <td>Expose<p><code>IA2_ROLE_SECTION</code></p><p>IAccessible2:</p> Object attribute <code>xml-roles:doc-epigraph</code></td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-epigraph' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'epigraph'</code>.</li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>epigraph</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-epigraph</code>. </p></td>
@@ -597,8 +596,8 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-epilogue' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'epilogue'</code>. </li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>epilogue</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-epilogue</code>. </p></td>
@@ -619,8 +618,8 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-errata' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'errata'</code>. Localized Control Type is based on <code>AriaRole</code>. </li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>errata</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-errata</code>. </p></td>
@@ -634,8 +633,8 @@ var mappingTableLabels = {
                                                                 <td>Expose<p><code>IA2_ROLE_SECTION</code></p><p>IAccessible2:</p> Object attribute <code>xml-roles:doc-example</code></td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-example' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'example'</code>.</li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>example</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-example</code>. </p></td>
@@ -654,8 +653,8 @@ var mappingTableLabels = {
 								</td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-footnote' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'footnote'</code>. </li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>footnote</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_FOOTNOTE</code> and object attribute <code>xml-roles:doc-footnote</code>. </p></td>
@@ -675,8 +674,8 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-foreword' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'foreword'</code>.</li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>foreword</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-foreword</code>. </p></td>
@@ -696,8 +695,8 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'glossary' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'glossary'</code>.</li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>glossary</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-glossary</code>. </p></td>
@@ -722,8 +721,8 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-glossref' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'glossary reference'</code>.</li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>glossref</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LINK</code> and object attribute <code>xml-roles:doc-glossref</code>. </p></td>
@@ -745,8 +744,8 @@ p
                                                                 </td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-index' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'index'</code>. </li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>index</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-index</code>. </p></td>
@@ -766,8 +765,8 @@ p
                                                                 </td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-introduction' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'introduction'</code>. </li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>introduction</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-introduction</code>. </p></td>
@@ -793,8 +792,8 @@ p
                                                                 </td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-noteref' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'note reference'</code>. </li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>noteref</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LINK</code> and object attribute <code>xml-roles:doc-noteref</code>. </p></td>
@@ -811,8 +810,8 @@ p
 								    <p> IAccessible2:</p> Object attribute <code>xml-roles:doc-notice</code>.</td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-notice' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'notice'</code>.</li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>notice</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_COMMENT</code> and object attribute <code>xml-roles:doc-notice</code>.</p></td>
@@ -829,8 +828,8 @@ p
 								</td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-pagebreak' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'pagebreak'</code>.</li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>pagebreak</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SEPARATOR</code> and object attribute <code>xml-roles:doc-pagebreak</code>. </p></td>
@@ -850,8 +849,8 @@ p
                                                                 </td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-pagelist' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'page list'</code>. </li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>pagelist</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td>Expose <p><code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-pagelist</code>. </p></td>
@@ -871,8 +870,8 @@ p
                                                                 </td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-part' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'part'</code>. </li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>part</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-part</code>. </p></td>
@@ -892,8 +891,8 @@ p
                                                                 </td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-preface' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>preface</code>. </li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>preface</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-pagebreak</code>. </p></td>
@@ -913,8 +912,8 @@ p
                                                                 </td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-prologue' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'prologue'</code>. </li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>prologue</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-prologue</code>. </p></td>
@@ -926,7 +925,12 @@ p
                                                          <tr id="role-map-pullquote">
                                                                 <th><a class="dpub-role-reference" href="#doc-pullquote"><code>doc-pullquote</code></a></th>
                                                                 <td>not mapped</td>
-                                                                <td>not mapped</td>
+                                                                <td>
+                                                                  <ul>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>pullquote</code>'</li>
+                                                                  </ul>
+                                                                </td>
                                                                 <td>not mapped</td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
                                                                         AXSubrole: <code>&lt;nil&gt;</code><br/>
@@ -938,8 +942,8 @@ p
                                                                 <td>Expose<p><code>IA2_ROLE_SECTION</code></p><p>IAccessible2:</p> Object attribute <code>xml-roles:doc-qna</code></td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-qna' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'questions and answers'</code>. </li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>qna</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-qna</code>. </p></td>
@@ -958,8 +962,8 @@ p
 								</td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-subtitle' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'subtitle'</code>. </li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>subtitle</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_HEADING</code> and object attribute <code>xml-roles:doc-subtitle</code>. </p></td>
@@ -978,8 +982,8 @@ p
 								</td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-tip' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'tip'</code>.</li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>tip</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-tip</code>. </p></td>
@@ -999,8 +1003,8 @@ p
                                                                 </td>
                                                                 <td>
                                                                   <ul>
-                                                                    <li>Expose as text string 'doc-toc' in <code>AriaRole</code>. </li>
-                                                                    <li>Control type/role is <code>'doc toc'</code>. </li>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>toc</code>'</li>
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_LANDMARK</code> and object attribute <code>xml-roles:doc-toc</code>.</p></td>

--- a/dpub-aam/dpub-aam.html
+++ b/dpub-aam/dpub-aam.html
@@ -925,12 +925,7 @@ p
                                                          <tr id="role-map-pullquote">
                                                                 <th><a class="dpub-role-reference" href="#doc-pullquote"><code>doc-pullquote</code></a></th>
                                                                 <td>not mapped</td>
-                                                                <td>
-                                                                  <ul>
-                                                                    <li>Control Type is <code>Text</code></li>
-                                                                    <li>Localized Control Type is '<code>pullquote</code>'</li>
-                                                                  </ul>
-                                                                </td>
+                                                                <td>not mapped</td>
                                                                 <td>not mapped</td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
                                                                         AXSubrole: <code>&lt;nil&gt;</code><br/>


### PR DESCRIPTION
UIA mapping is to expose digital publication text entities in the UIA tree. This is achieved by mapping them to UIA Control Type "Text" and using role as Localized Control Type (without "doc-" prefix). 

Using "doc-toc" as example - it's mapped to the following:
- Control Type is Text
- Localized Control Type is "toc"

This is true for all text based roles, the only exception is "doc-cover" that is mapped to UIA Image Control Type. 

Last doc-pullquote is not mapped as agreed upon in W3C.
