### PR TITLE
Core-AAM: Fix AXRoleDescription value for tablist role

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -1527,7 +1527,7 @@ var mappingTableLabels = {
 					</td>
 					<td>AXRole: <code>AXTabGroup</code><br />
               AXSubrole: <code>&lt;nil&gt;</code><br />
-              AXRoleDescription: <code>'tabgroup'</code></td>
+              AXRoleDescription: <code>'tab group'</code></td>
 				</tr>
 				<tr id="role-map-tabpanel">
 					<th><a class="role-reference" href="#tabpanel"><code>tabpanel</code></a></th>


### PR DESCRIPTION
Based on both Safari and Chrome, the correct value is "tab group";
not "tabgroup".