### PR TITLE
Graphics: Change superclass for graphics-object and graphihcs-symbol

### DIFF
--- a/aria/graphics.html
+++ b/aria/graphics.html
@@ -720,7 +720,7 @@ OK to omit the second example?
 					</tr>
 					<tr>
 						<th class="role-parent-head" scope="row">Superclass Role:</th>
-						<td class="role-parent"><rref>structure</rref></td>
+						<td class="role-parent"><rref>group</rref></td>
 					</tr>
 					<tr>
 						<th class="role-children-head" scope="row">Subclass Roles:</th>
@@ -891,7 +891,7 @@ OK to omit the second example?
 					</tr>
 					<tr>
 						<th class="role-parent-head" scope="row">Superclass Role:</th>
-						<td class="role-parent"><rref>graphics-object</rref></td>
+						<td class="role-parent"><rref>img</rref></td>
 					</tr>
 					<tr>
 						<th class="role-children-head" scope="row">Subclass Roles:</th>


### PR DESCRIPTION
The spec text, recommended fallback roles, and platform mappings of
graphics-object and graphics-symbol suggest that the superclass roles
should be group and img respectively; not structure and graphics-symbol.