### PR TITLE
DPUB-AAM: Update mappings

### DIFF
--- a/dpub-aam/dpub-aam.html
+++ b/dpub-aam/dpub-aam.html
@@ -242,8 +242,8 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-abstract</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: <code>AXLandmarkRegion</code><br/>
-                                                                    AXRoleDescription: <code>'region'</code>
+                                                                        AXSubrole: <code>AXApplicationGroup</code><br/>
+                                                                    AXRoleDescription: <code>'group'</code>
                                                                 </td>
                                                         </tr>
                                                        <tr id="role-map-acknowledgments">
@@ -437,7 +437,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-colophon</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: <code>&lt;nil&gt;</code><br/>
+                                                                        AXSubrole: AXApplicationGroup</code><br/>
                                                                     AXRoleDescription: <code>'group'</code>
                                                                 </td>
 
@@ -489,7 +489,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-credit</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: <code>&lt;nil&gt;</code><br/>
+                                                                        AXSubrole: <code>AXApplicationGroup</code><br/>
                                                                     AXRoleDescription: <code>'group'</code>
 								</td>
                                                         </tr>
@@ -525,7 +525,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-dedication</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: <code>&lt;nil&gt;</code><br/>
+                                                                        AXSubrole: <code>AXApplicationGroup</code><br/>
                                                                     AXRoleDescription: <code>'group'</code>
                                                                 </td>
                                                         </tr>
@@ -581,7 +581,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-epigraph</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: <code>&lt;nil&gt;</code><br/>
+                                                                        AXSubrole: <code>AXApplicationGroup</code><br/>
                                                                     AXRoleDescription: <code>'group'</code>
                                                                 </td>
                                                         </tr>
@@ -639,7 +639,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-example</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: <code>&lt;nil&gt;</code><br/>
+                                                                        AXSubrole: <code>AXApplicationGroup</code><br/>
                                                                     AXRoleDescription: <code>'group'</code>
                                                                 </td>
                                                         </tr>
@@ -659,7 +659,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_FOOTNOTE</code> and object attribute <code>xml-roles:doc-footnote</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: <code>&lt;nil&gt;</code><br/>
+                                                                        AXSubrole: <code>AXApplicationGroup</code><br/>
                                                                     AXRoleDescription: <code>'group'</code>
                                                                 </td>
                                                         </tr>
@@ -816,8 +816,8 @@ p
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_COMMENT</code> and object attribute <code>xml-roles:doc-notice</code>.</p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: <code>&lt;nil&gt;</code><br/>
-                                                                    AXRoleDescription: <code>'group'</code>
+                                                                        AXSubrole: <code>AXDocumentNote</code><br/>
+                                                                    AXRoleDescription: <code>'note'</code>
                                                                 </td>
                                                         </tr>
                                                         <tr id="role-map-pagebreak">
@@ -833,9 +833,9 @@ p
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SEPARATOR</code> and object attribute <code>xml-roles:doc-pagebreak</code>. </p></td>
-                                                                <td>AXRole: <code>AXGroup</code><br />
+                                                                <td>AXRole: <code>AXSplitter</code><br />
                                                                         AXSubrole: <code>&lt;nil&gt;</code><br/>
-                                                                    AXRoleDescription: <code>'group'</code>
+                                                                    AXRoleDescription: <code>'splitter'</code>
                                                                 </td>
                                                         </tr>
                                                         <tr id="role-map-pagelist">
@@ -939,7 +939,7 @@ p
                                                                  </td>
                                                                  <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-pullquote</code>.</p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: <code>&lt;nil&gt;</code><br/>
+                                                                        AXSubrole: <code>AXApplicationGroup</code><br/>
                                                                     AXRoleDescription: <code>'group'</code>
                                                                 </td>
                                                         </tr>
@@ -954,7 +954,7 @@ p
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-qna</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: <code>&lt;nil&gt;</code><br/>
+                                                                        AXSubrole: <code>AXApplicationGroup</code><br/>
                                                                     AXRoleDescription: <code>'group'</code>
                                                                 </td>
                                                         </tr>
@@ -992,10 +992,10 @@ p
                                                                     <li>Localized Control Type is '<code>tip</code>'</li>
                                                                   </ul>
                                                                 </td>
-                                                                <td><p>Expose <code>ROLE_SECTION</code> and object attribute <code>xml-roles:doc-tip</code>. </p></td>
+                                                                <td><p>Expose <code>ROLE_COMMENT</code> and object attribute <code>xml-roles:doc-tip</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: <code>&lt;nil&gt;</code><br/>
-                                                                    AXRoleDescription: <code>'group'</code>
+                                                                        AXSubrole: <code>AXDocumentNote</code><br/>
+                                                                    AXRoleDescription: <code>'note'</code>
                                                                 </td>
                                                         </tr>
 							<tr id="role-map-toc">
@@ -1073,6 +1073,7 @@ p
                 		<section>
                         		<h2>Substantive changes since the <a href="https://www.w3.org/TR/2015/WD-dpub-aam-1.0-20151203/">last public working draft</a></h2>
                         		<ul>
+                                		<li>20-Apr-2017: Update mappings. For AXAPI, the AXSubrole is now AXApplicationGroup for the following roles: doc-abstract, doc-colophon, doc-dedication, doc-epigraph, doc-example, doc-footnote, doc-pullquote, and doc-qna; the AXRoleDescription of doc-abstract is now 'group'; doc-pagebreak is now mapped to AXRole: AXSplitter, AXRoleDescription: 'splitter'; doc-notice and doc-tip are now mapped to AXSubrole: AXDocumentNote, AXRoleDescription: 'note'. For ATK/ATSPI2, doc-tip is now mapped to ROLE_COMMENT.</li>
                                 		<li>20-Apr-2017: Map doc-pullquote for ATK/ATSPI2, IA2, and UIA.</li>
                                 		<li>10-Mar-2016: Replace all ROLE_PANEL to ROLE_SECTION for ATK/ATSPI mappings</li>
                                 		<li>10-Mar-2016: Replace doc-locator with doc-backlink</li>


### PR DESCRIPTION
A couple of changes were made in the WebKit (Safari and WebKitGtk)
implementation for DPub ARIA:

1. A new AXSubrole was added for ARIA groups. As a consequence, quite
   a few DPub ARIA roles which had no AXSubrole now have one. See:
   https://trac.webkit.org/changeset/214623

2. Several mappings were modified based on the Core ARIA role subclassed
   by DPub ARIA. See: https://trac.webkit.org/changeset/215554

As a result of these combined changes:

* For AXAPI, the AXSubrole is now AXApplicationGroup for the following
  roles: doc-abstract, doc-colophon, doc-dedication, doc-epigraph,
  doc-example, doc-footnote, doc-pullquote, and doc-qna

* For AXAPI, the AXRoleDescription of doc-abstract is now 'group'.

* For AXAPI, doc-pagebreak is now mapped to AXRole: AXSplitter,
  AXRoleDescription: 'splitter'

* For AXAPI, doc-notice and doc-tip are now mapped to AXSubrole:
  AXDocumentNote, AXRoleDescription: 'note'

* For ATK/AT-SPI2, doc-tip is now mapped to ROLE_COMMENT