### PR TITLE
Remove SelectionPattern for role=list

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -1139,8 +1139,7 @@ var mappingTableLabels = {
 						State: <code>STATE_SYSTEM_READONLY</code>
 					</td>
 					<td>
-						Control Type: <code>List</code><br />
-						Control Pattern: <code>Selection</code> when the <code>list</code> contains <code>listitem</code> elements
+						Control Type: <code>List</code>
 					</td>
 					<td>
 						Role: <code>ROLE_LIST</code>


### PR DESCRIPTION
Per offline discussion:

The list role mentions that the Selection pattern should be
   supported "When the list contains listitems". But the definition
   of the ARIA list role is "A section containing listitem elements."
   Those listitem elements can be immediate descendants or owned
   elements of the list, or they can be inside a group which is an
   immediate descendant or owned element of the list. But it is
   expected that the list will contain listitems.