### PR TITLE
Clarify that owned-by author rules need explicit role attributes

### DIFF
--- a/common/terms.html
+++ b/common/terms.html
@@ -134,7 +134,7 @@
     <dd>
       <p>Usable by users in ways they can control. References in this document relate to <cite><a href="http://www.w3.org/TR/WCAG20/#operable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.0 Principle 2: Content must be operable</a></cite> [[WCAG20]]. See <a>Keyboard Accessible</a>.</p>
     </dd>
-    <dt><dfn data-lt="owned element|owned|owned element's|owned elements">Owned Element</dfn></dt>
+    <dt><dfn data-lt="owned element|owns|owned|owned element's|owned elements">Owned Element</dfn></dt>
     <dd>
       <p>An 'owned element' is any <abbr title="Document Object Model">DOM</abbr> descendant of the <a>element</a>, any element specified as a child via <pref>aria-owns</pref>, or any <abbr title="Document Object Model">DOM</abbr> descendant of the owned child.</p>
     </dd>

--- a/index.html
+++ b/index.html
@@ -1204,7 +1204,7 @@
 			<rdef>cell</rdef>
 			<div class="role-description">
 				<p>A cell in a tabular container. See related <rref>gridcell</rref>.</p>
-				<p>Authors MUST ensure <a>elements</a> with <a>role</a> cell are contained in, or owned by, an element with the <a>role</a> <rref>row</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <code>cell</code> are <a>owned</a> by an <a>element</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <rref>row</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -1396,7 +1396,7 @@
 				<p>A cell containing header information for a column.</p>
 				<p><code>columnheader</code> can be used as a column header in a table or grid. It could also be used in a pie chart to show a similar <a>relationship</a> in the data.</p>
 				<p>The <code>columnheader</code> establishes a relationship between it and all cells in the corresponding column. It is the structural equivalent to an <abbr title="Hypertext Markup Language">HTML</abbr> <code>th</code> <a>element</a> with a column scope.</p>
-				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>columnheader</code> are contained in, or owned by, an element with the role <rref>row</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <code>columnheader</code> are <a>owned</a> by an <a>element</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <rref>row</rref>.</p>
 				<p>Applying the <sref>aria-selected</sref> state on a columnheader MUST not cause the user agent to automatically propagate the <sref>aria-selected</sref> state to all the cells in the corresponding column. An author MAY choose to propagate selection in this manner depending on the specific application.</p>
 				<p>While the <code>columnheader</code> role can be used in both interactive grids and non-interactive tables, the use of <pref>aria-readonly</pref> and <pref>aria-required</pref> is only applicable to interactive elements. Therefore, authors SHOULD NOT use <pref>aria-required</pref> or <pref>aria-readonly</pref> in a <code>columnheader</code> that descends from a <rref>table</rref>, and user agents SHOULD NOT expose either property to <a>assistive technologies</a> unless the <code>columnheader</code> descends from a <rref>grid</rref>.</p>
 				<p class="note">Because cells are organized into rows, there is not a single container element for the column. The column is the set of <rref>gridcell</rref> elements in a particular position within their respective <rref>row</rref> containers.</p>
@@ -1488,9 +1488,9 @@
 			<rdef>combobox</rdef>
 			<div class="role-description">
 				<p>A composite <rref>widget</rref> containing a single-line <rref>textbox</rref> and another element, such as a <rref>listbox</rref> or <rref>grid</rref>, that can dynamically pop up to help the user set the value of the <rref>textbox</rref>.</p>
-				<p>Authors MUST ensure an element with role <code>combobox</code> contains or owns a text input element with role <rref>textbox</rref> or <rref>searchbox</rref> and that the text input has <pref>aria-multiline</pref> set to <code>false</code>. If the <code>combobox</code> provides autocompletion behavior for the text input as described in <pref>aria-autocomplete</pref>, authors MUST set <pref>aria-autocomplete</pref> on the <rref>textbox</rref> element to the value that corresponds to the provided behavior.</p>
+				<p>Authors MUST ensure an <a>element</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <code>combobox</code> <a>owns</a> a text input <a>element</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <rref>textbox</rref> or <rref>searchbox</rref> and that the text input has <pref>aria-multiline</pref> set to <code>false</code>. If the <code>combobox</code> provides autocompletion behavior for the text input as described in <pref>aria-autocomplete</pref>, authors MUST set <pref>aria-autocomplete</pref> on the <rref>textbox</rref> element to the value that corresponds to the provided behavior.</p>
 				<p>Typically, the default state of a <code>combobox</code> is collapsed. In the collapsed state, only the <rref>textbox</rref> element of a <code>combobox</code> is visible. A <code>combobox</code> is said to be expanded when both the <rref>textbox</rref> and a secondary element that serves as its popup are visible. Authors MUST set <sref>aria-expanded</sref> to <code>true</code> on an element with role <code>combobox</code> when it is expanded and <code>false</code> when it is collapsed. Elements with the role <code>combobox</code> have an implicit <sref>aria-expanded</sref> value of <code>false</code>.</p>
-				<p>When a <code>combobox</code> is expanded, authors MUST ensure it contains or owns an element that has a role of <rref>listbox</rref>, <rref>tree</rref>, <rref>grid</rref>, or <rref>dialog</rref>. This element is the <code>combobox</code> popup. When the <code>combobox</code> is expanded, authors MUST set <pref>aria-controls</pref> on the <rref>textbox</rref> element to a value that refers to the <code>combobox</code> popup element.</p>
+				<p>When a <code>combobox</code> is expanded, authors MUST ensure it <a>owns</a> an element that has an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <rref>listbox</rref>, <rref>tree</rref>, <rref>grid</rref>, or <rref>dialog</rref>. This element is the <code>combobox</code> popup. When the <code>combobox</code> is expanded, authors MUST set <pref>aria-controls</pref> on the <rref>textbox</rref> element to a value that refers to the <code>combobox</code> popup element.</p>
 				<p>Elements with the role <code>combobox</code> have an implicit <pref>aria-haspopup</pref> value of <code>listbox</code>. If the <code>combobox</code> popup element has a role other than <rref>listbox</rref>, authors MUST specify a value for <pref>aria-haspopup</pref> that corresponds to the type of its popup.</p>
 				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>. When a <code>combobox</code> receives focus, authors SHOULD ensure focus is placed on the <rref>textbox</rref> element.</p>
 				<p>Authors SHOULD provide keyboard mechanisms for moving focus between the <rref>textbox</rref> element and the elements contained in the popup. For example, one common convention is that <kbd>Down Arrow</kbd> moves focus from the text input to the first focusable descendant of the popup element. If the popup element supports <pref>aria-activedescendant</pref>, in lieu of moving focus, such keyboard mechanisms can control the value of <pref>aria-activedescendant</pref> on the <rref>textbox</rref> element. When a descendant of the popup element is active, authors MAY set <pref>aria-activedescendant</pref> on the <rref>textbox</rref> to a value that refers to the active element within the popup while focus remains on the <rref>textbox</rref> element.</p>
@@ -2492,7 +2492,7 @@
 			<div class="role-description">
 				<p>A composite <rref>widget</rref> containing a collection of one or more rows with one or more cells where some or all cells in the grid are focusable by using methods of two-dimensional navigation, such as directional arrow keys.</p>
 				<p>The <code>grid</code> role does not imply a specific visual, e.g., tabular, presentation. It describes <a>relationships</a> among <a>elements</a>. It may be used for purposes as simple as grouping a collection of checkboxes or navigation links or as complex as creating a full-featured spreadsheet application.</p>
-				<p>The cell elements of a <code>grid</code> have role <rref>gridcell</rref>. Authors MAY designate a cell as a row or column header by using either the <rref>rowheader</rref> or <rref>columnheader</rref> <a>role</a> in lieu of the <rref>gridcell</rref> role. Authors MUST ensure elements with role <rref>gridcell</rref>, <rref>columnheader</rref>, or <rref>rowheader</rref> are <a>owned</a> by elements with role <rref>row</rref>, which are in turn owned by an element with role <rref>rowgroup</rref>, or <code>grid</code>.</p>
+				<p>The cell elements of a <code>grid</code> have role <rref>gridcell</rref>. Authors MAY designate a cell as a row or column header by using either the <rref>rowheader</rref> or <rref>columnheader</rref> <a>role</a> in lieu of the <rref>gridcell</rref> role. Authors MUST ensure elements with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <rref>gridcell</rref>, <rref>columnheader</rref>, or <rref>rowheader</rref> are <a>owned</a> by elements with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <rref>row</rref>, which are in turn <a>owned</a> by an <a>element</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <rref>rowgroup</rref> or <code>grid</code>.</p>
 				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants of a <code>grid</code> as described in <a href="#managingfocus">Managing Focus</a>. When a user is navigating the <code>grid</code> content with a keyboard, authors SHOULD set focus as follows:</p>
 				<ul>
 					<li>If a <rref>gridcell</rref> contains a single interactive <rref>widget</rref> that will not consume arrow key presses when it receives focus, such as a <rref>checkbox</rref>, <rref>button</rref>, or <rref>link</rref>, authors MAY set focus on the interactive element contained in that cell. This allows the contained widget to be directly operable.</li>
@@ -2607,9 +2607,9 @@
 			<div class="role-description">
 				<p>A <rref>cell</rref> in a <rref>grid</rref> or <rref>treegrid</rref>.</p>
 				<p>A <code>gridcell</code> may be focusable, editable, and selectable. A <code>gridcell</code> may have <a>relationships</a> such as <pref>aria-controls</pref> to address the application of functional relationships.</p>
-				<p>If an author intends a <code>gridcell</code> to have a row header, column header, or both, and if the relevant headers cannot be determined from the <abbr title="Document Object Model">DOM</abbr> structure, authors SHOULD explicitly indicate which header cells are relevant to the <code>gridcell</code> by applying <pref>aria-describedby</pref> on the <code>gridcell</code> and referencing <a>elements</a> with <a>role</a> <rref>rowheader</rref> or <rref>columnheader</rref>.</p>
+				<p>If an author intends a <code>gridcell</code> to have a row header, column header, or both, and if the relevant headers cannot be determined from the <abbr title="Document Object Model">DOM</abbr> structure, authors SHOULD explicitly indicate which header cells are relevant to the <code>gridcell</code> by applying <pref>aria-describedby</pref> on the <code>gridcell</code> and referencing <a>elements</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <rref>rowheader</rref> or <rref>columnheader</rref>.</p>
 				<p>In a <rref>treegrid</rref>, authors MAY define a <code>gridcell</code> as expandable by using the <sref>aria-expanded</sref> attribute. If the <sref>aria-expanded</sref> attribute is provided, it applies only to the individual cell. It is not a proxy for the container <rref>row</rref>, which also can be expanded. The main use case for providing this attribute on a <code>gridcell</code> is pivot table behavior.</p>
-				<p>Authors MUST ensure <a>elements</a> with <a>role</a> gridcell are contained in, or owned by, an element with the <a>role</a> <rref>row</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <code>gridcell</code> are <a>owned</a> by an <a>element</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <rref>row</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -3383,7 +3383,7 @@
 			<rdef>listitem</rdef>
 			<div class="role-description">
 				<p>A single item in a list or directory.</p>
-				<p>Authors MUST ensure <a>elements</a> with <a>role</a>  <code>listitem</code> are contained in, or owned by, an <a>element</a> with the <a>role</a> <rref>list</rref> or <rref>group</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <code>listitem</code> are <a>owned </a> by an <a>element</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <rref>list</rref> or <rref>group</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4041,7 +4041,7 @@
 			<div class="role-description">
 				<p>An option in a set of choices contained by a <rref>menu</rref> or <rref>menubar</rref>.</p>
 				<p>Authors MAY disable a menu item with the <sref>aria-disabled</sref> attribute. If the menu item has its <pref>aria-haspopup</pref> attribute set to <code>true</code>, it indicates that the menu item may be used to launch a sub-level menu, and authors SHOULD display a new sub-level menu when the menu item is activated.</p>
-				<p>Authors MUST ensure that menu items are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref> in order to identify that they are related <a>widgets</a>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
+				<p>Authors MUST ensure that <a>elements</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <code>menuitem</code> are <a>owned</a> by an <a>element</a> with an explicit <a><code>role</code></a> attribute whose value contains <rref>menu</rref> or <rref>menubar</rref>, in order to identify that they are related <a>widgets</a>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4148,7 +4148,7 @@
 			<div class="role-description">
 				<p>A <rref>menuitem</rref> with a checkable state whose possible <span>values</span> are <code>true</code>, <code>false</code>, or <code>mixed</code>.</p>
 				<p>The <sref>aria-checked</sref> <a>attribute</a> of a <code>menuitemcheckbox</code> indicates whether the menu item is checked (<code>true</code>), unchecked (<code>false</code>), or represents a sub-level menu of other menu items that have a mixture of checked and unchecked values (<code>mixed</code>).</p>
-				<p>Authors MUST ensure that menu item checkboxes are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref> in order to identify that they are related widgets. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
+				<p>Authors MUST ensure that <a>elements</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <code>menuitemcheckbox</code> are <a>owned</a> by an <a>element</a> with an explicit <a><code>role</code></a> attribute whose value contains <rref>menu</rref> or <rref>menubar</rref>, in order to identify that they are related widgets. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4247,7 +4247,7 @@
 				<p>A checkable <rref>menuitem</rref> in a set of elements with the same role, only one of which can be checked at a time.</p>
 				<p>Authors SHOULD enforce that only one <code>menuitemradio</code> in a group can be checked at the same time. When one item in the group is checked, the previously checked item becomes unchecked (its <sref>aria-checked</sref> <a>attribute</a> becomes <code>false</code>).</p>
 				<!-- keep previous sentence synced with radiogroup, etc. -->
-				<p>Authors MUST ensure that menu item radios are <a>owned</a> by an element with role <rref>group</rref>, <rref>menu</rref>, or <rref>menubar</rref> in order to identify that they are related widgets. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
+				<p>Authors MUST ensure that <a>elements</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <code>menuitemradio</code> are <a>owned</a> by an <a>element</a> with an explicit <a><code>role</code></a> attribute whose value contains <rref>group</rref>, <rref>menu</rref>, or <rref>menubar</rref>, in order to identify that they are related widgets. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
                 <p>If a <rref>menu</rref> or <rref>menubar</rref> contains more than one group of <code>menuitemradio</code> elements, or if the menu contains one group and other, unrelated menu items, authors SHOULD nest each set of related <code>menuitemradio</code> elements in an element using the <rref>group</rref> role, and authors SHOULD delimit the group from other menu items with an element using the <rref>separator</rref> role.</p>
 			</div>
 			<table class="role-features">
@@ -4508,7 +4508,7 @@
 			<rdef>option</rdef>
 			<div class="role-description">
 				<p>A selectable item in a <rref>select</rref> list.</p>
-				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>option</code> are contained in, or owned by, an element with the <a>role</a>  <rref>listbox</rref>. Options not associated with a <rref>listbox</rref> might not be correctly mapped to an <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a>.</p>
+				<p>Authors MUST ensure <a>elements</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <code>option</code> are <a>owned</a> by an element with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <rref>listbox</rref>. Options not associated with a <rref>listbox</rref> might not be correctly mapped to an <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a>.</p>
 				<p>Elements with the role <code>option</code> have an implicit <sref>aria-selected</sref> value of <code>false</code>.</p>
 			</div>
 			<table class="role-features">
@@ -5364,7 +5364,7 @@
 				<p>A row of cells in a tabular container.</p>
 				<p>Rows contain <rref>cell</rref> or <rref>gridcell</rref> <a>elements</a>, and thus serve to organize the <rref>table</rref> or <rref>grid</rref>.</p>
 				<p>In a <rref>treegrid</rref>, authors MAY mark rows as expandable, using the <sref>aria-expanded</sref> <a>attribute</a> to indicate the present status. This is not the case for an ordinary <rref>table</rref> or <rref>grid</rref>, in which the <sref>aria-expanded</sref> attribute is not present.</p>
-				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>row</code> are contained in, or <a>owned</a> by, an element with the role <rref>table</rref>, <rref>grid</rref>, <rref>rowgroup</rref>, or <rref>treegrid</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <code>row</code> are <a>owned</a> by an element with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <rref>table</rref>, <rref>grid</rref>, <rref>rowgroup</rref>, or <rref>treegrid</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -5474,7 +5474,7 @@
 			<div class="role-description">
 				<p>A structure containing one or more row elements in a tabular container.</p>
 				<p>The <code>rowgroup</code> role establishes a <a>relationship</a> between <a>owned</a> <rref>row</rref> elements. It is a structural equivalent to the <code>thead</code>, <code>tfoot</code>, and <code>tbody</code> elements in an <abbr title="Hypertext Markup Language">HTML</abbr> <code>table</code> <a>element</a>.</p>
-				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>rowgroup</code> are contained in, or <a>owned</a> by, an element with the role <rref>table</rref> or <rref>grid</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <code>rowgroup</code> are <a>owned</a> by an element with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <rref>table</rref> or <rref>grid</rref>.</p>
 				<p class="note">The <code>rowgroup</code> role exists, in part, to support role symmetry in HTML, and allows for the propagation of presentation inheritance on HTML <code>table</code> elements with an explicit <code>presentation</code> role applied.</p>
 				<p class="note">This role does not differentiate between types of row groups (e.g., <code>thead</code> vs. <code>tbody</code>), but an issue has been raised for <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 2.0.</p>
 			</div>
@@ -5572,7 +5572,7 @@
 			<div class="role-description">
 				<p>A cell containing header information for a row in a grid.</p>
 				<p>Rowheader can be used as a row header in a table or grid. The rowheader establishes a <a>relationship</a> between it and all cells in the corresponding row. It is a structural equivalent to setting <code>scope="row"</code> on an <abbr title="Hypertext Markup Language">HTML</abbr> <code>th</code> <a>element</a>.</p>
-				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>rowheader</code> are contained in, or <a>owned</a> by, an element with the role <rref>grid</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <code>rowheader</code> are <a>owned</a> by an element with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <rref>grid</rref>.</p>
 				<p>Applying the <sref>aria-selected</sref> state on a rowheader MUST not cause the user agent to automatically propagate the <sref>aria-selected</sref> state to all the cells in the corresponding row. An author MAY choose to propagate selection in this manner depending on the specific application.</p>
 				<p>While the <code>rowheader</code> role can be used in both interactive grids and non-interactive tables, the use of <pref>aria-readonly</pref> and <pref>aria-required</pref> is only applicable to interactive elements. Therefore, authors SHOULD NOT use <pref>aria-required</pref> or <pref>aria-readonly</pref> in a <code>rowheader</code> that descends from a <rref>table</rref>, and user agents SHOULD NOT expose either property to <a>assistive technologies</a> unless the <code>rowheader</code> descends from a <rref>grid</rref>.</p>
 			</div>
@@ -6738,7 +6738,7 @@
 			<div class="role-description">
 				<p>A grouping label providing a mechanism for selecting the tab content that is to be rendered to the user.</p>
 				<p>If a  <rref>tabpanel</rref> or item in a <rref>tabpanel</rref> has focus, the associated <code>tab</code> is the currently active tab in the <rref>tablist</rref>, as defined in <a href="#managingfocus">Managing Focus</a>. <rref>tablist</rref> elements, which contain a set of associated <rref>tab</rref> elements, are typically placed near a series of <rref>tabpanel</rref> elements, usually preceding it. See the <cite><a href="https://www.w3.org/TR/wai-aria-practices-1.1/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> [[WAI-ARIA-PRACTICES-1.1]] for details on implementing a tab set design pattern.</p>
-				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <rref>tab</rref> are contained in, or <a>owned</a> by, an element with the role <rref>tablist</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <rref>tab</rref> are <a>owned</a> by an element with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <rref>tablist</rref>.</p>
 				<p>Authors SHOULD ensure the <rref>tabpanel</rref> associated with the currently active tab is <a>perceivable</a> to the user.</p>
 
 				<!-- keep following para synced with its counterpart in #tablist -->
@@ -7838,7 +7838,7 @@
 			<div class="role-description">
 				<p>An option item of a <rref>tree</rref>. This is an <a>element</a> within a tree that may be expanded or collapsed if it contains a sub-level group of tree item elements.</p>
 				<p>A collection of <code>treeitem</code> elements to be expanded and collapsed are enclosed in an element with the <rref>group</rref> <a>role</a>.</p>
-				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>treeitem</code> are contained in, or <a>owned</a> by, an element with the role <rref>group</rref> or <rref>tree</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <code>treeitem</code> are <a>owned</a> by an element with an explicit <a data-lt="dfn-role-attribute"><code>role</code></a> attribute whose value contains <rref>group</rref> or <rref>tree</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -10905,7 +10905,7 @@
 	<p>Although markup languages look alike superficially, they do not share language definition infrastructure. To accommodate differences in language-building approaches, the requirements are both general and modularization-specific. While allowing for differences in how the specifications are written, the intent is to maintain consistency in how the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> information looks to authors and how it is manipulated in the <abbr title="Document Object Model">DOM</abbr> by scripts.</p>
 	<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles, states, and properties are implemented as <a>attributes</a> of <a>elements</a>. Roles are applied by placing their names among the tokens appearing in the value of a host-language-provided <code>role</code> attribute. States and properties each get their own attribute, with values as defined for each particular state or property in this specification. The name of the attribute is the aria-prefixed name of the state or property.</p>
 	<section id="host_general_role">
-		<h2>Role Attribute</h2>
+		<h2><dfn>Role Attribute</dfn></h2>
 		<p>An implementing host language will provide an <a>attribute</a> with the following characteristics:</p>
 		<ul>
 			<li>The attribute name MUST be <code>role</code>;</li>


### PR DESCRIPTION
There are sentences in the ARIA spec which state document-conformance requirements for role values that have owned-by relationships with other role values. This change clarifies those sentences to state unambiguously that elements must have **explicit role attributes** containing those values in order for the requirements to be relevant.

For example, this change takes the following sentence:

> Authors MUST ensure elements with role `cell` are contained in, or owned by, an element with the role `row`. 

…and replaces that with this sentence:

> Authors MUST ensure elements with an explicit `role` attribute whose value contains `cell` are owned by an element with an explicit `role` attribute whose value contains `row`.

Also, the same sentences used the phrase “contained in, or owned by” but since the definition of “owned by” states that “An 'owned element' is any DOM *descendant* of the element, any element specified as a child via aria-owns, or any DOM *descendant* of the owned child” it’s not necessary to state “contained in, or owned by”; instead that phrase can be replaced by just “owned by”—since the definition of “owned by” already incorporates a “contained in” _descendant_-ancestor relationship as among what it means (so, “contained in, or owned by” is unnecessarily redundant).

Note that this change is relevant to the behavior for the HTML checker. For the context, see https://github.com/validator/validator/issues/425#issuecomment-269841829 and the discussion that follows that comment.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/511.html" title="Last updated on Jan 11, 2018, 1:13 PM GMT (2855dc6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/511/e81aa27...2855dc6.html" title="Last updated on Jan 11, 2018, 1:13 PM GMT (2855dc6)">Diff</a>