### PR TITLE
[Core AAM] Remove RELATION_POPUP_FOR from ATK/AT-SPI mappings of aria-haspopup

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -2051,7 +2051,6 @@ var mappingTableLabels = {
                     <ul>
                       <li>Expose <code>STATE_HAS_POPUP</code></li>
 				      <li>Expose as object attribute <code>haspopup:true</code></li>
-                      <li>[ARIA 1.1] Expose pointer <code>RELATION_POPUP_FOR</code> on the popup <a class="termref">accessible object</a> to point to the accessible object that has the <code>STATE_HAS_POPUP</code> state.  There is no reverse relationship from the accessible object that triggers the display of the popup to that popup accessible object.</li>
                     </ul>
                   </td>
                   <td>Expose <code>AXShowMenu</code> and <code>AXPress</code> actions</td>
@@ -2081,7 +2080,6 @@ var mappingTableLabels = {
                     <ul>
                       <li>Expose <code>STATE_HAS_POPUP</code></li>
                       <li>Expose as object attribute <code>haspopup:dialog</code></li>
-                      <li>Expose pointer <code>RELATION_POPUP_FOR</code> on the popup <a class="termref">accessible object</a> to point to the accessible object that has the <code>STATE_HAS_POPUP</code> state.  There is no reverse relationship from the accessible object that triggers the display of the popup to that popup accessible object.</li>
                     </ul>
                   </td>
                   <td>Expose <code>AXShowMenu</code> and <code>AXPress</code> actions</td>
@@ -2099,7 +2097,6 @@ var mappingTableLabels = {
                     <ul>
                       <li>Expose <code>STATE_HAS_POPUP</code></li>
                       <li>Expose as object attribute <code>haspopup:listbox</code></li>
-                      <li>Expose pointer <code>RELATION_POPUP_FOR</code> on the popup <a class="termref">accessible object</a> to point to the accessible object that has the <code>STATE_HAS_POPUP</code> state.  There is no reverse relationship from the accessible object that triggers the display of the popup to that popup accessible object.</li>
                    </ul>
                   </td>
                   <td>Expose <code>AXShowMenu</code> and <code>AXPress</code> actions</td>
@@ -2117,7 +2114,6 @@ var mappingTableLabels = {
                     <ul>
                       <li>Expose <code>STATE_HAS_POPUP</code></li>
                       <li>Expose as object attribute <code>haspopup:menu</code></li>
-                      <li>Expose pointer <code>RELATION_POPUP_FOR</code> on the popup <a class="termref">accessible object</a> to point to the accessible object that has the <code>STATE_HAS_POPUP</code> state.  There is no reverse relationship from the accessible object that triggers the display of the popup to that popup accessible object.</li>
                   </ul>
                   </td>
                   <td>Expose <code>AXShowMenu</code> and <code>AXPress</code> actions</td>
@@ -2135,7 +2131,6 @@ var mappingTableLabels = {
                     <ul>
 		              <li>Expose <code>STATE_HAS_POPUP</code></li>
 				      <li>Expose as object attribute <code>haspopup:tree</code></li>
-                      <li>Expose pointer <code>RELATION_POPUP_FOR</code> on the popup <a class="termref">accessible object</a> to point to the accessible object that has the <code>STATE_HAS_POPUP</code> state.  There is no reverse relationship from the accessible object that triggers the display of the popup to that popup accessible object.</li>
 			        </ul>
                   </td>
                   <td>Expose <code>AXShowMenu</code> and <code>AXPress</code> actions</td>
@@ -3397,12 +3392,13 @@ var mappingTableLabels = {
 		<section>
 			<h2>Substantive changes since the <a href="http://www.w3.org/TR/2015/WD-core-aam-1.1-20151119/">last public working draft</a></h2>
 			<ul>
+				<li>14-Mar-2017: Undid the 1.1 addition of RELATION_POPUP_FOR to ATK/AT-SPI mappings of aria-haspopup. While the addition is correct in terms of platform expectations, the ARIA spec provides no means through which user agents could reliably implement this.</li>
 				<li>20-Jan-2017: Added AX API mappings for aria-colcount, aria-colspan, aria-colindex, aria-rowcount, aria-rowindex, and aria-rowspan.</li>
 				<li>07-Dec-2016: Added UIA mappings for roles feed, figure, and term, and for aria-colcount, aria-colspan, aria-colindex, aria-rowcount, aria-rowindex, aria-rowspan, and aria-details.  Added UIA Range Value Pattern for range related roles scrollbar, slider, and spinbutton.</li>
 				<li>24-Oct-2016: Changed name of IA2 object property name for aria-placeholder to "placeholder-text" (was "placeholder").</li>
 				<li>04-Oct-2016: Add reverse relationships for aria-details and aria-errormessage on platforms MSAA/IA2 and ATK/ATSPI</li>
 				<li>03-Oct-2016: Added aria-roledescription mappings for empty and whitespace strings as well as error handling text.</li>
-				<li>12-Sep-2016: Added RELATION_POPUP_FOR to ATK/AT-SPI mappings of aria-haspopup, for ARIA 1.1.</li>
+				<li>12-Sep-2016: Added RELATION_POPUP_FOR to ATK/AT-SPI mappings of aria-haspopup, for ARIA 1.1. N.B. This change has subsequently been undone. See entry for 14-Mar-2017.</li>
 				<li>08-Sep-2016: Added figure role, term role, feed role, aria-colspan, and aria-rowspan mappings. Updated table properties for row and column for MSAA/IA2 and ATK/AT-SPI.  Added MSAA+IA2 and ATK/AT-SPI mappings of aria-details and aria-errormessage.</li>
 				<li>08-Aug-2016: Modified ATK/AT-SPI mappings of aria-readonly.</li>
 				<li>04-Jul-2016: Added AX API mapping for aria-keyshortcuts.</li>


### PR DESCRIPTION
This mapping was added during the 1.1 cycle. And while it is correct in terms
of platform expectations, the ARIA spec provides no means through which user
agents could reliably implement this.