### PR TITLE
Remove ValuePattern from link role

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -1118,9 +1118,7 @@ var mappingTableLabels = {
 						Interface: <code>IAccessibleHypertext</code>
 					</td>
 					<td>
-						Control Type: <code>HyperLink</code><br />
-						Control Pattern: <code>Value</code><br />
-						Property: Set <code>Value.Value</code> to the <code>href</code> attribute
+						Control Type: <code>HyperLink</code>
 					</td>
 					<td>
 						Role: <code>ROLE_LINK</code><br />


### PR DESCRIPTION
To be moved to HTML-AAM. As rightfully pointed out offline - ARIA doesn't have href attribute, so the existing mapping is not really correct...