### PR TITLE
Add AXAPI mappings for button when aria-haspopup is not false

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -635,7 +635,11 @@ var mappingTableLabels = {
 					    AXRole: <code>AXCheckBox</code><br />
 					    AXSubrole: <code>AXToggleButton</code><br />
 					    AXRoleDescription: <code>'toggle button'</code>
-					    <p>If <a class="property-reference" href="#aria-pressed"><code>aria-pressed</code></a> is not defined use:</p>
+					    <p>[Aria 1.1] Otherwise if <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a> is not false use:</p>
+					    AXRole: <code>AXPopUpButton</code><br />
+					    AXSubrole: <code>&lt;nil&gt;</code><br />
+					    AXRoleDescription: <code>'pop up button'</code>
+					    <p>Otherwise use:</p>
 					    AXRole: <code>AXButton</code><br />
 					    AXSubrole: <code>&lt;nil&gt;</code><br />
 					    AXRoleDescription: <code>'button'</code>
@@ -3437,6 +3441,7 @@ var mappingTableLabels = {
 		<section>
 			<h2>Substantive changes since the <a href="http://www.w3.org/TR/2015/WD-core-aam-1.1-20151119/">last public working draft</a></h2>
 			<ul>
+				<li>28-Apr-2017: Updated AX API AXRole and AXRoleDescription for role="button" where aria-haspoppup is not false. In this instance, the button element should be exposed as AXPopUpButton with a subrole of 'pop up button'.</li>
 				<li>27-Apr-2017: Updated AX API AXRoleDescription for role="grid" to 'table'.  It was formerly 'grid'.</li>
 				<li>27-Apr-2017: Replaced deprecated AX API accessibilityIsAttributeSettable() with AXUIElementIsAttributeSettable().</li>
 				<li>24-Apr-2017: Changed AX API AXRoleDescription for role="status" from "status" to "application status".</li>


### PR DESCRIPTION
In both Safari and Chrome, a button where aria-pressed is undefined and
aria-haspopup is true has the following mapping:

    AXRole: AXPopUpButton
    AXSubrole: <nil>
    AXRoleDescription: 'pop up button'

This is also implemented in Safari for the new role-based values for
aria-haspopup.

This mapping is not reflected in the Core AAM.