### PR TITLE
[Core AAM] Update AXRoleDescription mappings for alertdialog and dialog

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -537,7 +537,7 @@ var mappingTableLabels = {
                     </td>
 					<td>AXRole: <code>AXGroup</code><br />
                         AXSubrole: <code>AXApplictionAlertDialog</code><br />
-                        AXRoleDescription: <code> 'alert dialog'</code>
+                        AXRoleDescription: <code> 'web alert dialog'</code>
 				        <p>The user agent SHOULD fire a system alert event.<sup>[<a href="#ftn.note2">Note 2</a>]</sup></p></td>
 				</tr>
 				<tr id="role-map-application">
@@ -730,7 +730,7 @@ var mappingTableLabels = {
 				    </td>
 					<td>AXRole: <code>AXGroup</code><br />
               AXSubrole: <code>AXApplicationDialog</code><br />
-              AXRoleDescription: <code>'dialog'</code></td>
+              AXRoleDescription: <code>'web dialog'</code></td>
 				</tr>
         <tr id="role-map-directory">
 					<th><a class="role-reference" href="#directory"><code>directory</code></a></th>


### PR DESCRIPTION
* AXRoleDescription for alertdialog is now "web alert dialog"
* AXRoleDescription for dialog is now "web dialog"

Fixes github issue #535