### PR TITLE
Core-AAM: Update AXSubrole value for group role

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -869,7 +869,7 @@ var mappingTableLabels = {
           <td><code>Group</code></td>
 					<td><code>ROLE_PANEL</code></td>
 					<td>AXRole: <code>AXGroup</code><br />
-              AXSubrole: <code>&lt;nil&gt;</code><br />
+              AXSubrole: <code>AXApplicationGroup</code><br />
               AXRoleDescription: <code>'group'</code></td>
 				</tr>
 				<tr id="role-map-heading">


### PR DESCRIPTION
Apple has recently added a new AXSubrole value for ARIA's group role.
See https://trac.webkit.org/changeset/214623