### PR TITLE
Graphics AAM: Fix ATK mappings

### DIFF
--- a/graphics-aam/graphics-aam.html
+++ b/graphics-aam/graphics-aam.html
@@ -358,7 +358,7 @@ var mappingTableLabels = {
                                                                     <li>Control type/role is <code>'Document'</code>.</li>
                                                                   </ul>
                                                                 </td>
-                                                                <td><p>Expose <code>ROLE_DOCUMENT_FRAME</code> + do not expose <code>STATE_EDITABLE</code>. Expose object Attribute <code>xml-roles:graphics-document</code>. </p></td>
+                                                                <td><p>Expose <code>ROLE_DOCUMENT_FRAME</code> and object attribute <code>xml-roles:graphics-document</code>.</p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
                                                                         AXSubrole: ? <code>AXDocument</code><br />
                                                                     AXRoleDescription: <code>'document'</code>
@@ -373,7 +373,7 @@ var mappingTableLabels = {
                                                                     <li>Control type/role is <code>'graphics-object'</code></li>
                                                                   </ul>
                                                                 </td>
-                                                                <td><p>Expose <code>ROLE_GROUP</code> and object attribute <code>xml-roles:graphics-object</code>. </p></td>
+                                                                <td><p>Expose <code>ROLE_PANEL</code> and object attribute <code>xml-roles:graphics-object</code>.</p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
                                                                         AXSubrole: <code>&lt;nil&gt;</code><br/>
                                                                     AXRoleDescription: <code>'group'</code>


### PR DESCRIPTION
* Whether or not ROLE_DOCUMENT_FRAME exposes STATE_EDITABLE has nothing to
  to with the fact that it is a graphics-document. Removing this statement
  is also consistent with what is in the Core AAM for the document role:
  https://rawgit.com/w3c/aria/master/core-aam/core-aam.html#role-map-document

* The mapping of graphics-object to ROLE_GROUP is wrong because there is no
  such role in ATK. There is ROLE_GROUPING. However, for these sorts of
  containers, the preferred mapping is to ROLE_PANEL. ROLE_PANEL is the
  verified mapping of the ARIA group role (which is also how the SVG g
  element is exposed when inclusion in the accessibility tree is needed:
  https://rawgit.com/w3c/aria/master/core-aam/core-aam.html#role-map-group
  https://rawgit.com/w3c/aria/master/svg-aam/svg-aam.html#role-map-g