### PR TITLE
Core-AAM: Change ATK radiogroup mapping from ROLE_GROUPING to ROLE_PANEL

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -1264,7 +1264,7 @@ var mappingTableLabels = {
 					<th><a class="role-reference" href="#radiogroup"><code>radiogroup</code></a></th>
 					<td><code>ROLE_SYSTEM_GROUPING</code></td>
           <td><code>List</code></td>
-					<td><code>ROLE_GROUPING</code></td>
+					<td><code>ROLE_PANEL</code></td>
 					<td>AXRole: <code>AXRadioGroup</code><br />
               AXSubrole: <code>&lt;nil&gt;</code><br />
               AXRoleDescription: <code>'radio group'</code></td>


### PR DESCRIPTION
This restores the mapping from ARIA 1.0. While technically ROLE_GROUPING
is appropriate, it does not buy us, implementors, or platform assistive
technologies anything. And implementors and platform ATs are currently
using ROLE_PANEL for radiogroup.

Addresses github issue #595.