### PR TITLE
Core-AAM: Add macOS mapping for aria-errormessage

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -2047,7 +2047,7 @@ var mappingTableLabels = {
                   <td>
 			<p>If the referenced object is in the accessibility tree, expose a pointer to the accessible object using <code>RELATION_ERROR_MESSAGE</code>, and expose reverse relations as described in <a href="#mapping_additional_relations">Relations</a>.</p>
 		  </td>
-                  <td>Expose the textual content of the referenced element as the value of <code>AXHelp</code>.</td>
+                  <td>Expose the textual content of the referenced element as the text alternative value of <code>AXValidationError</code>.</td>
 </td>
                 </tr>
                 <tr id="ariaExpandedTrue">
@@ -3041,21 +3041,21 @@ var mappingTableLabels = {
               <td><code>IA2_EVENT_TEXT_REMOVED</code></td>
               <td><code>EVENT_OBJECT_LIVEREGIONCHANGED</code></td>
               <td><code>text_changed::delete</code></td>
-              <td>If in a <a class="termref">live region</a>, <code>AXLiveRegionChanged</code></td>
+              <td>If in a <a class="termref">live region</a>, <code>AXLiveRegionChanged</code>.<br>If in <code>aria-errormessage</code>, <code>AXValidationErrorChanged</code>.</td>
             </tr>
             <tr>
               <th>When text is inserted</th>
               <td><code>IA2_EVENT_TEXT_INSERTED</code></td>
               <td><code>EVENT_OBJECT_LIVEREGIONCHANGED</code></td>
               <td><code>text_changed::insert</code></td>
-              <td>If in a <a class="termref">live region</a>, <code>AXLiveRegionChanged</code></td>
+              <td>If in a <a class="termref">live region</a>, <code>AXLiveRegionChanged</code>.<br>If in <code>aria-errormessage</code>, <code>AXValidationErrorChanged</code>.</td>
             </tr>
             <tr>
               <th>When text is changed</th>
               <td><code>IA2_EVENT_TEXT_REMOVE</code> and <code>IA2_EVENT_TEXT_INSERTED</code></td>
               <td><code>EVENT_OBJECT_LIVEREGIONCHANGED</code></td>
               <td><code>text_changed::delete</code> and <code>text_changed::insert</code></td>
-              <td>If in a <a class="termref">live region</a>, <code>AXLiveRegionChanged</code></td>
+              <td>If in a <a class="termref">live region</a>, <code>AXLiveRegionChanged</code>.<br>If in <code>aria-errormessage</code>, <code>AXValidationErrorChanged</code>.</td>
             </tr>
           </tbody>
         </table>
@@ -3479,7 +3479,7 @@ var mappingTableLabels = {
 		<section>
 			<h2>Substantive changes since the <a href="http://www.w3.org/TR/2015/WD-core-aam-1.1-20151119/">last public working draft</a></h2>
 			<ul>
-				<li>02-Aug-2017: Add macOS mapping for aria-errormessage.</li>
+				<li>09-Aug-2017: Add macOS AXValidationError/AXValidationErrorChanged for aria-errormessage.</li>
 				<li>02-Aug-2017: Replace STATE_LINKED with STATE_SYSTEM_LINKED for MSAA + IAccessible2 mapping of role link.</li>
 				<li>02-Aug-2017: Change mapping of aria-readonly="false" from exposing ATK_STATE_EDITABLE on textbox to clearing ATK_STATE_READ_ONLY. For aria-readonly="true", add statement that AtkEditableText should not be implemented, and that ATK_STATE_CHECKABLE not be exposed on roles which support aria-checked.</li>
 				<li>01-Aug-2017: Remove explicit "do not expose STATE_EDITABLE" for roles which are by definition not editable from the ATK mappings.</li>

--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -2047,7 +2047,8 @@ var mappingTableLabels = {
                   <td>
 			<p>If the referenced object is in the accessibility tree, expose a pointer to the accessible object using <code>RELATION_ERROR_MESSAGE</code>, and expose reverse relations as described in <a href="#mapping_additional_relations">Relations</a>.</p>
 		  </td>
-                  <td>TBD.</td>
+                  <td>Expose the textual content of the referenced element as the value of <code>AXHelp</code>.</td>
+</td>
                 </tr>
                 <tr id="ariaExpandedTrue">
                   <th><a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a><code>=&quot;true&quot;</code> (state)</th>
@@ -3478,6 +3479,7 @@ var mappingTableLabels = {
 		<section>
 			<h2>Substantive changes since the <a href="http://www.w3.org/TR/2015/WD-core-aam-1.1-20151119/">last public working draft</a></h2>
 			<ul>
+				<li>02-Aug-2017: Add macOS mapping for aria-errormessage.</li>
 				<li>02-Aug-2017: Replace STATE_LINKED with STATE_SYSTEM_LINKED for MSAA + IAccessible2 mapping of role link.</li>
 				<li>02-Aug-2017: Change mapping of aria-readonly="false" from exposing ATK_STATE_EDITABLE on textbox to clearing ATK_STATE_READ_ONLY. For aria-readonly="true", add statement that AtkEditableText should not be implemented, and that ATK_STATE_CHECKABLE not be exposed on roles which support aria-checked.</li>
 				<li>01-Aug-2017: Remove explicit "do not expose STATE_EDITABLE" for roles which are by definition not editable from the ATK mappings.</li>


### PR DESCRIPTION
Expose the textual content of the referenced element as the value of
AXHelp.

Fixes github issue #457.