### PR TITLE
Core-AAM: Remove LocalizedLandmarkType where there is semantic Landma…

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -992,8 +992,7 @@ var mappingTableLabels = {
 					<td>
 						Control Type: <code>Group</code><br />
 						Localized Control Type: <code>form</code><br />
-						Landmark Type: <code>Form</code><br />
-						Localized Landmark Type: <code>form</code> (default for this Landmark Type)
+						Landmark Type: <code>Form</code>
 					</td>
 					<td>
 						Role: <code>ROLE_LANDMARK</code><br />
@@ -1230,8 +1229,7 @@ var mappingTableLabels = {
 					<td>
 						Control Type: <code>Group</code><br />
 						Localized Control Type: <code>main</code><br />
-						Landmark Type: <code>Main</code><br />
-						Localized Landmark Type: <code>main</code> (default for this Landmark Type)
+						Landmark Type: <code>Main</code>
 					</td>
 					<td>
 						Role: <code>ROLE_LANDMARK</code><br />
@@ -1401,8 +1399,7 @@ var mappingTableLabels = {
 					<td>
 						Control Type: <code>Group</code><br />
 						Localized Control Type: <code>navigation</code><br />
-						Landmark Type: <code>Navigation</code><br />
-						Localized Landmark Type: <code>navigation</code> (default for this Landmark Type)
+						Landmark Type: <code>Navigation</code>
 					</td>
 					<td>
 						Role: <code>ROLE_LANDMARK</code><br />
@@ -1680,8 +1677,7 @@ var mappingTableLabels = {
 					<td>
 						Control Type: <code>Group</code><br />
 						Localized Control Type: <code>search</code><br />
-						Landmark Type: <code>Search</code><br />
-						Localized Landmark Type: <code>search</code> (default for this Landmark Type)
+						Landmark Type: <code>Search</code>
 					</td>
 					<td>
 						Role: <code>ROLE_LANDMARK</code><br />


### PR DESCRIPTION
…rkType

This is redundant and not required for implementers Localized {Landmark, Control} Types are supposed to provide additional information, not duplicate the same available in {Landmark, Control} Type