### PR TITLE
Move Aria Orientation on scrollbar to supported section (from required)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5957,7 +5957,6 @@
 						<td class="role-required-properties">
 							<ul>
 								<li><pref>aria-controls</pref></li>
-								<li><pref>aria-orientation</pref></li>
 								<li><pref>aria-valuemax</pref></li>
 								<li><pref>aria-valuemin</pref></li>
 								<li><pref>aria-valuenow</pref></li>
@@ -5966,7 +5965,9 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"> </td>
+						<td class="role-properties">
+							<pref>aria-orientation</pref>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -11553,6 +11554,7 @@ PUBLIC "-//W3C//ENTITIES XHTML ARIA Attributes 1.0//EN" "aria-attributes-1.mod"
 			<li>06-Dec-2017: Make <sref>aria-expanded</sref> a supported state of <rref>menuitem</rref>. This change also makes it a supported property of <rref>menuitemcheckbox</rref> and <rref>menuitemradio</rref> via inheritance.</li>
 			<li>06-Dec-2017: When aria-errormessage is not pertinent, authors MUST either ensure the content is not rendered or remove the aria-errormessage attribute or its value. User agents MUST NOT expose <code>aria-errormessage</code> for an object with an <sref>aria-invalid</sref> value of <code>false</code>.</li>
 			<li>01-Apr-2018: Added ARIA IDL Section (JavaScript interfaces).</li>
+			<li>06-Jun-2018: Moved aria-orientation on scrollbar from required section to supported section.</li>
 		</ul>
 	</section>
 	<section>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/781.html" title="Last updated on Jun 6, 2018, 7:53 PM GMT (d9e9ae2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/781/f048989...d9e9ae2.html" title="Last updated on Jun 6, 2018, 7:53 PM GMT (d9e9ae2)">Diff</a>