### PR TITLE
Add aria-current mapping for values not in allowed list

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -1971,14 +1971,14 @@ var mappingTableLabels = {
                   <th><a class="state-reference" href="#aria-current"><code>aria-current</code></a> value not in list of allowed values (state) [ARIA 1.1]</th>
                   <td>
                     <ul>
-                      <li>Expose the value of <code>aria-current</code> in object attribute <code>current:true</code>.</li>
+                      <li>Expose as object attribute <code>current:true</code>.</li>
                     </ul>
                   </td>
                   <td>Expose <code>current=true</code> in <code>AriaProperties</code>.</td>
                   <td>
                     <ul>
                       <li>Set <code>STATE_ACTIVE</code>. </li>
-                      <li>Expose the value of <code>aria-current</code> in object attribute <code>current:true</code>.</li>
+                      <li>Expose as object attribute <code>current:true</code>.</li>
                     </ul>
                   </td>
                   <td><code>AXARIACurrent: true</code>.</td>

--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -1967,6 +1967,22 @@ var mappingTableLabels = {
                   </td>
                   <td><code>AXARIACurrent: &lt;value&gt;</code>.</td>
                 </tr>
+                <tr id="ariaCurrentValueNotInList">
+                  <th><a class="state-reference" href="#aria-current"><code>aria-current</code></a> value not in list of allowed values (state) [ARIA 1.1]</th>
+                  <td>
+                    <ul>
+                      <li>Expose the value of <code>aria-current</code> in object attribute <code>current:true</code>.</li>
+                    </ul>
+                  </td>
+                  <td>Expose <code>current=true</code> in <code>AriaProperties</code>.</td>
+                  <td>
+                    <ul>
+                      <li>Set <code>STATE_ACTIVE</code>. </li>
+                      <li>Expose the value of <code>aria-current</code> in object attribute <code>current:true</code>.</li>
+                    </ul>
+                  </td>
+                  <td><code>AXARIACurrent: true</code>.</td>
+                </tr>
                 <tr id="ariaCurrentUndefined">
                   <th><a class="state-reference" href="#aria-current"><code>aria-current</code></a> is undefined (state) [ARIA 1.1]</th>
                   <td><a href="#not_mapped">Not mapped*</a>.</td>
@@ -3449,6 +3465,7 @@ var mappingTableLabels = {
 		<section>
 			<h2>Substantive changes since the <a href="http://www.w3.org/TR/2015/WD-core-aam-1.1-20151119/">last public working draft</a></h2>
 			<ul>
+				<li>21-Jul-2017: Add aria-current mapping to "true" when value is not in list of allowed alues. </li>
 				<li>20-Jul-2017: Change AXRoleDescription for contentinfo from "content" to "content information".</li>
 				<li>20-Jul-2017: Change AXRoleDescription for AXCheckBox from "check box" to "checkbox".</li>
 				<li>20-Jul-2017: Add role exposure via xml-roles object attribute for searchbox and switch to ATK mappings.</li>


### PR DESCRIPTION
addresses gap in core-aam for values that are not in the allowed list. 