### PR TITLE
Core-AAM: Fix "current" state name for AXAPI

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -1938,7 +1938,7 @@ var mappingTableLabels = {
                       <li>Expose the value of <code>aria-current</code> in object attribute <code>current:&lt;value&gt;</code>.</li>
                     </ul>
                   </td>
-                  <td><code>AXAriaCurrent: &lt;value&gt;</code>.</td>
+                  <td><code>AXARIACurrent: &lt;value&gt;</code>.</td>
                 </tr>
                 <tr id="ariaCurrentUndefined">
                   <th><a class="state-reference" href="#aria-current"><code>aria-current</code></a> is undefined (state) [ARIA 1.1]</th>


### PR DESCRIPTION
Safari exposes the value of aria-current via AXARIACurrent; not
AXAriaCurrent. This capitalization of "ARIA" is consistent with
the other AXAPI state and property names.