### PR TITLE
Graphics AAM: Fix macOS mapping for graphics-symbol

### DIFF
--- a/graphics-aam/graphics-aam.html
+++ b/graphics-aam/graphics-aam.html
@@ -360,7 +360,7 @@ var mappingTableLabels = {
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_DOCUMENT_FRAME</code> + do not expose <code>STATE_EDITABLE</code>. Expose object Attribute <code>xml-roles:graphics-document</code>. </p></td>
                                                                 <td>AXRole: <code>AXGroup</code><br />
-                                                                        AXSubrole: ? <code>AXDocument</code><br />
+                                                                        AXSubrole: <code>AXDocument</code><br />
                                                                     AXRoleDescription: <code>'document'</code>
                                                                 </td>
                                                         </tr>
@@ -389,9 +389,9 @@ var mappingTableLabels = {
                                                                   </ul>
                                                                 </td>
                                                                 <td><p>Expose <code>ROLE_IMAGE</code> and object attribute <code>xml-roles:graphics-symbol</code>. </p></td>
-                                                                <td>AXRole: <code>AX</code><br />
+                                                                <td>AXRole: <code>AXImage</code><br />
                                                                         AXSubrole: <code>&lt;nil&gt;</code><br />
-                                                                    AXRoleDescription: <code>'group'</code>
+                                                                    AXRoleDescription: <code>'image'</code>
                                                                 </td>
                                                         </tr>
 						</tbody>


### PR DESCRIPTION
The graphics-symbol role functions as an image. Therefore it should be
exposed as an AXImage; not an AXGroup.

Also remove "?" appearing before graphics-document subrole.