### PR TITLE
Core-AAM: Fix error in IA2 and ATK mappings for aria-current

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -1925,14 +1925,14 @@ var mappingTableLabels = {
                   <th><a class="state-reference" href="#aria-current"><code>aria-current</code></a> (state) [ARIA 1.1] </th>
                   <td>
                     <ul>
-                      <li>Expose the value of <code>aria-current</code> in object attribute <code>active:&lt;value&gt;</code>.</li>
+                      <li>Expose the value of <code>aria-current</code> in object attribute <code>current:&lt;value&gt;</code>.</li>
                     </ul>
                   </td>
                   <td>Expose <code>current=&lt;value&gt;</code> in <code>AriaProperties</code>.</td>
                   <td>
                     <ul>
                       <li>Set <code>STATE_ACTIVE</code>. </li>
-                      <li>Expose the value of <code>aria-current</code> in object attribute <code>active:&lt;value&gt;</code>.</li>
+                      <li>Expose the value of <code>aria-current</code> in object attribute <code>current:&lt;value&gt;</code>.</li>
                     </ul>
                   </td>
                   <td><code>AXAriaCurrent: &lt;value&gt;</code>.</td>


### PR DESCRIPTION
The mappings state that the name of the object attribute is "active"; it should instead be "current."