### PR TITLE
Update UIA mapping for aria-autocomplete=list, etc

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -1791,7 +1791,7 @@ var mappingTableLabels = {
                     <p>Object attribute <code>autocomplete:&lt;value&gt;</code></p>
                     <p>Expose the <code>IA2_STATE_SUPPORTS_AUTOCOMPLETION</code> equivalent state</p>
                   </td>
-                  <td>Expose <code>autocomplete=&lt;value&gt;</code> in <code>AriaProperties</code></td>
+                  <td><a href="#not_mapped">Not mapped</a></td>
                   <td>
                     <p>Object attribute <code>autocomplete:&lt;value&gt;</code></p>
                     <p>Expose the <code>SUPPORTS_AUTOCOMPLETION</code> equivalent state</p></td>


### PR DESCRIPTION
Similarly to AX API (as I understand) and differently from MSAA/IA2/ATK - UIA doesn't have a concept of information that conveys the fact that autocomplete is present. So while proposal discussed in https://github.com/w3c/aria/issues/419 makes some sense - that would be very brittle heuristic and not something that I would comfortably specify generically. 

Moreover when contrasted against other APIs mappings - this seems like purely informational mapping that conveys presence of the autocomplete list (or other types of autocompletes) - and there is jsut no such thing in UIA. If that changes - we should revisit and add it here.