### PR TITLE
UIA changes to table of accessibility APIs for focus states and events

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -275,21 +275,21 @@ var mappingTableLabels = {
   <tr>
     <th>Focusable state</th>
     <td><code>STATE_SYSTEM_FOCUSABLE</code></td>
-    <td><code>UIA_IsKeyboardFocusablePropertyId</code></td>
+    <td>Current state reflected in <code>IUIAutomationElement::CurrentIsKeyboardFocusable</code>, can be retrieved with <code>IUIAutomationElement::GetCurrentPropertyValue</code> method using <code>UIA_IsKeyboardFocusablePropertyId</code> property identifier.</td>
     <td><code>STATE_FOCUSABLE</code></td>
     <td><code>boolean AXFocused</code>: the <code>accessibilityIsAttributeSettable</code> method returns <code>YES</code>.</td>
   </tr>
   <tr>
     <th>Focused state</th>
     <td><code>STATE_SYSTEM_FOCUSED</code></td>
-    <td><code>UIA_HasKeyboardFocusPropertyId</code></td>
+    <td>Current state reflected in <code>IUIAutomationElement::CurrentHasKeyboardFocus</code>, can be retrieved with <code>IUIAutomationElement::GetCurrentPropertyValue</code> method using <code>UIA_HasKeyboardFocusPropertyId</code> property identifier.</td>
     <td><code>STATE_FOCUSED</code></td>
     <td><code>boolean AXFocused</code></td>
   </tr>
   <tr>
     <th>Focus event</th>
     <td><code>EVENT_OBJECT_FOCUS</code></td>
-    <td><code>UIA_AutomationFocusChangedEventId</code></td>
+	  <td>Clients can subscribe with <code>IUIAutomation::AddFocusChangedEventHandler</code> using callback interface is <code>IUIAutomationFocusChangedEventHandler</code></td>
     <td><code>object:state-changed:focused</code> and:
 		<ul>
 	      <li><code>detail1 = 1</code> for the <a class="termref">accessible object</a> which just gained focus.</li>


### PR DESCRIPTION
Using literal descriptions from current documentation:

[1] IUIAutomationElement: https://technet.microsoft.com/en-us/library/dd319590(v=vs.85).aspx#PropertyIds
[2] Automation Element Property Identifiers: https://technet.microsoft.com/en-us/library/dd757479(v=vs.85).aspx 
[3] UI Automation Events for Clients: https://technet.microsoft.com/en-us/library/dd319588(v=vs.85).aspx 
[4] IUIAutomation::AddFocusChangedEventHandler Method: https://technet.microsoft.com/en-us/library/dd388739(v=vs.85).aspx 
[5] IUIAutomationFocusChangedEventHandler Interface: https://technet.microsoft.com/en-us/library/dd375418(v=vs.85).aspx