### PR TITLE
Tooltipterm

### DIFF
--- a/accname-aam/accname-aam.html
+++ b/accname-aam/accname-aam.html
@@ -349,11 +349,10 @@
               </details></div>
             </li>
             <li id="step2G">Otherwise, if the <code>current node</code> is a <a class="termref">Text node</a>, return its textual contents.</li>
-            <li id="step2H">Otherwise, if the <code>current node</code> has a tooltip <a class="termref">attribute</a>, return its value. 
+            <li id="step2H">Otherwise, if the <code>current node</code> has a <a class="termref">Tooltip attribute</a>, return its value. 
               <div><details>
                 <summary>Comment:</summary>
                 <p>Tooltip attributes are used only if nothing else, including subtree content, has provided results. </p>
-                <p class="ednote">(Joseph) Define "tooltip attribute"?</p>
               </details></div>
             </li>
           </ol>

--- a/common/terms.html
+++ b/common/terms.html
@@ -1,5 +1,5 @@
 <p>While some terms are defined in place, the following definitions are used throughout this document. </p>
-  <dl class="termlist">
+<dl class="termlist">
     <dt><dfn data-lt="accessibility api|accessibility apis">Accessibility <abbr title="Application Programming Interface">API</abbr></dfn></dt>
     <dd>
       <p>Operating systems and other platforms provide a set of interfaces that expose information about <a class="termref" data-lt="object">objects</a> and <a class="termref" data-lt="event">events</a> to <a>assistive technologies</a>. Assistive technologies use these interfaces to get information about and interact with those <a class="termref" data-lt="widget">widgets</a>. Examples of accessibility APIs are <a href="https://msdn.microsoft.com/en-us/library/ms697270(VS.85).aspx">Microsoft Active Accessibility</a> [[MSAA]], <a href="https://msdn.microsoft.com/en-us/library/ee684013%28VS.85%29.aspx">Microsoft User Interface Automation</a> [[UI-AUTOMATION]], <abbr title="Microsoft Active Accessibility">MSAA</abbr> with <cite><a href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd561898(v=vs.85).aspx"><abbr title="User Interface Automation">UIA</abbr> Express</a></cite> [[UIA-EXPRESS]], the
@@ -185,6 +185,10 @@
     <dt><dfn>Text node</dfn></dt>
     <dd>
       <p>Type of <abbr title="Document Object Model">DOM</abbr> <a class="termref" data-lt="node">node</a> that represents the textual content of an <a class="termref">attribute</a> or an <a class="termref">element</a>. A Text node has no child nodes.  </p>
+    </dd>
+    <dt><dfn>Tooltip attribute</dfn></dt>
+    <dd>
+      <p>Any host language attribute that would result in a user agent generating a tooltip such as in response to a mouse hover in desktop user agents.</p>
     </dd>
     <dt><dfn>Understandable</dfn></dt>
     <dd>


### PR DESCRIPTION
Addressed the introduction of a tooltip term (Joseph's editor's note), referenced it in accname, and removed the editor's note. There is no use of this term in the ARIA spec. itself. 