### PR TITLE
Update UIA mapping for role=term

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -1568,7 +1568,11 @@ var mappingTableLabels = {
                 <tr id="role-map-term">
                         <th><a class="role-reference" href="#term"><code>term</code></a> [ARIA 1.1]</th>        
                         <td><code>IA2_ROLE_TEXT_FRAME</code> and object attribute <code>xml-roles:term</code></td>
-			<td>Control Type is <code>ListItem</code>
+			<td>
+				<ul>
+					<li>Control Type is <code>Text</code></li>
+					<li>Localized Control Type is <code>term</code></li>
+				</ul>
                         </td>
                         <td><code>ROLE_DESCRIPTION_TERM</code></td>
                         <td>    AXRole: <code>AXGroup</code><br />


### PR DESCRIPTION
This looks straightforward as a semantic way to signify word of phrase that is a term - hard to come up with better mapping than CT: Text + LCT: "term" which would map nicely to new IA2 mapping as well