### PR TITLE
Issue737 menuitem and groups

### DIFF
--- a/index.html
+++ b/index.html
@@ -4205,7 +4205,7 @@
 			<div class="role-description">
 				<p>An option in a set of choices contained by a <rref>menu</rref> or <rref>menubar</rref>.</p>
 				<p>Authors MAY disable a menu item with the <sref>aria-disabled</sref> attribute. If the menu item has its <pref>aria-haspopup</pref> attribute set to <code>true</code>, it indicates that the menu item may be used to launch a sub-level menu, and authors SHOULD display a new sub-level menu when the menu item is activated.</p>
-				<p>Authors MUST ensure that menu items are <a>owned</a> by an element with role <rref>group</rref>, <rref>menu</rref> or <rref>menubar</rref> in order to identify that they are related <a>widgets</a>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
+				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu items are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>, or by a role <rref>group</rref> which itself is <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4312,7 +4312,7 @@
 			<div class="role-description">
 				<p>A <rref>menuitem</rref> with a checkable state whose possible <span>values</span> are <code>true</code>, <code>false</code>, or <code>mixed</code>.</p>
 				<p>The <sref>aria-checked</sref> <a>attribute</a> of a <code>menuitemcheckbox</code> indicates whether the menu item is checked (<code>true</code>), unchecked (<code>false</code>), or represents a sub-level menu of other menu items that have a mixture of checked and unchecked values (<code>mixed</code>).</p>
-				<p>Authors MUST ensure that menu item checkboxes are <a>owned</a> by an element with role <rref>group</rref>, <rref>menu</rref> or <rref>menubar</rref> in order to identify that they are related widgets. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
+				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu item checkboxes are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>, or by a role <rref>group</rref> which itself is <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4412,7 +4412,7 @@
 				<p>A checkable <rref>menuitem</rref> in a set of elements with the same role, only one of which can be checked at a time.</p>
 				<p>Authors SHOULD enforce that only one <code>menuitemradio</code> in a group can be checked at the same time. When one item in the group is checked, the previously checked item becomes unchecked (its <sref>aria-checked</sref> <a>attribute</a> becomes <code>false</code>).</p>
 				<!-- keep previous sentence synced with radiogroup, etc. -->
-				<p>Authors MUST ensure that menu item radios are <a>owned</a> by an element with role <rref>group</rref>, <rref>menu</rref>, or <rref>menubar</rref> in order to identify that they are related widgets. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
+				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu item radios are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>, or by a role <rref>group</rref> which itself is <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
                 <p>If a <rref>menu</rref> or <rref>menubar</rref> contains more than one group of <code>menuitemradio</code> elements, or if the menu contains one group and other, unrelated menu items, authors SHOULD nest each set of related <code>menuitemradio</code> elements in an element using the <rref>group</rref> role, and authors SHOULD delimit the group from other menu items with an element using the <rref>separator</rref> role.</p>
 			</div>
 			<table class="role-features">

--- a/index.html
+++ b/index.html
@@ -4058,7 +4058,9 @@
 						<td class="role-mustcontain">
 							<ul>
 								<!-- keep in sync with #menubar -->
+								<li><rref>group</rref> <abbr title="containing" class="symbol">→</abbr> <rref>menuitem</rref></li>
 								<li><rref>group</rref> <abbr title="containing" class="symbol">→</abbr> <rref>menuitemradio</rref></li>
+								<li><rref>group</rref> <abbr title="containing" class="symbol">→</abbr> <rref>menuitemcheckbox</rref></li>
 								<li><rref>menuitem</rref></li>
 								<li><rref>menuitemcheckbox</rref></li>
 								<li><rref>menuitemradio</rref></li>
@@ -4150,7 +4152,9 @@
 						<td class="role-mustcontain">
 							<ul>
 								<!-- keep in sync with #menu -->
+								<li><rref>group</rref> <abbr title="containing" class="symbol">→</abbr> <rref>menuitem</rref></li>
 								<li><rref>group</rref> <abbr title="containing" class="symbol">→</abbr> <rref>menuitemradio</rref></li>
+								<li><rref>group</rref> <abbr title="containing" class="symbol">→</abbr> <rref>menuitemcheckbox</rref></li>
 								<li><rref>menuitem</rref></li>
 								<li><rref>menuitemcheckbox</rref></li>
 								<li><rref>menuitemradio</rref></li>
@@ -4201,7 +4205,7 @@
 			<div class="role-description">
 				<p>An option in a set of choices contained by a <rref>menu</rref> or <rref>menubar</rref>.</p>
 				<p>Authors MAY disable a menu item with the <sref>aria-disabled</sref> attribute. If the menu item has its <pref>aria-haspopup</pref> attribute set to <code>true</code>, it indicates that the menu item may be used to launch a sub-level menu, and authors SHOULD display a new sub-level menu when the menu item is activated.</p>
-				<p>Authors MUST ensure that menu items are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref> in order to identify that they are related <a>widgets</a>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
+				<p>Authors MUST ensure that menu items are <a>owned</a> by an element with role <rref>group</rref>, <rref>menu</rref> or <rref>menubar</rref> in order to identify that they are related <a>widgets</a>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4308,7 +4312,7 @@
 			<div class="role-description">
 				<p>A <rref>menuitem</rref> with a checkable state whose possible <span>values</span> are <code>true</code>, <code>false</code>, or <code>mixed</code>.</p>
 				<p>The <sref>aria-checked</sref> <a>attribute</a> of a <code>menuitemcheckbox</code> indicates whether the menu item is checked (<code>true</code>), unchecked (<code>false</code>), or represents a sub-level menu of other menu items that have a mixture of checked and unchecked values (<code>mixed</code>).</p>
-				<p>Authors MUST ensure that menu item checkboxes are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref> in order to identify that they are related widgets. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
+				<p>Authors MUST ensure that menu item checkboxes are <a>owned</a> by an element with role <rref>group</rref>, <rref>menu</rref> or <rref>menubar</rref> in order to identify that they are related widgets. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4348,6 +4352,7 @@
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
 						<td class="role-scope">
 							<ul>
+								<li><rref>group</rref></li>
 								<li><rref>menu</rref></li>
 								<li><rref>menubar</rref></li>
 							</ul>

--- a/index.html
+++ b/index.html
@@ -11554,6 +11554,7 @@ PUBLIC "-//W3C//ENTITIES XHTML ARIA Attributes 1.0//EN" "aria-attributes-1.mod"
 		<h2>Substantive changes since the last public working draft</h2>
 		<ul>
 			<!-- EdNote: After each WD publish, move contents of this list into the next one below. -->
+			<li>21-Jun-2018: Resolve inconsistencies around group ownevership of menuitem, menuitemcheckbox and menuitemradio</li>
 			<li>31-May-2018: Add <rref>blockquote</rref>, <rref>caption</rref>, and <rref>paragraph</rref> roles.</li>
 			<li>01-Apr-2018: Added ARIA IDL Section (JavaScript interfaces).</li>
 			<li>06-Dec-2017: Make <sref>aria-expanded</sref> a supported state of <rref>menuitem</rref>. This change also makes it a supported property of <rref>menuitemcheckbox</rref> and <rref>menuitemradio</rref> via inheritance.</li>


### PR DESCRIPTION
* resolve inconsistencies around menuitems being allowed in groups
* allow menuitemcheckbox to be in a group.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/784.html" title="Last updated on Jul 10, 2018, 8:38 PM GMT (bb80ff8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/784/8b9d3c5...bb80ff8.html" title="Last updated on Jul 10, 2018, 8:38 PM GMT (bb80ff8)">Diff</a>