### PR TITLE
Core-AAM: Correct spelling of two constants for ATK/AT-SPI2

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -962,7 +962,7 @@ var mappingTableLabels = {
 					<td><code>ROLE_SYSTEM_LISTITEM</code> + <code>STATE_SYSTEM_READONLY</code></td>
           <td><p><code>ListItem</code></p>
               <p>Also requires <code>selectionitem</code> pattern; <code>selectionContainer</code> property must reference the parent <code>list</code> object</p></td>
-					<td><code>ROLE_LISTITEM</code> + do not expose <code>STATE_EDITABLE</code></td>
+					<td><code>ROLE_LIST_ITEM</code> + do not expose <code>STATE_EDITABLE</code></td>
 					<td>AXRole: <code>AXGroup</code><br />
               AXSubrole: <code>&lt;nil&gt;</code><br />
               AXRoleDescription: <code>'group'</code></td>
@@ -2442,10 +2442,10 @@ var mappingTableLabels = {
                     <p>For elements with <code>role='gridcell'</code>, and no <code>aria-readonly</code> property, the grid cell MUST inherit any author <code>aria-readonly='true'</code> property from the containing <code>grid</code> or <code>treegrid</code> and expose <code>Value.IsReadOnly=&quot;true&quot;</code>.</p></td>
                   <td><p>[ARIA 1.1]</p>
                     <ul>
-                      <li><code>STATE_READONLY</code></li>
+                      <li><code>STATE_READ_ONLY</code></li>
                       <li>Clear <code>STATE_EDITABLE</code> if on a <a class="role-reference" href="#textbox">textbox</a></li>
                     </ul>
-                    <p>For elements with <code>role='gridcell'</code>, and no <code>aria-readonly</code> property, the grid cell MUST inherit any author <code>aria-readonly='true'</code> property from the containing <code>grid</code> or <code>treegrid</code> and expose <code>STATE_READONLY</code>.</p></td>
+                    <p>For elements with <code>role='gridcell'</code>, and no <code>aria-readonly</code> property, the grid cell MUST inherit any author <code>aria-readonly='true'</code> property from the containing <code>grid</code> or <code>treegrid</code> and expose <code>STATE_READ_ONLY</code>.</p></td>
                   <td><p><code>AXValue</code>:  the <code>accessibilityIsAttributeSettable</code> method returns <code>NO</code>.</p>
                     <p>For elements with <code>role='gridcell'</code>, and no <code>aria-readonly</code> property, the grid cell MUST inherit any author <code>aria-readonly='true'</code> property from the containing <code>grid</code> or <code>treegrid</code> and expose <code>AXValue</code> such that the <code>accessibilityIsAttributeSettable</code> method returns <code>NO</code>.</p></td>
                 </tr>


### PR DESCRIPTION
In both ATK and AT-SPI2:
* The listitem role constant is ROLE_LIST_ITEM (not ROLE_LISTITEM)
* The readonly state constant is STATE_READ_ONLY (not STATE_READONLY)