### PR TITLE
Core-AAM: Remove the AXPress action from the macOS mapping of aria-haspopup

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -3448,6 +3448,7 @@ var mappingTableLabels = {
 		<section>
 			<h2>Substantive changes since the <a href="http://www.w3.org/TR/2015/WD-core-aam-1.1-20151119/">last public working draft</a></h2>
 			<ul>
+				<li>06-Jul-2017: Remove AXPress action from the macOS mapping of aria-haspopup.</li>
 				<li>01-May-2017: Changed AX API AXSubrole for role="feed" from "&lt;nil&gt;" to "AXApplicationGroup" and its AXRoleDescription from "group" to "feed".</li>
 				<li>28-Apr-2017: Updated AX API AXRole and AXRoleDescription for role="button" where aria-haspoppup is not false. In this instance, the button element should be exposed as AXPopUpButton with a subrole of 'pop up button'.</li>
 				<li>27-Apr-2017: Updated AX API AXRoleDescription for role="grid" to 'table'.  It was formerly 'grid'.</li>

--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -2106,7 +2106,7 @@ var mappingTableLabels = {
 				      <li>Expose as object attribute <code>haspopup:true</code></li>
                     </ul>
                   </td>
-                  <td>Expose <code>AXShowMenu</code> and <code>AXPress</code> actions</td>
+                  <td>Expose <code>AXShowMenu</code> action</td>
                 </tr>
                 <tr id="ariaHaspopupFalse">
                   <th><a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a><code>=&quot;false&quot;</code> (default)</th>
@@ -2135,7 +2135,7 @@ var mappingTableLabels = {
                       <li>Expose as object attribute <code>haspopup:dialog</code></li>
                     </ul>
                   </td>
-                  <td>Expose <code>AXShowMenu</code> and <code>AXPress</code> actions</td>
+                  <td>Expose <code>AXShowMenu</code> action</td>
                 </tr>
                 <tr id="ariaHaspopupListbox">
                   <th>[ARIA 1.1] <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a><code>=&quot;listbox&quot;</code> (default for role <a class="role-reference" href="#combobox"><code>combobox</code></a>)</th>
@@ -2152,7 +2152,7 @@ var mappingTableLabels = {
                       <li>Expose as object attribute <code>haspopup:listbox</code></li>
                    </ul>
                   </td>
-                  <td>Expose <code>AXShowMenu</code> and <code>AXPress</code> actions</td>
+                  <td>Expose <code>AXShowMenu</code> action</td>
                 </tr>
                 <tr id="ariaHaspopupMenu">
                   <th>[ARIA 1.1] <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a><code>=&quot;menu&quot;</code></th>
@@ -2169,7 +2169,7 @@ var mappingTableLabels = {
                       <li>Expose as object attribute <code>haspopup:menu</code></li>
                   </ul>
                   </td>
-                  <td>Expose <code>AXShowMenu</code> and <code>AXPress</code> actions</td>
+                  <td>Expose <code>AXShowMenu</code> action</td>
                 </tr>
                 <tr id="ariaHaspopupTree">
                   <th>[ARIA 1.1] <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a><code>=&quot;tree&quot;</code></th>
@@ -2186,7 +2186,7 @@ var mappingTableLabels = {
 				      <li>Expose as object attribute <code>haspopup:tree</code></li>
 			        </ul>
                   </td>
-                  <td>Expose <code>AXShowMenu</code> and <code>AXPress</code> actions</td>
+                  <td>Expose <code>AXShowMenu</code> action</td>
                 </tr>
                 <tr id="ariaHiddenTrue">
                   <th><a class="state-reference" href="#aria-hidden"><code>aria-hidden</code></a><code>=&quot;true&quot;</code> (state)</th>


### PR DESCRIPTION
Non-false values of aria-haspopup should be mapped to just the AXShowMenu
action. This change is consistent with exposure of native UI in macOS. For
instance, native combo boxes, which do have a popup, do not expose AXPress.