### PR TITLE
Update UIA mapping for role=cell

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -661,9 +661,7 @@ var mappingTableLabels = {
 					</td>
                     <td>
                       <ul>
-                        <li>Control Type is <code>TableItem</code></li>
-                        <li>Supports the <code>selection</code> pattern</li>
-                        <li>MUST NOT support the <code>invoke</code> pattern</li>
+                        <li>Control Type is <code>DataItem</code></li>
                       </ul>
                     </td>
 					<td>


### PR DESCRIPTION
As pointed out in https://github.com/w3c/aria/issues/303 TableItem is ControlPattern, not Control Type.

Additionally:
- Removed SelectionPattern requirement - it should not be required for this role.
- Removed MUST NOT implement InvokePattern. InvokePattern in UIA can be implemented for many reasons, including ancestry tree element that has click handlers. Not only it would be hard to guarantee lack of InvokePattern - this would be counterintuitive and not helpful for the users