### PR TITLE
DPUB-AAM: Map doc-pullquote for ATK, IA2, and UIA.

### DIFF
--- a/dpub-aam/dpub-aam.html
+++ b/dpub-aam/dpub-aam.html
@@ -1073,6 +1073,7 @@ p
                 		<section>
                         		<h2>Substantive changes since the <a href="https://www.w3.org/TR/2015/WD-dpub-aam-1.0-20151203/">last public working draft</a></h2>
                         		<ul>
+                                		<li>20-Apr-2017: Map doc-pullquote for ATK/ATSPI2, IA2, and UIA.</li>
                                 		<li>10-Mar-2016: Replace all ROLE_PANEL to ROLE_SECTION for ATK/ATSPI mappings</li>
                                 		<li>10-Mar-2016: Replace doc-locator with doc-backlink</li>
 						<li>10-Mar-2016: Remove doc-title</li>

--- a/dpub-aam/dpub-aam.html
+++ b/dpub-aam/dpub-aam.html
@@ -924,9 +924,20 @@ p
                                                         </tr>
                                                          <tr id="role-map-pullquote">
                                                                 <th><a class="dpub-role-reference" href="#doc-pullquote"><code>doc-pullquote</code></a></th>
-                                                                <td>not mapped</td>
-                                                                <td>not mapped</td>
-                                                                <td>not mapped</td>
+                                                                <td>
+                                                                        Expose IAccessible2:
+                                                                        <ul>
+                                                                                <li><code>IA2_ROLE_SECTION</code></li>
+                                                                                <li>Object attribute <code>xml-roles:doc-pullquote</code> </li>
+                                                                        </ul>
+                                                                </td>
+                                                                <td>
+                                                                  <ul>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>pullquote</code>'</li>
+                                                                  </ul>
+                                                                 </td>
+                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-pullquote</code>.</p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
                                                                         AXSubrole: <code>&lt;nil&gt;</code><br/>
                                                                     AXRoleDescription: <code>'group'</code>


### PR DESCRIPTION
The "not mapped" mapping in this spec contradicts what is stated in the
DPub ARIA spec, namely that doc-pullquote will be exposed unless authors
explicitly mark it as presentational or hidden. See mailing list thread:
https://lists.w3.org/Archives/Public/public-dpub-aria/2017Apr/thread.html#msg0