### PR TITLE
Updated UIA mappings for role=heading

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -854,7 +854,12 @@ var mappingTableLabels = {
 					<th><a class="role-reference" href="#heading"><code>heading</code></a>
 					  <span class="el-context">&#8211; The heading level is specified by the <a href="#ariaLevel"><code>aria-level</code></a> property.</span></th>
 					<td>Expose as object attribute <code>xml-roles:heading</code>.<p>Also, expose <code>IA2_ROLE_HEADING</code></p></td>
-          <td><code>Text</code></td>
+          <td>
+		  	<ul>
+                            <li>Control Type is <code>Text</code>.</li>
+                            <li>Localized Control Type is <code>heading</code>.</li>
+                        </ul>
+					</td>
 					<td><code>ROLE_HEADING</code></td>
 					<td>AXRole: <code>AXHeading</code><br />
               AXSubrole: <code>&lt;nil&gt;</code><br />


### PR DESCRIPTION
Control Type=Text is the best current UIA target (no change), additionally use Localized Control Type=heading to capture "heading" semantic