### PR TITLE
Add ValuePattern to role=link

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -939,7 +939,13 @@ var mappingTableLabels = {
 					    <li>Implement Interface <code>IAccessibleHypertext</code></li>
 					  </ul>
 					</td>
-					<td><code>HyperLink</code></td>
+					<td>
+						<ul>
+							<li>Control Type is <code>HyperLink</code></li>
+							<li>Implement <code>ValuePattern</code></li>
+							<li>Expose <code>href</code> attribute as <code>Value.Value</code> in the <code>ValuePattern</code></li>
+						</ul>
+					</td>
 					<td>
 					  <ul>
 					    <li><code>ROLE_LINK</code></li>


### PR DESCRIPTION
For the role=link Control Type is unchanged = HyperLink, but add support for ValuePattern and expose href as Value.Value