### PR TITLE
Core-AAM: Update AX API mappings for feed role

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -804,10 +804,9 @@ var mappingTableLabels = {
                                 <code>ROLE_PANEL</code> + object attribute <code>xml-roles:feed</code>
                         </td>
                         <td>
-				Need to verify. 
 			        AXRole: <code>AXGroup</code><br />
-                                AXSubrole: <code>&lt;nil&gt;</code><br />
-                                AXRoleDescription: <code>'group'</code></td>
+                                AXSubrole: <code>AXApplicationGroup</code><br />
+                                AXRoleDescription: <code>'feed'</code></td>
                 </tr>
 
         	<tr id="role-map-figure">
@@ -3441,6 +3440,7 @@ var mappingTableLabels = {
 		<section>
 			<h2>Substantive changes since the <a href="http://www.w3.org/TR/2015/WD-core-aam-1.1-20151119/">last public working draft</a></h2>
 			<ul>
+				<li>01-May-2017: Changed AX API AXSubrole for role="feed" from "&lt;nil&gt;" to "AXApplicationGroup" and its AXRoleDescription from "group" to "feed".</li>
 				<li>28-Apr-2017: Updated AX API AXRole and AXRoleDescription for role="button" where aria-haspoppup is not false. In this instance, the button element should be exposed as AXPopUpButton with a subrole of 'pop up button'.</li>
 				<li>27-Apr-2017: Updated AX API AXRoleDescription for role="grid" to 'table'.  It was formerly 'grid'.</li>
 				<li>27-Apr-2017: Replaced deprecated AX API accessibilityIsAttributeSettable() with AXUIElementIsAttributeSettable().</li>


### PR DESCRIPTION
* Changed AXSubrole from "<nil>" to "AXApplicationGroup"
* changed AXRoleDescription from "group" to "feed"

Fixes github issue 456.