### PR TITLE
Update Practices references

### DIFF
--- a/common/biblio.js
+++ b/common/biblio.js
@@ -16,25 +16,6 @@ var biblio = {
 			"http://www.w3.org/WAI/ARIA/"
 		]
 	},
-	"ARIA-PRACTICES": {
-		"title": "WAI-ARIA Authoring Practicess 1.1",
-		"href": "http://www.w3.org/TR/wai-aria-practices-1.1/",
-		"status": "WD",
-		"publisher": "W3C",
-		"authors": [
-			"Matt King",
-			"James Nurthen",
-			"Michael Cooper",
-			"Michiel Bijl",
-			"Joseph Scheuhammer",
-			"Lisa Pappas",
-			"Richard Schwerdtfeger"
-		],
-		"etAl": true,
-		"deliveredBy": [
-			"http://www.w3.org/WAI/ARIA/"
-		]
-	},
 	"CORE-AAM": {
 		"title": "Core Accessibility API Mappings 1.1",
 		"href": "http://www.w3.org/TR/core-aam-1.1/",

--- a/graphics-aam/graphics-aam.html
+++ b/graphics-aam/graphics-aam.html
@@ -289,7 +289,7 @@ var mappingTableLabels = {
       for elements that are exposed to assistive technologies.
     </li>
     <li>
-      <cite><a href="http://www.w3.org/TR/wai-aria-practices/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices Guide</a></cite> [[ARIA-PRACTICES]], 
+      <cite><a href="http://www.w3.org/TR/wai-aria-practices/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices Guide</a></cite> [[WAI-ARIA-PRACTICES-1.1]],
       a planned W3C Working Group Note, 
       which describes how web content developers can develop 
       accessible rich internet applications using <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>. 

--- a/svg-aam/svg-aam.html
+++ b/svg-aam/svg-aam.html
@@ -364,7 +364,7 @@ var mappingTableLabels = {
       for elements that are exposed to assistive technologies.
     </li>
     <li>
-      <cite><a href="http://www.w3.org/TR/wai-aria-practices/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices Guide</a></cite> [[ARIA-PRACTICES]], 
+      <cite><a href="http://www.w3.org/TR/wai-aria-practices/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices Guide</a></cite> [[WAI-ARIA-PRACTICES-1.1]], 
       a planned W3C Working Group Note, 
       which describes how web content developers can develop 
       accessible rich internet applications using <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>. 


### PR DESCRIPTION
Specref contains a reference to ARIA Authoring Practices 1.1. The local
reference is still being used by SVG-AAM and Graphics-AAM. Therefore,
update those specs to point to WAI-ARIA-PRACTICES-1.1 and then remove
our local reference.