### PR TITLE
Row Role: allow aria-posinset and aria-setsize for issue 558

### DIFF
--- a/index.html
+++ b/index.html
@@ -5599,8 +5599,11 @@
 			<rdef>row</rdef>
 			<div class="role-description">
 				<p>A row of cells in a tabular container.</p>
-				<p>Rows contain <rref>cell</rref> or <rref>gridcell</rref> <a>elements</a>, and thus serve to organize the <rref>table</rref> or <rref>grid</rref>.</p>
-				<p>In a <rref>treegrid</rref>, authors MAY mark rows as expandable, using the <sref>aria-expanded</sref> <a>attribute</a> to indicate the present status. This is not the case for an ordinary <rref>table</rref> or <rref>grid</rref>, in which the <sref>aria-expanded</sref> attribute is not present.</p>
+				<p>Rows contain <rref>cell</rref> or <rref>gridcell</rref> <a>elements</a>, and thus serve to organize a <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>.</p>
+			  <p>
+          While the row role can be used in <rref>tables</rref>, <rref>grids</rref>, and <rref>treegrids</rref>, the semantics of <sref>aria-expanded</sref>, <pref>aria-posinset</pref>, <pref>aria-setsize</pref>, and <pref>aria-level</pref> are only applicable to the hierarchical structure of an interactive treegrid.
+          Therefore, authors SHOULD NOT apply <sref>aria-expanded</sref>, <pref>aria-posinset</pref>, <pref>aria-setsize</pref>, and <pref>aria-level</pref> to a <rref>row</rref> that descends from a <rref>table</rref> or <rref>grid</rref>, and user agents SHOULD NOT expose any of these four properties to assistive technologies unless the <rref>row</rref> descends from a <rref>treegrid</rref>.
+        </p>
 				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>row</code> are contained in, or <a>owned</a> by, an element with the role <rref>table</rref>, <rref>grid</rref>, <rref>rowgroup</rref>, or <rref>treegrid</rref>.</p>
 			</div>
 			<table class="role-features">
@@ -5669,7 +5672,9 @@
 							<ul>
 								<li><pref>aria-colindex</pref></li>
 								<li><pref>aria-level</pref></li>
+                <li><pref>aria-posinset</pref></li>
 								<li><pref>aria-rowindex</pref></li>
+                <li><pref>aria-setsize</pref></li>
 								<li><sref>aria-selected</sref></li>
 							</ul>
 						</td>

--- a/index.html
+++ b/index.html
@@ -5601,8 +5601,8 @@
 				<p>A row of cells in a tabular container.</p>
 				<p>Rows contain <rref>cell</rref> or <rref>gridcell</rref> <a>elements</a>, and thus serve to organize a <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>.</p>
 			  <p>
-          While the row role can be used in <rref>tables</rref>, <rref>grids</rref>, and <rref>treegrids</rref>, the semantics of <sref>aria-expanded</sref>, <pref>aria-posinset</pref>, <pref>aria-setsize</pref>, and <pref>aria-level</pref> are only applicable to the hierarchical structure of an interactive treegrid.
-          Therefore, authors SHOULD NOT apply <sref>aria-expanded</sref>, <pref>aria-posinset</pref>, <pref>aria-setsize</pref>, and <pref>aria-level</pref> to a <rref>row</rref> that descends from a <rref>table</rref> or <rref>grid</rref>, and user agents SHOULD NOT expose any of these four properties to assistive technologies unless the <rref>row</rref> descends from a <rref>treegrid</rref>.
+          While the row role can be used in <rref>tables</rref>, <rref>grids</rref>, and <rref>treegrids</rref>, the semantics of <sref>aria-expanded</sref>, <pref>aria-posinset</pref>, <pref>aria-setsize</pref>, and <pref>aria-level</pref> are only applicable to the hierarchical structure of an interactive tree grid.
+          Therefore, authors MUST NOT apply <sref>aria-expanded</sref>, <pref>aria-posinset</pref>, <pref>aria-setsize</pref>, and <pref>aria-level</pref> to a <rref>row</rref> that descends from a <rref>table</rref> or <rref>grid</rref>, and user agents SHOULD NOT expose any of these four properties to assistive technologies unless the <rref>row</rref> descends from a <rref>treegrid</rref>.
         </p>
 				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>row</code> are contained in, or <a>owned</a> by, an element with the role <rref>table</rref>, <rref>grid</rref>, <rref>rowgroup</rref>, or <rref>treegrid</rref>.</p>
 			</div>


### PR DESCRIPTION
Modified text and properties of the role row for issue #558:
- Removed paragraph about aria-expanded in treegrids.
- Add paragraph with two normative statements:
  * Authors should only use setsize, posinset, level, and expanded attributes in treegrids
  * User agents should only expose them in treegrids
- Modified allowed states and properties to allow aria-posinset and aria-setsize.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/789.html" title="Last updated on Aug 16, 2018, 6:27 PM GMT (a5b4a41)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/789/8b9d3c5...a5b4a41.html" title="Last updated on Aug 16, 2018, 6:27 PM GMT (a5b4a41)">Diff</a>