### PR TITLE
Core-AAM: Fix CFRange property names for AXAPI

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -1908,9 +1908,9 @@ var mappingTableLabels = {
 			</ul>
                   </td>
                   <td><code>AXColumnIndexRange:<br />
-				loc=&lt;column index&gt;<br />
-				len=&lt;colspan value&gt;</code>,<br />
-				where <code>loc</code> is 0-based.
+				location=&lt;column index&gt;<br />
+				length=&lt;colspan value&gt;</code>,<br />
+				where <code>location</code> is 0-based.
 		  </td>
                 </tr>
 
@@ -2577,9 +2577,9 @@ var mappingTableLabels = {
                         </ul>
                   </td>
                   <td><code>AXRowIndexRange:<br />
-								loc=&lt;row index&gt;<br />
-								len=&lt;rowspan value&gt;,</code>
-								where <code>loc</code> is 0-based.
+								location=&lt;row index&gt;<br />
+								length=&lt;rowspan value&gt;,</code>
+								where <code>location</code> is 0-based.
                   </td>
                 </tr>
 


### PR DESCRIPTION
AXAPI exposes aria-colspan and aria-rowspan through AXColumnIndexRange
and AXRowIndexRange respectively. These range values are of type
kAXValueCFRangeType which is a wrapper for CFRange [1]. Looking at the
documentation for CFRange [2], the properties are location and length;
not loc and len.

[1] https://developer.apple.com/reference/applicationservices/axvaluetype/kaxvaluecfrangetype
[2] https://developer.apple.com/reference/corefoundation/cfrange