### PR TITLE
Add RangeValue CP to separator (focusable)

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -1735,7 +1735,8 @@ var mappingTableLabels = {
 						Interface: <code>IAccessibleValue</code>
 					</td>
 					<td>
-						Control Type: <code>Thumb</code>
+						Control Type: <code>Thumb</code><br />
+						Control Pattern: <code>RangeValue</code>
 					</td>
 					<td>
 						Role: <code>ROLE_SEPARATOR</code><br />


### PR DESCRIPTION
Pointed out offline:

The focusable separator, which in ARIA supports the aria-value* attributes and works like a window or pane splitter

It makes sense to add RangeValue Control Pattern.