### PR TITLE
Core AAM: Fix ATK/AT-SPI2 mapping for ARIA listitem role

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -959,7 +959,7 @@ var mappingTableLabels = {
 					<td><code>ROLE_SYSTEM_LISTITEM</code> + <code>STATE_SYSTEM_READONLY</code></td>
           <td><p><code>ListItem</code></p>
               <p>Also requires <code>selectionitem</code> pattern; <code>selectionContainer</code> property must reference the parent <code>list</code> object</p></td>
-					<td><code>ROLE_LISTITEM</code> + do not expose <code>STATE_EDITABLE</code></td>
+					<td><code>ROLE_LIST_ITEM</code></td>
 					<td>AXRole: <code>AXGroup</code><br />
               AXSubrole: <code>&lt;nil&gt;</code><br />
               AXRoleDescription: <code>'group'</code></td>


### PR DESCRIPTION
* Change ROLE_LISTITEM to ROLE_LIST_ITEM to reflect what is in both ATK and AT-SPI2.

* Remove "do not expose STATE_EDITABLE" because that is not necessarily accurate, nor is it specific to ARIA's listitem role: STATE_EDITABLE should be exposed for any element, regardless of role, if and only if the text of that element can be changed by the user.