### PR TITLE
one mapping-tables script that works with or without respec

### DIFF
--- a/common/script/mapping-tables.js
+++ b/common/script/mapping-tables.js
@@ -1,7 +1,18 @@
-/* globals $, require */
+//check for require() and respec context
+if (typeof require !== "undefined") {
+	/* globals $, require */
+	require(["core/pubsubhub"], function(respecEvents) {
+		mapTables(respecEvents);
+	});
+} else {
+	$(document).ready(function() {
+		mapTables(false);
+	});
+}
 
-require(["core/pubsubhub"], function(respecEvents) {
-    "use strict";
+function mapTables(respecEvents) {
+   
+  "use strict";
 
 	var mappingTableInfos = [];
 
@@ -249,6 +260,6 @@ require(["core/pubsubhub"], function(respecEvents) {
 			});
 		});
 	} else {
-		$(document).ready(mappingTables);
+		mappingTables();
 	}
-});
+}


### PR DESCRIPTION
A single mapping-tables.js that checks for respec context, and executes
accordingly. This is instead of having two versions, one for the respec
context in the master branch, and a different version for the snapshot
gh-pages branch. See related w3c/html-aam issue 74:
https://github.com/w3c/html-aam/issues/74

I'm sure my implementation can be improved, but is currently working.

We needed to do this to support auto-publishing of WD for the HTML-AAM. It also reduces the number of exceptions to publishing from a 'master' branch, since mapping-tables.js has only version, regardless of branch/context.