### PR TITLE
Option role: Change aria-selected from required to supported and remove default value

### DIFF
--- a/index.html
+++ b/index.html
@@ -4679,7 +4679,6 @@
 			<div class="role-description">
 				<p>A selectable item in a <rref>select</rref> list.</p>
 				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>option</code> are contained in, or owned by, an element with the <a>role</a>  <rref>listbox</rref> or <rref>group</rref>. Options not associated with a <rref>listbox</rref> might not be correctly mapped to an <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a>.</p>
-				<p>Elements with the role <code>option</code> have an implicit <sref>aria-selected</sref> value of <code>false</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4730,11 +4729,7 @@
 					</tr>
 					<tr>
 						<th class="role-required-properties-head">Required States and Properties:</th>
-						<td class="role-required-properties">
-							<ul>
-								<li><sref>aria-selected</sref></li>
-							</ul>
-						</td>
+						<td class="role-required-properties"></td>
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
@@ -4743,6 +4738,7 @@
 								<li><sref>aria-checked</sref></li>
 								<li><pref>aria-posinset</pref></li>
 								<li><pref>aria-setsize</pref></li>
+                <li><sref>aria-selected</sref></li>
 							</ul>
 						</td>
 					</tr>
@@ -4777,7 +4773,7 @@
 					</tr>
 					<tr>
 						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
-						<td class="implicit-values">Default for <sref>aria-selected</sref> is <code class="default">false</code>.</td>
+						<td class="implicit-values"></td>
 					</tr>
 				</tbody>
 			</table>

--- a/index.html
+++ b/index.html
@@ -1,33 +1,24 @@
-<!--?xml version='1.0' encoding='UTF-8'?-->
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
 <head>
 <title>Accessible Rich Internet Applications (WAI-ARIA) 1.2</title>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
-	<script src="common/biblio.js" class="remove"></script>
 <link href="common/css/common.css" rel="stylesheet" type="text/css"/>
 <script class="remove" src="common/script/aria.js"></script>
 <script src="common/script/resolveReferences.js" class="remove"></script>
 <script class="remove">
 	var respecConfig = {
-		// embed RDFa data in the output
-		trace:  true,
-        useExperimentalStyles: true,
-		doRDFa: '1.1',
-		includePermalinks: true,
-		permalinkEdge:     true,
-		permalinkHide:     false,
+		github: "w3c/aria",
+		doJsonLd: true,
 		// specification status (e.g., WD, LC, NOTE, etc.). If in doubt use ED.
 		specStatus:           "ED",
 		//crEnd:                "2012-04-30",
 		//perEnd:               "2013-07-23",
 		//publishDate:          "2013-08-22",
-		diffTool:             "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
 
 		// the specifications short name, as in https://www.w3.org/TR/short-name/
 		shortName:            "wai-aria-1.2",
-
 
 		// if you wish the publication date to be other than today, set this
 		//publishDate:  "2014-12-11",
@@ -42,7 +33,7 @@
 		//previousDiffURI: "https://www.w3.org/TR/2014/REC-wai-aria-20140320/",
 
 		// if there a publicly available Editors Draft, this is the link
-		edDraftURI: "https://w3c.github.io/aria/", 
+		edDraftURI: "https://w3c.github.io/aria/",
 
 		// if this is a LCWD, uncomment and set the end of its review period
 		// lcEnd: "2012-02-21",
@@ -57,16 +48,10 @@
 				w3cid: 68182
 			},
 			{
-				name: "Shane McCarron",
-				company: "Spec-Ops",
-				companyURL: "https://www.spec-ops.io",
-				w3cid: 89030
-			},
-			{
-    			name: "James Nurthen",
-    			company: "Adobe",
-    			companyURL: "https://www.adobe.com/",
-    			w3cid: 37155
+				name: "James Nurthen",
+				company: "Adobe",
+				companyURL: "https://www.adobe.com/",
+				w3cid: 37155
   			},
 			{
 				name: "Michael Cooper",
@@ -76,6 +61,13 @@
 			}
 		],
 		formerEditors: [
+		    {
+				name: "Shane McCarron",
+				company: "Spec-Ops",
+				companyURL: "https://www.spec-ops.io",
+				w3cid: 89030,
+				note: "Editor until 2018"
+			},
 			{
 				name: "Richard Schwerdtfeger",
 				company: "Knowbility",
@@ -137,40 +129,40 @@
         },
         accNameURLs: {
           "ED": "https://w3c.github.io/accname/",
-          "WD" : "https://www.w3.org/TR/accname-aam-1.1/",
-          "FPWD": "https://www.w3.org/TR/accname-aam-1.1/",
-          "CR" : "https://www.w3.org/TR/accname-aam-1.1/",
-          "REC": "https://www.w3.org/TR/accname-aam-1.1/"
+          "WD" : "https://www.w3.org/TR/accname-aam-1.2/",
+          "FPWD": "https://www.w3.org/TR/accname-aam-1.2/",
+          "CR" : "https://www.w3.org/TR/accname-aam-1.2/",
+          "REC": "https://www.w3.org/TR/accname-aam-1.2/"
         },
         coreMappingURLs: {
           "ED": "https://w3c.github.io/core-aam/",
-          "WD" : "https://www.w3.org/TR/core-aam-1.1/",
-          "FPWD": "https://www.w3.org/TR/core-aam-1.1/",
-          "CR": "https://www.w3.org/TR/core-aam-1.1/",
-          "REC": "https://www.w3.org/TR/core-aam-1.1/"
+          "WD" : "https://www.w3.org/TR/core-aam-1.2/",
+          "FPWD": "https://www.w3.org/TR/core-aam-1.2/",
+          "CR": "https://www.w3.org/TR/core-aam-1.2/",
+          "REC": "https://www.w3.org/TR/core-aam-1.2/"
         },
         practicesURLs: {
           "ED": "https://w3c.github.io/aria-practices/",
-          "WD" : "https://www.w3.org/TR/wai-aria-practices-1.1/",
-          "FPWD": "https://www.w3.org/TR/wai-aria-practices-1.1/",
-          "CR": "https://www.w3.org/TR/wai-aria-practices-1.1/",
-          "REC": "https://www.w3.org/TR/wai-aria-practices-1.1/"
+          "WD" : "https://www.w3.org/TR/wai-aria-practices-1.2/",
+          "FPWD": "https://www.w3.org/TR/wai-aria-practices-1.2/",
+          "CR": "https://www.w3.org/TR/wai-aria-practices-1.2/",
+          "REC": "https://www.w3.org/TR/wai-aria-practices-1.2/"
         },
 
-	localBiblio: biblio,
-	
-	preProcess: [ linkCrossReferences ]
+	preProcess: [ linkCrossReferences ],
+	definitionMap: []
 
 	};
 </script>
+<script src="common/biblio.js" class="remove"></script>
 </head>
 <body>
 <section id="abstract">
-	<p>Accessibility of web content requires semantic information about widgets, structures, and behaviors, in order to allow assistive technologies to convey appropriate information to persons with disabilities. This specification provides an ontology of roles, states, and properties that define accessible user interface elements and can be used to improve the accessibility and interoperability of web content and applications. These semantics are designed to allow an author to properly convey user interface behaviors and structural information to assistive technologies in document-level markup. This version adds features new since WAI-ARIA 1.0 [[wai-aria-1.0]] to improve interoperability with assistive technologies to form a more consistent accessibility model for [[HTML5]] and [[SVG2]]. This specification complements both [[HTML5]] and [[SVG2]].</p>
+	<p>Accessibility of web content requires semantic information about widgets, structures, and behaviors, in order to allow assistive technologies to convey appropriate information to persons with disabilities. This specification provides an ontology of roles, states, and properties that define accessible user interface elements and can be used to improve the accessibility and interoperability of web content and applications. These semantics are designed to allow an author to properly convey user interface behaviors and structural information to assistive technologies in document-level markup. This version adds features new since WAI-ARIA 1.1 [[wai-aria-1.1]] to improve interoperability with assistive technologies to form a more consistent accessibility model for [[HTML]] and [[SVG2]]. This specification complements both [[HTML]] and [[SVG2]].</p>
 	<p>This document is part of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> suite described in the <a href="http://www.w3.org/WAI/intro/aria.php"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Overview</a>.</p>
 </section>
 <section id="sotd">
-	<p>The Accessible Rich Internet Applications Working Group seeks feedback on any aspect of the specification is accepted. When submitting feedback, please consider issues in the context of the companion documents. To comment, <a href="https://github.com/w3c/aria/issues/new">file an issue in the <abbr title="World Wide Web Consortium">W3C</abbr> ARIA GitHub repository</a>. If this is not feasible, send email to <a href="mailto:public-aria@w3.org?subject=Comment%20on%20WAI-ARIA%201.2">public-aria@w3.org</a> (<a href="http://lists.w3.org/Archives/Public/public-aria/">comment archive</a>). In-progress updates to the document may be viewed in the <a href="http://w3c.github.io/aria/aria/aria.html">publicly visible editors' draft</a>.</p>
+	<p>The Accessible Rich Internet Applications Working Group seeks feedback on any aspect of the specification. When submitting feedback, please consider issues in the context of the companion documents. To comment, <a href="https://github.com/w3c/aria/issues/new">file an issue in the <abbr title="World Wide Web Consortium">W3C</abbr> ARIA GitHub repository</a>. If this is not feasible, send email to <a href="mailto:public-aria@w3.org?subject=Comment%20on%20WAI-ARIA%201.2">public-aria@w3.org</a> (<a href="http://lists.w3.org/Archives/Public/public-aria/">comment archive</a>). In-progress updates to the document may be viewed in the <a href="http://w3c.github.io/aria/">publicly visible editors' draft</a>.</p>
 </section>
 <section class="informative" id="introduction">
 	<h1>Introduction</h1>
@@ -181,9 +173,9 @@
 		<li>improving the accessibility of dynamic content generated by scripts; and</li>
 		<li>providing for interoperability with <a>assistive technologies</a>.</li>
 	</ul>
-	<p>WAI-ARIA is a technical specification that provides a framework to improve the accessibility and interoperability of web content and applications. This document is primarily for developers creating custom widgets and other web application components. Please see the <a href="http://www.w3.org/WAI/intro/aria">WAI-ARIA Overview</a> for links to related documents for other audiences, such as <a href="https://www.w3.org/TR/wai-aria-practices/">WAI-ARIA Authoring Practices</a> [[WAI-ARIA-PRACTICES-1.1]] that introduces developers to the accessibility problems that WAI-ARIA is intended to solve, the fundamental concepts, and the technical approach of WAI-ARIA.</p>
-	<p>This draft currently handles two aspects of <a>roles</a>: user interface functionality and structural <a>relationships</a>. For more information and use cases, see [[WAI-ARIA-PRACTICES-1.1]] for the use of roles in making interactive content accessible.</p>
-	<p>The role <a>taxonomy</a> is designed in part to support the common roles found in platform <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a>. Reference to roles found in this taxonomy by dynamic web content may be used to support interoperability with assistive technologies.</p>
+	<p>WAI-ARIA is a technical specification that provides a framework to improve the accessibility and interoperability of web content and applications. This document is primarily for developers creating custom widgets and other web application components. Please see the <a href="http://www.w3.org/WAI/intro/aria">WAI-ARIA Overview</a> for links to related documents for other audiences, such as <cite><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> [[WAI-ARIA-PRACTICES-1.2]] that introduces developers to the accessibility problems that WAI-ARIA is intended to solve, the fundamental concepts, and the technical approach of WAI-ARIA.</p>
+	<p>This document currently handles two aspects of <a>roles</a>: user interface functionality and structural <a>relationships</a>. For more information and use cases, see <cite><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> [[WAI-ARIA-PRACTICES-1.2]] for the use of roles in making interactive content accessible.</p>
+	<p>Roles defined by this specification are designed to support the roles used by platform <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a>. Declaration of these roles on elements within dynamic web content is intended to support interoperability between the web content and assistive technologies that utilize <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a>.</p>
 	<p>The schema to support this standard has been designed to be extensible so that custom roles can be created by extending base roles. This allows <a>user agents</a> to support at least the base role, and user agents that support the custom role can provide enhanced access. Note that much of this could be formalized in [[XMLSCHEMA11-2]]. However, being able to define similarities between roles, such as <a href="#baseConcept">baseConcepts</a> and more descriptive definitions, would not be available in <abbr title="Extensible Markup Language Schema Datatypes">XSD</abbr>.</p>
 	<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 1.2 is a member of the <a href="https://www.w3.org/WAI/intro/aria"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 1.2 suite</a> that defines how to expose semantics of WAI-ARIA and other web content languages to <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a>.
 	</p>
@@ -193,20 +185,18 @@
 		<p>New technologies often overlook semantics required for accessibility, and new authoring practices often misuse the intended semantics of those technologies. <a>Elements</a> that have one defined meaning in the language are used with a different meaning intended to be understood by the user.</p>
 		<p>For example, web application developers create collapsible tree widgets in HTML using CSS and JavaScript even though HTML has no semantic <code>tree</code> element. To a non-disabled user, it may look and act like a collapsible tree widget, but without appropriate semantics, the tree widget may not be <a>perceivable</a> to, or <a>operable</a> by, a person with a disability because assistive technologies may not recognize the role. Similarly, web application developers create interactive button widgets in SVG using JavaScript even though SVG has no semantic <code>button</code> element. To a non-disabled user, it may look and act like a button widget, but without appropriate semantics, the button widget may not be <a>perceivable</a> to, or <a>operable</a> by, a person with a disability because assistive technologies may not recognize the role.</p>
 		<p>The incorporation of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is a way for an author to provide proper semantics for custom widgets to make these widgets accessible, usable, and interoperable with assistive technologies. This specification identifies the types of widgets and structures that are commonly recognized by accessibility products, by providing an <a>ontology</a> of corresponding <a>roles</a> that can be attached to content. This allows elements with a given role to be understood as a particular widget or structural type regardless of any semantics inherited from the implementing host language. Roles are a common property of platform <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a> which assistive technologies use to provide the user with effective presentation and interaction.</p>
-		<p>This role <a>taxonomy</a> includes interaction <a>widgets</a> and elements denoting document structure. The role taxonomy describes inheritance and details the <a>attributes</a> each role supports. Information about mapping of roles to accessibility <abbr title="Application Programing Interfaces">APIs</abbr> is provided by the <cite><a href="https://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1</a></cite> [[CORE-AAM-1.1]].</p>
+		<p>The Roles Model includes interaction <a>widgets</a> and elements denoting document structure. The Roles Model describes inheritance and details the <a>attributes</a> each role supports. Information about mapping of roles to accessibility <abbr title="Application Programing Interfaces">APIs</abbr> is provided by the <cite><a href="" class="core-mapping">Core Accessibility API Mappings</a></cite> [[CORE-AAM-1.2]].</p>
 		<p>Roles are element types and will not change with time or user actions. Role information is used by assistive technologies, through interaction with the user agent, to provide normal processing of the specified element type.</p>
 		<p>States and properties are used to declare important attributes of an element that affect and describe interaction. They enable the <a>user agent</a> and operating system to properly handle the element even when the attributes are dynamically changed by client-side scripts. For example, alternative input and output technology, such as screen readers and speech dictation software, need to be able to recognize and effectively manipulate and communicate various interaction states (e.g., disabled, checked) to the user.</p>
-		<p>While it is possible for assistive technologies to access these properties directly through the <cite><a href="https://www.w3.org/TR/dom/">Document Object Model</a></cite> [[DOM4]], the preferred mechanism is for the user agent to map the states and properties to the accessibility <abbr title="Application Programing Interfaces">API</abbr> of the operating system. See the <cite><a href="https://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1</a></cite> [[CORE-AAM-1.1]] and the <cite><a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings 1.1</a></cite> [[ACCNAME-AAM-1.1]] for details.</p>
+		<p>While it is possible for assistive technologies to access these properties directly through the <cite><a href="https://www.w3.org/TR/dom/">Document Object Model</a></cite> [[DOM]], the preferred mechanism is for the user agent to map the states and properties to the accessibility <abbr title="Application Programing Interfaces">API</abbr> of the operating system. See the <cite><a href="" class="core-mapping">Core Accessibility API Mappings</a></cite> [[CORE-AAM-1.2]] and the <cite><a href="" class="accname">Accessible Name and Description Computation</a></cite> [[ACCNAME-1.2]] for details.</p>
 		<p id="desc_contractmodel">Figure 1.0 illustrates the relationship between user agents (e.g., browsers), accessibility APIs, and assistive technologies. It describes the "contract" provided by the user agent to assistive technologies, which includes typical accessibility information found in the accessibility <abbr title="Application Programing Interfaces">API</abbr> for many of our accessible platforms for GUIs (role, state, selection, <a>event</a> notification, <a>relationship</a> information, and descriptions). The DOM, usually HTML, acts as the data model and view in a typical model-view-controller relationship, and JavaScript acts as the controller by manipulating the style and content of the displayed data. The user agent conveys relevant information to the operating system's accessibility API, which can be used by any assistive technologies, such as screen readers.</p>
 		<div class="image">
 			<p><img alt="The contract model with accessibility APIs" height="389" id="contractmodel" src="img/accessibleelement.png" width="723"/></p>
 			<p class="img-caption">Figure 1: The contract model with accessibility <abbr title="Application Programing Interfaces">APIs</abbr></p>
 		</div>
-		<p>For more information see <cite><a href="https://www.w3.org/TR/wai-aria-practices/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> [[WAI-ARIA-PRACTICES-1.1]] for the use of roles in making interactive content accessible.</p>
-		<p>In addition to the prose documentation, the role taxonomy is provided in <cite><a href="https://www.w3.org/TR/2004/REC-owl-features-20040210/">Web Ontology Language (OWL)</a></cite> [[OWL-FEATURES]], which is expressed in <cite><a href="https://www.w3.org/TR/2014/REC-rdf11-concepts-20140225/">Resource Description Framework (RDF)</a></cite> [[RDF-CONCEPTS]]. Tools can use these to validate the implementation of roles in a given content document. For example, instances of some roles are expected to be children of a specific parent role. Also, some roles may support a specific <a>state</a> or <a>property</a> that another role does not support.</p>
-		<p class="note">The use of <abbr title="Resource Description Framework">RDF</abbr>/OWL as a formal representation of roles may be used to support future extensibility. Standard RDF/OWL mechanisms can be used to define new roles that inherit from the roles defined in this specification. The mechanism to define and use role extensions in an interoperable manner, however, is not defined by this specification, and RDF/OWL processing is not essential to interoperable implementation of this specification. A future version of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is expected to define how to extend roles.</p>
-		<p>Users of alternate input devices need <a>keyboard accessible</a> content. The new semantics, when combined with the recommended keyboard interactions provided in <cite><a href="https://www.w3.org/TR/wai-aria-practices-1.1/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> [[WAI-ARIA-PRACTICES-1.1]], will allow alternate input solutions to facilitate command and control via an alternate input solution.</p>
-		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> introduces navigational <a>landmarks</a> through its taxonomy and the <abbr title="Extensible Hypertext Markup Language">XHTML</abbr> role landmarks, which can help persons with dexterity and vision impairments by providing for improved keyboard navigation. <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> may also be used to assist persons with cognitive learning disabilities. The additional semantics allow authors to restructure and substitute alternative content as needed.</p>
+		<p>For more information see <cite><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> for the use of roles in making interactive content accessible.</p>
+		<p>Users of alternate input devices need <a>keyboard accessible</a> content. The new semantics, when combined with the recommended keyboard interactions provided in <cite><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite>, will allow alternate input solutions to facilitate command and control via an alternate input solution.</p>
+		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> introduces navigational <a>landmarks</a> through its Roles Model and the <abbr title="Extensible Hypertext Markup Language">XHTML</abbr> role landmarks, which can help persons with dexterity and vision impairments by providing for improved keyboard navigation. <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> may also be used to assist persons with cognitive learning disabilities. The additional semantics allow authors to restructure and substitute alternative content as needed.</p>
 		<p><a>Assistive technologies</a> need the ability to support alternative inputs by getting and setting the current value of <a>widget</a> states and properties. Assistive technologies also need to determine what <a>objects</a> are selected and manage widgets that allow multiple selections, such as list boxes and grids.</p>
 		<p>Speech-based command and control systems can benefit from <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics like the <code>role</code> attribute to assist in conveying audio information to the user. For example, upon encountering an element with a role of <rref>menu</rref> with child elements of role <rref>menuitem</rref> each containing text content representing a different flavor, a speech system might state to the user, "Select one of three choices: chocolate, strawberry, or vanilla."</p>
 		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is intended to be used as a supplement for native language semantics, not a replacement. When the host language provides a feature that provides equivalent accessibility to the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> feature, use the host language feature. <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> should only be used in cases where the host language lacks the needed <a>role</a>, <a>state</a>, and <a>property</a> indicators. Use a host language feature that is as similar as possible to the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> feature, then refine the meaning by adding <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>. For instance, a multi-selectable grid could be implemented as a table, and then <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> used to clarify that it is an interactive grid, not just a static data table. This allows for the best possible fallback for user agents that do not support <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> and preserves the integrity of the host language semantics.</p>
@@ -224,16 +214,16 @@
 		<p>Each conformance requirement indicates the audience to which it applies.</p>
 		<p>Although this specification is applicable to the above audiences, it is not specifically targeted to, nor is it intended to be the sole source of information for, any of these audiences. The following documents provide important supporting information:</p>
 		<ul>
-			<li><cite><a href="https://www.w3.org/TR/wai-aria-practices-1.1/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices 1.1</a></cite> addresses authoring recommendations for HTML, and is also of interest to developers of authoring tools and conformance checkers.</li>
-			<li><cite><a href="https://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1</a></cite> addresses developers of <a class="termref">user agents</a> and <a class="termref">assistive technologies</a>.</li>
-			<li><cite><a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings 1.1</a></cite> also addresses developers of <a class="termref">user agents</a> and <a class="termref">assistive technologies</a>.</li>
+			<li>[[[WAI-ARIA-PRACTICES-1.2]]] addresses authoring recommendations for HTML, and is also of interest to developers of authoring tools and conformance checkers.</li>
+			<li>[[[CORE-AAM-1.2]]]</cite> addresses developers of <a class="termref">user agents</a> and <a class="termref">assistive technologies</a>.</li>
+			<li>[[[ACCNAME-1.2]]] also addresses developers of <a class="termref">user agents</a> and <a class="termref">assistive technologies</a>.</li>
 		</ul>
 	</section>
 	<section id="ua-support">
 		<h2>User Agent Support</h2>
 		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> relies on user agent support for its features in two ways:</p>
 		<ul>
-			<li>Mainstream <a>user agents</a> use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> to alter how host language features are exposed to <a>accessibility APIs</a> in order to improve accessibility. The mechanism for this is defined in the <cite><a href="https://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings</a></cite> [[CORE-AAM-1.1]].</li>
+			<li>Mainstream <a>user agents</a> use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> to alter how host language features are exposed to <a>accessibility APIs</a> in order to improve accessibility. The mechanism for this is defined in the <cite><a href="" class="core-mapping">Core Accessibility API Mappings</a></cite>.</li>
 			<li><a>Assistive technologies</a> use the enhanced information available in an accessibility API, or uses the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> markup directly via the <abbr title="Document Object Model">DOM</abbr>, to convey semantic and interaction information to the user.</li>
 		</ul>
 		<p>Aside from using <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> markup to improve what is exposed to accessibility APIs, user agents behave as they would natively. Assistive technologies react to the extra information in the accessibility API as they already do for the same information on non-web content. User agents that are not assistive technologies, however, need do nothing beyond providing appropriate updates to the accessibility API.</p>
@@ -242,11 +232,11 @@
 		</section>
 	<section id="co-evolution">
 		<h2>Co-Evolution of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> and Host Languages</h2>
-		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is intended to augment semantics in supporting languages like [[HTML5]] and [[SVG2]], or to be used as an accessibility enhancement technology in other markup-based languages that do not explicitly include support for ARIA. It clarifies semantics to assistive technologies when authors create new types of objects, via style and script, that are not yet directly supported by the language of the page, because the invention of new types of objects is faster than standardized support for them appears in web languages.</p>
+		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is intended to augment semantics in supporting languages like [[HTML]] and [[SVG2]], or to be used as an accessibility enhancement technology in other markup-based languages that do not explicitly include support for ARIA. It clarifies semantics to assistive technologies when authors create new types of objects, via style and script, that are not yet directly supported by the language of the page, because the invention of new types of objects is faster than standardized support for them appears in web languages.</p>
 		<p>It is not appropriate to create objects with style and script when the host language provides a semantic element for that type of object. While <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> can improve the accessibility of these objects, accessibility is best provided by allowing the user agent to handle the object natively. For example, it's better to use an <code>h1</code> element in HTML than to use the <rref>heading</rref> role on a <code>div</code> element.</p>
 		<p>It is expected that, over time, host languages will evolve to provide semantics for objects that currently can only be declared with <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>. This is natural and desirable, as one goal of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is to help stimulate the emergence of more semantic and accessible markup. When native semantics for a given feature become available, it is appropriate for authors to use the native feature and stop using <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> for that feature. Legacy content may continue to use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>, however, so the need for user agents to support <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> remains.</p>
 		<p>While specific features of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> may lose importance over time, the general possibility of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> to add semantics to web pages is expected to be a persistent need. Host languages may not implement all the semantics <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> provides, and various host languages may implement different subsets of the features. New types of objects are continually being developed, and one goal of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is to provide a way to make such objects accessible, because web authoring practices often advance faster than host language standards. In this way, <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> and host languages both evolve together but at different rates.</p>
-		<p>Some host languages exist to create semantics for features other than the user interface. For example, SVG expresses the semantics behind production of graphical objects, not of user interface components that those objects may represent; XForms provides semantics for form controls and does not provide wider user interface features. Host languages such as these might, by design, not provide native semantics that map to <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> features. In these cases, <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> could be adopted as a long-term approach to add semantic information to user interface components.</p>
+		<p>Some host languages exist to create semantics for features other than the user interface. For example, SVG expresses the semantics behind production of graphical objects, not of user interface components that those objects may represent. Host languages might, by design, not provide native semantics that map to <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> features. In these cases, <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> could be adopted as a long-term approach to add semantic information to user interface components.</p>
 	</section>
 	<section id="authoring_practices">
 		<h2>Authoring Practices</h2>
@@ -266,67 +256,13 @@
 		<p>While some assistive technologies interact with these accessibility APIs, others may access the content directly from the <abbr title="Document Object Model">DOM</abbr>. These technologies can restructure, simplify, style, or reflow the content to help a different set of users. Common use cases for these types of adaptations may be the aging population, persons with cognitive impairments, or persons in environments that interfere with use of their tools. For example, the availability of regional navigational landmarks may allow for a mobile device adaptation that shows only portions of the content at any one time based on its semantics. This could reduce the amount of information the user needs to process at any one time. In other situations it may be appropriate to replace a custom user interface control with something that is easier to navigate with a keyboard, or touch screen device.</p>
 	</section>
 </section>
-<section class="informative" id="usage">
-	<h1>Using <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr></h1>
-	<p>Complex web applications become inaccessible when <a>assistive technologies</a> cannot determine the <a>semantics</a> behind portions of a document or when the user is unable to effectively navigate to all parts of it in a usable way (see <cite><a href="https://www.w3.org/TR/wai-aria-practices/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> [[WAI-ARIA-PRACTICES-1.1]]). <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> divides the semantics into <a>roles</a> (the type defining a user interface element) and <a>states</a> and <a>properties</a> supported by the roles.</p>
-	<p>Authors need to associate <a>elements</a> in the document to a WAI-ARIA role and the appropriate states and properties (aria-* <a>attributes</a>) during its life-cycle, unless the elements already have the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantics</a> for states and properties. In these instances the equivalent host language states and properties take precedence to avoid a conflict while the role attribute will take precedence over the implicit role of the host language element.</p>
-	<section id="usage_intro">
-		<h2><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Roles</h2>
-		<p>A <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>role</a> is set on an <a>element</a> using a <code>role</code> <a>attribute</a>, similar to the <code>role</code> attribute defined in <cite><a href="https://www.w3.org/TR/role-attribute/">Role Attribute</a></cite> [[ROLE-ATTRIBUTE]].</p>
-		<pre class="example highlight">&lt;li role="menuitem"&gt;Open file…&lt;/li&gt;</pre>
-		<p>The roles defined in this specification include a collection of <a href="#landmark_roles">document landmarks</a> and the <a href="#role_definitions"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role taxonomy</a>.</p>
-		<p>The roles in this <a>taxonomy</a> and their expected behaviors are modeled using <cite><a href="https://www.w3.org/TR/2004/REC-owl-features-20040210/"><abbr title="Resource Description Framework">RDF</abbr>/<abbr title="Web Ontology Language">OWL</abbr></a></cite> [[OWL-FEATURES]]. Features of the role taxonomy provide the following information for each role:</p>
-		<ul>
-			<li>an informative description of the role;</li>
-			<li>hierarchical information about related roles (e.g., a <rref>directory</rref> is a type of <rref>list</rref>);</li>
-			<li>context of the role (e.g., a <rref>listitem</rref> is contained inside a <rref>list</rref>);</li>
-			<li>references to related concepts in other specifications;</li>
-			<li>use of <abbr title="Web Ontology Language">OWL</abbr> to provide a type hierarchy allowing for <a>semantic</a> inheritance (similar to a <a>class</a> hierarchy); and</li>
-			<li>supported <a>states</a> and <a>properties</a> for each role (e.g., a <rref>checkbox</rref> supports being checked via <sref>aria-checked</sref>).</li>
-		</ul>
-		<p>Attaching a role gives <a>assistive technologies</a> information about how to handle each element.</p>
-	</section>
-	<section id="introstates">
-		<h2><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> States and Properties</h2>
-		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> provides a collection of accessibility <a>states</a> and <a>properties</a> which are used to support platform <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a> on various operating system platforms. <a>Assistive technologies</a> may access this information through an exposed <a>user agent</a> DOM or through a mapping to the platform accessibility <abbr title="Application Programing Interfaces">API</abbr>. When combined with <a>roles</a>, the user agent can supply the assistive technologies with user interface information to convey to the user at any time. Changes in states or properties will result in a notification to assistive technologies, which could alert the user that a change has occurred.</p>
-		<p>In the following example, a list item (<code>html:li</code>) has been used to create a checkable menu item, and JavaScript <a>events</a> will capture mouse and keyboard events to toggle the value of <sref>aria-checked</sref>. A role is used to make the behavior of this simple <a>widget</a> known to the user agent. <a>Attributes</a> that change with user actions (such as <sref>aria-checked</sref>) are defined in the <a href="#states_and_properties">states and properties</a> section.</p>
-		<pre class="example highlight">&lt;li role=&quot;menuitemcheckbox&quot; aria-checked=&quot;true&quot;&gt;Sort by Last Modified&lt;/li&gt;</pre>
-		<p>Some accessibility states, called <em><a>managed states</a></em>, are controlled by the user agent. Examples of managed state include keyboard focus and selection. Managed states often have corresponding <abbr title="Cascading Style Sheets">CSS</abbr> pseudo-classes (such as <code>:focus</code> and <code>::selection</code>) to define style changes. In contrast, the states in this specification are typically controlled by the author and are called <em>unmanaged states.</em> Some states are managed by the user agent, such as <pref>aria-posinset</pref> and <pref>aria-setsize</pref>, but the author can override them if the <abbr title="Document Object Model">DOM</abbr> is incomplete and would cause the user agent calculation to be incorrect. User agents map both managed and unmanaged states to the platform accessibility <abbr title="Application Programing Interfaces">APIs</abbr>.</p>
-		<p>Most modern user agents support <cite><a href="https://www.w3.org/TR/css3-selectors/#attribute-selectors"><abbr title="Cascading Style Sheets">CSS</abbr> attribute selectors</a></cite> ([[CSS3-SELECTORS]]), and can allow the author to create <abbr title="User Interface">UI</abbr> changes based on <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attribute information, reducing the amount of scripts necessary to achieve equivalent functionality. In the following example, a <abbr title="Cascading Style Sheets">CSS</abbr> selector is used to determine whether or not the text is bold and an image of a check mark is shown, based on the value of the <sref>aria-checked</sref> attribute.</p>
-		<pre class="example highlight lang-css">[aria-checked=&quot;true&quot;] { font-weight: bold; }
-[aria-checked=&quot;true&quot;]::before { background-image: url(checked.gif); }</pre>
-		<p>If CSS is not used to toggle the visual representation of the check mark, the author could include additional markup and scripts to manage an image that represents whether or not the <rref>menuitemcheckbox</rref> is checked.</p>
-		<pre class="example highlight">&lt;li role=&quot;menuitemcheckbox&quot; aria-checked=&quot;true&quot;&gt;
-  &lt;img src=&quot;checked.gif&quot; role=&quot;presentation&quot; alt=&quot;&quot;&gt;
-  <span class="comment">&lt;!-- note: additional scripts required to toggle image source --&gt;</span>
-  Sort by Last Modified
-&lt;/li&gt;</pre>
-	</section>
-	<section id="managingfocus">
-		<h2>Managing Focus</h2>
-		<p>An <rref>application</rref> should always have an <a>element</a> with focus when in use, as applications require users to have a place to provide user input. Authors are advised to <em>not</em> destroy the element with focus or scroll it off-screen unless through user intervention. All interactive <a>objects</a> should be focusable. All parts of composite interactive controls need to be focusable or have a documented alternative method to achieve their function, such as a keyboard shortcut. Authors are advised to maintain an obvious, discoverable way, either through tabbing or other standard navigation techniques, for keyboard users to move the focus to any interactive element. See <a href="https://www.w3.org/TR/2002/REC-UAAG10-20021217/guidelines.html#gl-navigation">User Agent Accessibility Guidelines, Guideline 9</a> ([[UAAG10]], Guideline 9).</p>
-		<p>When using standard <abbr title="Hypertext Markup Language">HTML</abbr> and basic <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>widgets</a>, application developers can simply manipulate the tab order or use a script to create keyboard shortcuts to elements in the document. Use of more complex widgets requires the author to manage focus within them. SVG Tiny provides a similar navigation "ring" mechanism that by default follows document order and which should be implemented using system dependent input facilities (the TAB key on most desktop computers). SVG authors may place elements in the navigation order by manipulating the <a href="https://www.w3.org/TR/SVGTiny12/interact.html#FocusableAttribute">focusable</a> attribute and they may dynamically <a href="https://www.w3.org/TR/SVGTiny12/interact.html#specifyingnavigation">specify the navigation order</a> by modifying elements' <a href="https://www.w3.org/TR/SVGTiny12/intro.html#TermNavigationAttribute">navigation attributes</a>.</p>
-		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> includes a number of &quot;managing container&quot; widgets, also known as &quot;composite&quot; widgets. When appropriate, the container is responsible for tracking the last descendant that was active (the default is usually the first item in the container). It is essential that a container maintain a usable and consistent strategy when focus leaves a container and is then later refocused. While there may be exceptions, it is recommended that when a previously focused container is refocused, the active descendant be the same element as the active descendant when the container was last focused. Exceptions include cases where the contents of a container widget have changed, and widgets like a menubar where the user expects to always return to the first item when focus leaves the menu bar. For example, if the second item of a tree group was the active descendant when the user tabbed out of the tree group, then the second item of the tree group remains the active descendant when the tree group gets focus again. The user may also activate the container by clicking on one of the descendants within it.</p>
-		<p>When the container or its active descendant has focus, the user may navigate through the container by pressing additional keys, such as the arrow keys, to change the currently active descendant. Any additional press of the main navigation key (generally the <kbd>TAB</kbd> key) will move out of the container to the next widget.</p>
-		<p>For example, a <rref>grid</rref> may be used as a spreadsheet with thousands of <rref>gridcell</rref> elements, all of which may not be present in the document at one time. This requires focus to be managed by the container using the <pref>aria-activedescendant</pref> <a>attribute</a> on the managing container element, or by the container managing the <code>tabindex</code> of its child elements and setting focus on the appropriate child.</p>
-		<p>Content authors are required to manage focus on the following container roles:</p>
-		<ul>
-			<li><rref>combobox</rref></li>
-			<li><rref>grid</rref></li>
-			<li><rref>listbox</rref></li>
-			<li><rref>menu</rref></li>
-			<li><rref>menubar</rref></li>
-			<li><rref>radiogroup</rref></li>
-			<li><rref>tree</rref></li>
-			<li><rref>treegrid</rref></li>
-			<li><rref>tablist</rref></li>
-		</ul>
-		<p>More information on managing focus can be found in the <a href="https://www.w3.org/TR/wai-aria-practices-1.1/#keyboard">Developing a Keyboard Interface</a> section of the <cite><a href="https://www.w3.org/TR/wai-aria-practices-1.1/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> [[WAI-ARIA-PRACTICES-1.1]].</p>
-	</section>
+<section class="informative" id="terms">
+	<h1>Important Terms</h1>
+	<div data-include="common/terms.html" data-oninclude="restrictReferences"></div>
 </section>
-<section class="normative">
+<section class="normative override" id="conformance">
 	<h2>Conformance</h2>
-	<p>The main content of Graphics ARIA is <a>normative</a> and defines requirements that impact conformance claims. Introductory material, appendices, sections marked as "non-normative" and their subsections, diagrams, examples, and notes are <a>informative</a> (non-normative). Non-normative material provides advisory information to help interpret the guidelines but does not create requirements that impact a conformance claim.</p>
+	<p>The main content of Accessible Rich Internet Applications is <a>normative</a> and defines requirements that impact conformance claims. Introductory material, appendices, sections marked as "non-normative" and their subsections, diagrams, examples, and notes are <a>informative</a> (non-normative). Non-normative material provides advisory information to help interpret the guidelines but does not create requirements that impact a conformance claim.</p>
 	<p>Normative sections provide requirements that <a class="termref">user agents</a> must follow for an implementation to conform to this specification. The keywords <em class="rfc2119">MUST</em>, <em class="rfc2119">MUST NOT</em>, <em class="rfc2119">REQUIRED</em>, <em class="rfc2119">SHALL</em>, <em class="rfc2119">SHALL NOT</em>, <em class="rfc2119">SHOULD</em>, <em class="rfc2119">RECOMMENDED</em>, <em class="rfc2119">MAY</em>, and <em class="rfc2119">OPTIONAL</em> in this document are to be interpreted as described in <cite><a href="http://www.rfc-editor.org/rfc/rfc2119.txt">Keywords for use in RFCs to indicate requirement levels</a></cite> [[!RFC2119]]. RFC-2119 keywords are formatted in uppercase and contained in an element with <code>class="rfc2119"</code>. When the keywords shown above are used, but do not share this format, they do not convey formal information in the RFC 2119 sense, and are merely explanatory, i.e., informative. As much as possible, such usages are avoided in this specification.</p>
 	<p>Normative sections provide requirements that authors, user agents and assistive technologies MUST follow for an implementation to conform to this specification.</p>
 	<p>Non-normative (informative) sections provide information useful to understanding the specification. Such sections may contain examples of recommended practice, but it is not required to follow such recommendations in order to conform to this specification.</p>
@@ -355,167 +291,247 @@
 		<p>As the technology evolves, sometimes new ways to meet a use case become available, that work better than a feature that was previously defined. But because of existing implementation of the older feature, that feature cannot be removed from the conformance model without rendering formerly conforming content non-conforming. In this case, the older feature is marked as "deprecated". This indicates that the feature is allowed in the conformance model and expected to be supported by user agents, but it is recommended that authors do not use it for new content. In future versions of the specification, if the feature is no longer widely used, the feature could be removed and no longer expected to be supported by user agents.</p>
 	</section>
 </section>
-<section class="informative" id="terms">
-	<h1>Important Terms</h1>
-	<div data-include="common/terms.html" data-oninclude="restrictReferences"></div>
+<section class="normative" id="usage">
+	<h1>Using <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr></h1>
+	<p>Complex web applications become inaccessible when <a>assistive technologies</a> cannot determine the <a>semantics</a> behind portions of a document or when the user is unable to effectively navigate to all parts of it in a usable way (see <cite><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite>). <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> divides the semantics into <a>roles</a> (the type defining a user interface element) and <a>states</a> and <a>properties</a> supported by the roles.</p>
+	<p>Authors need to associate <a>elements</a> in the document to a WAI-ARIA role and the appropriate states and properties (aria-* <a>attributes</a>) during its life-cycle, unless the elements already have the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantics</a> for states and properties. In these instances the equivalent host language states and properties take precedence to avoid a conflict while the role attribute will take precedence over the implicit role of the host language element.</p>
+	<section id="introroles" class="normative">
+		<h2><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Roles</h2>
+		<p>A <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>role</a> is set on an <a>element</a> using a <code>role</code> <a>attribute</a>, similar to the <code>role</code> attribute defined in <cite><a href="https://www.w3.org/TR/role-attribute/">Role Attribute</a></cite> [[ROLE-ATTRIBUTE]].</p>
+		<pre class="example highlight">&lt;li role="menuitem"&gt;Open file…&lt;/li&gt;</pre>
+		<p>The definition of each role in the model provides the following information :</p>
+		<ul>
+			<li>an informative description of the role;</li>
+			<li>hierarchical information about related roles (e.g., a <rref>searchbox</rref> is a type of <rref>textbox</rref>);</li>
+			<li>context of the role (e.g., a <rref>listitem</rref> is contained inside a <rref>list</rref>);</li>
+			<li>references to related concepts in other specifications;</li>
+			<li>supported <a>states</a> and <a>properties</a> for each role (e.g., a <rref>checkbox</rref> supports being checked via <sref>aria-checked</sref>).</li>
+		</ul>
+		<p>Attaching a role gives <a>assistive technologies</a> information about how to handle each element. When <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> roles override host language semantics, there are no changes in the <abbr title="Document Object Model">DOM</abbr>, only in the <a class="termref">accessibility tree</a>.</p>
+		<p>User agents MUST use the first token in the sequence of tokens in the <code>role</code> <a>attribute</a> value that matches the name of any non-abstract <abbr title="Accessible Internet Application">WAI-ARIA</abbr> <a>role</a>. The following steps will correctly identify the applicable <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role:</p>
+		<ol>
+			<li>Use the rules of the host language to detect that an element has a role attribute and to identify the attribute value string for it.</li>
+			<li>Separate the attribute value string for that attribute into a sequence of whitespace-free substrings by separating on whitespace.</li>
+			<li>Compare the substrings to all the names of the non-abstract <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> roles. Case-sensitivity of the comparison inherits from the case-sensitivity of the host language.</li>
+			<li>Use the first such substring in textual order that matches the name of a non-abstract <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role.</li>
+		</ol>
+	</section>
+	<section id="introstates">
+		<h2><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> States and Properties</h2>
+		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> provides a collection of accessibility <a>states</a> and <a>properties</a> which are used to support platform <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a> on various operating system platforms. <a>Assistive technologies</a> may access this information through an exposed <a>user agent</a> DOM or through a mapping to the platform accessibility <abbr title="Application Programing Interfaces">API</abbr>. When combined with <a>roles</a>, the user agent can supply the assistive technologies with user interface information to convey to the user at any time. Changes in states or properties will result in a notification to assistive technologies, which could alert the user that a change has occurred.</p>
+		<p>In the following example, a list item (<code>html:li</code>) has been used to create a checkable menu item, and JavaScript <a>events</a> will capture mouse and keyboard events to toggle the value of <sref>aria-checked</sref>. A role is used to make the behavior of this simple <a>widget</a> known to the user agent. <a>Attributes</a> that change with user actions (such as <sref>aria-checked</sref>) are defined in the <a href="#states_and_properties">states and properties</a> section.</p>
+		<pre class="example highlight">&lt;li role=&quot;menuitemcheckbox&quot; aria-checked=&quot;true&quot;&gt;Sort by Last Modified&lt;/li&gt;</pre>
+		<p>Some accessibility states, called <em><a>managed states</a></em>, are controlled by the user agent. Examples of managed state include keyboard focus and selection. Managed states often have corresponding <abbr title="Cascading Style Sheets">CSS</abbr> pseudo-classes (such as <code>:focus</code> and <code>::selection</code>) to define style changes. In contrast, the states in this specification are typically controlled by the author and are called <em>unmanaged states.</em> Some states are managed by the user agent, such as <pref>aria-posinset</pref> and <pref>aria-setsize</pref>, but the author can override them if the <abbr title="Document Object Model">DOM</abbr> is incomplete and would cause the user agent calculation to be incorrect. User agents map both managed and unmanaged states to the platform accessibility <abbr title="Application Programing Interfaces">APIs</abbr>.</p>
+		<p>Most modern user agents support <cite><a href="https://www.w3.org/TR/css3-selectors/#attribute-selectors"><abbr title="Cascading Style Sheets">CSS</abbr> attribute selectors</a></cite> ([[CSS3-SELECTORS]]), and can allow the author to create <abbr title="User Interface">UI</abbr> changes based on <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attribute information, reducing the amount of scripts necessary to achieve equivalent functionality. In the following example, a <abbr title="Cascading Style Sheets">CSS</abbr> selector is used to determine whether or not the text is bold and an image of a check mark is shown, based on the value of the <sref>aria-checked</sref> attribute.</p>
+		<pre class="example highlight lang-css">[aria-checked=&quot;true&quot;] { font-weight: bold; }
+[aria-checked=&quot;true&quot;]::before { background-image: url(checked.gif); }</pre>
+		<p>If CSS is not used to toggle the visual representation of the check mark, the author could include additional markup and scripts to manage an image that represents whether or not the <rref>menuitemcheckbox</rref> is checked.</p>
+		<pre class="example highlight">&lt;li role=&quot;menuitemcheckbox&quot; aria-checked=&quot;true&quot;&gt;
+  &lt;img src=&quot;checked.gif&quot; role=&quot;presentation&quot; alt=&quot;&quot;&gt;
+  <span class="comment">&lt;!-- note: additional scripts required to toggle image source --&gt;</span>
+  Sort by Last Modified
+&lt;/li&gt;</pre>
+	</section>
+	<section id="managingfocus" class="normative">
+	  <h2>Managing Focus and Supporting Keyboard Navigation</h2>
+	  <p>When using standard <abbr title="Hypertext Markup Language">HTML</abbr> interactive elements and simple <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>widgets</a>, application developers can manipulate the tab order or associate keyboard shortcuts with elements in the document.</p>
+	  <p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> includes a number of &quot;managing container&quot; widgets, also known as &quot;composite&quot; widgets. When appropriate, the container is responsible for tracking the last descendant that was active (the default is usually the first item in the container). It is essential that a container maintain a usable and consistent strategy when focus leaves a container and is then later refocused. While there may be exceptions, it is recommended that when a previously focused container is refocused, the active descendant be the same element as the active descendant when the container was last focused. Exceptions include cases where the contents of a container widget have changed, and widgets like a menubar where the user expects to always return to the first item when focus leaves the menu bar. For example, if the second item of a tree group was the active descendant when the user tabbed out of the tree group, then the second item of the tree group remains the active descendant when the tree group gets focus again. The user may also activate the container by clicking on one of the descendants within it. When the container or its active descendant has focus, the user may navigate through the container by pressing additional keys, such as the arrow keys, to change the currently active descendant. Any additional press of the main navigation key (generally the <kbd>TAB</kbd> key) will move out of the container to the next widget.</p>
+	  <p>Usable keyboard navigation in a rich internet application is different from the tabbing paradigm among interactive elements, such as links and form controls, in a static document. In rich internet applications, the user tabs to significantly complex <a class="termref">widgets</a>, such as a menu or spreadsheet, and uses the arrow keys to navigate within the widget. The changes that <abbr title="accessible rich internet applications">WAI-ARIA</abbr> introduces to keyboard navigation make this enhanced accessibility possible. In <abbr title="accessible rich internet applications">WAI-ARIA</abbr>, any element can be keyboard focusable. In addition to host language mechanisms such as <code>tabindex</code>, <pref>aria-activedescendant</pref> provides another mechanism for keyboard operation. Most other aspects of <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> widget development depend on keyboard navigation functioning properly.</p>
+          <p>
+            When implementing <pref>aria-activedescendant</pref> as described below, the user agent keeps the <abbr title="Document Object Model">DOM</abbr> focus on the container element or on an input element that controls the container element.
+            However, the user agent communicates <a>desktop focus events</a> and states to the assistive technology as if the element referenced by <pref>aria-activedescendant</pref> has focus.
+            User agents are not expected to validate that the active descendant is a descendant of the container element.
+            It is the responsibility of the user agent to ensure that keyboard events are processed at the <a>element</a> that has <abbr title="Document Object Model">DOM</abbr> focus.
+            Any keyboard events directed at the active descendant bubble up to the <abbr title="Document Object Model">DOM</abbr> element with focus for processing.
+          </p>
+	  <section id="managingfocus_authors">
+	    <h3>Information for Authors</h3>
+	    <p>If the author removes the element with focus, the author SHOULD move focus to a logical element. Similarly, authors SHOULD not scroll the element with focus off screen unless the user performed a scrolling action.</p>
+	    <p>Authors SHOULD ensure that all interactive <a>elements</a> are focusable and that all parts of composite widgets are either focusable or have a documented alternative method to achieve their function.</p>
+	    <p>Authors MUST manage focus on the following container roles:</p>
+	    <ul>
+	      <li><rref>grid</rref></li>
+	      <li><rref>listbox</rref></li>
+	      <li><rref>menu</rref></li>
+	      <li><rref>menubar</rref></li>
+	      <li><rref>radiogroup</rref></li>
+	      <li><rref>tree</rref></li>
+	      <li><rref>treegrid</rref></li>
+	      <li><rref>tablist</rref></li>
+	    </ul>
+	    <p>User agents that support <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> expand the usage of host language mechanisms such as <code>tabindex</code>, <code>focus</code>, and <code>blur</code> to allow them on all <a>elements</a>. Where the host language supports it, authors MAY add any element such as a <code>div</code>, <code>span</code>, or <code>img</code> to the default tab order by setting <code>tabindex=&quot;0&quot;</code>. In addition, any item with <code>tabindex</code> equal to a negative integer is focusable via script or a mouse click, but is not part of the default tab order. This is supported in both [[HTML]] and [[SVG2]].</p>
+	    <p>
+        Authors MAY use <pref>aria-activedescendant</pref> to inform <a>assistive technologies</a> which descendant of a <rref>widget</rref> element is treated as having keyboard focus in the user interface if the role of the widget element supports <code>aria-activedescendant</code>.
+        This is often a more convenient way of providing keyboard navigation within widgets, such as a <rref>listbox</rref>, where the widget occupies only one stop in the page <kbd>Tab</kbd> sequence and other keys, typically arrow keys, are used to focus elements inside the widget.
+      </p>
+	    <p>Typically, the author will use host language <a>semantics</a> to put the widget in the <kbd>Tab</kbd> sequence (e.g., <code>tabindex="0"</code> in <abbr title="Hypertext Markup Language">HTML</abbr>) and <code>aria-activedescendant</code> to point to the ID of the currently active descendant. The author, not the user agent, is responsible for styling the currently active descendant to show it has keyboard focus. The author cannot use <code>:<span class="css-selector">focus</span></code> to style the currently active descendant since the actual focus is on the container.</p>
+	    <p>More information on managing focus can be found in the <a href="#keyboard" class="practices">Developing a Keyboard Interface</a> section of the <cite><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</cite>.</p>
+	  </section>
+	  <section id="managingfocus_useragents">
+	    <h3>Information for User Agents</h3>
+	    <p>The user agent MUST do the following to implement <pref>aria-activedescendant</pref>:</p>
+	    <ol>
+	      <li>Implement the host language method for keyboard navigation so that widgets that support <code>aria-activedescendant</code> may be included in the tab order.</li>
+	      <li>For platforms that expose <a>desktop focus</a> or <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> focus separately from <abbr title="Document Object Model">DOM</abbr> focus, do not expose the focused state in the accessibility <abbr title="application programming interface">API</abbr> for any element when it has <abbr title="Document Object Model">DOM</abbr> focus and also has <pref>aria-activedescendant</pref> which points to a valid <a href="#valuetype_idref">ID reference</a>.</li>
+	      <li>When the <pref>aria-activedescendant</pref> attribute changes on an element that currently has <abbr title="Document Object Model">DOM</abbr> focus, remove the focused state from the previously focused object and fire an accessibility <abbr title="application programming interface">API</abbr> <a>desktop focus event</a> on the new element referenced by <code>aria-activedescendant</code>. If <pref>aria-activedescendant</pref> is cleared or does not point to an element in the current document, fire a desktop focus event for the <a>object</a> that had the attribute change.</li>
+	      <li>Apply the following accessibility <abbr title="Application Programming Interface">API</abbr> states to any element with an ID attribute that can be referenced by an element with both an <pref>aria-activedescendant</pref> attribute and has <abbr title="Document Object Model">DOM</abbr> focus. There are two ways an element can be referenced by <pref>aria-activedescendant</pref>. One way is when it is <a>owned</a> by an element with <pref>aria-activedescendant</pref> and the other is when it is <a>owned</a> by an element that is controlled by an element with role of <rref>combobox</rref>, <rref>textbox</rref> or <rref>searchbox</rref> with an <pref>aria-activedescendant</pref> attribute:
+		<ol>
+		  <li>Focusable, if the element also has a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref">role</a>. The element needs to be focusable because it could be referenced by the <pref>aria-activedescendant</pref> attribute. Native elements that have no <a class="termref">role</a> attribute do not need to be checked; their native semantics determine the focusable state.</li>
+		  <li>Focused, whenever the element is the target of the <pref>aria-activedescendant</pref> attribute and the element with the <pref>aria-activedescendant</pref> attribute has <abbr title="Document Object Model">DOM</abbr> focus.</li>
+		</ol>
+	      </li>
+	    </ol>
+	    <p>When an assistive technology uses its platform's accessibility <abbr title="Application Programming Interfaces">API</abbr> to request a change of focus, user agents MUST do the following:</p>
+	    <ol>
+	      <li>Remove the platform's focused state from the previously focused object.</li>
+	      <li>Set the <abbr title="Document Object Model">DOM</abbr> focus:
+		<ol>
+		  <li>If the <a class="termref">element</a> can take <abbr title="Document Object Model">DOM</abbr> focus, the <a class="termref">user agent</a> MUST set the <abbr title="Document Object Model">DOM</abbr> focus to it.</li>
+		  <li>Otherwise, if the current element has an ID and the ID is referenced by the <pref>aria-activedescendant</pref> attribute of an element that is focusable, the user agent MUST set <abbr title="Document Object Model">DOM</abbr> focus to the element that has the <pref>aria-activedescendant</pref> attribute.
+		  	<p class="note">An element with an ID can be referenced when it is <a>owned</a> by a container element that has the <pref>aria-activedescendant</pref> attribute or by a container element that is controlled by an element that has the <pref>aria-activedescendant</pref> attribute  (e.g. see <ref>combobox</ref>).  Otherwise the <pref>aria-activedescendant</pref> attribute reference indicates an author error.</p>
+		    <p class="note">The inability to set <abbr title="Document Object Model">DOM</abbr> focus to the containing element indicates an author error.</p>
+		  </li>
+		  <li>Otherwise, the user agent MAY attempt to set <abbr title="Document Object Model">DOM</abbr> focus to the child element itself.</li>
+		</ol>
+	      </li>
+	      <li>If the current element has an ID and is <a>owned</a> by either a container element with both an <code>aria-activedescendant</code> attribute and has <abbr title="Document Object Model">DOM</abbr> focus, or by a container element that is controlled by an element with both an <pref>aria-activedescendant</pref> attribute and has <abbr title="Document Object Model">DOM</abbr> focus, the user agent MUST set the accessibility <abbr title="Application Programming Interface">API</abbr> focused state and fire an accessibility <abbr title="Application Programming Interface">API</abbr> focus <a>event</a> on the element identified  by the value of <code>aria-activedescendant</code>.</li>
+	    </ol>
+	  </section>
+	</section>
 </section>
 <section class="normative" id="roles">
 	<h1>The Roles Model</h1>
-	<p>This section defines the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>role</a> <a>taxonomy</a> and describes the characteristics and properties of all <a>roles</a>. A formal <abbr title="Resource Description Framework">RDF</abbr>/<abbr title="Web Ontology Language">OWL</abbr> representation of all the information presented here is available in <a href="#a_schemata">Schemata Appendix</a>.</p>
-	<p>The roles, their characteristics, the states and properties they support, and specification of how they may be used in markup, shall be considered normative. The RDF/OWL representation used to model the taxonomy shall be considered informative. The RDF/OWL taxonomy may be used as a vehicle to extend <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> in the future or by tool manufacturers to validate states and properties applicable to roles per this specification.</p>
-	<p>Roles are element types and authors MUST NOT change role values over time or with user actions. Authors wishing to change a role MUST do so by deleting the associated element and its children and replacing it with a new element with the appropriate role. Typically, platform accessibility APIs do not provide a vehicle to notify assistive technologies of a role value change, and consequently, assistive technologies may not update their cache with the new role attribute value. </p>
+	<p>This section defines <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>roles</a> and describes their characteristics and properties.</p>
+	<p>The roles, their characteristics, the states and properties they support, and specification of how they may be used in markup, shall be considered normative.</p>
 	<p>In order to reflect the content in the DOM, user agents SHOULD map the role attribute to the appropriate value in the implemented accessibility API, and user agents SHOULD update the mapping when the role attribute changes.</p>
 	<section id="relationshipsconcepts">
 		<h2>Relationships Between Concepts</h2>
-		<p>The <a>role</a> <a>taxonomy</a> uses the following relationships to relate <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles to each other and to concepts from other specifications, such as HTML and XForms.</p>
+		<p>The Roles Model uses the following relationships to relate <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles to each other and to concepts from other specifications, such as HTML.</p>
 		<section id="superclassrole">
 			<h3>Superclass Role</h3>
-			<p>Inheritance is expressed in <abbr title="Resource Description Framework">RDF</abbr> using the <abbr title="Resource Description Framework">RDF</abbr> Schema 1.1 <cite><a href="https://www.w3.org/TR/2014/REC-rdf-schema-20140225/#ch_subclassof">subClassOf</a></cite> ([[RDF-SCHEMA]]) property.</p>
-			<dl class="runin">
-				<dt><abbr title="Resource Description Framework">RDF</abbr> Property</dt>
-				<dd>rdfs:subClassOf</dd>
-			</dl>
-			<p>The <a>role</a> that the current subclassed role extends in the <a>taxonomy</a>. This extension causes all the properties and constraints of the superclass role to propagate to the subclass role. Other than well known stable specifications, inheritance may be restricted to items defined inside this specification, so that external items cannot be changed and affect inherited <a>classes</a>.</p>
+			<p>The <a>role</a> that the current subclassed role extends in the Roles Model. This extension causes all the properties and constraints of the superclass role to propagate to the subclass role. Other than well known stable specifications, inheritance may be restricted to items defined inside this specification, so that external items cannot be changed and affect inherited <a>classes</a>.</p>
 		</section>
 		<section id="subclassroles">
 			<h3>Subclass Roles</h3>
-			<dl class="runin">
-				<dt><abbr title="Resource Description Framework">RDF</abbr> Property</dt>
-				<dd>&lt;none&gt;</dd>
-			</dl>
 			<p>Informative list of <a>roles</a> for which this role is the superclass. This is provided to facilitate reading of the specification but adds no new information.</p>
 		</section>
 		<section id="relatedConcept">
 			<h3>Related Concepts</h3>
-			<dl class="runin">
-				<dt><abbr title="Resource Description Framework">RDF</abbr> Property</dt>
-				<dd>role:relatedConcept</dd>
-			</dl>
 			<p>Informative data about a similar or related idea from other specifications. Concepts that are related are not necessarily identical. Related concepts do not inherit properties from each other. Hence if the definition of one concept changes, the properties, behavior, and definition of its related concept is not affected.</p>
-			<p>For example, a progress bar is like a status indicator. Therefore, the <rref>progressbar</rref> <a>widget</a> has a <code>relatedConcept</code> value which includes <rref>status</rref>. However, if the definition of <rref>status</rref> is modified, the definition of a <rref>progressbar</rref> is not affected.</p>
+			<p>For example, a progress bar is like a status indicator. Therefore, the <rref>progressbar</rref> <a>widget</a> has a related concept which includes <rref>status</rref>. However, if the definition of <rref>status</rref> is modified, the definition of a <rref>progressbar</rref> is not affected.</p>
 		</section>
 		<section id="baseConcept">
 			<h3>Base Concept</h3>
-			<dl class="runin">
-				<dt><abbr title="Resource Description Framework">RDF</abbr> Property</dt>
-				<dd>role:baseConcept</dd>
-			</dl>
 			<p>Informative data about <a>objects</a> that are considered prototypes for the <a>role</a>. Base concept is similar to type, but without inheritance of limitations and properties. Base concepts are designed as a substitute for inheritance for external concepts. A base concept is like a <a href="#relatedConcept">related concept</a> except that the base concept is almost identical to the role definition.</p>
-			<p>For example, the <rref>checkbox</rref> defined in this document has similar functionality and anticipated behavior to a <a href="https://www.w3.org/TR/html5/forms.html#checkbox-state-(type=checkbox)">checkbox defined in <abbr title="Hypertext Markup Language">HTML</abbr></a>. Therefore, a <rref>checkbox</rref> has an <abbr title="Hypertext Markup Language">HTML</abbr> <code>checkbox</code> as a <code>baseConcept</code>. However, if the original <abbr title="Hypertext Markup Language">HTML</abbr> checkbox baseConcept definition is modified, the definition of a <rref>checkbox</rref> in this document will not be affected, because there is no actual inheritance of the respective type.</p>
+			<p>For example, the <rref>checkbox</rref> defined in this document has similar functionality and anticipated behavior to a <code>&lt;input[type="checkbox"]&gt;</code> defined in [[HTML]]. Therefore, a <rref>checkbox</rref> has an [[HTML]] <code>checkbox</code> as a <code>baseConcept</code>. However, if the original [[HTML]] checkbox baseConcept definition is modified, the definition of a <rref>checkbox</rref> in this document will not be affected, because there is no actual inheritance of the respective type.</p>
 		</section>
 	</section>
 	<section id="Properties">
 		<h2>Characteristics of Roles</h2>
-		<p>Roles are defined and described by their characteristics. Characteristics define the structural function of a role, such as what a role is, concepts behind it, and what instances the role can or must contain. In the case of <a>widgets</a> this also includes how it interacts with the <a>user agent</a> based on mapping to <abbr title="Hypertext Markup Language">HTML</abbr> forms and XForms. States and properties from <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> that are supported by the role are also indicated.</p>
-		<p>The roles <a>taxonomy</a> defines the following characteristics. These characteristics are implemented in <abbr title="Resource Description Framework">RDF</abbr> as properties of the OWL <a>classes</a> that describe the roles.</p>
+		<p>Roles are defined and described by their characteristics. Characteristics define the structural function of a role, such as what a role is, concepts behind it, and what instances the role can or must contain. In the case of <a>widgets</a> this also includes how it interacts with the <a>user agent</a> based on mapping to <abbr title="Hypertext Markup Language">HTML</abbr> forms. States and properties from <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> that are supported by the role are also indicated.</p>
+		<p>Roles define the following characteristics. </p>
 		<section id="isAbstract">
 			<h3>Abstract Roles</h3>
 			<dl class="runin">
-				<dt><abbr title="Resource Description Framework">RDF</abbr> Property</dt>
-				<dd>N/A</dd>
-				<dt>Values</dt>
-				<dd>Boolean</dd>
-			</dl>
+					<dt>Values</dt>
+					<dd>Boolean</dd>
+				</dl>
 			<p>Abstract <a>roles</a> are the foundation upon which all other <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles are built. Content authors MUST NOT use abstract roles because they are not implemented in the <abbr title="application programing interface">API</abbr> binding. User agents MUST NOT map abstract roles to the standard role mechanism of the accessibility API. Abstract roles are provided to help with the following:</p>
 			<ol>
-				<li>Organize the role <a>taxonomy</a> and provide roles with a meaning in the context of known concepts.</li>
+				<li>Organize the Roles Model and provide roles with a meaning in the context of known concepts.</li>
 				<li>Streamline the addition of roles that include necessary features.</li>
 			</ol>
 		</section>
 		<section id="requiredState">
 			<h3>Required States and Properties</h3>
-			<dl class="runin">
-				<dt><abbr title="Resource Description Framework">RDF</abbr> Property</dt>
-				<dd>role:requiredState</dd>
-				<dt>Values</dt>
-				<dd>Any valid <abbr title="Resource Description Framework">RDF</abbr> object reference, such as a <abbr title="Uniform Resource Identifier">URI</abbr>.</dd>
-			</dl>
 			<p><a>States</a> and <a>properties</a> specifically required for the <a>role</a> and subclass roles. Content authors MUST provide a non-empty <span>value</span> for required states and properties. Content authors MUST NOT use the value <code>undefined</code> for required states and properties, unless <code>undefined</code> is an explicitly-supported value of that state or property.</p>
 			<p>When an <a>object</a> inherits from multiple ancestors and one ancestor indicates that property is supported while another ancestor indicates that it is required, the property is required in the inheriting object.</p>
 			<p class="note">A host language attribute with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> fulfills this requirement.</p>
 		</section>
 		<section id="supportedState">
 			<h3>Supported States and Properties</h3>
-			<dl class="runin">
-				<dt><abbr title="Resource Description Framework">RDF</abbr> Property</dt>
-				<dd>role:supportedState</dd>
-				<dt>Values</dt>
-				<dd>Any valid <abbr title="Resource Description Framework">RDF</abbr> object reference, such as a <abbr title="Uniform Resource Identifier">URI</abbr>.</dd>
-			</dl>
-			<p><a>States</a> and <a>properties</a> specifically applicable to the <a>role</a> and child roles. <a>User agents</a> MUST map all supported states and properties for the role to an accessibility API. Content authors MAY provide <span>values</span> for supported states and properties, but need not in some cases where default values are sufficient.</p>
+			<p><a>States</a> and <a>properties</a> specifically applicable to the <a>role</a> and child roles. Content authors MAY provide <span>values</span> for supported states and properties, but need not in cases where default values are sufficient. <a>User agents</a> MUST map all supported states and properties for the role to an accessibility API. If the state or property is undefined and it has a default value for the role, <a>user agents</a> SHOULD expose the default value.</p>
 			<p class="note">A host language attribute with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> fulfills this requirement.</p>
 		</section>
 		<section id="inheritedattributes">
 			<h3>Inherited States and Properties</h3>
-			<p>Informative list of properties that are inherited onto a <a>role</a> from superclass roles. <a>States</a> and <a>properties</a> are inherited from superclass roles in the role <a>taxonomy</a>, not from ancestor <a>elements</a> in the <abbr title="Document Object Model">DOM</abbr> tree. These properties are not explicitly defined on the role, as the inheritance of properties is automatic. This information is provided to facilitate reading of the specification. The set of supported states and properties combined with inherited states and properties forms the full set of states and properties supported by the role.</p>
+			<p>Informative list of properties that are inherited by a <a>role</a> from superclass roles. <a>States</a> and <a>properties</a> are inherited from superclass roles in the Roles Model, not from ancestor <a>elements</a> in the <abbr title="Document Object Model">DOM</abbr> tree. These properties are not explicitly defined on the role, as the inheritance of properties is automatic. This information is provided to facilitate reading of the specification. The set of supported states and properties combined with inherited states and properties forms the full set of states and properties supported by the role.</p>
 		</section>
+		<section id="prohibitedattributes">
+				<h3>Prohibited States and Properties</h3>
+				<p>List of states and properties that are prohibited on a <a>role</a>. Authors MUST NOT specify a prohibited state or property.</p>
+				<p class="note">A host language attribute with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> would also prohibit a state or property in this section. </p>
+			</section>
 		<section id="mustContain">
 			<h3>Required Owned Elements</h3>
-			<dl class="runin">
-				<dt><abbr title="Resource Description Framework">RDF</abbr> Property</dt>
-				<dd>role:mustContain</dd>
-				<dt>Values</dt>
-				<dd>Any valid <abbr title="Resource Description Framework">RDF</abbr> object reference, such as a <abbr title="Uniform Resource Identifier">URI</abbr>.</dd>
-			</dl>
-			<p>Any <a>element</a> that will be <a>owned</a> by the element with this <a>role</a>. For example, an element with the role <rref>list</rref> will own at least one element with the role <rref>group</rref> or <rref>listitem</rref>.</p>
-			<p>When multiple roles are specified as <em>required owned elements</em> for a role, at least one instance of one required owned element is expected. This specification does <em>not</em> require an instance of each of the listed owned roles. For example, a <code>menu</code> should have at least one instance of a <code>menuitem</code>, <code>menuitemcheckbox</code>, <em>or</em> <code>menuitemradio</code>. The <code>menu</code> role does not require one instance of each. </p>
-			<p>There may be times that required owned elements are missing, for example, while editing or while loading a data set. When a widget is missing <em>required owned elements</em> due to script execution or loading, authors MUST mark a containing element with <sref>aria-busy</sref> equal to <code>true</code>. For example, until a page is fully initialized and complete, an author could mark the document element as busy.</p>
+			<p>Any <a>element</a> that will be <a>owned</a> by the element with this <a>role</a>. For example, an element with the role <rref>list</rref> will own at least one element with the role <rref>listitem</rref>.</p>
+			<p>When multiple roles are specified as <em>required owned elements</em> for a role, at least one instance of one required <a>owned</a> element is expected. This specification does <em>not</em> require an instance of each of the listed owned roles. For example, a <code>menu</code> should have at least one instance of a <code>menuitem</code>, <code>menuitemcheckbox</code>, <em>or</em> <code>menuitemradio</code>. The <code>menu</code> role does not require one instance of each. </p>
+			<p>There may be times that required <a>owned</a> elements are missing, for example, while editing or while loading a data set. When a widget is missing <em>required owned elements</em> due to script execution or loading, authors MUST mark a containing element with <sref>aria-busy</sref> equal to <code>true</code>. For example, until a page is fully initialized and complete, an author could mark the document element as busy.</p>
 			<p class="note">A role that has 'required owned elements' does not imply the reverse relationship. While processing of a role may be incomplete without elements of given roles present as descendants, elements with roles in this list do not always have to be found within elements of the given role. See <a href="#scope">required context role</a> for requirements about the context where elements of a given role will be contained.</p>
-			<p class="note">An element with a <a href="#subclassroles">subclass role</a> of the 'required owned element' does not fulfill this requirement. For example, the <rref>list</rref> role requires ownership of an element using either the <rref>listitem</rref> or <rref>group</rref> role. Although the <rref>group</rref> role is the superclass of <rref>row</rref>, adding a owned element with a role of <rref>row</rref> will not fulfill the requirement that <rref>list</rref> must own a <rref>listitem</rref> or a <rref>group</rref>.</p>
+			<p class="note">An element with a <a href="#subclassroles">subclass role</a> of the 'required owned element' does not fulfill this requirement. For example, the <rref>listbox</rref> role requires ownership of an element using the <rref>option</rref> or <rref>group</rref> role. Although the <rref>group</rref> role is the superclass of <rref>row</rref>, adding an <a>owned</a> element with a role of <rref>row</rref> will not fulfill the requirement that <rref>listbox</rref> owns an <rref>option</rref> or a <rref>group</rref>.</p>
 			<p class="note">An element with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> fulfills this requirement.</p>
 		</section>
 		<section id="scope">
 			<h3>Required Context Role</h3>
-			<dl class="runin">
-				<dt><abbr title="Resource Description Framework">RDF</abbr> Property</dt>
-				<dd>role:scope</dd>
-				<dt>Values</dt>
-				<dd>Any valid <abbr title="Resource Description Framework">RDF</abbr> object reference, such as a <abbr title="Uniform Resource Identifier">URI</abbr>.</dd>
-			</dl>
-			<p>The required context role defines the owning container where this <a>role</a> is allowed. If a role has a required context, authors MUST ensure that an element with the role is contained inside (or <a>owned</a> by) an element with the required context role. For example, an element with role <code>listitem</code> is only meaningful when contained inside (or owned by) an element with role <code>list</code>.</p>
+			<p>The required context role defines the owning container where this <a>role</a> is allowed. If a role has a required context, authors MUST ensure that an element with the role is contained inside (or <a>owned</a> by) an element with the required context role. For example, an element with role <code>listitem</code> is only meaningful when contained inside (or <a>owned</a> by) an element with role <code>list</code>.</p>
 			<p class="note">A role that has 'required context role' does not imply the reverse relationship. While an element with the given role needs to appear within an element of the listed role(s) in order to be meaningful, elements of the listed roles do not always need descendant elements of the given role in order to be meaningful. See <a href="#mustContain">required owned elements</a> for requirements about elements that require presence of a given descendant to be processed properly.</p>
 			<p class="note">An element with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> fulfills this requirement.</p>
 		</section>
 		<section id="namecalculation">
 			<h3>Accessible Name Calculation</h3>
 			<dl class="runin">
-				<dt><abbr title="Resource Description Framework">RDF</abbr> Property</dt>
-				<dd>role:nameFrom</dd>
 				<dt>Values</dt>
 				<dd>One of the following values:
 					<ol>
 						<li>author: name comes from values provided by the author in explicit markup features such as the <pref>aria-label</pref> attribute, the <pref>aria-labelledby</pref> attribute, or the host language labeling mechanism, such as the <code>alt</code> or <code>title</code> attributes in <abbr title="Hypertext Markup Language">HTML</abbr>, with HTML <code>title</code> attribute having the lowest precedence for specifying a text alternative.</li>
-						<li>contents: name comes from the text value of the <a>element</a> node. Although this may be allowed in addition to "author" in some <a>roles</a>, this is used in content only if higher priority "author" features are not provided. Priority is defined by the <a href="https://www.w3.org/TR/accname-aam-1.1/#mapping_additional_nd_te">text alternative computation</a> algorithm.</li>
+						<li>contents: name comes from the text value of the <a>element</a> node. Although this may be allowed in addition to "author" in some <a>roles</a>, this is used in content only if higher priority "author" features are not provided. Priority is defined by the <a href="#mapping_additional_nd_te" class="accname">accessible name and description computation</a> algorithm [[ACCNAME-1.2]].</li>
+            <li>encapsulation: name comes from the text value of the <a>element</a> node with role <code>label</code> that is the closest ancestor. Although "encapsulation" may be allowed in addition to "author" and "contents" in some <a>roles</a>, "encapsulation" is used only if higher priority "author" features are not provided. Priority is defined by the <a href="#mapping_additional_nd_te" class="accname">accessible name and description computation</a> algorithm.</li>
+            <li>legend: name comes from the text value of the first descendant <a>element</a> node with the role of <code>legend</code>.  Although "legend" may be allowed in addition to "author" in some <a>roles</a>, "legend" is used in content only if higher priority "author" features are not provided. Priority is defined by the <a href="#mapping_additional_nd_te" class="accname">accessible name and description computation</a> algorithm.</li>
+            <li>prohibited: the element has no name. Authors MUST NOT use the <pref>aria-label</pref> or <pref>aria-labelledby</pref> attributes to name the element.</li>
 					</ol>
 				</dd>
 			</dl>
 			<section id="namecomputation">
 				<h4>Name Computation</h4>
-				<p><a href="https://www.w3.org/TR/accname-aam-1.1/#mapping_additional_nd_name">Name Computation</a> is defined in the Accessible Name and Description specification [[ACCNAME-AAM-1.1]].</p>
+				<p><a href="#mapping_additional_nd_name" class="accname">Name Computation</a> is defined in the Accessible Name and Description specification.</p>
 			</section>
 			<section id="descriptioncomputation">
 				<h4>Description Computation</h4>
-				<p><a href="https://www.w3.org/TR/accname-aam-1.1/#mapping_additional_nd_description">Description Computation</a> is defined in the Accessible Name and Description specification [[ACCNAME-AAM-1.1]].</p>
+				<p><a href="#mapping_additional_nd_description" class="accname">Description Computation</a> is defined in the Accessible Name and Description specification.</p>
 			</section>
 			<section id="textalternativecomputation">
-				<h4>Text Alternative Computation</h4>
-				<p><a href="https://www.w3.org/TR/accname-aam-1.1/#mapping_additional_nd_te">Text Alternative Computation</a> is defined in the Accessible Name and Description specification [[ACCNAME-AAM-1.1]].</p>
+				<h4>Accessible Name and Description Computation</h4>
+				<p><a href="#mapping_additional_nd_te" class="accname">Accessible Name and Description Computation</a> is defined in the Accessible Name and Description specification.</p>
 			</section>
             <section id="namefromauthor">
                 <h4>Roles Supporting Name from Author</h4>
-                <p>All roles support name from author with two exceptions.  The roles that do not support name from author are <rref>presentation</rref> and <rref>none</rref>.</p>
-            </section>
+                <div id="index_fromauthor">
+                </div>
+			</section>
             <section id="namefromcontent">
                 <h4>Roles Supporting Name from Content</h4>
                 <div id="index_fromcontent">
+                </div>
+			</section>
+            <section id="namefromencapsulation">
+                <h4>Roles Supporting Name from Encapsulation</h4>
+                <div id="index_fromencapsulation">
+                </div>
+			</section>
+            <section id="namefromlegend">
+                <h4>Roles Supporting Name from Legend</h4>
+                <div id="index_fromlegend">
+                </div>
+			</section>
+			<section id="namefromprohibited">
+                <h4>Roles which cannot be named (Name prohibited)</h4>
+                <div id="index_fromprohibited">
                 </div>
             </section>
 		</section>
 		<section id="childrenArePresentational">
 			<h3>Presentational Children</h3>
 			<dl class="runin">
-				<dt><abbr title="Resource Description Framework">RDF</abbr> Property</dt>
-				<dd>role:childrenArePresentational</dd>
 				<dt>Values</dt>
 				<dd>
 					<p>Boolean (<code>true</code> | <code>false</code>)</p>
@@ -525,16 +541,13 @@
 		</section>
 		<section id="implictValueForRole">
 			<h3>Implicit Value for Role</h3>
-			<p>Many states and properties have default values. Occasionally, the default value when used on a given role should be different from the usual default. Roles that require a state or property to have a non-standard default value indicate this in the "Implicit Value for Role". This is expressed in the form "<code>state or property name</code> is <code>new default value</code>". Roles that define this have the new default value for the state or property if the author does not provide an explicit value.</p>
+			<p>Many states and properties have default values. Occasionally, the default value when used on a given role should be different from the usual default. Roles that require a state or property to have a non-standard default value indicate this in the "Implicit Value for Role". This is expressed in the form "Default for <code>state or property name</code> is <code>new default value</code>". Roles that define this have the new default value for the state or property if the author does not provide an explicit value.</p>
 		</section>
 	</section>
 	<section id="roles_categorization">
 		<h2>Categorization of Roles</h2>
 		<p>To support the current user scenario, this specification categorizes <a>roles</a> that define user interface <a>widgets</a> (sliders, tree controls, etc.) and those that define page structure (sections, navigation, etc.). Note that some assistive technologies provide special modes of interaction for regions marked with role <code>application</code> or <code>document</code>.</p>
-		<div class="img" id="rdf_model"><a href="img/rdf_model"><img alt="Class diagram of the relationships described in the role data model" src="img/rdf_model_sm.png" longdesc="img/rdf_model.html" width="600" height="269" /></a>
-			<p>Class diagram of the relationships described in the role data model.</p>
-			<p><a href="img/rdf_model.svg"><abbr title="Scalable Vector Graphics">SVG</abbr> class diagram</a> | <a href="img/rdf_model.png"><abbr title="Portable Network Graphics">PNG</abbr> class diagram</a> | <a href="img/rdf_model.html">Class diagram description</a></p>
-		</div>
+		<p>A visual description of the relationships among roles is available in the <a href="https://www.w3.org/WAI/ARIA/1.2/class-diagram/">ARIA 1.2 Class Diagram</a>.</p>
 		<p>Roles are categorized as follows:</p>
 		<ol>
 			<li><a href="#abstract_roles">Abstract Roles</a></li>
@@ -546,7 +559,7 @@
 		</ol>
 		<section id="abstract_roles">
 			<h3>Abstract Roles</h3>
-			<p>The following <a>roles</a> are used to support the WAI-ARIA role <a>taxonomy</a> for the purpose of defining general role concepts.</p>
+			<p>The following <a>roles</a> are used to support the WAI-ARIA Roles Model for the purpose of defining general role concepts.</p>
 			<p>Abstract roles are used for the ontology. Authors MUST NOT use abstract roles in content.</p>
 			<ul>
 				<li><rref>command</rref></li>
@@ -607,26 +620,38 @@
 			</ul>
 		</section>
 		<section id="document_structure_roles">
-			<h3>Document Structure</h3>
+			<h3>Document Structure Roles</h3>
 			<p>The following <a>roles</a> describe structures that organize content in a page. Document structures are not usually interactive.</p>
 			<ul>
 				<li><rref>application</rref></li>
 				<li><rref>article</rref></li>
+       <li><rref>associationlist</rref></li>
+        <li><rref>associationlistitemkey</rref></li>
+        <li><rref>associationlistitemvalue</rref></li>
 				<li><rref>blockquote</rref></li>
 				<li><rref>caption</rref></li>
 				<li><rref>cell</rref></li>
 				<li><rref>columnheader</rref></li>
+				<li><rref>comment</rref></li>
 				<li><rref>definition</rref></li>
+				<li><rref>deletion</rref></li>
 				<li><rref>directory</rref></li>
 				<li><rref>document</rref></li>
+				<li><rref>emphasis</rref></li>
 				<li><rref>feed</rref></li>
 				<li><rref>figure</rref></li>
+				<li><rref>generic</rref></li>
 				<li><rref>group</rref></li>
 				<li><rref>heading</rref></li>
 				<li><rref>img</rref></li>
+				<li><rref>insertion</rref></li>
+				<li><rref>label</rref></li>
+				<li><rref>legend</rref></li>
 				<li><rref>list</rref></li>
 				<li><rref>listitem</rref></li>
+				<li><rref>mark</rref></li>
 				<li><rref>math</rref></li>
+				<li><rref>meter</rref></li>
 				<li><rref>none</rref></li>
 				<li><rref>note</rref></li>
 				<li><rref>paragraph</rref></li>
@@ -635,8 +660,13 @@
 				<li><rref>rowgroup</rref></li>
 				<li><rref>rowheader</rref></li>
 				<li><rref>separator</rref> (when not focusable)</li>
+				<li><rref>strong</rref></li>
+				<li><rref>subscript</rref></li>
+				<li><rref>suggestion</rref></li>
+				<li><rref>superscript</rref></li>
 				<li><rref>table</rref></li>
 				<li><rref>term</rref></li>
+				<li><rref>time</rref></li>
 
 <!-- FIXME: This is commented out because the ARIA Working Group agreed to move the text role to ARIA 2.0,
      but we've not branched for 1.1 yet. Once we have branched, this entire section should be deleted from
@@ -649,7 +679,7 @@
 		</section>
 		<section id="landmark_roles">
 			<h3>Landmark Roles</h3>
-			<p>The following <a>roles</a> are regions of the page intended as navigational <a>landmarks</a>. All of these roles inherit from the <code>landmark</code> base type and all are imported from the <cite><a href="https://www.w3.org/TR/role-attribute/#s_role_module_attributes">Role Attribute</a></cite> [[ROLE-ATTRIBUTE]]. The roles are included here in order to make them clearly part of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Role <a>taxonomy</a>.</p>
+			<p>The following <a>roles</a> are regions of the page intended as navigational <a>landmarks</a>. All of these roles inherit from the <code>landmark</code> base type and all are imported from the <cite><a href="https://www.w3.org/TR/role-attribute/#s_role_module_attributes">Role Attribute</a></cite> [[ROLE-ATTRIBUTE]]. The roles are included here in order to make them clearly part of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Roles Model.</p>
 			<ul>
 				<li><rref>banner</rref></li>
 				<li><rref>complementary</rref></li>
@@ -683,15 +713,16 @@
 	</section>
 	<section id="role_definitions">
 		<h2>Definition of Roles</h2>
-		<p>Below is an alphabetical list of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>roles</a> to be used by rich internet application authors.</p>
+		<p>Below is an alphabetical list of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>roles</a> to be used by authors.</p>
 		<p>Abstract roles are used for the ontology. Authors MUST NOT use abstract roles in content.</p>
 		<p id="index_role">Placeholder for compact list of roles</p>
 		<div class="role" id="alert">
 			<rdef>alert</rdef>
 			<div class="role-description">
 				<p>A type of <a>live region</a> with important, and usually time-sensitive, information. See related <rref>alertdialog</rref> and <rref>status</rref>.</p>
-				<p>Alerts are used to convey messages to alert the user. In the case of audio warnings this is an accessible alternative for a hearing-impaired user. The <code>alert</code> <a>role</a> goes on the node containing the alert message. Alerts are specialized forms of the <rref>status</rref> role, which will be processed as an atomic <a>live region</a>.</p>
-				<p>Alerts are assertive live regions and will be processed as such by assistive technologies. Neither authors nor user agents are required to set or manage focus to them in order for them to be processed. Since alerts are not required to receive focus, content authors SHOULD NOT require users to close an alert. If the operating system allows, the <a>user agent</a> SHOULD fire a system alert <a>event</a> through the accessibility API when the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> alert is created. If an alert requires focus to close the alert, then content authors SHOULD use <rref>alertdialog</rref> instead.</p>
+				<p>Alerts are used to convey messages that may be immediately important to users. In the case of audio warnings, alerts provide an accessible alternative for hearing-impaired users. The <code>alert</code> <a>role</a> is applied to the element containing the alert message. An <code>alert</code> is a specialized form of the <rref>status</rref> role, which is processed as an atomic <a>live region</a>.</p>
+				<p>Alerts are assertive live regions, which means they cause immediate notification for assistive technology users. If the operating system allows, the <a>user agent</a> SHOULD fire a system alert <a>event</a> through the accessibility API when the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> alert is created.</p>
+				<p>Neither authors nor user agents are required to set or manage focus to an alert in order for it to be processed. Since alerts are not required to receive focus, authors SHOULD NOT require users to close an alert. If an author desires focus to move to a message when it is conveyed, the author SHOULD use <rref>alertdialog</rref> instead of <code>alert</code>.</p>
 				<p>Elements with the role <code>alert</code> have an implicit <pref>aria-live</pref> value of <code>assertive</code>, and an implicit <pref>aria-atomic</pref> value of <code>true</code>.</p>
 			</div>
 			<table class="role-features">
@@ -721,7 +752,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-common-elements-alert">XForms alert</a></td>
+						<td class="role-related"> </td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -777,8 +808,8 @@
 			<rdef>alertdialog</rdef>
 			<div class="role-description">
 				<p>A type of dialog that contains an alert message, where initial focus goes to an <a>element</a> within the dialog. See related <rref>alert</rref> and <rref>dialog</rref>.</p>
-				<p>Alert dialogs are used to convey messages to alert the user. The <code>alertdialog</code> <a>role</a> goes on the node containing both the alert message and the rest of the dialog. Content authors SHOULD make alert dialogs modal by ensuring that, while the <code>alertdialog</code> is shown, keyboard and mouse interactions only operate within the dialog. See <pref>aria-modal</pref>.</p>
-				<p>Unlike <rref>alert</rref>, <code>alertdialog</code> can receive a response from the user. For example, to confirm that the user understands the alert being generated. When the alert dialog is displayed, authors SHOULD set focus to an active element within the alert dialog, such as a form edit field or an OK button. The <a>user agent</a> SHOULD fire a system alert <a>event</a> through the accessibility API when the alert is created, provided one is specified by the intended <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a>.</p>
+				<p>Alert dialogs are used to convey messages to alert the user. The <code>alertdialog</code> <a>role</a> goes on the <a>node</a> containing both the alert message and the rest of the dialog. Content authors SHOULD make alert dialogs modal by ensuring that, while the <code>alertdialog</code> is shown, keyboard and mouse interactions only operate within the dialog. See <pref>aria-modal</pref>.</p>
+				<p>Unlike <rref>alert</rref>, <code>alertdialog</code> can receive a response from the user. For example, to confirm that the user understands the alert being generated. When the alert dialog is displayed, authors SHOULD set focus to an active element within the alert dialog, such as a form control or confirmation button. The <a>user agent</a> SHOULD fire a system alert <a>event</a> through the accessibility API when the alert is created, provided one is specified by the intended <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a>.</p>
 				<p>Authors SHOULD use <pref>aria-describedby</pref> on an <code>alertdialog</code> to reference the alert message element in the dialog. If they do not, an <a>assistive technology</a> can resort to its internal recovery mechanism to determine the contents of the alert message.</p>
 			</div>
 			<table class="role-features">
@@ -813,7 +844,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-common-elements-alert">XForms alert</a></td>
+						<td class="role-related"> </td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -869,7 +900,7 @@
 				<ol>
 					<li>Associate the content with a focusable element using <pref>aria-labelledby</pref> or <pref>aria-describedby</pref>.</li>
 					<li>Place the content in a focusable element that has role <rref>document</rref> or <rref>article</rref>.</li>
-					<li>Manage focus of descendants as described in <a href="#managingfocus">Managing Focus</a>, updating the value of <pref>aria-activedescendant</pref> to reference the <a>element</a> containing the focused content.</li>
+					<li>Manage focus of <a>owned</a> elements as described in <a href="#managingfocus">Managing Focus</a>, updating the value of <pref>aria-activedescendant</pref> to reference the <a>element</a> containing the focused content.</li>
 				</ol>
 				</div>
 			<table class="role-features">
@@ -899,7 +930,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/di-gloss/#def-delivery-unit">Device Independence Delivery Unit</a></td>
+						<td class="role-related"> </td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -915,7 +946,16 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"><pref>aria-activedescendant</pref></td>
+						<td class="role-properties">
+							<ul>
+								<li><pref>aria-activedescendant</pref></li>
+								<li><sref>aria-disabled</sref></li>
+								<li><pref>aria-errormessage</pref></li>
+								<li><sref>aria-expanded</sref></li>
+								<li><pref>aria-haspopup</pref></li>
+								<li><sref>aria-invalid</sref></li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -979,7 +1019,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/html5/sections.html#the-article-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>article</code></a></td>
+						<td class="role-related"><code>&lt;article&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -1029,10 +1069,281 @@
 				</tbody>
 			</table>
 		</div>
+    <div class="role" id="associationlist">
+      <rdef>associationlist</rdef>
+      <div class="role-description">
+        <p>A <rref>section</rref> containing <rref>associationlistitemkey</rref> and <rref>associationlistitemvalue</rref> elements.</p>
+
+        <p>Association lists contain children whose <a>role</a> is <rref>associationlistitemkey</rref> and <rref>associationlistitemvalue</rref> to represent a list of key items each having one or more values.</p>
+
+        <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>associationlist</code>:</p>
+        <ul>
+          <li>MUST only use an element with role <rref>associationlistitemkey</rref> as the first child in the <code>associationlist</code>.</li>
+          <li>MUST contain at least one element with role <rref>associationlistitemkey</rref>.</li>
+          <li>Each element with role <rref>associationlistitemkey</rref> SHOULD have at least one following sibling element with role <rref>associationlistitemvalue</rref>.</li>
+        </ul>
+
+      </div>
+      <table class="role-features">
+        <caption>Characteristics:</caption>
+        <thead>
+          <tr>
+            <th scope="col">Characteristic</th>
+            <th scope="col">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th class="role-abstract-head" scope="row">Is Abstract:</th>
+            <td class="role-abstract"> </td>
+          </tr>
+          <tr>
+            <th class="role-parent-head" scope="row">Superclass Role:</th>
+            <td class="role-parent"><rref>section</rref></td>
+          </tr>
+          <tr>
+            <th class="role-children-head" scope="row">Subclass Roles:</th>
+            <td class="role-children">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-base-head" scope="row">Base Concept:</th>
+            <td class="role-base">
+                <a href="https://www.w3.org/TR/html5/grouping-content.html#the-dl-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dl</code></a>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-related-head" scope="row">Related Concepts:</th>
+            <td class="role-related"> </td>
+          </tr>
+          <tr>
+            <th class="role-scope-head" scope="row">Required Context Role:</th>
+            <td class="role-scope"> </td>
+          </tr>
+          <tr>
+            <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+            <td class="role-mustcontain">
+              <ul>
+								<li><rref>associationlistitemkey</rref></li>
+								<li><rref>associationlistitemvalue</rref></li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-required-properties-head">Required States and Properties:</th>
+            <td class="role-required-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
+            <td class="role-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+            <td class="role-inherited">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-namefrom-head" scope="row">Name From:</th>
+            <td class="role-namefrom">author</td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+            <td class="role-namerequired"> </td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+            <td class="role-namerequired-inherited"> </td>
+          </tr>
+          <tr>
+            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+            <td class="role-childpresentational"> </td>
+          </tr>
+          <tr>
+            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+            <td class="role-presentational-inherited"> </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="role" id="associationlistitemkey">
+      <rdef>associationlistitemkey</rdef>
+      <div class="role-description">
+        <p>A single key item in an association list.</p>
+
+        <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>associationlistitemkey</code>:</p>
+        <ul>
+          <li>MUST be contained in an element whose <a>role</a> is <rref>associationlist</rref>.</li>
+          <li>SHOULD be followed by one or more sibling <a>elements</a> whose <a>role</a> is <rref>associationlistitemvalue</rref>.</li>
+          <li>MAY be followed by one or more sibling elements whose role is also <rref>associationlistitemkey</rref>.</li>
+        </ul>
+
+      </div>
+      <table class="role-features">
+        <caption>Characteristics:</caption>
+        <thead>
+          <tr>
+            <th scope="col">Characteristic</th>
+            <th scope="col">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th class="role-abstract-head" scope="row">Is Abstract:</th>
+            <td class="role-abstract"> </td>
+          </tr>
+          <tr>
+            <th class="role-parent-head" scope="row">Superclass Role:</th>
+            <td class="role-parent"><rref>section</rref></td>
+          </tr>
+          <tr>
+            <th class="role-children-head" scope="row">Subclass Roles:</th>
+            <td class="role-children">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-base-head" scope="row">Base Concept:</th>
+            <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dt-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dt</code></a></td>
+          </tr>
+          <tr>
+            <th class="role-related-head" scope="row">Related Concepts:</th>
+            <td class="role-related"><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-common-elements-item">XForms item</a></td>
+          </tr>
+          <tr>
+            <th class="role-scope-head" scope="row">Required Context Role:</th>
+            <td class="role-scope"><rref>associationlist</rref></td>
+          </tr>
+          <tr>
+            <th class="role-required-properties-head">Required States and Properties:</th>
+            <td class="role-required-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
+            <td class="role-properties">
+              <ul>
+                <li><pref>aria-level</pref></li>
+                <li><pref>aria-posinset</pref></li>
+                <li><pref>aria-setsize</pref></li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+            <td class="role-inherited">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-namefrom-head" scope="row">Name From:</th>
+            <td class="role-namefrom">author</td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+            <td class="role-namerequired"> </td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+            <td class="role-namerequired-inherited"> </td>
+          </tr>
+          <tr>
+            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+            <td class="role-childpresentational"> </td>
+          </tr>
+          <tr>
+            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+            <td class="role-presentational-inherited"> </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="role" id="associationlistitemvalue">
+      <rdef>associationlistitemvalue</rdef>
+      <div class="role-description">
+        <p>A single value item in an association list.</p>
+
+        <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>associationlistitemvalue</code>:</p>
+        <ul>
+          <li>MUST be contained in an element whose <a>role</a> is <rref>associationlist</rref>.</li>
+          <li>SHOULD have a preceding sibling <a>element</a> whose <a>role</a> is <rref>associationlistitemkey</rref>.</li>
+          <li>MAY be followed by one or more sibling elements whose role is also <rref>associationlistitemvalue</rref>.</li>
+        </ul>
+
+      </div>
+      <table class="role-features">
+        <caption>Characteristics:</caption>
+        <thead>
+          <tr>
+            <th scope="col">Characteristic</th>
+            <th scope="col">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th class="role-abstract-head" scope="row">Is Abstract:</th>
+            <td class="role-abstract"> </td>
+          </tr>
+          <tr>
+            <th class="role-parent-head" scope="row">Superclass Role:</th>
+            <td class="role-parent"><rref>section</rref></td>
+          </tr>
+          <tr>
+            <th class="role-children-head" scope="row">Subclass Roles:</th>
+            <td class="role-children">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-base-head" scope="row">Base Concept:</th>
+            <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dd-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dd</code></a></td>
+          </tr>
+          <tr>
+            <th class="role-related-head" scope="row">Related Concepts:</th>
+            <td class="role-related"><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-common-elements-item">XForms item</a></td>
+          </tr>
+          <tr>
+            <th class="role-scope-head" scope="row">Required Context Role:</th>
+            <td class="role-scope"><rref>associationlist</rref></td>
+          </tr>
+          <tr>
+            <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+            <td class="role-mustcontain"> </td>
+          </tr>
+          <tr>
+            <th class="role-required-properties-head">Required States and Properties:</th>
+            <td class="role-required-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
+            <td class="role-properties">
+              <ul>
+                <li><pref>aria-posinset</pref></li>
+                <li><pref>aria-setsize</pref></li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+            <td class="role-inherited">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-namefrom-head" scope="row">Name From:</th>
+            <td class="role-namefrom">author</td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+            <td class="role-namerequired"> </td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+            <td class="role-namerequired-inherited"> </td>
+          </tr>
+          <tr>
+            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+            <td class="role-childpresentational"> </td>
+          </tr>
+          <tr>
+            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+            <td class="role-presentational-inherited"> </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
 		<div class="role" id="banner">
 			<rdef>banner</rdef>
 			<div class="role-description">
-				<p>A region that contains mostly site-oriented content, rather than page-specific content.</p>
+				<p>A <rref>landmark</rref> that contains mostly site-oriented content, rather than page-specific content.</p>
 				<p>Site-oriented content typically includes things such as the logo or identity of the site sponsor, and a site-specific search tool. A banner usually appears at the top of the page and typically spans the full width.</p>
 				<p>User agents SHOULD treat elements with the role of <code>banner</code> as navigational <a>landmarks</a>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #main and #contentinfo-->
@@ -1143,7 +1454,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/html/grouping-content.html#the-blockquote-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>blockquote</code></a></td>
+						<td class="role-related"><code>&lt;blockquote&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -1218,15 +1529,12 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><a href="https://www.w3.org/TR/html5/forms.html#the-button-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>button</code></a></td>
+						<td class="role-base"><code>&lt;button&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
 						<td class="role-related">
-							<ul>
-								<li><rref>link</rref></li>
-								<li><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-button">XForms trigger</a></li>
-							</ul>
+						    <rref>link</rref>
 						</td>
 					</tr>
 					<tr>
@@ -1245,6 +1553,8 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
+								<li><sref>aria-disabled</sref></li>
+								<li><pref>aria-haspopup</pref></li>
 								<li><sref>aria-expanded</sref></li>
 								<li><sref>aria-pressed</sref></li>
 							</ul>
@@ -1285,8 +1595,26 @@
 		<div class="role" id="caption">
 			<rdef>caption</rdef>
 			<div class="role-description">
-				<p>On-screen descriptive text for a figure or table in the page.</p>
-				<p>Authors SHOULD reference the element with role <code>caption</code> by setting <pref>aria-describedby</pref> on the figure or table.</p>
+				<p>Visible content that names, and may also describe, a <rref>figure</rref>, <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>.</p>
+				<p>When using <code>caption</code> authors SHOULD ensure:</p>
+				<ul>
+					<li>The <code>caption</code> is a direct child of a <rref>figure</rref>, <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>.</li>
+					<li>The <code>caption</code> is the first child of a <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>.</li>
+					<li>The <code>caption</code> is the first or last child of a <rref>figure</rref>.</li>
+				</ul>
+				<p>Authors SHOULD set <pref>aria-labelledby</pref> on the parent <code>figure</code>, <code>table</code>, <code>grid</code>, or <rref>treegrid</rref> to reference the element with role <code>caption</code>. However, if a <code>caption</code> contains content that serves as both a name and description for its parent, authors MAY instead set <pref>aria-labelledby</pref> to reference an element within the <code>caption</code> that contains a concise name, and set <pref>aria-describedby</pref> to reference an element within the <code>caption</code> that contains the descriptive content.</p>
+
+				<pre class="example highlight">
+					&lt;div role="table" aria-labelledby="name" aria-describedby="desc"&gt;
+				    &lt;div role="caption"&gt;
+				      &lt;div id="name"&gt;Contest Entrants&lt;/div&gt;
+				      &lt;div id="desc"&gt;
+				        This table shows the total number of entrants (500) the
+				        contest accepted over the past four weeks.
+				      &lt;/div&gt;
+				    &lt;/div&gt;
+				    &lt;!-- ... --&gt;
+				</pre>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -1315,11 +1643,18 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/html/grouping-content.html#the-figcaption-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>figcaption</code></a><br /><a href="https://www.w3.org/TR/html/tabular-data.html#the-caption-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>caption</code></a></td>
+						<td class="role-related"><code>&lt;caption&gt;</code> in [[HTML]] <br/> <code>&lt;figcaption&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
-						<td class="role-scope"> </td>
+						<td class="role-scope">
+							<ul>
+								<li><rref>figure</rref></li>
+								<li><rref>grid</rref></li>
+								<li><rref>table</rref></li>
+								<li><rref>treegrid</rref></li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
@@ -1338,8 +1673,17 @@
 						<td class="role-inherited">Placeholder</td>
 					</tr>
 					<tr>
+						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
+						<td class="role-disallowed">
+							<ul>
+								<li><pref>aria-label</pref></li>
+								<li><pref>aria-labelledby</pref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom">prohibited</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -1389,7 +1733,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><a href="https://www.w3.org/TR/html5/tabular-data.html#the-td-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>td</code></a></td>
+						<td class="role-base"><code>&lt;td&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -1412,8 +1756,10 @@
 						<td class="role-properties">
 							<ul>
 								<li><pref>aria-colindex</pref></li>
+								<li><pref>aria-colindextext</pref></li>
 								<li><pref>aria-colspan</pref></li>
 								<li><pref>aria-rowindex</pref></li>
+								<li><pref>aria-rowindextext</pref></li>
 								<li><pref>aria-rowspan</pref></li>
 							</ul>
 						</td>
@@ -1485,7 +1831,7 @@
 						<th class="role-related-head" scope="row">Related Concepts:</th>
 						<td class="role-related">
 							<ul>
-								<li><a href="https://www.w3.org/TR/html5/forms.html#checkbox-state-(type=checkbox)"><abbr title="Hypertext Markup Language">HTML</abbr> <code>input[type="checkbox"]</code></a></li>
+								<li><code>&lt;input[type="checkbox"]&gt;</code> in [[HTML]]</li>
 								<li><rref>option</rref></li>
 							</ul>
 						</td>
@@ -1510,7 +1856,11 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
+								<li><pref>aria-errormessage</pref></li>
+								<li><sref>aria-expanded</sref></li>
+								<li><sref>aria-invalid</sref></li>
 								<li><pref>aria-readonly</pref></li>
+								<li><pref>aria-required</pref></li>
 							</ul>
 						</td>
 					</tr>
@@ -1523,6 +1873,7 @@
 						<td class="role-namefrom">
 							<ul>
 								<li>contents</li>
+								<li>encapsulation</li>
 								<li>author</li>
 							</ul>
 						</td>
@@ -1543,10 +1894,105 @@
 						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
 						<td class="role-presentational-inherited"> </td>
 					</tr>
-						<tr>
-							<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
-							<td class="implicit-values">Default for <sref>aria-checked</sref> is <code class="default">false</code>.</td>
-						</tr>
+					<tr>
+						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
+						<td class="implicit-values"></td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div class="role" id="code">
+			<rdef>code</rdef>
+			<div class="role-description">
+				<p>A section whose content represents a fragment of computer code.</p>
+				<p>The primary purpose of the code role is to inform assistive technologies that the content is computer code and thus may require special presentation, in particular with respect to synthesized speech. More specifically, screen readers and other tools which provide text-to-speech presentation of content SHOULD prefer full punctuation verbosity to ensure common symbols (e.g. "-") are spoken.</p>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent">
+							<rref>section</rref>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-children-head" scope="row">Subclass Roles:</th>
+						<td class="role-children">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"> </td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related">
+							<code>&lt;code&gt;</code> in [[HTML]]
+						</td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Context Role:</th>
+						<td class="role-scope"> </td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"></td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties"></td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
+						<td class="role-disallowed">
+							<ul>
+								<li><pref>aria-label</pref></li>
+								<li><pref>aria-labelledby</pref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">prohibited</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired"></td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational"> </td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
+						<td class="implicit-values"></td>
+					</tr>
 				</tbody>
 			</table>
 		</div>
@@ -1556,10 +2002,11 @@
 				<p>A cell containing header information for a column.</p>
 				<p><code>columnheader</code> can be used as a column header in a table or grid. It could also be used in a pie chart to show a similar <a>relationship</a> in the data.</p>
 				<p>The <code>columnheader</code> establishes a relationship between it and all cells in the corresponding column. It is the structural equivalent to an <abbr title="Hypertext Markup Language">HTML</abbr> <code>th</code> <a>element</a> with a column scope.</p>
-				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>columnheader</code> are contained in, or owned by, an element with the role <rref>row</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>columnheader</code> are contained in, or <a>owned</a> by, an element with the role <rref>row</rref>.</p>
 				<p>Applying the <sref>aria-selected</sref> state on a columnheader MUST not cause the user agent to automatically propagate the <sref>aria-selected</sref> state to all the cells in the corresponding column. An author MAY choose to propagate selection in this manner depending on the specific application.</p>
 				<p>While the <code>columnheader</code> role can be used in both interactive grids and non-interactive tables, the use of <pref>aria-readonly</pref> and <pref>aria-required</pref> is only applicable to interactive elements. Therefore, authors SHOULD NOT use <pref>aria-required</pref> or <pref>aria-readonly</pref> in a <code>columnheader</code> that descends from a <rref>table</rref>, and user agents SHOULD NOT expose either property to <a>assistive technologies</a> unless the <code>columnheader</code> descends from a <rref>grid</rref>.</p>
 				<p class="note">Because cells are organized into rows, there is not a single container element for the column. The column is the set of <rref>gridcell</rref> elements in a particular position within their respective <rref>row</rref> containers.</p>
+                <p class="note" title="Usage of aria-disabled">While <sref>aria-disabled</sref> is currently supported on <rref>columnheader</rref>, in a future version the working group plans to prohibit its use on elements with role <rref>columnheader</rref> except when the element is in the context of a <rref>grid</rref> or <rref>treegrid</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -1590,7 +2037,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><a href="https://www.w3.org/TR/html5/tabular-data.html#attr-th-scope"><abbr title="Hypertext Markup Language">HTML</abbr> <code>th[scope="col"]</code></a></td>
+						<td class="role-base"><code>&lt;th[scope="col"]&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -1647,24 +2094,69 @@
 		<div class="role" id="combobox">
 			<rdef>combobox</rdef>
 			<div class="role-description">
-				<p>A composite <rref>widget</rref> containing a single-line <rref>textbox</rref> and another element, such as a <rref>listbox</rref> or <rref>grid</rref>, that can dynamically pop up to help the user set the value of the <rref>textbox</rref>.</p>
-				<p>Authors MUST ensure an element with role <code>combobox</code> contains or owns a text input element with role <rref>textbox</rref> or <rref>searchbox</rref> and that the text input has <pref>aria-multiline</pref> set to <code>false</code>. If the <code>combobox</code> provides autocompletion behavior for the text input as described in <pref>aria-autocomplete</pref>, authors MUST set <pref>aria-autocomplete</pref> on the <rref>textbox</rref> element to the value that corresponds to the provided behavior.</p>
-				<p>Typically, the default state of a <code>combobox</code> is collapsed. In the collapsed state, only the <rref>textbox</rref> element of a <code>combobox</code> is visible. A <code>combobox</code> is said to be expanded when both the <rref>textbox</rref> and a secondary element that serves as its popup are visible. Authors MUST set <sref>aria-expanded</sref> to <code>true</code> on an element with role <code>combobox</code> when it is expanded and <code>false</code> when it is collapsed. Elements with the role <code>combobox</code> have an implicit <sref>aria-expanded</sref> value of <code>false</code>.</p>
-				<p>When a <code>combobox</code> is expanded, authors MUST ensure it contains or owns an element that has a role of <rref>listbox</rref>, <rref>tree</rref>, <rref>grid</rref>, or <rref>dialog</rref>. This element is the <code>combobox</code> popup. When the <code>combobox</code> is expanded, authors MUST set <pref>aria-controls</pref> on the <rref>textbox</rref> element to a value that refers to the <code>combobox</code> popup element.</p>
-				<p>Elements with the role <code>combobox</code> have an implicit <pref>aria-haspopup</pref> value of <code>listbox</code>. If the <code>combobox</code> popup element has a role other than <rref>listbox</rref>, authors MUST specify a value for <pref>aria-haspopup</pref> that corresponds to the type of its popup.</p>
-				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>. When a <code>combobox</code> receives focus, authors SHOULD ensure focus is placed on the <rref>textbox</rref> element.</p>
-				<p>Authors SHOULD provide keyboard mechanisms for moving focus between the <rref>textbox</rref> element and the elements contained in the popup. For example, one common convention is that <kbd>Down Arrow</kbd> moves focus from the text input to the first focusable descendant of the popup element. If the popup element supports <pref>aria-activedescendant</pref>, in lieu of moving focus, such keyboard mechanisms can control the value of <pref>aria-activedescendant</pref> on the <rref>textbox</rref> element. When a descendant of the popup element is active, authors MAY set <pref>aria-activedescendant</pref> on the <rref>textbox</rref> to a value that refers to the active element within the popup while focus remains on the <rref>textbox</rref> element.</p>
+				<p>An <rref>input</rref> that controls another element, such as a <rref>listbox</rref> or <rref>grid</rref>, that can dynamically pop up to help the user set the value of the <rref>input</rref>.</p>
+				<p class="ednote" title="Major Changes to combobox role in ARIA 1.2">
+					The Guidance for <rref>combobox</rref> has changed significantly in ARIA 1.2 due to problems with implementation of the previous patterns.
+					Authors and developers of User Agents, Assistive Technologies, and Conformance Checkers are advised to review this section carefully to understand the changes.
+          			Explanation of the changes is available in the <a href="https://github.com/w3c/aria/wiki/Resolving-ARIA-1.1-Combobox-Issues">ARIA repository wiki</a>.
+				</p>
+				<p>
+				A <code>combobox</code> functionally combines a named input field with the ability to assist value selection via a supplementary popup element.
+				A <code>combobox</code> input MAY be either a single-line text field that supports editing and typing or an element that only displays the current value of the <code>combobox</code>.
+				If the <code>combobox</code> supports text input and provides autocompletion behavior as described in <pref>aria-autocomplete</pref>, authors MUST set <pref>aria-autocomplete</pref> on the <code>combobox</code> element to the value that corresponds to the provided behavior.
+				</p>
+				<p>
+				Typically, the initial state of a <code>combobox</code> is collapsed.
+				In the collapsed state, only the <code>combobox</code> element and a separate, optional popup control <rref>button</rref> are visible.
+				A <code>combobox</code> is said to be expanded when both the <code>combobox</code> element showing its current value and its associated popup element are visible.
+				Authors MUST set <sref>aria-expanded</sref> to <code>true</code> on an element with role <code>combobox</code> when it is expanded and <code>false</code> when it is collapsed.
+				</p>
+				<p>
+				Authors MUST ensure the popup element associated with a <code>combobox</code> has a role of <rref>listbox</rref>, <rref>tree</rref>, <rref>grid</rref>, or <rref>dialog</rref>.
+				Authors MUST set <pref>aria-controls</pref> on a <code>combobox</code> element to a value that refers to the <code>combobox</code> popup element.
+				</p>
+				<p>
+				Elements with the role <code>combobox</code> have an implicit <pref>aria-haspopup</pref> value of <code>listbox</code>.
+				If the <code>combobox</code> popup element has a role other than <rref>listbox</rref>, authors MUST specify a value for <pref>aria-haspopup</pref> that corresponds to the role of its popup.
+				</p>
+				<p>
+				If the user interface includes an additional icon that allows the visibility of the popup to be controlled via pointer and touch events, authors SHOULD ensure that element has role <rref>button</rref>, that it is focusable but not included in the page <kbd>Tab</kbd> sequence, and that it is not a descendant of the element with role <code>combobox</code>.
+				In addition, to be keyboard accessible, authors SHOULD provide keyboard mechanisms for moving focus between the <code>combobox</code> element and elements contained in the popup.
+				For example, one common convention is that <kbd>Down Arrow</kbd> moves focus from the input to the first focusable descendant of the popup element.
+				If the popup element supports <pref>aria-activedescendant</pref>, in lieu of moving focus, such keyboard mechanisms can control the value of <pref>aria-activedescendant</pref> on the <code>combobox</code> element.
+				When a descendant of the popup element is active, authors MAY set <pref>aria-activedescendant</pref> on the <code>combobox</code> to a value that refers to the active element within the popup while focus remains on the <code>combobox</code> element.
+				</p>
+				<p>
+				User agents MUST expose the value of elements with role <code>combobox</code> to <a>assistive technologies</a>.
+				The value of a <code>combobox</code> is represented by one of the following:
+				</p>
+				<ul>
+					<li>If the <code>combobox</code> element is a host language element that provides a value, such as an HTML <code>input</code> element, the value of the combobox is the value of that element.</li>
+					<li>Otherwise, the value of the <code>combobox</code> is represented by its descendant elements and can be determined using the same method used to compute the name of a <rref>button</rref> from its descendant content.</li>
+				</ul>
 				<pre class="example highlight">
-				  &lt;div aria-label="Tag" role="combobox" aria-expanded="true" aria-owns="owned_listbox" aria-haspopup="listbox"&gt;
-				      &lt;input type="text" aria-autocomplete="list" aria-controls="owned_listbox" aria-activedescendant="selected_option"&gt;
-				  &lt;/div&gt;
-				  &lt;ul role="listbox" id="owned_listbox"&gt;
-				      &lt;li role="option"&gt;Zebra&lt;/li&gt;
-				      &lt;li role="option" id="selected_option"&gt;Zoom&lt;/li&gt;
+          &lt;label for="tag_combo">Tag&lt;/label>
+		      &lt;input type="text" id="tag_combo"
+            role="combobox" aria-autocomplete="list"
+            aria-haspopup="listbox" aria-expanded="true"
+            aria-controls="popup_listbox" aria-activedescendant="selected_option"&gt;
+				  &lt;ul role="listbox" id="popup_listbox"&gt;
+			      &lt;li role="option"&gt;Zebra&lt;/li&gt;
+			      &lt;li role="option" id="selected_option"&gt;Zoom&lt;/li&gt;
 				  &lt;/ul&gt;
 				</pre>
-				<p>The ARIA 1.0 specification describes a <code>combobox</code> pattern where a text input element has the <code>combobox</code> role and owns a <rref>listbox</rref> element. <a>User agents</a>, <a>assistive technologies</a>, and conformance checkers SHOULD continue to support the ARIA 1.0 pattern so that existing implementations of the ARIA 1.0 pattern remain functional.</p>
-				<p>The features and behaviors of combobox implementations vary widely. Consequently, there are many important authoring considerations. See the <cite><a href="https://www.w3.org/TR/wai-aria-practices/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices Guide</a></cite> [[WAI-ARIA-PRACTICES-1.1]] for additional details on implementing combobox design patterns.</p>
+				<p class="ednote" title="Validity changes combobox for ARIA 1.2">
+					Please review the following carefully. As a result of these changes a combobox following the ARIA 1.1 combobox specification will no longer conform with the ARIA specification.
+				</p>
+				<div class="note">
+				<p>The structural requirements  for <code>combobox</code> defined by this version of the specification are different from the requirements defined by ARIA 1.0 and ARIA 1.1:</p>
+				<ul>
+					<li>The ARIA 1.0 specification required the input element with the <code>combobox</code> role to be a single-line text field and reference the popup element with <pref>aria-owns</pref> instead of <pref>aria-controls</pref>.</li>
+					<li>The ARIA 1.1 specification, which was not broadly supported by assistive technologies, required the <code>combobox</code> to be a non-focusable element with two required owned elements -- a focusable <rref>textbox</rref> and a popup element controlled by the <rref>textbox</rref>.</li>
+					<li>The changes introduced in ARIA 1.2 improve interoperability with assistive technologies and enable authors to create presentations of combobox that more closely imitate a native HTML <code>select</code> element.</li>
+				</ul>
+				</div>
+				<p>The features and behaviors of combobox implementations vary widely. Consequently, there are many important authoring considerations. See the <cite><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> for additional details on implementing combobox design patterns.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -1681,7 +2173,7 @@
 					</tr>
 					<tr>
 						<th class="role-parent-head" scope="row">Superclass Role:</th>
-						<td class="role-parent"><rref>select</rref></td>
+						<td class="role-parent"><rref>input</rref></td>
 					</tr>
 					<tr>
 						<th class="role-children-head" scope="row">Subclass Roles:</th>
@@ -1694,10 +2186,7 @@
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
 						<td class="role-related">
-							<ul>
-								<li><a href="https://www.w3.org/TR/html5/forms.html#the-select-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>select</code></a></li>
-								<li><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-selectMany">XForms select</a></li>
-							</ul>
+							<code>&lt;select&gt;</code> in [[HTML]]
 						</td>
 					</tr>
 					<tr>
@@ -1706,15 +2195,7 @@
 					</tr>
 					<tr>
 						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
-						<td class="role-mustcontain">
-							<rref>textbox</rref> and, when expanded, one of:
-							<ul>
-								<li><rref>listbox</rref></li>
-								<li><rref>tree</rref></li>
-								<li><rref>grid</rref></li>
-								<li><rref>dialog</rref></li>
-							</ul>
-						</td>
+						<td class="role-mustcontain"></td>
 					</tr>
 					<tr>
 						<th class="role-required-properties-head">Required States and Properties:</th>
@@ -1729,7 +2210,11 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
+                <li><pref>aria-activedescendant</pref></li>
 								<li><pref>aria-autocomplete</pref></li>
+								<li><pref>aria-errormessage</pref></li>
+								<li><pref>aria-haspopup</pref></li>
+								<li><sref>aria-invalid</sref></li>
 								<li><pref>aria-readonly</pref></li>
 								<li><pref>aria-required</pref></li>
 							</ul>
@@ -1762,7 +2247,6 @@
 					<tr>
 						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
 						<td class="implicit-values">
-							Default for <sref>aria-expanded</sref> is <code class="default">false</code>.<br/>
 							Default for <pref>aria-haspopup</pref> is <code class="default">listbox</code>.<br/>
 						</td>
 					</tr>
@@ -1802,7 +2286,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/html51/interactive-elements.html#the-menuitem-element"><code>menuitem</code></a> in [[HTML51]]</td>
+						<td class="role-related"> </td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -1847,10 +2331,111 @@
 				</tbody>
 			</table>
 		</div>
+		<div class="role" id="comment">
+			<rdef>comment</rdef>
+			<div class="role-description">
+				<p>A comment contains content expressing reaction to other content.</p>
+				<p>Comments can annotate any visible content, from small spans of text, to other comments, to entire articles. Authors SHOULD identify the relationships between comments and the commented content, as follows:</p>
+				<ol>
+					<li>If the comment is a reply to another <code>comment</code>:
+						<ul>
+							<li>If all ancestor comments are available in the DOM, make each reply <code>comment</code> a semantic descendant of the <code>comment</code> to which it is replying, either by making it a DOM descendant element or by using <pref>aria-owns</pref>.</li>
+							<li>Alternatively, if all ancestor comments are not in the DOM, such as when comments are paginated, the hierarchical
+								level MAY be indicated via <pref>aria-level</pref>. Additional group positional information MAY be indicated via <pref>aria-posinset</pref> and <pref>aria-setsize</pref>.</li>
+						</ul>
+					</li>
+					<li>Otherwise, if the comment relates to other content in the page:
+						<ul>
+							<li>Provide <pref>aria-details</pref> on the element containing the commented content with a value refering to the element with role <code>comment</code>.</li>
+							<li>If there are multiple comments related to the same commented content, either provide a value for <pref>aria-details</pref> on the commented content that refers to each individual comment, or use <pref>aria-details</pref> to refer to a parent container of the comments. If <pref>aria-details</pref> refers to an element containing comments rather than <code>comment</code> elements, authors SHOULD assign a role of <rref>group</rref> or <rref>region</rref> to the referenced container.</li>
+						</ul>
+					</li>
+				</ol>
+				<p>If the author has not explicitly declared <pref>aria-level</pref>, <pref>aria-posinset</pref>, or <pref>aria-setsize</pref> for a <code>comment</code> element, user agents MUST automatically compute the missing values and expose them to assistive technologies.</p>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent"><rref>article</rref></td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"> </td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"> </td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Context Role:</th>
+						<td class="role-scope"> </td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties">
+							<ul>
+								<li><pref>aria-level</pref></li>
+								<li><pref>aria-posinset</pref></li>
+								<li><pref>aria-setsize</pref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">
+							<ul>
+								<li>contents</li>
+								<li>author</li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired"> </td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational"> </td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
 		<div class="role" id="complementary">
 			<rdef>complementary</rdef>
 			<div class="role-description">
-				<p>A supporting section of the document, designed to be complementary to the main content at a similar level in the DOM hierarchy, but remains meaningful when separated from the main content.</p>
+				<p>A <rref>landmark</rref> that is designed to be complementary to the main content at a similar level in the DOM hierarchy, but remaining meaningful when separated from the main content.</p>
 				<p>There are various types of content that would appropriately have this <a>role</a>. For example, in the case of a portal, this may include but not be limited to show times, current weather, related articles, or stocks to watch. The complementary role indicates that contained content is relevant to the main content. If the complementary content is completely separable from the main content, it may be appropriate to use a more general role.</p>
 				<p>User agents SHOULD treat elements with the role of <code>complementary</code> as navigational <a>landmarks</a>.</p>
 			</div>
@@ -1929,7 +2514,7 @@
 		<div class="role" id="composite">
 			<rdef>composite</rdef>
 			<div class="role-description">
-				<p>A <a>widget</a> that may contain navigable descendants or owned children.</p>
+				<p>A <a>widget</a> that may contain navigable descendants or <a>owned</a> children.</p>
 				<p>Authors SHOULD ensure that a composite widget exists as a single navigation stop within the larger navigation system of the web page. Once the composite widget has focus, authors SHOULD provide a separate navigation mechanism for users to navigate to <a>elements</a> that are descendants or owned children of the composite element.</p>
 				<p class="note"><code>composite</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
 			</div>
@@ -1968,7 +2553,12 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"><pref>aria-activedescendant</pref></td>
+						<td class="role-properties">
+							<ul>
+								<li><pref>aria-activedescendant</pref></li>
+								<li><sref>aria-disabled</sref></li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -2000,7 +2590,7 @@
 		<div class="role" id="contentinfo">
 			<rdef>contentinfo</rdef>
 			<div class="role-description">
-				<p>A large perceivable region that contains information about the parent document.</p>
+				<p>A <rref>landmark</rref> that contains information about the parent document.</p>
 				<p>Examples of information included in this region of the page are copyrights and links to privacy statements.</p>
 				<p>User agents SHOULD treat elements with the role of <code>contentinfo</code> as navigational <a>landmarks</a>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #banner and #main -->
@@ -2083,7 +2673,7 @@
 			<rdef>definition</rdef>
 			<div class="role-description">
 				<p>A definition of a term or concept. See related <rref>term</rref>.</p>
-				<p>Authors SHOULD identify the <a>element</a> being defined by giving that element a role of <rref>term</rref> and referencing it with the <pref>aria-labelledby</pref> <a>attribute</a>.</p>
+				<p>Authors SHOULD identify the <a>element</a> being defined by giving that element a role of <rref>term</rref> and referencing it with the <pref>aria-labelledby</pref> <a>attribute</a> or by making the element with role <rref>term</rref> a descendant of the element with role <code>definition</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -2109,15 +2699,6 @@
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
 						<td class="role-base"> </td>
-					</tr>
-					<tr>
-						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related">
-							<ul>
-								<li><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dd-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dd</code></a></li>
-								<li><a href="https://www.w3.org/TR/html5/text-level-semantics.html#the-dfn-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dfn</code></a></li>
-							</ul>
-						</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2162,12 +2743,95 @@
 				</tbody>
 			</table>
 		</div>
+		<div class="role" id="deletion">
+			<rdef>deletion</rdef>
+			<div class="role-description">
+				<p>A deletion contains content that is marked as removed or content that is being suggested for removal. See related <rref>insertion</rref>.</p>
+				<p>Deletions are typically used to either mark differences between two versions of content or to designate content suggested for removal in scenarios where multiple people are revising content.</p>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent"><rref>section</rref></td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"> </td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"><code>&lt;del&gt;</code> in [[HTML]]</td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Context Role:</th>
+						<td class="role-scope"> </td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
+						<td class="role-disallowed">
+							<ul>
+								<li><pref>aria-label</pref></li>
+								<li><pref>aria-labelledby</pref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">prohibited</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired"> </td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational"> </td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
 		<div class="role" id="dialog">
 			<rdef>dialog</rdef>
 			<div class="role-description">
 				<p>A dialog is a descendant window of the primary window of a web application. For <abbr title="Hypertext Markup Language">HTML</abbr> pages, the primary application window is the entire web document, i.e., the <code>body</code> element.</p>
 				<p>Dialogs are most often used to prompt the user to enter or respond to information. A dialog that is designed to interrupt workflow is usually modal. See related <rref>alertdialog</rref>.</p>
-<p>Authors SHOULD provide a dialog label, which can be done with the <pref>aria-label</pref> or <pref>aria-labelledby</pref> attribute.</p>
+				<p>Authors MUST provide an accessible name for a dialog, which can be done with the <pref>aria-label</pref> or <pref>aria-labelledby</pref> attribute.</p>
 				<p>Authors SHOULD ensure that all dialogs (both modal and non-modal) have at least one focusable descendant element. Authors SHOULD focus an element in the modal dialog when it is displayed, and authors SHOULD manage focus of modal dialogs.</p>
 				<p class="note">In the description of this role, the term "web application" does not refer to the <rref>application</rref> role, which specifies specific assistive technology behaviors.</p>
 			</div>
@@ -2246,8 +2910,9 @@
 		<div class="role" id="directory">
 			<rdef>directory</rdef>
 			<div class="role-description">
-				<p>A list of references to members of a group, such as a static table of contents.</p>
-				<p>Authors SHOULD use this <a>role</a> for a static table of contents, whether linked or unlinked. This includes tables of contents built with lists, including nested lists. Dynamic tables of contents, however, might use a <rref>tree</rref> role instead.</p>
+				<p>[Deprecated in ARIA 1.2] A list of references to members of a group, such as a static table of contents.</p>
+				<p class="note">As exposed by accessibility APIs, the <code>directory</code> <a>role</a> is essentially equivalent to the <code>list</code> <a>role</a>. So, using <code>directory</code> does not provide any additional benefits to assistive technology users. Authors are advised to treat <code>directory</code> as deprecated and to use <code>list</code>, or a host language's equivalent semantics instead.</p>
+				<p>A <code>directory</code> is a static table of contents, whether linked or unlinked. This includes tables of contents built with lists, including nested lists. Dynamic tables of contents, however, might use a <rref>tree</rref> role instead.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -2276,7 +2941,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="http://www.daisy.org/z3986/2005/Z3986-2005.html#Guide"><abbr title="Digital Accessible Information System">DAISY</abbr> Guide</a></td>
+						<td class="role-related"> </td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2355,7 +3020,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/di-gloss/#def-delivery-unit">Device Independence Delivery Unit</a></td>
+						<td class="role-related"> </td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2371,7 +3036,7 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"><sref>aria-expanded</sref></td>
+						<td class="role-properties"></td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -2400,6 +3065,94 @@
 				</tbody>
 			</table>
 		</div>
+		<div class="role" id="emphasis">
+			<rdef>emphasis</rdef>
+			<div class="role-description">
+				<p>One or more emphasized characters. See related <rref>strong</rref>.</p>
+				<p>The purpose of the <code>emphasis</code> role is to stress or emphasize content. It is not for communicating changes in typographical presentation that do not impact the meaning of the content. Authors SHOULD use the <code>emphasis</code> role only if its absence would change the meaning of the content.</p>
+				<p>The <code>emphasis</code> role is not intended to convey importance; for that purpose, the <rref>strong</rref> role is more appropriate.</p>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent"><rref>section</rref></td>
+					</tr>
+					<tr>
+						<th class="role-children-head" scope="row">Subclass Roles:</th>
+						<td class="role-children">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"> </td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"><code>&lt;em&gt;</code> in [[HTML]]</td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Context Role:</th>
+						<td class="role-scope"> </td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
+						<td class="role-disallowed">
+							<ul>
+								<li><pref>aria-label</pref></li>
+								<li><pref>aria-labelledby</pref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">prohibited</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired"> </td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational"> </td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
 		<div class="role" id="feed">
 			<rdef>feed</rdef>
 				<div class="role-description">
@@ -2410,10 +3163,10 @@
 					<p>Authors SHOULD make each <rref>article</rref> in a <code>feed</code> focusable and ensure that the application scrolls an <rref>article</rref> into view when <a>user agent</a> focus is set on the <rref>article</rref> or one of its descendant elements. For example, in HTML, each <rref>article</rref> element should have a <code>tabindex</code> value of either <code>-1</code> or <code>0</code>.</p>
 					<p> When an <a>assistive technology</a> reading cursor moves from one <rref>article</rref> to another, <a>assistive technologies</a> SHOULD set user agent focus on the <rref>article</rref> that contains the reading cursor. If the reading cursor lands on a focusable element inside the <rref>article</rref>, the assistive technology MAY set focus on that element in lieu of setting focus on the containing <rref>article</rref>.</p>
 					<p>Because the ability to scroll to another <rref>article</rref> with an <a>assistive technology</a> reading cursor depends on the presence of another <rref>article</rref> in the page, authors SHOULD attempt to load additional <rref data-lt="article">articles</rref> before <a>user agent</a> focus reaches an <rref>article</rref> at either end of the set of <rref data-lt="article">articles</rref> that has been loaded. Alternatively, authors MAY include an <rref>article</rref> at either or both ends of the loaded set of <rref data-lt="article">articles</rref> that includes an element, such as a <rref>button</rref>, that lets the user request more <rref data-lt="article">articles</rref> to be loaded.</p>
-					<p>In addition to providing a brief label, authors MAY apply <pref>aria-describedby</pref> to <rref>article</rref> elements in a <code>feed</code> to suggest to screen readers which elements to speak after the label when users navigate by <rref>article</rref>. Screen readers MAY provide users with a way to quickly scan <code>feed</code> content by speaking both the label and accessible description when navigating by <rref>article</rref>, enabling the user to ignore repetitive or less important elements, such as embedded interaction widgets, that the author has left out of the description.</p>
+					<p>In addition to providing a brief label, authors MAY apply <pref>aria-describedby</pref> to <rref>article</rref> elements in a <code>feed</code> to suggest to screen readers which elements to speak after the label when users navigate by <rref>article</rref>. Screen readers MAY provide users with a way to quickly scan <code>feed</code> content by speaking both the label and <a>accessible description</a> when navigating by <rref>article</rref>, enabling the user to ignore repetitive or less important elements, such as embedded interaction widgets, that the author has left out of the description.</p>
 					<p> Authors SHOULD provide keyboard commands for moving focus among <rref data-lt="article">articles</rref> in a <code>feed</code> so users who do not utilize an assistive technology that provides <rref>article</rref> navigation features can use the keyboard to navigate the <code>feed</code>.</p>
 					<p>If the number of articles available in a <code>feed</code> supply is static, authors MAY specify <pref>aria-setsize</pref> on <rref>article</rref> elements in that <code>feed</code>. However, if the total number is extremely large, indefinite, or changes often, authors MAY set <pref>aria-setsize</pref> to <code>-1</code> to communicate the unknown size of the set.</p>
-					<p>See the <cite><a href="https://www.w3.org/TR/wai-aria-practices-1.1/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> [[WAI-ARIA-PRACTICES-1.1]] for additional details on implementing a feed design pattern.</p>
+					<p>See the <cite><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> for additional details on implementing a feed design pattern.</p>
 				</div>
 				<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -2522,7 +3275,7 @@
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
 						<td class="role-related">
-							<a href="https://www.w3.org/TR/html5/grouping-content.html#the-figure-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>figure</code></a>
+							<code>&lt;figure&gt;</code> in [[HTML]]
 						</td>
 					</tr>
 					<tr>
@@ -2572,7 +3325,9 @@
 			<rdef>form</rdef>
 			<div class="role-description">
 				<p>A <rref>landmark</rref> region that contains a collection of items and objects that, as a whole, combine to create a form. See related <rref>search</rref>.</p>
-				<p>A form may be a mix of host language form controls, scripted controls, and hyperlinks. Authors are reminded to use native host language semantics to create form controls, whenever possible. For search facilities, authors SHOULD use the <rref>search</rref> role and not the generic <code>form</code> role. Authors SHOULD provide a visible label for the form referenced with <pref>aria-labelledby</pref>. If an author uses a script to submit a form based on a user action that would otherwise not trigger an <code>onsubmit</code> event (for example, a form submission triggered by the user changing a form element's value), the author SHOULD provide the user with advance notification of the behavior.</p>
+				<p>A form may contain a mix of host language form controls, scripted controls, and hyperlinks. Authors are reminded to use native host language semantics to create form controls whenever possible. If the purpose of a form is to submit search criteria, authors SHOULD use the <rref>search</rref> role instead of the generic <code>form</code> role.</p>
+				<p>Authors MUST give each element with role <code>form</code> a brief label that describes the purpose of the form. Authors SHOULD reference a visible label with <pref>aria-labelledby</pref> if a visible label is present. Authors SHOULD include the label inside of a heading whenever possible. The heading MAY be an instance of the standard host language heading element or an instance of an element with role <rref>heading</rref>.</p>
+				<p>If an author uses a script to submit a form based on a user action that would otherwise not trigger an <code>onsubmit</code> event (for example, a form submission triggered by the user changing a form element's value), the author SHOULD provide the user with advance notification of the behavior.</p>
 				<p>User agents SHOULD treat elements with the role of <code>form</code> as navigational <a>landmarks</a>.</p>
 			</div>
 			<table class="role-features">
@@ -2598,7 +3353,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><a href="https://www.w3.org/TR/html5/forms.html#the-form-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>form</code></a></td>
+						<td class="role-base"><code>&lt;form&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -2630,7 +3385,97 @@
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-						<td class="role-namerequired"> </td>
+						<td class="role-namerequired">true</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational"> </td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div class="role" id="generic">
+			<rdef>generic</rdef>
+			<div class="role-description">
+				<p>A nameless container <a>element</a> that has no semantic meaning on its own.</p>
+				<p>The <code>generic</code> role is intended for use as the implicit role of generic elements in host languages (such as <abbr title="Hypertext Markup Language">HTML</abbr> <code>div</code> or <code>span</code>), so is primarily for implementors of user agents. Authors SHOULD NOT use this role in content. Authors MAY use <rref>presentation</rref> or <rref>none</rref> to remove implicit accessibility semantics, or a semantic container role such as <rref>group</rref> to semantically group descendants in a named container.</p>
+				<p>Like an element with role <rref>presentation</rref>, an element with role <code>generic</code> can provide a limited number of accessible states and properties for its descendants, such as <pref>aria-live</pref> attributes. However, unlike elements with role <rref>presentation</rref>, <code>generic</code> elements are exposed in <a>accessibility APIs</a> so that assistive technologies can gather certain properties such as layout and bounds.</p>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent"><rref>structure</rref></td>
+					</tr>
+					<tr>
+						<th class="role-children-head" scope="row">Subclass Roles:</th>
+						<td class="role-children">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"> </td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"><a href="https://www.w3.org/TR/html/grouping-content.html#the-div-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>div</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-span-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>span</code></a></td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Context Role:</th>
+						<td class="role-scope"> </td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
+						<td class="role-disallowed">
+							<ul>
+								<li><pref>aria-brailleroledescription</pref></li>
+								<li><pref>aria-label</pref></li>
+								<li><pref>aria-labelledby</pref></li>
+								<li><pref>aria-roledescription</pref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">prohibited</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
@@ -2667,12 +3512,12 @@
 				<p>For example, if a cell in a spreadsheet contains a <rref>combobox</rref> or editable text, the <kbd>Enter</kbd> key might be used to activate a cell interaction or editing mode when that cell has focus so the directional arrow keys can be used to operate the contained <rref>combobox</rref> or <rref>textbox</rref>. Depending on the implementation, pressing <kbd>Enter</kbd> again, <kbd>Tab</kbd>, <kbd>Escape</kbd>, or another key may switch the application back to the grid navigation mode.</p>
 				<p>Authors MAY use a <rref>gridcell</rref> to display the result of a formula, which could be editable by the user. In a spreadsheet application, for example, a <rref>gridcell</rref> may show a value calculated from a formula until the user activates the <rref>gridcell</rref> for editing when a <rref>textbox</rref> appears in the <rref>gridcell</rref> containing the formula in an editable state.</p>
 				<!-- make sure the following para remains synced with its counterpart in #treegrid -->
-				 <p>If <pref>aria-readonly</pref> is set on an element with role <code>grid</code>, <a>user agents</a> MUST propagate the value to all <rref>gridcell</rref> elements owned by the <code>grid</code> and expose the value in the accessibility API. An author MAY override the propagated value of <pref>aria-readonly</pref> for an individual <rref>gridcell</rref> element.</p>
+				 <p>If <pref>aria-readonly</pref> is set on an element with role <code>grid</code>, <a>user agents</a> MUST propagate the value to all <rref>gridcell</rref> elements <a>owned</a> by the <code>grid</code> and expose the value in the accessibility API. An author MAY override the propagated value of <pref>aria-readonly</pref> for an individual <rref>gridcell</rref> element.</p>
 				 <p>In a <code>grid</code> that provides cell content editing functions, if the content of a focusable <rref>gridcell</rref> element is not editable, authors MAY set <pref>aria-readonly</pref> to <code>true</code> on the <code>gridcell</code> element. However, the value of <pref>aria-readonly</pref>, whether specified for a <code>grid</code> or individual cells, only indicates whether the content contained in cells is editable. It does not represent availability of functions for navigating or manipulating the <code>grid</code> itself.</p>
 				 <p>An unspecified value for <pref>aria-readonly</pref> does not imply that a <code>grid</code> or a <rref>gridcell</rref> contains editable content. For example, if a <code>grid</code> presents a collection of elements that are not editable, such as a collection of <rref>link</rref> elements representing dates in a datepicker, it is not necessary for the author to specify a value for <pref>aria-readonly</pref>.</p>
 				<p>Authors MAY indicate that a focusable <rref>gridcell</rref> is selectable as the object of an action with the <sref>aria-selected</sref> attribute. If the <code>grid</code> allows multiple <rref>gridcell</rref>s to be selected, the author SHOULD set <pref>aria-multiselectable</pref> to <code>true</code> on the element with role <code>grid</code>.</p>
 				<p>Since <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> can augment an element of the host language, a <code>grid</code> can reuse the elements and attributes of a native table, such as an HTML <code>table</code> element. For example, if an author applies the <code>grid</code> role to an HTML <code>table</code> element, the author does not need to apply the <rref>row</rref> and <rref>gridcell</rref> roles to the descendant HTML <code>tr</code> and <code>td</code> elements because the <a>user agent</a> will automatically make the appropriate translations. When the author is reusing a native host language table element and needs a <rref>gridcell</rref> element to span multiple rows or columns, the author SHOULD apply the appropriate host language attributes instead of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <pref>aria-rowspan</pref> or <pref>aria-colspan</pref> properties.</p>
-				<p>See the <cite><a href="https://www.w3.org/TR/wai-aria-practices-1.1/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices Guide</a></cite> [[WAI-ARIA-PRACTICES-1.1]] for additional details on implementing grid design patterns.</p>
+				<p>See the <cite><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> for additional details on implementing grid design patterns.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -2702,7 +3547,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><a href="https://www.w3.org/TR/html5/tabular-data.html#the-table-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>table</code></a></td>
+						<td class="role-base"><code>&lt;table&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -2729,7 +3574,6 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
-								<li><pref>aria-level</pref></li>
 								<li><pref>aria-multiselectable</pref></li>
 								<li><pref>aria-readonly</pref></li>
 							</ul>
@@ -2769,7 +3613,7 @@
 				<p>A <code>gridcell</code> may be focusable, editable, and selectable. A <code>gridcell</code> may have <a>relationships</a> such as <pref>aria-controls</pref> to address the application of functional relationships.</p>
 				<p>If an author intends a <code>gridcell</code> to have a row header, column header, or both, and if the relevant headers cannot be determined from the <abbr title="Document Object Model">DOM</abbr> structure, authors SHOULD explicitly indicate which header cells are relevant to the <code>gridcell</code> by applying <pref>aria-describedby</pref> on the <code>gridcell</code> and referencing <a>elements</a> with <a>role</a> <rref>rowheader</rref> or <rref>columnheader</rref>.</p>
 				<p>In a <rref>treegrid</rref>, authors MAY define a <code>gridcell</code> as expandable by using the <sref>aria-expanded</sref> attribute. If the <sref>aria-expanded</sref> attribute is provided, it applies only to the individual cell. It is not a proxy for the container <rref>row</rref>, which also can be expanded. The main use case for providing this attribute on a <code>gridcell</code> is pivot table behavior.</p>
-				<p>Authors MUST ensure <a>elements</a> with <a>role</a> gridcell are contained in, or owned by, an element with the <a>role</a> <rref>row</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with <a>role</a> gridcell are contained in, or <a>owned</a> by, an element with the <a>role</a> <rref>row</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -2799,7 +3643,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><a href="https://www.w3.org/TR/html5/tabular-data.html#the-td-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>td</code></a></td>
+						<td class="role-base"><code>&lt;td&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -2821,6 +3665,11 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
+								<li><sref>aria-disabled</sref></li>
+								<li><pref>aria-errormessage</pref></li>
+								<li><sref>aria-expanded</sref></li>
+								<li><pref>aria-haspopup</pref></li>
+								<li><sref>aria-invalid</sref></li>
 								<li><pref>aria-readonly</pref></li>
 								<li><pref>aria-required</pref></li>
 								<li><sref>aria-selected</sref></li>
@@ -2842,7 +3691,7 @@
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-						<td class="role-namerequired">True</td>
+						<td class="role-namerequired"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
@@ -2862,10 +3711,10 @@
 		<div class="role" id="group">
 			<rdef>group</rdef>
 			<div class="role-description">
-				<p>A set of user interface <a>objects</a> which are not intended to be included in a page summary or table of contents by <a>assistive technologies</a>.</p>
-				<p>Contrast with <rref>region</rref> which is a grouping of user interface objects that will be included in a page summary or table of contents.</p>
-				<p>Authors SHOULD use a <code>group</code> to form logical collection of items in a <a>widget</a> such as children in a tree widget forming a collection of siblings in a hierarchy, or a collection of items having the same container in a directory. However, when a <code>group</code> is used in the context of list, authors MUST limit its children to <rref>listitem</rref> elements. Therefore, proper handling of <code>group</code> by authors and assistive technologies is determined by the context in which it is provided.</p>
-				<p>Authors MAY nest <code>group</code> elements. If a section is significant enough to warrant inclusion in the web page's table of contents, the author SHOULD assign the section a <a>role</a> of <rref>region</rref> or a <a href="#landmark_roles">standard landmark role</a>.</p>
+				<p>A set of user interface <a>objects</a> that is not intended to be included in a page summary or table of contents by <a>assistive technologies</a>.</p>
+				<p>Contrast with <rref>region</rref>, which is a grouping of user interface objects that will be included in a page summary or table of contents.</p>
+				<p>Authors SHOULD use a <code>group</code> to form a logical collection of items in a <a>widget</a>, such as children in a tree widget forming a collection of siblings in a hierarchy. However, when a <code>group</code> is used in the context of a <rref>listbox</rref>, authors MUST limit its children to <rref>option</rref> elements. Therefore, proper handling of <code>group</code> by authors and assistive technologies is determined by the context in which it is provided.</p>
+				<p>Authors MAY nest <code>group</code> elements. If a section is significant enough to warrant inclusion in the web page's table of contents, the author SHOULD assign it a <a>role</a> of <rref>region</rref> or a <a href="#landmark_roles">standard landmark role</a>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -2894,7 +3743,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/html5/forms.html#the-fieldset-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>fieldset</code></a></td>
+						<td class="role-related"><code>&lt;fieldset&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2910,7 +3759,12 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"><pref>aria-activedescendant</pref></td>
+						<td class="role-properties">
+							<ul>
+								<li><pref>aria-activedescendant</pref></li>
+								<li><sref>aria-disabled</sref></li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -2918,7 +3772,12 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom">
+              <ul>
+                <li>author</li>
+                <li>legend</li>
+              </ul>
+            </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -2943,7 +3802,7 @@
 			<rdef>heading</rdef>
 			<div class="role-description">
 				<p>A heading for a section of the page.</p>
-				<p>Often, <code>heading</code> elements will be referenced with the <pref>aria-labelledby</pref> <a>attribute</a> of the section for which they serve as a heading. If headings are organized into a logical outline, the <pref>aria-level</pref> attribute is used to indicate the nesting level.</p>
+				<p>To ensure elements with a role of <code>heading</code> are organized into a logical outline, authors MUST use the <pref>aria-level</pref> attribute to indicate the proper nesting level.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -2972,7 +3831,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/html5/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements"><abbr title="Hypertext Markup Language">HTML</abbr> <code>h1</code>, <code>h2</code>, <code>h3</code>, <code>h4</code>, <code>h5</code>, and <code>h6</code></a></td>
+						<td class="role-related"><code>&lt;h1&gt;</code>, <code>&lt;h2&gt;</code>, <code>&lt;h3&gt;</code>, <code>&lt;h4&gt;</code>, <code>&lt;h5&gt;</code>, and <code>&lt;h6&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -3019,10 +3878,6 @@
 						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
 						<td class="role-presentational-inherited"> </td>
 					</tr>
-					<tr>
-						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
-						<td class="implicit-values">Default for <pref>aria-level</pref> is <code class="default">2</code>.</td>
-					</tr>
 				</tbody>
 			</table>
 		</div>
@@ -3059,11 +3914,8 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related">
-							<ul>
-								<li><a href="https://www.w3.org/TR/html5/embedded-content-0.html#the-img-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>img</code></a></li>
-							</ul>
-						</td>
+						<td class="role-related"><code>&lt;img&gt;</code> in [[HTML]]</td>
+
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -3140,7 +3992,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-input">XForms input</a></td>
+						<td class="role-related"> </td>
 					</tr>
 					<tr>
 						<th class="role-required-properties-head">Required States and Properties:</th>
@@ -3148,7 +4000,7 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"> </td>
+						<td class="role-properties"><sref>aria-disabled</sref></td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -3173,6 +4025,194 @@
 					<tr>
 						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
 						<td class="role-presentational-inherited"> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div class="role" id="insertion">
+			<rdef>insertion</rdef>
+			<div class="role-description">
+				<p>An insertion contains content that is marked as added or content that is being suggested for addition. See related <rref>deletion</rref>.</p>
+				<p>Insertions are typically used to either mark differences between two versions of content or to designate content suggested for addition in scenarios where multiple people are revising content.</p>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent"><rref>section</rref></td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"> </td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"><code>&lt;ins&gt;</code> in [[HTML]]</td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Context Role:</th>
+						<td class="role-scope"> </td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
+						<td class="role-disallowed">
+							<ul>
+								<li><pref>aria-label</pref></li>
+								<li><pref>aria-labelledby</pref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">prohibited</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired"> </td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational"> </td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div class="role" id="label">
+			<rdef>label</rdef>
+			<div class="role-description">
+				<p>A visible name or caption for a user interface component.</p>
+				<p>An element with role <code>label</code> can provide an <a>accessible name</a> for a user interface component if it is programmatically associated with the element. Authors MAY associate an element with role <code>label</code> with another element by using one of two methods:</p>
+				<ul>
+					<li>encapsulation: The element with role <code>label</code> contains the element it names.
+					<li>reference: The element with role <code>label</code> is referenced by the element it names via the <pref>aria-labelledby</pref> attribute.</li>
+				</ul>
+				<p>The encapsulation method of naming is supported only if the element being named has one of the following roles:</p>
+				<ul>
+					<li><pref>checkbox</pref></li>
+					<li><pref>listbox</pref></li>
+					<li><pref>meter</pref></li>
+					<li><pref>radio</pref></li>
+					<li><pref>searchbox</pref></li>
+					<li><pref>spinbutton</pref></li>
+					<li><pref>switch</pref></li>
+					<li><pref>textbox</pref></li>
+				</ul>
+				<p>Authors SHOULD ensure that:</p>
+				<ul>
+					<li>All elements with role <code>label</code> are associated with one or more other elements.</li>
+					<li>When an element with role <code>label</code> is activated by touch or a pointer and its associated element is focusable, focus moves to the associated element. If more than one focusable element is associated with the same label, focus moves to the first element.</li>
+				</ul>
+				<p class="ednote">Implementation of the <code>label</code> role as described here is currently unlikely. At this time it is anticipated that the <code>label</code> role will not be available in the ARIA 1.3 release</p>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent"><rref>section</rref></td>
+					</tr>
+					<tr>
+						<th class="role-children-head" scope="row">Subclass Roles:</th>
+						<td class="role-children"></td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"><code>&lt;label&gt;</code> in [[HTML]]</td>
+
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"> </td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Context Role:</th>
+						<td class="role-scope"><rref></rref></td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties"></td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">
+							<ul>
+								<li>contents</li>
+								<li>author</li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired">True</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational"> </td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
 					</tr>
 				</tbody>
 			</table>
@@ -3213,7 +4253,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related">&#160;</td>
+						<td class="role-related"> </td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -3242,6 +4282,103 @@
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
 						<td class="role-namerequired">False</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational"> </td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div class="role" id="legend">
+			<rdef>legend</rdef>
+			<div class="role-description">
+				<p>A visible name or caption for a group of related user interface components.</p>
+				<p>A element with role <code>legend</code> element can provide an accessible name for elements with grouping roles if it is progammatically associated with the element.  Authors MAY associate an element with role <code>legend</code> with an element by using one of two methods:</p>
+				<ul>
+					<li>legend: The element contains an element with role <code>legend</code> element.  If the element contains more than one element with role <code>legend</code>, only the first descendant element with role <code>legend</code> is used for computing the accessible name.</li>
+					<li>reference: The element with role <code>legend</code> is referenced by the element it names via the <pref>aria-labelledby</pref> attribute.</li>
+				</ul>
+				<p>The legend method of naming is supported only if the element being named has one of the following grouping roles:</p>
+				<ul>
+					<li><pref>group</pref></li>
+					<li><pref>radiogroup</pref> </li>
+				</ul>
+				<p>Authors SHOULD ensure that:</p>
+				<ul>
+					<li>All elements with role <code>legend</code> are associated with one or more elements with grouping roles.</li>
+					<li>When an element with role <code>legend</code> is activated by touch or a pointer, focus moves to the first focusable element in the associated group of user interface components.</li>
+				</ul>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent"><rref>section</rref></td>
+					</tr>
+					<tr>
+						<th class="role-children-head" scope="row">Subclass Roles:</th>
+						<td class="role-children"></td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"><code>&lt;legend&gt;</code> in [[HTML]]</td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"> </td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Context Role:</th>
+						<td class="role-scope"><rref></rref></td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties"></td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">
+							<ul>
+								<li>contents</li>
+								<li>author</li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired">True</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
@@ -3294,8 +4431,9 @@
 						<th class="role-related-head" scope="row">Related Concepts:</th>
 						<td class="role-related">
 							<ul>
-								<li><a href="https://www.w3.org/TR/html5/text-level-semantics.html#the-a-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>a</code></a></li>
-								<li><a href="https://www.w3.org/TR/html5/document-metadata.html#the-link-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>link</code></a></li>
+								<li><code>&lt;a&gt;</code> in [[HTML]]</li>
+								<li><code>&lt;link&gt;</code> in [[HTML]]</li>
+
 							</ul>
 						</td>
 					</tr>
@@ -3315,7 +4453,9 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
+								<li><sref>aria-disabled</sref></li>
 								<li><sref>aria-expanded</sref></li>
+								<li><pref>aria-haspopup</pref></li>
 							</ul>
 						</td>
 					</tr>
@@ -3355,7 +4495,7 @@
 			<rdef>list</rdef>
 			<div class="role-description">
 				<p>A <rref>section</rref> containing <rref>listitem</rref> elements. See related <rref>listbox</rref>.</p>
-				<p>Lists contain children whose <a>role</a> is <rref>listitem</rref>, or elements whose <a>role</a> is <rref>group</rref> which in turn contains children whose <a>role</a> is <rref>listitem</rref>.</p>
+				<p>Lists contain children whose <a>role</a> is <rref>listitem</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -3382,8 +4522,8 @@
 						<th class="role-base-head" scope="row">Base Concept:</th>
 						<td class="role-base">
 							<ul>
-								<li><a href="https://www.w3.org/TR/html5/grouping-content.html#the-ol-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>ol</code></a></li>
-								<li><a href="https://www.w3.org/TR/html5/grouping-content.html#the-ul-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>ul</code></a></li>
+								<li><code>&lt;ol&gt;</code> in [[HTML]]</li>
+								<li><code>&lt;ul&gt;</code> in [[HTML]]</li>
 							</ul>
 						</td>
 					</tr>
@@ -3397,12 +4537,7 @@
 					</tr>
 					<tr>
 						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
-						<td class="role-mustcontain">
-							<ul>
-								<li><rref>group</rref> <abbr title="containing" class="symbol">→</abbr> <rref>listitem</rref></li>
-								<li><rref>listitem</rref></li>
-							</ul>
-						</td>
+						<td class="role-mustcontain"><rref>listitem</rref></td>
 					</tr>
 					<tr>
 						<th class="role-required-properties-head">Required States and Properties:</th>
@@ -3481,8 +4616,7 @@
 						<td class="role-related">
 							<ul>
 								<li><rref>list</rref></li>
-								<li><a href="https://www.w3.org/TR/html5/forms.html#the-select-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>select</code></a></li>
-								<li><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-selectMany">XForms select</a></li>
+								<li><code>&lt;select&gt;</code> in [[HTML]]</li>
 							</ul>
 						</td>
 					</tr>
@@ -3507,6 +4641,9 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
+								<li><pref>aria-errormessage</pref></li>
+								<li><sref>aria-expanded</sref></li>
+								<li><sref>aria-invalid</sref></li>
 								<li><pref>aria-multiselectable</pref></li>
 								<li><pref>aria-readonly</pref></li>
 								<li><pref>aria-required</pref></li>
@@ -3519,7 +4656,12 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom">
+							<ul>
+								<li>encapsulation</li>
+								<li>author</li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -3548,7 +4690,7 @@
 			<rdef>listitem</rdef>
 			<div class="role-description">
 				<p>A single item in a list or directory.</p>
-				<p>Authors MUST ensure <a>elements</a> with <a>role</a>  <code>listitem</code> are contained in, or owned by, an <a>element</a> with the <a>role</a> <rref>list</rref> or <rref>group</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> whose <a>role</a> is <code>listitem</code> are contained in, or <a>owned</a> by, an <a>element</a> whose <a>role</a> is <rref>list</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -3573,17 +4715,17 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-li-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>li</code></a></td>
+						<td class="role-base"><code>&lt;li&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-common-elements-item">XForms item</a></td>
+						<td class="role-related"> </td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
 						<td class="role-scope">
 							<ul>
-								<li><rref>group</rref></li>
+								<li><rref>directory</rref></li>
 								<li><rref>list</rref></li>
 							</ul>
 						</td>
@@ -3695,7 +4837,7 @@
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-						<td class="role-namerequired">True</td>
+						<td class="role-namerequired"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
@@ -3719,7 +4861,7 @@
 		<div class="role" id="main">
 			<rdef>main</rdef>
 			<div class="role-description">
-				<p>The main content of a document.</p>
+				<p>A <rref>landmark</rref> containing the main content of a document.</p>
 				<p>This marks the content that is directly related to or expands upon the central topic of the document. The <code>main</code> <a>role</a> is a non-obtrusive alternative for "skip to main content" links, where the navigation option to go to the main content (or other <a>landmarks</a>) is provided by the <a>user agent</a> through a dialog or by <a>assistive technologies</a>.</p>
 				<p>User agents SHOULD treat elements with the role of <code>main</code> as navigational landmarks.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #banner and #contentinfo -->
@@ -3798,6 +4940,94 @@
 				</tbody>
 			</table>
 		</div>
+		<div class="role" id="mark">
+			<rdef>mark</rdef>
+			<div class="role-description">
+				<p>Content which is marked or highlighted for reference or notation purposes, due to the content's relevance in the enclosing context.</p>
+				<p>Example uses for <code>mark</code> include:</p>
+				<ul>
+					<li>Highlighting text in a quotation which is of special interest but is not marked in the original source material, comparable to using a highlighter pen to mark passages of a print article.</li>
+					<li>Indicating portions of the content that are relevant to the user's current activity, such as highlighting text matches found by a search feature.</li>
+				</ul>
+				<p>Authors SHOULD NOT use <code>mark</code> for purely decorative styling such as syntax highlighting.</p>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent"><rref>section</rref></td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"> </td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"><code>&lt;mark&gt;</code> in [[HTML]]</td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Context Role:</th>
+						<td class="role-scope"> </td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
+						<td class="role-disallowed">
+							<ul>
+								<li><pref>aria-label</pref></li>
+								<li><pref>aria-labelledby</pref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">prohibited</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired"> </td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational"> </td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
 		<div class="role" id="marquee">
 			<rdef>marquee</rdef>
 			<div class="role-description">
@@ -3856,7 +5086,7 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-                        <td class="role-namefrom">author</td>
+						<td class="role-namefrom">author</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -3998,11 +5228,108 @@
 					</tr>
 					<tr>
 						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational"> </td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div class="role" id="meter">
+			<rdef>meter</rdef>
+			<div class="role-description">
+				<p>An <a>element</a> that represents a scalar measurement within a known range, or a fractional value. See related <rref>progressbar</rref>.</p>
+				<p>Authors MAY set <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> to indicate the minimum and maximum values for the <code>meter</code>. Otherwise, their implicit values follow the same rules as <code>&lt;input[type="range"]&gt;</code> in [[HTML]]:</p>
+				<ul>
+					<li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero).</li>
+					<li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100.</li>
+				</ul>
+				<p>The value of <pref>aria-valuenow</pref> MUST NOT fall below or exceed the computed values of <code>aria-valuemin</code> and <code>aria-valuemax</code>, respectively.</p>
+				<p>Authors SHOULD NOT use the <code>meter</code> role to indicate progress; the <rref>progressbar</rref> role exists to address that need.</p>
+				<p class="note">Presently, there are no <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> properties corresponding to the <code>low</code>, <code>optimum</code>, and <code>high</code> attributes supported on the <code>&lt;meter&gt;</code> element in [[HTML]]. The addition of these properties will be considered for ARIA version 1.3.</p>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent"><rref>range</rref></td>
+					</tr>
+					<tr>
+						<th class="role-children-head" scope="row">Subclass Roles:</th>
+						<td class="role-children">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"> </td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"><code>&lt;meter&gt;</code> in [[HTML]]</td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Context Role:</th>
+						<td class="role-scope"> </td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"><pref>aria-valuenow</pref></td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">
+							<ul>
+								<li>encapsulation</li>
+								<li>author</li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired">True</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
 						<td class="role-childpresentational">True</td>
 					</tr>
 					<tr>
 						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
 						<td class="role-presentational-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
+						<td class="implicit-values">
+							Default for <pref>aria-valuemin</pref> is <code class="default">0</code>. <br/>
+							Default for <pref>aria-valuemax</pref> is <code class="default">100</code>.
+						</td>
 					</tr>
 				</tbody>
 			</table>
@@ -4046,13 +5373,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related">
-							<ul>
-								<li><rref>list</rref></li>
-								<li><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-selectMany">XForms select</a></li>
-								<li><a href="http://docs.oracle.com/javase/6/docs/api/javax/accessibility/AccessibleRole.html#MENU"><abbr title="Java Accessibility Application Programing Interface">JAPI</abbr> MENU</a></li>
-							</ul>
-						</td>
+						<td class="role-related"><rref>list</rref></td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -4210,7 +5531,7 @@
 			<div class="role-description">
 				<p>An option in a set of choices contained by a <rref>menu</rref> or <rref>menubar</rref>.</p>
 				<p>Authors MAY disable a menu item with the <sref>aria-disabled</sref> attribute. If the menu item has its <pref>aria-haspopup</pref> attribute set to <code>true</code>, it indicates that the menu item may be used to launch a sub-level menu, and authors SHOULD display a new sub-level menu when the menu item is activated.</p>
-				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu items are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>, or by a role <rref>group</rref> which itself is <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
+				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu items are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4245,8 +5566,6 @@
 						<th class="role-related-head" scope="row">Related Concepts:</th>
 						<td class="role-related">
 							<ul>
-								<li><a href="http://docs.oracle.com/javase/6/docs/api/javax/accessibility/AccessibleRole.html#MENU_ITEM"><abbr title="Java Accessibility Application Programing Interface">JAPI</abbr> MENU_ITEM</a></li>
-								<li><a href="https://www.w3.org/TR/html51/interactive-elements.html#the-menuitem-element"><code>menuitem</code></a> in [[HTML51]]</li>
 								<li><rref>listitem</rref></li>
 								<li><rref>option</rref></li>
 							</ul>
@@ -4274,7 +5593,9 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
+								<li><sref>aria-disabled</sref></li>
 								<li><sref>aria-expanded</sref></li>
+								<li><pref>aria-haspopup</pref></li>
 								<li><pref>aria-posinset</pref></li>
 								<li><pref>aria-setsize</pref></li>
 							</ul>
@@ -4317,7 +5638,7 @@
 			<div class="role-description">
 				<p>A <rref>menuitem</rref> with a checkable state whose possible <span>values</span> are <code>true</code>, <code>false</code>, or <code>mixed</code>.</p>
 				<p>The <sref>aria-checked</sref> <a>attribute</a> of a <code>menuitemcheckbox</code> indicates whether the menu item is checked (<code>true</code>), unchecked (<code>false</code>), or represents a sub-level menu of other menu items that have a mixture of checked and unchecked values (<code>mixed</code>).</p>
-				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu item checkboxes are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>, or by a role <rref>group</rref> which itself is <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
+				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu item checkboxes are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4336,7 +5657,6 @@
 						<th class="role-parent-head" scope="row">Superclass Role:</th>
 						<td class="role-parent">
 							<ul>
-								<li><rref>checkbox</rref></li>
 								<li><rref>menuitem</rref></li>
 							</ul>
 						</td>
@@ -4369,7 +5689,11 @@
 					</tr>
 					<tr>
 						<th class="role-required-properties-head">Required States and Properties:</th>
-						<td class="role-required-properties"> </td>
+						<td class="role-required-properties">
+							<ul>
+								<li><sref>aria-checked</sref></li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
@@ -4404,10 +5728,6 @@
 						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
 						<td class="role-presentational-inherited"> </td>
 					</tr>
-					<tr>
-						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
-						<td class="implicit-values">Default for <sref>aria-checked</sref> is <code class="default">false</code>.</td>
-					</tr>
 				</tbody>
 			</table>
 		</div>
@@ -4417,8 +5737,8 @@
 				<p>A checkable <rref>menuitem</rref> in a set of elements with the same role, only one of which can be checked at a time.</p>
 				<p>Authors SHOULD enforce that only one <code>menuitemradio</code> in a group can be checked at the same time. When one item in the group is checked, the previously checked item becomes unchecked (its <sref>aria-checked</sref> <a>attribute</a> becomes <code>false</code>).</p>
 				<!-- keep previous sentence synced with radiogroup, etc. -->
-				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu item radios are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>, or by a role <rref>group</rref> which itself is <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
-                <p>If a <rref>menu</rref> or <rref>menubar</rref> contains more than one group of <code>menuitemradio</code> elements, or if the menu contains one group and other, unrelated menu items, authors SHOULD nest each set of related <code>menuitemradio</code> elements in an element using the <rref>group</rref> role, and authors SHOULD delimit the group from other menu items with an element using the <rref>separator</rref> role.</p>
+				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu item radios are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>, or by a role <rref>group</rref> which itself is <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>.</p>
+        <p>If a <rref>menu</rref> or <rref>menubar</rref> contains more than one group of <code>menuitemradio</code> elements, or if the menu contains one group and other, unrelated menu items, authors SHOULD contain each set of related <code>menuitemradio</code> elements in an element using the <rref>group</rref> role. Authors MAY also delimit the group from other menu items with an element using the <rref>separator</rref> role, or an element with an equivalent role from the native markup language.
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4437,8 +5757,7 @@
 						<th class="role-parent-head" scope="row">Superclass Role:</th>
 						<td class="role-parent">
 							<ul>
-								<li><rref>menuitemcheckbox</rref> (see structure)</li>
-								<li><rref>radio</rref></li>
+								<li><rref>menuitemcheckbox</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -4501,17 +5820,13 @@
 						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
 						<td class="role-presentational-inherited"> </td>
 					</tr>
-					<tr>
-						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
-						<td class="implicit-values">Default for <sref>aria-checked</sref> is <code class="default">false</code>.</td>
-					</tr>
 				</tbody>
 			</table>
 		</div>
 		<div class="role" id="navigation">
 			<rdef>navigation</rdef>
 			<div class="role-description">
-				<p>A collection of navigational <a>elements</a> (usually links) for navigating the document or related documents.</p>
+				<p>A <rref>landmark</rref> containing a collection of navigational <a>elements</a> (usually links) for navigating the document or related documents.</p>
 				<p>User agents SHOULD treat elements with the role of <code>navigation</code> as navigational <a>landmarks</a>.</p>
 			</div>
 			<table class="role-features">
@@ -4541,7 +5856,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/html5/sections.html#the-nav-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>nav</code></a></td>
+						<td class="role-related"><code>&lt;nav&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -4593,7 +5908,6 @@
 				<div class="note" id="role-none-note-none">
 					<h5>Note regarding the ARIA 1.1 <code>none</code> role.</h5>
 					<p>In ARIA 1.1, the working group introduced <code>none</code> as a synonym to the <rref>presentation</rref> role, due to author confusion surrounding the intended meaning of the word "presentation" or "presentational." Many individuals erroneously consider <code>role="presentation"</code> to be synonymous with <code>aria-hidden="true"</code>, and we believe <code>role="none"</code> conveys the actual meaning more unambiguously.</p>
-					<p>Until implementations include sufficient support for <code>role="none"</code>, web authors are advised to use the <rref>presentation</rref> role alone <code>role="presentation"</code> or redundantly as a fallback to the <code>none</code> role <code>role="none presentation"</code>.</p>
 				</div>
 			</div>
 		</div>
@@ -4677,8 +5991,26 @@
 		<div class="role" id="option">
 			<rdef>option</rdef>
 			<div class="role-description">
-				<p>A selectable item in a <rref>select</rref> list.</p>
-				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>option</code> are contained in, or owned by, an element with the <a>role</a>  <rref>listbox</rref> or <rref>group</rref>. Options not associated with a <rref>listbox</rref> might not be correctly mapped to an <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a>.</p>
+				<p>An item in a <rref>listbox</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>option</code> are contained in, or <a>owned</a> by, an element with the <a>role</a>  <rref>listbox</rref> or <rref>group</rref> within a <code>listbox</code>. Options not associated with a <rref>listbox</rref> might not be correctly mapped to an <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a>.</p>
+        <p>User agents MAY provide an implicit value of <sref>aria-selected</sref> for each <rref>option</rref> in a <rref>listbox</rref> if the following conditions are met, but user agents MUST NOT provide an implicit value of <sref>aria-selected</sref> if any of the following conditions are not met:</p>
+        <ul>
+          <li>The value of <pref>aria-multiselectable</pref> on the <rref>listbox</rref> is <code>false</code> or <code>undefined</code>.</li>
+          <li>None of the <rref>option</rref> elements in the <rref>listbox</rref> have an explicitly declared value for <sref>aria-selected</sref> or <sref>aria-checked</sref>.</li>  
+        </ul>
+        <p>
+          If a user agent provides an implicit <sref>aria-selected</sref> value for an <rref>option</rref>, the value SHOULD be <code>true</code> if the <rref>option</rref> has DOM focus or the <ref>listbox</ref> has DOM focus and the option is referenced by <pref>aria-activedescendant</pref>.
+          Otherwise, if a user agent provides an implicit <sref>aria-selected</sref> value for an <rref>option</rref>, the value SHOULD be <code>false</code>.
+        </p>
+        <p>
+          The <rref>option</rref> role supports both <sref>aria-selected</sref> and <sref>aria-checked</sref> because it is common for authors to use selection in single-select list boxes and check marks in multi-select list boxes.
+          However, authors SHOULD NOT specify both <sref>aria-selected</sref> and <sref>aria-checked</sref> on <rref>option</rref> elements contained by the same <rref>listbox</rref> except in the extremely rare circumstances where all the following conditions are met:
+        </p>
+        <ul>
+          <li>The meaning and purpose of <sref>aria-selected</sref> is different from the meaning and purpose of <sref>aria-checked</sref> in the user interface.</li>
+          <li>The user interface makes the mening and purpose of each state apparent.</li>
+          <li>The user interface provides a separate method for controling each state.</li>
+        </ul>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4703,20 +6035,17 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><a href="https://www.w3.org/TR/html5/forms.html#the-option-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>option</code></a></td>
+						<td class="role-base"><code>&lt;option&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
 						<td class="role-related">
-							<ul>
-								<li><rref>listitem</rref></li>
-								<li><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-common-elements-item">XForms item</a></li>
-							</ul>
+							<rref>listitem</rref>
 						</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
-						<td>
+						<td class="role-scope">
 							<ul>
 								<li><rref>group</rref></li>
 								<li><rref>listbox</rref></li>
@@ -4737,8 +6066,8 @@
 							<ul>
 								<li><sref>aria-checked</sref></li>
 								<li><pref>aria-posinset</pref></li>
-								<li><pref>aria-setsize</pref></li>
                 <li><sref>aria-selected</sref></li>
+								<li><pref>aria-setsize</pref></li>
 							</ul>
 						</td>
 					</tr>
@@ -4903,7 +6232,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/html/grouping-content.html#the-p-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>p</code></a></td>
+						<td class="role-related"><code>&lt;p&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -4926,8 +6255,17 @@
 						<td class="role-inherited">Placeholder</td>
 					</tr>
 					<tr>
+						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
+						<td class="role-disallowed">
+							<ul>
+								<li><pref>aria-label</pref></li>
+								<li><pref>aria-labelledby</pref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom">prohibited</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -4979,11 +6317,11 @@
 <span class="comment">&lt;!-- 4. In all cases, the element contents are exposed to accessibility APIs without any implied role semantics. --&gt;</span>
 <span class="comment">&lt;!-- &lt;&gt; --&gt;</span> Sample Content <span class="comment">&lt;!-- &lt;/&gt; --&gt;</span>
 </pre>
-				<p>The <code>presentation</code> role is used on an element that has implicit native semantics, meaning that there is a default accessibility <abbr title="Application Programing Interface">API</abbr> role for the element. Some elements are only complete when additional descendant elements are provided. For example, in <abbr title="Hypertext Markup Language">HTML</abbr>, table elements (matching the <rref>grid</rref> role) require <code>tr</code> descendants (the <rref>row</rref> <a>role</a>), which in turn require <code>th</code> or <code>td</code> children (the <rref>gridcell</rref>, <rref>columnheader</rref>, <rref>rowheader</rref> roles). Similarly, lists require list item children. The descendant elements that complete the semantics of an element are described in <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> as <a href="#mustContain">required owned elements</a>.</p>
+				<p>The <code>presentation</code> role is used on an element that has implicit native semantics, meaning that there is a default accessibility <abbr title="Application Programing Interface">API</abbr> role for the element. Some elements are only complete when additional descendant elements are provided. For example, in <abbr title="Hypertext Markup Language">HTML</abbr>, table elements (matching the <rref>table</rref> role) require <code>tr</code> descendants (the <rref>row</rref> <a>role</a>), which in turn require <code>th</code> or <code>td</code> children (the <rref>cell</rref>, <rref>columnheader</rref>, <rref>rowheader</rref> roles). Similarly, lists require list item children. The descendant elements that complete the semantics of an element are described in <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> as <a href="#mustContain">required owned elements</a>.</p>
 				<p>When an explicit or inherited role of <code>presentation</code> is applied to an element with the implicit semantic of a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role that has <a href="#mustContain">required owned elements</a>, in addition to the element with the explicit role of <code>presentation</code>, the user agent MUST apply an inherited role of presentation to any owned elements that do not have an explicit role defined. Also, when an explicit or inherited role of presentation is applied to a host language element which has required children as defined by the host language specification, in addition to the element with the explicit role of presentation, the user agent MUST apply an inherited role of presentation to any required children that do not have an explicit role defined.</p>
-				<p>In <abbr title="Hypertext Markup Language">HTML</abbr>, the <a href="https://www.w3.org/TR/html5/embedded-content-0.html#the-img-element"><code>img</code></a> <a>element</a> is treated as a single entity regardless of the type of image file. Consequently, using <code>role="presentation"</code> or <code>role="none"</code> on an <abbr title="Hypertext Markup Language">HTML</abbr> <code>img</code> is equivalent to using <code>aria-hidden="true"</code>. In order to make the image contents accessible, authors can embed the object using an <a href="https://www.w3.org/TR/html5/embedded-content-0.html#the-object-element"><code>object</code></a> or <a href="https://www.w3.org/TR/html5/embedded-content-0.html#the-iframe-element"><code>iframe</code></a> <a>element</a>, or use inline <abbr title="Scalable Vector Graphics">SVG</abbr> code, and follow the accessibility guidelines for the image content.</p>
-				<p>For any element with an explicit or inherited role of presentation and which is not focusable, user agents MUST ignore role-specific <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties for that element. For example, in <abbr title="Hypertext Markup Language">HTML</abbr>, a <code>ul</code> or <code>ol</code> element with a role of <code>presentation</code> will have the implicit native semantics of its <code>li</code> elements removed because the <rref>list</rref> role to which the <code>ul</code> or <code>ol</code> corresponds has a <a href="#mustContain">required owned element</a> of <rref>listitem</rref>. Likewise, although an <abbr title="Hypertext Markup Language">HTML</abbr> <code>table</code> element does not have an implicit native semantic role corresponding directly to a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role, the implicit native semantics of its <code>thead</code>/<code>tbody</code>/<code>tfoot</code>/<code>tr</code>/<code>th</code>/<code>td</code> descendants will also be removed, because the <abbr title="Hypertext Markup Language">HTML</abbr> specification indicates that these are required structural descendants of the <code>table</code> element.</p>
-				<p class="note">Only the implicit native semantics of elements that correspond to <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a href="#mustContain">required owned elements</a> are removed. All other content remains intact, including nested tables or lists, unless those elements also have a explicit role of <code>presentation</code> applied.</p>
+				<p>In <abbr title="Hypertext Markup Language">HTML</abbr>, the <code>&lt;img&gt;</code> <a>element</a> is treated as a single entity regardless of the type of image file. Consequently, using <code>role="presentation"</code> or <code>role="none"</code> on an <abbr title="Hypertext Markup Language">HTML</abbr> <code>img</code> is equivalent to using <code>aria-hidden="true"</code>. In order to make the image contents accessible, authors can embed the object using an <code>&lt;object&gt;</code> or <code>&lt;iframe&gt;</code> <a>element</a>, or use inline <abbr title="Scalable Vector Graphics">SVG</abbr> code, and follow the accessibility guidelines for the image content.</p>
+				<p>For any element with an explicit or inherited role of presentation and which is not focusable, user agents MUST ignore role-specific <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties for that element. For example, in <abbr title="Hypertext Markup Language">HTML</abbr>, a <code>ul</code> or <code>ol</code> element with a role of <code>presentation</code> will have the implicit native semantics of its <code>li</code> elements removed because the <rref>list</rref> role to which the <code>ul</code> or <code>ol</code> corresponds has a <a href="#mustContain">required owned element</a> of <rref>listitem</rref>. Likewise, the implicit native semantics of an <abbr title="Hypertext Markup Language">HTML</abbr> <code>table</code> element's <code>thead</code>/<code>tbody</code>/<code>tfoot</code>/<code>tr</code>/<code>th</code>/<code>td</code> descendants will also be removed, because the <abbr title="Hypertext Markup Language">HTML</abbr> specification indicates that these are required structural descendants of the <code>table</code> element.</p>
+				<p class="note">Only the implicit native semantics of elements that correspond to <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a href="#mustContain">required owned elements</a> are removed. All other content remains intact, including nested tables or lists, unless those elements also have an explicit role of <code>presentation</code> applied.</p>
 				<p>For example, according to an accessibility <abbr title="Application Programing Interface">API</abbr>, the following markup elements would appear to have identical role semantics (no roles) and identical content.</p>
 				<pre class="example highlight"><span class="comment">&lt;!-- 1. [role="presentation"] negates the implicit 'list' and 'listitem' role semantics but does not affect the contents. --&gt;</span>
 &lt;ul role="presentation"&gt;
@@ -5015,17 +6353,19 @@
 				<section id="conflict_resolution_presentation_none">
 					<h5>Presentational Roles Conflict Resolution</h5>
 					<p>There are a number of ways presentational role conflicts are resolved.</p>
-					<p>Host languages elements, having implicit presentational roles for which no roles, may be applied, MUST never be exposed to in the accessibility tree. With this exception, user agents MUST always expose global WAI-ARIA states and properties to accessibility APIs. In this case, the user agent ignores the <code>presentation</code> role and exposes the element according to its implicit native semantics. However, user agents MUST ignore any non-global, role-specific WAI-ARIA states and properties, unless it is on an inherited presentational role where an explicit role is applied.</p>
-					<p>For example, <pref>aria-haspopup</pref> is a global attribute and would always be applied; <pref>aria-level</pref> is not a global attribute and would therefore only apply if the element was not in a presentational state.</p>
+					<p>User agents MUST NOT expose <a>elements</a> having explicit or inherited presentational role in the accessibility tree, with these exceptions:</p>
+					<ul>
+						<li>If an element is focusable, or otherwise interactive, user agents MUST ignore the <code>presentation</code> role and expose the element with its implicit role, in order to ensure that the element is <a>operable</a>.</li>
+						<li>If a <a href="#mustContain">required owned element</a> has an explicit non-presentational role, user agents MUST ignore an inherited presentational role and expose the element with its explicit role. If the action of exposing the explicit role causes the accessibility tree to be malformed, the expected results are undefined.</li>
+						<li>If an element has global WAI-ARIA states or properties, user agents MUST ignore the <code>presentation</code> role and expose the element with its implicit role. However, if an element has only non-global, role-specific WAI-ARIA states or properties, the element MUST NOT be exposed unless the presentational role is inherited and an explicit non-presentational role is applied.</li>
+					</ul>
+					<p>For example, <pref>aria-describedby</pref> is a global attribute and would always be applied; <pref>aria-level</pref> is not a global attribute and would therefore only apply if the element was not in a presentational state.</p>
 					<pre class="example highlight">
-						<span class="comment">&lt;!-- 1. [role="presentation"] is ignored due to the global aria-haspopup property. --&gt;</span>
-&lt;h1 role="presentation" aria-haspopup="true"&gt; Sample Content &lt;/h1&gt;
-						<span class="comment">&lt;!-- 2. [role="presentation"] negates the both the implicit 'heading' and the non-global level. --&gt;</span>
+<span class="comment">&lt;!-- 1. [role="presentation"] is ignored due to the global aria-describedby property. --&gt;</span>
+&lt;h1 role="presentation" aria-describedby="comment-1"&gt; Sample Content &lt;/h1&gt;
+<span class="comment">&lt;!-- 2. [role="presentation"] negates both the implicit 'heading' and the non-global aria-level. --&gt;</span>
 &lt;h1 role="presentation" aria-level="2"&gt; Sample Content &lt;/h1&gt;
 					</pre>
-					<p>Explicit roles on a descendant or <a>owned</a> element override the inherited role of <code>presentation</code>, and cause the owned element to behave as any other element with an explicit role. If the action of exposing the implicit role causes the accessibility tree to be malformed, the expected results are undefined and the user agent MAY resort to an internal recovery mechanism to repair the accessibility tree.</p>
-					<p>If an element with a role of presentation is focusable, or otherwise interactive, user agents MUST ignore the normal effect of the role and expose the element with implicit native semantics, in order to ensure that the element is both <a>understandable</a> and <a>operable</a>.</p>
-					<p>User agents MUST always expose global WAI-ARIA states and properties to accessibility APIs, even if an element has an explicit or inherited role of presentation. In this case, the user agent ignores the <code>presentation</code> role and exposes the element according to its implicit native semantics. However, user agents MUST ignore any non-global, role-specific WAI-ARIA states and properties, unless it is on an inherited presentational role where an explicit role is applied.</p>
 				</section>
 			</div>
 			<table class="role-features">
@@ -5078,8 +6418,17 @@
 						<td class="role-inherited">Placeholder</td>
 					</tr>
 					<tr>
+						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
+						<td class="role-disallowed">
+							<ul>
+								<li><pref>aria-label</pref></li>
+								<li><pref>aria-labelledby</pref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author (if role discarded by error conditions)</td>
+						<td class="role-namefrom">prohibited</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -5104,8 +6453,16 @@
 			<rdef>progressbar</rdef>
 			<div class="role-description">
 				<p>An <a>element</a> that displays the progress status for tasks that take a long time.</p>
-				<p>A progressbar indicates that the user's request has been received and the application is making progress toward completing the requested action. The author SHOULD supply <span>values</span> for <pref>aria-valuenow</pref>, <pref>aria-valuemin</pref>, and <pref>aria-valuemax</pref>, unless the value is indeterminate, in which case the author SHOULD omit the <pref>aria-valuenow</pref> attribute. Authors SHOULD update these values when the visual progress indicator is updated. If the <code>progressbar</code> is describing the loading progress of a particular region of a page, the author SHOULD use <pref>aria-describedby</pref> to point to the status, and set the <sref>aria-busy</sref> attribute to <code>true</code> on the region until it is finished loading. It is not possible for the user to alter the value of a <code>progressbar</code> because it is always read-only.</p>
-				<p class="note">Assistive technologies generally will render the value of <pref>aria-valuenow</pref> as a percent of a range between the value of <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref>, unless <pref>aria-valuetext</pref> is specified. It is best to set the values for <pref>aria-valuemin</pref>, <pref>aria-valuemax</pref>, and <pref>aria-valuenow</pref> in a manner that is appropriate for this calculation.</p>
+				<p>A progressbar indicates that the user's request has been received and the application is making progress toward completing the requested action.</p>
+				<p>Authors MAY set <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> to indicate the minimum and maximum progress indicator values. Otherwise, their implicit values follow the same rules as <code>&lt;input[type="range"]&gt;</code> in [[HTML]]:</p>
+					<ul>
+						<li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero).</li>
+						<li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100.</li>
+					</ul>
+				</p>
+				<p>The author SHOULD supply a <span>value</span> for <pref>aria-valuenow</pref> unless the value is indeterminate, in which case the author SHOULD omit the <pref>aria-valuenow</pref> attribute.
+				Authors SHOULD update this value when the visual progress indicator is updated. If the <code>progressbar</code> is describing the loading progress of a particular region of a page, the author SHOULD use <pref>aria-describedby</pref> to point to the status, and set the <sref>aria-busy</sref> attribute to <code>true</code> on the region until it is finished loading. It is not possible for the user to alter the value of a <code>progressbar</code> because it is always read-only.</p>
+				<p class="note">Assistive technologies generally will render the value of <pref>aria-valuenow</pref> as a percent of a range between the value of <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref>, unless <pref>aria-valuetext</pref> is specified.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -5122,7 +6479,12 @@
 					</tr>
 					<tr>
 						<th class="role-parent-head" scope="row">Superclass Role:</th>
-						<td class="role-parent"><rref>range</rref></td>
+						<td class="role-parent">
+							<ul>
+								<li><rref>range</rref></li>
+								<li><rref>widget</rref></li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-children-head" scope="row">Subclass Roles:</th>
@@ -5176,6 +6538,13 @@
 						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
 						<td class="role-presentational-inherited"> </td>
 					</tr>
+					<tr>
+						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
+						<td class="implicit-values">
+							Default for <pref>aria-valuemin</pref> is <code class="default">0</code>. <br/>
+							Default for <pref>aria-valuemax</pref> is <code class="default">100</code>. <br/>
+						</td>
+					</tr>
 				</tbody>
 			</table>
 		</div>
@@ -5216,7 +6585,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/html5/forms.html#radio-button-state-(type=radio)"><abbr title="Hypertext Markup Language">HTML</abbr> <code>input[type="radio"]</code></a></td>
+						<td class="role-related"><code>&lt;input[type="radio"]&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -5252,6 +6621,7 @@
 						<td class="role-namefrom">
 							<ul>
 								<li>contents</li>
+                				<li>encapsulation</li>
 								<li>author</li>
 							</ul>
 						</td>
@@ -5271,10 +6641,6 @@
 					<tr>
 						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
 						<td class="role-presentational-inherited"> </td>
-					</tr>
-					<tr>
-						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
-						<td class="implicit-values">Default for <sref>aria-checked</sref> is <code class="default">false</code>.</td>
 					</tr>
 				</tbody>
 			</table>
@@ -5331,6 +6697,8 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
+								<li><pref>aria-errormessage</pref></li>
+								<li><sref>aria-invalid</sref></li>
 								<li><pref>aria-readonly</pref></li>
 								<li><pref>aria-required</pref></li>
 							</ul>
@@ -5342,7 +6710,12 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom">
+							<ul>
+								<li>author</li>
+								<li>legend</li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -5366,7 +6739,7 @@
 		<div class="role" id="range">
 			<rdef>range</rdef>
 			<div class="role-description">
-				<p>An input representing a range of values that can be set by the user.</p>
+				<p>An element representing a range of values.</p>
 				<p class="note"><code>range</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
 			</div>
 			<table class="role-features">
@@ -5384,7 +6757,7 @@
 					</tr>
 					<tr>
 						<th class="role-parent-head" scope="row">Superclass Role:</th>
-						<td class="role-parent"><rref>widget</rref></td>
+						<td class="role-parent"><rref>structure</rref></td>
 					</tr>
 					<tr>
 						<th class="role-children-head" scope="row">Subclass Roles:</th>
@@ -5409,8 +6782,9 @@
 								<li><pref>aria-valuemax</pref></li>
 								<li><pref>aria-valuemin</pref></li>
 								<li><pref>aria-valuenow</pref></li>
+								<li><pref>aria-valuetext</pref></li>
 							</ul>
-							<pref>aria-valuetext</pref></td>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -5442,7 +6816,7 @@
 		<div class="role" id="region">
 			<rdef>region</rdef>
 			<div class="role-description">
-				<p>A perceivable <rref>section</rref> containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.</p>
+				<p>A <rref>landmark</rref> containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.</p>
 				<p>Authors SHOULD limit use of the region role to sections containing content with a purpose that is not accurately described by one of the other <rref>landmark</rref> roles, such as <rref>main</rref>, <rref>complementary</rref>, or <rref>navigation</rref>.</p>
 				<p>Authors MUST give each element with role region a brief label that describes the purpose of the content in the region. Authors SHOULD reference a visible label with <pref>aria-labelledby</pref> if a visible label is present. Authors SHOULD include the label inside of a heading whenever possible. The heading MAY be an instance of the standard host language heading element or an instance of an element with role <rref>heading</rref>.</p>
 				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role region. Mainstream <a>user agents</a> MAY enable users to quickly navigate to elements with role region.</p>
@@ -5474,13 +6848,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related">
-							<ul>
-								<li><a href="https://www.w3.org/TR/html5/obsolete.html#frame"><abbr title="Hypertext Markup Language">HTML</abbr> <code>frame</code></a></li>
-								<li><a href="https://www.w3.org/TR/di-gloss/#def-perceivable-unit">Device Independence Glossary perceivable unit</a></li>
-								<li><rref>section</rref></li>
-							</ul>
-						</td>
+						<td class="role-related"><code>&lt;section&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -5528,8 +6896,8 @@
 		<div class="role" id="roletype">
 			<rdef>roletype</rdef>
 			<div class="role-description">
-				<p>The base <a>role</a> from which all other roles in this <a>taxonomy</a> inherit.</p>
-				<p>Properties of this role describe the structural and functional purpose of <a>objects</a> that are assigned this role (known in <abbr title="Resource Description Framework">RDF</abbr> terms as "instances"). A role is a concept that can be used to understand and operate instances.</p>
+				<p>The base <a>role</a> from which all other roles inherit.</p>
+				<p>Properties of this role describe the structural and functional purpose of <a>objects</a> that are assigned this role. A role is a concept that can be used to understand and operate instances.</p>
 				<p class="note"><code>roletype</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
 			</div>
 			<table class="role-features">
@@ -5559,13 +6927,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related">
-							<ul>
-								<li><a href="https://www.w3.org/TR/xhtml-role/#s_role_module_attributes"><abbr title="Extensible Hypertext Markup Language">XHTML</abbr> role</a></li>
-								<li><a href="https://www.w3.org/TR/html5/document-metadata.html#attr-link-rel"><abbr title="Hypertext Markup Language">HTML</abbr> <code>rel</code></a></li>
-								<li><a href="http://dublincore.org/documents/2012/06/14/dcmi-terms/">Dublin Core type</a></li>
-							</ul>
-						</td>
+						<td class="role-related"> </td>
 					</tr>
 					<tr>
 						<th class="role-required-properties-head">Required States and Properties:</th>
@@ -5610,9 +6972,11 @@
 			<rdef>row</rdef>
 			<div class="role-description">
 				<p>A row of cells in a tabular container.</p>
-				<p>Rows contain <rref>cell</rref> or <rref>gridcell</rref> <a>elements</a>, and thus serve to organize the <rref>table</rref> or <rref>grid</rref>.</p>
-				<p>In a <rref>treegrid</rref>, authors MAY mark rows as expandable, using the <sref>aria-expanded</sref> <a>attribute</a> to indicate the present status. This is not the case for an ordinary <rref>table</rref> or <rref>grid</rref>, in which the <sref>aria-expanded</sref> attribute is not present.</p>
+				<p>Rows contain <rref>cell</rref> or <rref>gridcell</rref> <a>elements</a>, and thus serve to organize a <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>.</p>
+				<p>While the row role can be used in a <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>, the semantics of <sref>aria-expanded</sref>, <pref>aria-posinset</pref>, <pref>aria-setsize</pref>, and <pref>aria-level</pref> are only applicable to the hierarchical structure of an interactive tree grid. Therefore, authors MUST NOT apply <sref>aria-expanded</sref>, <pref>aria-posinset</pref>, <pref>aria-setsize</pref>, and <pref>aria-level</pref> to a <rref>row</rref> that descends from a <rref>table</rref> or <rref>grid</rref>, and user agents SHOULD NOT expose any of these four properties to assistive technologies unless the <rref>row</rref> descends from a <rref>treegrid</rref>.
+				</p>
 				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>row</code> are contained in, or <a>owned</a> by, an element with the role <rref>table</rref>, <rref>grid</rref>, <rref>rowgroup</rref>, or <rref>treegrid</rref>.</p>
+				<p class="note" title="Usage of aria-disabled">While <sref>aria-disabled</sref> is currently supported on <rref>row</rref>, in a future version the working group plans to prohibit its  on elements with role <rref>row</rref> except when the element is in the context of a <rref>grid</rref> or <rref>treegrid</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -5642,7 +7006,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><a href="https://www.w3.org/TR/html5/tabular-data.html#the-tr-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>tr</code></a></td>
+						<td class="role-base"><code>&lt;tr&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -5679,8 +7043,12 @@
 						<td class="role-properties">
 							<ul>
 								<li><pref>aria-colindex</pref></li>
+								<li><sref>aria-expanded</sref></li>
 								<li><pref>aria-level</pref></li>
+								<li><pref>aria-posinset</pref></li>
 								<li><pref>aria-rowindex</pref></li>
+								<li><pref>aria-rowindextext</pref></li>
+								<li><pref>aria-setsize</pref></li>
 								<li><sref>aria-selected</sref></li>
 							</ul>
 						</td>
@@ -5722,7 +7090,7 @@
 			<div class="role-description">
 				<p>A structure containing one or more row elements in a tabular container.</p>
 				<p>The <code>rowgroup</code> role establishes a <a>relationship</a> between <a>owned</a> <rref>row</rref> elements. It is a structural equivalent to the <code>thead</code>, <code>tfoot</code>, and <code>tbody</code> elements in an <abbr title="Hypertext Markup Language">HTML</abbr> <code>table</code> <a>element</a>.</p>
-				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>rowgroup</code> are contained in, or <a>owned</a> by, an element with the role <rref>table</rref> or <rref>grid</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>rowgroup</code> are contained in, or <a>owned</a> by, an element with the role <rref>grid</rref>, <rref>table</rref>, or <rref>treegrid</rref>.</p>
 				<p class="note">The <code>rowgroup</code> role exists, in part, to support role symmetry in HTML, and allows for the propagation of presentation inheritance on HTML <code>table</code> elements with an explicit <code>presentation</code> role applied.</p>
 				<p class="note">This role does not differentiate between types of row groups (e.g., <code>thead</code> vs. <code>tbody</code>), but an issue has been raised for <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 2.0.</p>
 			</div>
@@ -5749,13 +7117,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base">
-							<ul>
-								<li><a href="https://www.w3.org/TR/html5/tabular-data.html#the-tbody-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>tbody</code></a></li>
-								<li><a href="https://www.w3.org/TR/html5/tabular-data.html#the-tfoot-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>tfoot</code></a></li>
-								<li><a href="https://www.w3.org/TR/html5/tabular-data.html#the-thead-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>thead</code></a></li>
-							</ul>
-						</td>
+						<td class="role-base"><code>&lt;tbody&gt;</code>, <code>&lt;tfoot&gt;</code> and <code>&lt;thead&gt;</code>in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -5789,12 +7151,7 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">
-							<ul>
-								<li>contents</li>
-								<li>author</li>
-							</ul>
-						</td>
+						<td class="role-namefrom">author</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -5818,11 +7175,12 @@
 		<div class="role" id="rowheader">
 			<rdef>rowheader</rdef>
 			<div class="role-description">
-				<p>A cell containing header information for a row in a grid.</p>
-				<p>Rowheader can be used as a row header in a table or grid. The rowheader establishes a <a>relationship</a> between it and all cells in the corresponding row. It is a structural equivalent to setting <code>scope="row"</code> on an <abbr title="Hypertext Markup Language">HTML</abbr> <code>th</code> <a>element</a>.</p>
-				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>rowheader</code> are contained in, or <a>owned</a> by, an element with the role <rref>grid</rref>.</p>
-				<p>Applying the <sref>aria-selected</sref> state on a rowheader MUST not cause the user agent to automatically propagate the <sref>aria-selected</sref> state to all the cells in the corresponding row. An author MAY choose to propagate selection in this manner depending on the specific application.</p>
-				<p>While the <code>rowheader</code> role can be used in both interactive grids and non-interactive tables, the use of <pref>aria-readonly</pref> and <pref>aria-required</pref> is only applicable to interactive elements. Therefore, authors SHOULD NOT use <pref>aria-required</pref> or <pref>aria-readonly</pref> in a <code>rowheader</code> that descends from a <rref>table</rref>, and user agents SHOULD NOT expose either property to <a>assistive technologies</a> unless the <code>rowheader</code> descends from a <rref>grid</rref>.</p>
+				<p>A cell containing header information for a row.</p>
+				<p>The <rref>rowheader</rref> role can be used to identify a cell as a header for a row in a <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>. The rowheader establishes a <a>relationship</a> between it and all cells in the corresponding row. It is a structural equivalent to setting <code>scope="row"</code> on an <abbr title="Hypertext Markup Language">HTML</abbr> <code>th</code> <a>element</a>.</p>
+				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>rowheader</code> are contained in, or <a>owned</a> by, an element with the role <rref>row</rref>.</p>
+				<p>Applying the <sref>aria-selected</sref> state on a rowheader MUST NOT cause the user agent to automatically propagate the <sref>aria-selected</sref> state to all the cells in the corresponding row. An author MAY choose to propagate selection in this manner depending on the specific application.</p>
+				<p>While the <code>rowheader</code> role can be used in both interactive grids and non-interactive tables, the use of <sref>aria-expanded</sref>, <pref>aria-readonly</pref>, and <pref>aria-required</pref> is only applicable to interactive elements. Therefore, authors SHOULD NOT use <sref>aria-expanded</sref>, <pref>aria-readonly</pref>, or <pref>aria-required</pref> in a <code>rowheader</code> that descends from a <rref>table</rref>, and user agents SHOULD NOT expose these properties to <a>assistive technologies</a> unless the <code>rowheader</code> descends from a <rref>grid</rref> or <rref>treegrid</rref>.</p>
+				<p class="note" title="Usage of aria-disabled">While <sref>aria-disabled</sref> is currently supported on <rref>rowheader</rref>, in a future version the working group plans to prohibit its use on elements with role <rref>rowheader</rref> except when the element is in the context of a <rref>grid</rref> or <rref>treegrid</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -5853,7 +7211,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><a href="https://www.w3.org/TR/html5/tabular-data.html#attr-th-scope"><abbr title="Hypertext Markup Language">HTML</abbr> <code>th[scope="row"]</code></a></td>
+						<td class="role-base"><code>&lt;th[scope="row"]&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -5873,7 +7231,12 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"><pref>aria-sort</pref></td>
+						<td class="role-properties">
+							<ul>
+								<li><sref>aria-expanded</sref></li>
+								<li><pref>aria-sort</pref></li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -5913,14 +7276,12 @@
 				<p>A graphical object that controls the scrolling of content within a viewing area, regardless of whether the content is fully displayed within the viewing area.</p>
 				<p>A scrollbar represents the current value and range of possible values via the size of the scrollbar and position of the thumb with respect to the visible range of the orientation (horizontal or vertical) it controls. Its orientation represents the orientation of the scrollbar and the scrolling effect on the viewing area controlled by the scrollbar. It is typically possible to add or subtract to the current value by using directional keys such as arrow keys.</p>
 				<p>Authors MUST set the <pref>aria-controls</pref> attribute on the scrollbar element to reference the scrollable area it controls.</p>
-				<p>Authors MUST set the <pref>aria-valuemin</pref>, <pref>aria-valuemax</pref>, and <pref>aria-valuenow</pref> attributes.  If missing, their implicit values follow the same rules as the <a href="https://www.w3.org/TR/html5/forms.html#range-state-%28type=range%29" title="Range state">HTML range input type</a>:</p>
+				<p>Authors MAY set <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> to indicate the minimum and maximum thumb position. Otherwise, their implicit values follow the same rules as <code>&lt;input[type="range"]&gt;</code> in [[HTML]]:</p>
 				<ul>
-				    <li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero). </li>
-				    <li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100. </li>
-				    <li>If <code>aria-valuenow</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to the value half way between <code>aria-valuemin</code> and <code>aria-valuemax</code>. </li>
-				    <li>If <code>aria-valuenow</code> is present but less than <code>aria-valuemin</code>, it defaults to the value of <code>aria-valuemin</code>. </li>
-				    <li>If <code>aria-valuenow</code> is present but greater than <code>aria-valuemax</code>, it defaults to the value of <code>aria-valuemax</code>. </li>
+				    <li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero).</li>
+				    <li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100.</li>
 				</ul>
+				<p>Authors MUST set the <pref>aria-valuenow</pref> attribute to indicate the current thumb position. If aria-valuenow is missing or has an unexpected value, browsers MAY implement the repair techniques specified in the <a href="#authorErrorDefaultValuesTable">section describing handling author errors in states and properties</a>, which are equivalent to the repair techniques for <code>&lt;input[type="range"]&gt;</code> in [[HTML]].</p>
 				<p>Elements with the role <code>scrollbar</code> have an implicit <pref>aria-orientation</pref> value of <code>vertical</code>.</p>
 				<p class="note">Assistive technologies generally will render the value of <pref>aria-valuenow</pref> as a percent of a range between the value of <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref>, unless <pref>aria-valuetext</pref> is specified. It is best to set the values for <pref>aria-valuemin</pref>, <pref>aria-valuemax</pref>, and <pref>aria-valuenow</pref> in a manner that is appropriate for this calculation.</p>
 			</div>
@@ -5939,9 +7300,12 @@
 					</tr>
 					<tr>
 						<th class="role-parent-head" scope="row">Superclass Role:</th>
-						<td class="role-parent"><ul>
-							<li><rref>range</rref></li>
-						</ul></td>
+						<td class="role-parent">
+							<ul>
+								<li><rref>range</rref></li>
+								<li><rref>widget</rref></li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-children-head" scope="row">Subclass Roles:</th>
@@ -5968,16 +7332,20 @@
 						<td class="role-required-properties">
 							<ul>
 								<li><pref>aria-controls</pref></li>
-								<li><pref>aria-orientation</pref></li>
-								<li><pref>aria-valuemax</pref></li>
-								<li><pref>aria-valuemin</pref></li>
 								<li><pref>aria-valuenow</pref></li>
 							</ul>
 						</td>
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"> </td>
+						<td class="role-properties">
+							<ul>
+								<li><sref>aria-disabled</sref></li>
+								<li><pref>aria-orientation</pref></li>
+								<li><pref>aria-valuemax</pref></li>
+								<li><pref>aria-valuemin</pref></li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -6009,7 +7377,6 @@
 							Default for <pref>aria-orientation</pref> is <code class="default">vertical</code>. <br/>
 							Default for <pref>aria-valuemin</pref> is <code class="default">0</code>. <br/>
 							Default for <pref>aria-valuemax</pref> is <code class="default">100</code>. <br/>
-							Default for <pref>aria-valuenow</pref> is half way between <code class="default">aria-valuemax</code> and <code class="default">aria-valuemin</code>.
 						</td>
 					</tr>
 				</tbody>
@@ -6122,7 +7489,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><a href="https://www.w3.org/TR/html5/forms.html#text-(type=text)-state-and-search-state-(type=search)"><abbr title="Hypertext Markup Language">HTML</abbr> <code>input[type="search"]</code></a></td>
+						<td class="role-base"><code>&lt;input[type="search"]&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -6142,7 +7509,12 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom">
+							<ul>
+								<li>encapsulation</li>
+								<li>author</li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -6196,11 +7568,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related">
-							<ul>
-								<li><a href="https://www.w3.org/TR/SMIL3/smil-timing.html#edef-par"><abbr title="Synchronized Multimedia Integration Language">SMIL</abbr> par</a></li>
-							</ul>
-						</td>
+						<td class="role-related"> </td>
 					</tr>
 					<tr>
 						<th class="role-required-properties-head">Required States and Properties:</th>
@@ -6208,7 +7576,7 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"><sref>aria-expanded</sref></td>
+						<td class="role-properties"></td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -6278,7 +7646,7 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"><sref>aria-expanded</sref></td>
+						<td class="role-properties"></td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -6397,7 +7765,6 @@
 				<ul>
 				    <li>The implicit value of <code>aria-valuemin</code> is <code>0</code>.</li>
 				    <li>The implicit value of <code>aria-valuemax</code> is <code>100</code>.</li>
-				    <li>The implicit value of <code>aria-valuenow</code> is <code>50</code>.</li>
 				</ul>
 				<p>In applications where there is more than one focusable <code>separator</code>, authors SHOULD provide an accessible name for each one.</p>
 				<p>Elements with the role <code>separator</code> have an implicit <pref>aria-orientation</pref> value of <code>horizontal</code>.</p>
@@ -6434,7 +7801,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-hr-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>hr</code></a></td>
+						<td class="role-related"><code>&lt;hr&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -6446,19 +7813,16 @@
 					</tr>
 					<tr>
 						<th class="role-required-properties-head">Required States and Properties:</th>
-						<td class="role-required-properties">
-							<ul>
-								<li><pref>aria-valuemax</pref> (if focusable)</li>
-								<li><pref>aria-valuemin</pref> (if focusable)</li>
-								<li><pref>aria-valuenow</pref> (if focusable)</li>
-							</ul>
-						</td>
+						<td class="role-required-properties"><pref>aria-valuenow</pref> (if focusable)</td>
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
+								<li><sref>aria-disabled</sref> (if focusable)</li>
 								<li><pref>aria-orientation</pref></li>
+								<li><pref>aria-valuemax</pref> (if focusable)</li>
+								<li><pref>aria-valuemin</pref> (if focusable)</li>
 								<li><pref>aria-valuetext</pref> (if focusable)</li>
 							</ul>
 						</td>
@@ -6492,14 +7856,8 @@
 						<td class="implicit-values">
 							Default for <pref>aria-orientation</pref> is <code class="default">horizontal</code>.<br/>
 							Default for <pref>aria-valuemin</pref> is <code>0</code>.<br/>
-							Default for <pref>aria-valuemax</pref> is <code>100</code>.<br/>
-							Default for <pref>aria-valuenow</pref> is <code>50</code>.<br/>
+							Default for <pref>aria-valuemax</pref> is <code>100</code>.
 						</td>
-					</tr>
-
-					<tr>
-						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
-						<td class="implicit-values">Default for <pref>aria-orientation</pref> is <code class="default">horizontal</code>.</td>
 					</tr>
 				</tbody>
 			</table>
@@ -6507,16 +7865,14 @@
 		<div class="role" id="slider">
 			<rdef>slider</rdef>
 			<div class="role-description">
-				<p>A user input where the user selects a value from within a given range.</p>
+				<p>An input where the user selects a value from within a given range.</p>
 				<p>A slider represents the current value and range of possible values via the size of the slider and position of the thumb. It is typically possible to add or subtract to the value by using directional keys such as arrow keys.</p>
-				<p>Authors MUST set the <pref>aria-valuemin</pref>, <pref>aria-valuemax</pref>, and <pref>aria-valuenow</pref> attributes.	If missing, their implicit values follow the same rules as the <a href="https://www.w3.org/TR/html5/forms.html#range-state-%28type=range%29" title="Range state">HTML range input type</a>:</p>
+				<p>Authors MAY set the <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> attributes.	Otherwise, their implicit values follow the same rules as <code>&lt;input[type="range"]&gt;</code> in [[HTML]]:</p>
 				<ul>
 				    <li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero). </li>
 				    <li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100. </li>
-				    <li>If <code>aria-valuenow</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to the value half way between <code>aria-valuemin</code> and <code>aria-valuemax</code>. </li>
-				    <li>If <code>aria-valuenow</code> is present but less than <code>aria-valuemin</code>, it defaults to the value of <code>aria-valuemin</code>. </li>
-				    <li>If <code>aria-valuenow</code> is present but greater than <code>aria-valuemax</code>, it defaults to the value of <code>aria-valuemax</code>. </li>
 				</ul>
+				<p>Authors MUST set the <pref>aria-valuenow</pref> attribute. If aria-valuenow is missing or has an unexpected value, browsers MAY implement the repair techniques specified in the <a href="#authorErrorDefaultValuesTable">section describing handling author errors in states and properties</a>, which are equivalent to the repair techniques for <code>&lt;input[type="range"]&gt;</code> in [[HTML]].</p>
 				<p>Elements with the role <code>slider</code> have an implicit <pref>aria-orientation</pref> value of <code>horizontal</code>.</p>
 			</div>
 			<table class="role-features">
@@ -6563,8 +7919,6 @@
 						<th class="role-required-properties-head">Required States and Properties:</th>
 						<td class="role-required-properties">
 							<ul>
-								<li><pref>aria-valuemax</pref></li>
-								<li><pref>aria-valuemin</pref></li>
 								<li><pref>aria-valuenow</pref></li>
 							</ul>
 						</td>
@@ -6573,8 +7927,13 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
+								<li><pref>aria-errormessage</pref></li>
+								<li><pref>aria-haspopup</pref></li>
+								<li><sref>aria-invalid</sref></li>
 								<li><pref>aria-orientation</pref></li>
 								<li><pref>aria-readonly</pref></li>
+								<li><pref>aria-valuemax</pref></li>
+								<li><pref>aria-valuemin</pref></li>
 							</ul>
 						</td>
 					</tr>
@@ -6607,8 +7966,7 @@
 						<td class="implicit-values">
 							Default for <pref>aria-orientation</pref> is <code class="default">horizontal</code>. <br/>
 							Default for <pref>aria-valuemin</pref> is <code class="default">0</code>. <br/>
-							Default for <pref>aria-valuemax</pref> is <code class="default">100</code>. <br/>
-							Default for <pref>aria-valuenow</pref> is half way between <code class="default">aria-valuemax</code> and <code class="default">aria-valuemin</code>.
+							Default for <pref>aria-valuemax</pref> is <code class="default">100</code>.
 						</td>
 					</tr>
 				</tbody>
@@ -6618,16 +7976,11 @@
 			<rdef>spinbutton</rdef>
 			<div class="role-description">
 				<p>A form of <rref>range</rref> that expects the user to select from among discrete choices.</p>
-				<p>A <code>spinbutton</code> typically allows the user to select from the given range through the use of an up and down button on the keyboard. Visibly, the current value is incremented or decremented until a maximum or minimum value is reached. Authors SHOULD ensure this functionality is accomplished programmatically through the use of <kbd>up</kbd> and <kbd>down</kbd> arrows on the keyboard.</p>
+				<p>A <code>spinbutton</code> typically allows users to change its displayed value by activating increment and decrement buttons that step through a set of allowed values. Some implementations display the value in an text field that allows editing and typing but typically limits input in ways that help prevent invalid values.</p>
 				<p>Although a <code>spinbutton</code> is similar in appearance to many presentations of <code>select</code>, it is advisable to use <code>spinbutton</code> when working with known ranges (especially in the case of large ranges) as opposed to distinct options. For example, a <code>spinbutton</code> representing a range from 1 to 1,000,000 would provide much better performance than a <code>select</code> <a>widget</a> representing the same values.</p>
-				<p>Authors MAY create a <code>spinbutton</code> with children or owned elements, but MUST limit those elements to a <rref>textbox</rref> and/or two <rref title="button">buttons</rref>.</p>
-				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>. When a <code>spinbutton</code> receives focus, authors SHOULD ensure focus is placed on the <rref>textbox</rref> element if one is present, and on the <code>spinbutton</code> itself otherwise. Authors SHOULD NOT include contained <rref>button</rref> elements in the primary navigation ring, e.g., the Tab ring in <abbr title="Hypertext Markup Language">HTML</abbr>, because they are superfluous for people using keyboard devices.</p>
-				<p>Authors MUST set the <pref>aria-valuenow</pref> attribute. Authors SHOULD set the <pref>aria-valuemin</pref> attribute when there is a minimum value, and the <pref>aria-valuemax</pref> attribute when there is a maximum value. If missing or not a <a href="#valuetype_number">number</a>, the implicit values of these attributes are as follows:</p>
-				<ul>
-				    <li>The implicit value of <code>aria-valuemin</code> is that there is no minimum value.</li>
-				    <li>The implicit value of <code>aria-valuemax</code> is that there is no maximum value.</li>
-				    <li>The implicit value of <code>aria-valuenow</code> is <code>0</code>.</li>
-				</ul>
+				<p>Authors MAY create a <code>spinbutton</code> with children or owned elements, but MUST limit those elements to a <rref>textbox</rref> and/or two <rref title="button">buttons</rref>. Alternatively, authors MAY apply the <rref>spinbutton</rref> role to a text input and create sibling buttons to support the increment and decrement functions.</p>
+				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>. When a <code>spinbutton</code> receives focus, authors SHOULD ensure focus is placed on the <rref>textbox</rref> element if one is present, and on the <code>spinbutton</code> itself otherwise. Authors SHOULD also ensure the <kbd>up</kbd> and <kbd>down</kbd> arrows on a keyboard perform the increment and decrement functions and that the increment and decrement <rref>button</rref> elements are <em>NOT</em> included in the primary navigation ring, e.g., the Tab ring in <abbr title="Hypertext Markup Language">HTML</abbr>.</p>
+				<p>Authors SHOULD set the <pref>aria-valuenow</pref> attribute when the <rref>spinbutton</rref> has a value. Authors SHOULD set the <pref>aria-valuemin</pref> attribute when there is a minimum value, and the <pref>aria-valuemax</pref> attribute when there is a maximum value.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -6674,20 +8027,20 @@
 					</tr>
 					<tr>
 						<th class="role-required-properties-head">Required States and Properties:</th>
-						<td class="role-required-properties">
-							<ul>
-								<li><pref>aria-valuemax</pref></li>
-								<li><pref>aria-valuemin</pref></li>
-								<li><pref>aria-valuenow</pref></li>
-							</ul>
-						</td>
+						<td class="role-required-properties"></td>
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
+								<li><pref>aria-errormessage</pref></li>
+								<li><sref>aria-invalid</sref></li>
 								<li><pref>aria-readonly</pref></li>
 								<li><pref>aria-required</pref></li>
+								<li><pref>aria-valuemax</pref></li>
+								<li><pref>aria-valuemin</pref></li>
+								<li><pref>aria-valuenow</pref></li>
+								<li><pref>aria-valuetext</pref></li>
 							</ul>
 						</td>
 					</tr>
@@ -6697,7 +8050,12 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom">
+							<ul>
+								<li>encapsulation</li>
+								<li>author</li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -6720,7 +8078,7 @@
 						<td class="implicit-values">
 							Default for <pref>aria-valuemin</pref> is that there is no minimum value.<br/>
 							Default for <pref>aria-valuemax</pref> is that there is no maximum value.<br/>
-							Default for <pref>aria-valuenow</pref> is <code>0</code>.<br/>
+							Default for <pref>aria-valuenow</pref> is that there is no current value.<br/>
 						</td>
 					</tr>
 				</tbody>
@@ -6814,6 +8172,94 @@
 				</tbody>
 			</table>
 		</div>
+		<div class="role" id="strong">
+			<rdef>strong</rdef>
+			<div class="role-description">
+				<p>Content that is important, serious, or urgent. See related <rref>emphasis</rref>.</p>
+				<p>The purpose of the <code>strong</code> role is to communicate strong importance, seriousness, or urgency. It is not for communicating changes in typographical presentation that are not important to the meaning of the content. Authors SHOULD use the <code>strong</code> role only if its absence would change the meaning of the content.</p>
+				<p>The <code>strong</code> role is not intended to convey stress or emphasis; for that purpose, the <rref>emphasis</rref> role is more appropriate.</p>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent"><rref>section</rref></td>
+					</tr>
+					<tr>
+						<th class="role-children-head" scope="row">Subclass Roles:</th>
+						<td class="role-children">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"> </td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"><code>&lt;strong&gt;</code> in [[HTML]]</td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Context Role:</th>
+						<td class="role-scope"> </td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
+						<td class="role-disallowed">
+							<ul>
+								<li><pref>aria-label</pref></li>
+								<li><pref>aria-labelledby</pref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">prohibited</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired"> </td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational"> </td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
 		<div class="role" id="structure">
 			<rdef>structure</rdef>
 			<div class="role-description">
@@ -6856,7 +8302,7 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties">&#160;</td>
+						<td class="role-properties"> </td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -6869,6 +8315,283 @@
 								<li><abbr title="not applicable">n/a</abbr></li>
 							</ul>
 						</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired"> </td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational"> </td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div class="role" id="subscript">
+			<rdef>subscript</rdef>
+			<div class="role-description">
+				<p>One or more subscripted characters. See related <rref>superscript</rref>.</p>
+				<p>The <code>subscript</code> role is intended to be used only to mark up typographical conventions that have specific meanings; not for typographical presentation for presentation's sake. In general, authors SHOULD use this role only if the absence of the subscript would change the meaning of the content.</p>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent"><rref>section</rref></td>
+					</tr>
+					<tr>
+						<th class="role-children-head" scope="row">Subclass Roles:</th>
+						<td class="role-children">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"> </td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"><code>&lt;sub&gt;</code> and <code>&lt;sup&gt;</code> in [[HTML]]</td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Context Role:</th>
+						<td class="role-scope"> </td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
+						<td class="role-disallowed">
+							<ul>
+								<li><pref>aria-label</pref></li>
+								<li><pref>aria-labelledby</pref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">prohibited</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired"> </td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational"> </td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div class="role" id="suggestion">
+			<rdef>suggestion</rdef>
+			<div class="role-description">
+					<p>A single proposed change to content.</p>
+					<p>For example, in an editing system that supports multiple users, one user may suggest a change, and another user would be responsible
+					for accepting or rejecting the suggestion.</p>
+					<p>Authors MUST ensure that a <code>suggestion</code> contains either one <rref>insertion</rref> child or one <rref>deletion</rref> child or ensure that it contains two children where one is an <rref>insertion</rref> and the other is a <rref>deletion</rref>. Authors MUST ensure a <code>suggestion</code> does not contain any other children.</p>
+					<p>Authors MAY use <pref>aria-details</pref> or <pref>aria-description</pref> to associate the <code>suggestion</code> with related information such as comments, authoring info, and time stamps.</p>
+					<pre class="example highlight">
+						&lt;p&gt;
+						  The best pet is a
+						  &lt;span role="suggestion"&gt;
+						    &lt;span role="deletion"&gt;cat&lt;/span&gt;
+						    &lt;span role="insertion"&gt;dog&lt;/span&gt;
+						  &lt;/span&gt;
+						&lt;/p&gt;
+					</pre>
+					<p>When a suggestion is accepted, authors SHOULD remove the <code>suggestion</code> role, indicating that the proposed revision has been made.
+						After the <code>suggestion</code> role is removed, child <rref>insertion</rref> and <rref>deletion</rref> elements can either be retained to document the revision or replaced with the revised content.
+					  </p>
+			</div>
+			<table class="role-features">
+					<caption>Characteristics:</caption>
+					<thead>
+							<tr>
+									<th scope="col">Characteristic</th>
+									<th scope="col">Value</th>
+							</tr>
+					</thead>
+					<tbody>
+							<tr>
+									<th class="role-abstract-head" scope="row">Is Abstract:</th>
+									<td class="role-abstract"> </td>
+							</tr>
+							<tr>
+									<th class="role-parent-head" scope="row">Superclass Role:</th>
+									<td class="role-parent"><rref>section</rref></td>
+							</tr>
+							<tr>
+									<th class="role-base-head" scope="row">Base Concept:</th>
+									<td class="role-base"> </td>
+							</tr>
+							<tr>
+									<th class="role-related-head" scope="row">Related Concepts:</th>
+									<td class="role-related"> </td>
+							</tr>
+							<tr>
+									<th class="role-scope-head" scope="row">Required Context Role:</th>
+									<td class="role-scope"> </td>
+							</tr>
+							<tr>
+									<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+									<td class="role-mustcontain">
+										<ul>
+											<li><rref>insertion</rref></li>
+											<li><rref>deletion</rref></li>
+										</ul>
+									</td>
+							</tr>
+							<tr>
+									<th class="role-required-properties-head">Required States and Properties:</th>
+									<td class="role-required-properties"> </td>
+							</tr>
+							<tr>
+									<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+									<td class="role-properties"> </td>
+							</tr>
+							<tr>
+									<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+									<td class="role-inherited">Placeholder</td>
+							</tr>
+							<tr>
+									<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
+									<td class="role-disallowed">
+											<ul>
+													<li><pref>aria-label</pref></li>
+													<li><pref>aria-labelledby</pref></li>
+											</ul>
+									</td>
+							</tr>
+							<tr>
+									<th class="role-namefrom-head" scope="row">Name From:</th>
+									<td class="role-namefrom">prohibited</td>
+							</tr>
+							<tr>
+									<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+									<td class="role-namerequired"> </td>
+							</tr>
+							<tr>
+									<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+									<td class="role-namerequired-inherited"> </td>
+							</tr>
+							<tr>
+									<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+									<td class="role-childpresentational"> </td>
+							</tr>
+							<tr>
+									<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+									<td class="role-presentational-inherited"> </td>
+							</tr>
+					</tbody>
+			</table>
+		</div>
+		<div class="role" id="superscript">
+			<rdef>superscript</rdef>
+			<div class="role-description">
+				<p>One or more superscripted characters.  See related <rref>superscript</rref>.</p>
+				<p>The <code>superscript</code> role is intended to be used only to mark up typographical conventions that have specific meanings; not for typographical presentation for presentation's sake. In general, authors SHOULD use this role only if the absence of the superscript would change the meaning of the content.</p>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent"><rref>section</rref></td>
+					</tr>
+					<tr>
+						<th class="role-children-head" scope="row">Subclass Roles:</th>
+						<td class="role-children">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"> </td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"><code>&lt;sub&gt;</code> and <code>&lt;sup&gt;</code> in [[HTML]]</td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Context Role:</th>
+						<td class="role-scope"> </td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
+						<td class="role-disallowed">
+							<ul>
+								<li><pref>aria-label</pref></li>
+								<li><pref>aria-labelledby</pref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">prohibited</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -6954,6 +8677,7 @@
 						<td class="role-namefrom">
 							<ul>
 								<li>contents</li>
+								<li>encapsulation</li>
 								<li>author</li>
 							</ul>
 						</td>
@@ -6974,10 +8698,6 @@
 						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
 						<td class="role-presentational-inherited"> </td>
 					</tr>
-					<tr>
-						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
-						<td class="implicit-values">Default for <sref>aria-checked</sref> is <code class="default">false</code>.</td>
-					</tr>
 				</tbody>
 			</table>
 		</div>
@@ -6985,12 +8705,12 @@
 			<rdef>tab</rdef>
 			<div class="role-description">
 				<p>A grouping label providing a mechanism for selecting the tab content that is to be rendered to the user.</p>
-				<p>If a  <rref>tabpanel</rref> or item in a <rref>tabpanel</rref> has focus, the associated <code>tab</code> is the currently active tab in the <rref>tablist</rref>, as defined in <a href="#managingfocus">Managing Focus</a>. <rref>tablist</rref> elements, which contain a set of associated <rref>tab</rref> elements, are typically placed near a series of <rref>tabpanel</rref> elements, usually preceding it. See the <cite><a href="https://www.w3.org/TR/wai-aria-practices-1.1/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> [[WAI-ARIA-PRACTICES-1.1]] for details on implementing a tab set design pattern.</p>
+				<p>If a  <rref>tabpanel</rref> or item in a <rref>tabpanel</rref> has focus, the associated <code>tab</code> is the currently active tab in the <rref>tablist</rref>, as defined in <a href="#managingfocus">Managing Focus</a>. <rref>tablist</rref> elements, which contain a set of associated <rref>tab</rref> elements, are typically placed near a series of <rref>tabpanel</rref> elements, usually preceding it. See the <cite><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> for details on implementing a tab set design pattern.</p>
 				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <rref>tab</rref> are contained in, or <a>owned</a> by, an element with the role <rref>tablist</rref>.</p>
 				<p>Authors SHOULD ensure the <rref>tabpanel</rref> associated with the currently active tab is <a>perceivable</a> to the user.</p>
 
 				<!-- keep following para synced with its counterpart in #tablist -->
-				<p>For a single-selectable <rref>tablist</rref>, authors SHOULD hide other <code>tabpanel</code> <a>elements</a> from the user until the user selects the tab associated with that tabpanel. For a multi-selectable <rref>tablist</rref>, authors SHOULD ensure each visible <rref>tabpanel</rref> has its <sref>aria-expanded</sref> <a>attribute</a> set to <code>true</code>, and that the remaining hidden <code>tabpanel</code> elements have their <sref>aria-expanded</sref> attributes set to <code>false</code>.</p>
+				<p>For a single-selectable <rref>tablist</rref>, authors SHOULD hide other <code>tabpanel</code> <a>elements</a> from the user until the user selects the tab associated with that tabpanel. For a multi-selectable <rref>tablist</rref>, authors SHOULD ensure that the <rref>tab</rref> for each visible <rref>tabpanel</rref> has the <sref>aria-expanded</sref> <a>attribute</a> set to <code>true</code>, and that the <code>tabs</code> associated with the remaining hidden <code>tabpanel</code> elements have their <sref>aria-expanded</sref> attributes set to <code>false</code>.</p>
 
 				<p>In either case, authors SHOULD ensure that a selected tab has its <sref>aria-selected</sref> attribute set to <code>true</code>, that inactive tab elements have their <sref>aria-selected</sref> attribute set to <code>false</code>, and that the currently selected tab provides a visual indication that it is selected. In the absence of an <sref>aria-selected</sref> attribute on the current tab, <a>user agents</a> SHOULD indicate to <a>assistive technologies</a> through the platform <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> that the currently focused tab is selected.</p>
 			</div>
@@ -7044,6 +8764,9 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
+								<li><sref>aria-disabled</sref></li>
+								<li><sref>aria-expanded</sref></li>
+								<li><pref>aria-haspopup</pref></li>
 								<li><pref>aria-posinset</pref></li>
 								<li><sref>aria-selected</sref></li>
 								<li><pref>aria-setsize</pref></li>
@@ -7091,7 +8814,7 @@
 			<div class="role-description">
 				<p>A <rref>section</rref> containing data arranged in rows and columns. See related <rref>grid</rref>.</p>
 				<p>The <code>table</code> role is intended for tabular containers which are not interactive. If the tabular container maintains a selection state, provides its own two-dimensional navigation, or allows the user to rearrange or otherwise manipulate its contents or the display thereof, authors SHOULD use <rref>grid</rref> or <rref>treegrid</rref> instead.</p>
-				<p>Authors SHOULD prefer the use of the host language's semantics for table whenever possible, such as the <a href="https://www.w3.org/TR/html5/tabular-data.html#the-table-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>table</code></a> element.</p>
+				<p>Authors SHOULD prefer the use of the host language's semantics for table whenever possible, such as the <code>&lt;table&gt;</code> element in [[HTML]].</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -7116,7 +8839,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><a href="https://www.w3.org/TR/html5/tabular-data.html#the-table-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>table</code></a></td>
+						<td class="role-base"><code>&lt;table&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -7185,7 +8908,7 @@
 				<p>For a single-selectable <code>tablist</code>, authors SHOULD hide other <code>tabpanel</code> <a>elements</a> from the user until the user selects the tab associated with that tabpanel. For a multi-selectable <rref>tablist</rref>, authors SHOULD ensure each visible <rref>tabpanel</rref> has its <sref>aria-expanded</sref> <a>attribute</a> set to <code>true</code>, and that the remaining hidden <code>tabpanel</code> elements have their <sref>aria-expanded</sref> attributes set to <code>false</code>.</p>
 
 				<!-- keep following para synced with its counterpart in #tabpanel -->
-				<p><rref>tablist</rref> elements are typically placed near usually preceding, a series of <rref>tabpanel</rref> elements. See the <cite><a href="https://www.w3.org/TR/wai-aria-practices-1.1/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> [[WAI-ARIA-PRACTICES-1.1]] for details on implementing a tab set design pattern.</p>
+				<p><rref>tablist</rref> elements are typically placed near usually preceding, a series of <rref>tabpanel</rref> elements. See the <cite><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> for details on implementing a tab set design pattern.</p>
 
 				<p>Elements with the role <rref>tablist</rref> have an implicit <pref>aria-orientation</pref> value of <code>horizontal</code>.</p>
 			</div>
@@ -7220,7 +8943,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="http://www.daisy.org/z3986/2005/Z3986-2005.html#Guide"><abbr title="Digital Accessible Information System">DAISY</abbr> Guide</a></td>
+						<td class="role-related"> </td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -7238,7 +8961,6 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
-								<li><pref>aria-level</pref></li>
 								<li><pref>aria-multiselectable</pref></li>
 								<li><pref>aria-orientation</pref></li>
 							</ul>
@@ -7250,7 +8972,7 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-                        <td class="role-namefrom">author</td>
+						<td class="role-namefrom">author</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -7281,7 +9003,7 @@
 				<p>A container for the resources associated with a <rref>tab</rref>, where each <rref>tab</rref> is contained in a <rref>tablist</rref>.</p>
 				<p>Authors SHOULD associate a <code>tabpanel</code> <a>element</a> with its <rref>tab</rref>, either by using the <pref>aria-controls</pref> attribute on the tab to reference the tab panel, or by using the  <pref>aria-labelledby</pref> attribute on the tab panel to reference the tab.</p>
 				<!-- keep following para synced with its counterpart in #tablist -->
-				<p><rref>tablist</rref> elements are typically placed near, usually preceding, a series of <rref>tabpanel</rref> elements. See the <cite><a href="https://www.w3.org/TR/wai-aria-practices-1.1/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> [[WAI-ARIA-PRACTICES-1.1]] for details on implementing a tab set design pattern.</p>
+				<p><rref>tablist</rref> elements are typically placed near, usually preceding, a series of <rref>tabpanel</rref> elements. See the <cite><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> for details on implementing a tab set design pattern.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -7389,7 +9111,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dt-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dt</code></a></td>
+						<td class="role-related"><code>&lt;dfn&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -7594,9 +9316,8 @@
 						<th class="role-related-head" scope="row">Related Concepts:</th>
 						<td class="role-related">
 							<ul>
-								<li><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-input">XForms input</a></li>
-								<li><a href="https://www.w3.org/TR/html5/forms.html#the-textarea-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>textarea</code></a></li>
-								<li><a href="https://www.w3.org/TR/html5/forms.html#text-(type=text)-state-and-search-state-(type=search)"><abbr title="Hypertext Markup Language">HTML</abbr> <code>input[type="text"]</code></a></li>
+								<li><code>&lt;textarea&gt;</code> in [[HTML]]</li>
+								<li><code>&lt;input[type="text"]&gt;</code> in [[HTML]]</li>
 							</ul>
 						</td>
 					</tr>
@@ -7610,6 +9331,9 @@
 							<ul>
 								<li><pref>aria-activedescendant</pref></li>
 								<li><pref>aria-autocomplete</pref></li>
+								<li><pref>aria-errormessage</pref></li>
+								<li><pref>aria-haspopup</pref></li>
+								<li><sref>aria-invalid</sref></li>
 								<li><pref>aria-multiline</pref></li>
 								<li><pref>aria-placeholder</pref></li>
 								<li><pref>aria-readonly</pref></li>
@@ -7623,11 +9347,108 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom">
+							<ul>
+								<li>encapsulation</li>
+								<li>author</li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
 						<td class="role-namerequired">True</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational"> </td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div class="role" id="time">
+			<rdef>time</rdef>
+			<div class="role-description">
+				<p>An element that represents a specific point in time.</p>
+				<p class="note">At the present time, there are no <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> properties corresponding to the <code>datetime</code> attribute supported on <code>&lt;time&gt;</code> in [[HTML]]. The addition of this property will be considered for ARIA version 1.3.</p>
+				<p>Authors SHOULD limit text contents to a valid date- or time-related string, or apply this future <code>datetime</code>-equivalent property to the element which has role <code>time</code>.</p>
+				<p>Examples of valid date- or time-related strings as text contents of an element with the <code>time</code> role:</p>
+				<ul>
+					<li>A valid month string: <code><span role="time">2019-11</span></code></li>
+					<li>A valid date string: <code><span role="time">2019-11-18</span></code></li>
+					<li>A valid yearless date string: <code><span role="time">11-18</span></code></li>
+					<li>A valid time string: <code><span role="time">09:54:39</span></code></li>
+					<li>A valid floating date and time string: <code><span role="time">2019-11-18T14:54</span></code></li>
+					<li>A valid time-zone offset string: <code><span role="time">-08:00</span></code></li>
+					<li>A valid global date and time string: <code><span role="time">2019-11-18T14:54Z</span></code></li>
+					<li>A valid week string: <code><span role="time">2019-W47</span></code></li>
+					<li>Four or more ASCII digits, at least one of which is not U+0030 DIGIT ZERO (0): <code><span role="time">0001</span></code></li>
+					<li>A valid duration string: <code><span role="time">4h 18m 3s</span></code></li>
+				</ul>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent"><rref>section</rref></td>
+					</tr>
+					<tr>
+						<th class="role-children-head" scope="row">Subclass Roles:</th>
+						<td class="role-children"> </td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"> </td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"><code>&lt;time&gt;</code> in [[HTML]]</td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Context Role:</th>
+						<td class="role-scope"> </td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">author</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
@@ -7706,7 +9527,7 @@
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-						<td class="role-namerequired">True</td>
+						<td class="role-namerequired"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
@@ -7774,7 +9595,9 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"><pref>aria-orientation</pref></td>
+						<td class="role-properties">
+							<pref>aria-orientation</pref>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -7811,7 +9634,7 @@
 			<rdef>tooltip</rdef>
 			<div class="role-description">
 				<p>A contextual popup that displays a description for an element.</p>
-				<p>The <code>tooltip</code> typically becomes visible in response to a mouse hover, or after the owning element receives keyboard focus. In each of these cases, authors SHOULD display the tooltip after a short delay. The use of a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> tooltip is a supplement to the normal tooltip behavior of the user agent.</p>
+				<p>The <code>tooltip</code> typically becomes visible, after a short delay, in response to a mouse hover, or after the owning element receives keyboard focus. The use of a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> tooltip is a supplement to the normal tooltip behavior of the user agent.</p>
 				<p class="note">Typical tooltip delays last from one to five seconds.</p>
 				<p>Authors SHOULD ensure that elements with the <a>role</a> <code>tooltip</code> are referenced through the use of <pref>aria-describedby</pref> before or at the time the tooltip is displayed.</p>
 			</div>
@@ -7949,6 +9772,8 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
+								<li><pref>aria-errormessage</pref></li>
+								<li><sref>aria-invalid</sref></li>
 								<li><pref>aria-multiselectable</pref></li>
 								<li><pref>aria-required</pref></li>
 							</ul>
@@ -7960,11 +9785,7 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">
-							<ul>
-								<li>author</li>
-							</ul>
-						</td>
+						<td class="role-namefrom">author</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -8141,7 +9962,12 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"> </td>
+						<td class="role-properties">
+							<ul>
+								<li><sref>aria-expanded</sref></li>
+								<li><pref>aria-haspopup</pref></li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -8293,12 +10119,7 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties">
-							<ul>
-								<li><sref>aria-expanded</sref></li>
-								<li><pref>aria-modal</pref></li>
-							</ul>
-						</td>
+						<td class="role-properties"><pref>aria-modal</pref></td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -8355,11 +10176,11 @@
 			<p>Value type of the <a>state</a> or <a>property</a>. The value may be one of the following types:</p>
 			<dl>
 				<dt id="valuetype_true-false">true/false</dt>
-				<dd>Value representing either true or false. The default value for this value type is <code>false</code> unless otherwise specified.</dd>
+				<dd>Enumerated value representing either <code>true</code> or <code>false</code>. The default value for this value type is <code>false</code> unless otherwise specified.</dd>
 				<dt id="valuetype_tristate">tristate</dt>
-				<dd>Value representing true or false, with an intermediate "mixed" value. The default value for this value type is <code>undefined</code> unless otherwise specified.</dd>
+				<dd>Enumerated value representing <code>true</code>, <code>false</code>, <code>mixed</code>, or <code>undefined</code> values. The default value for this value type is <code>undefined</code> unless otherwise specified.</dd>
 				<dt id="valuetype_true-false-undefined">true/false/undefined</dt>
-				<dd>Value representing true, false, or not applicable. For example, an element with <sref>aria-expanded</sref> set to <code>false</code> is not currently expanded; an element with <sref>aria-expanded</sref> set to <code>undefined</code> is not expandable. The default value for this value type is <code>undefined</code> unless otherwise specified.</dd>
+				<dd>Enumerated value representing <code>true</code>, <code>false</code>, or <code>undefined</code> (not applicable). The default value for this value type is <code>undefined</code> unless otherwise specified. For example, an element with <sref>aria-expanded</sref> set to <code>false</code> is not currently expanded; an element with <sref>aria-expanded</sref> set to <code>undefined</code> is not expandable.</dd>
 				<dt id="valuetype_idref">ID reference</dt>
 				<dd>Reference to the ID of another <a>element</a> in the same document</dd>
 				<dt id="valuetype_idref_list">ID reference list</dt>
@@ -8371,24 +10192,87 @@
 				<dt id="valuetype_string">string</dt>
 				<dd>Unconstrained value type.</dd>
 				<dt id="valuetype_token">token</dt>
-				<dd>One of a limited set of allowed values. An explicit value of <code>undefined</code> for this type is the equivalent of providing no value.</dd>
+				<dd>One of a limited set of allowed enumerated values. The default value is defined in each attribute's Values table, as specified in the <a href="#enumerated-attribute-values">Enumerated Attribute Values</a> section.</dd>
 				<dt id="valuetype_token_list">token list</dt>
 				<dd>A list of one or more tokens.</dd>
-				<dt id="valuetype_uri">URI</dt>
-				<dd>A Uniform Resource Identifier as defined by <cite><a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a></cite> [[RFC3986]]. It may reference a separate document, or a content fragment identifier in a separate document, or a content fragment identifier within the same document.</dd>
 			</dl>
 			<p>These are generic types for states and properties, but do not define specific representation. See <a href="#state_property_processing">State and Property Attribute Processing</a> for details on how these values are expressed and handled in host languages.</p>
 		</section>
 	</section>
-	<section id="state_prop_values">
-		<h2>Values for States and Properties</h2>
-		<p>Many <a>states</a> and <a>properties</a> accept a specific set of tokens as <span>values</span>. The allowed values and explanation of their meaning is shown after the table of characteristics. The default value, if defined, is shown in <strong>strong</strong> type, followed by the parenthetical term 'default'. When a value is indicated as the default, the user agent MUST follow the behavior prescribed by this value when the state or property is empty or unspecified. Some <a>roles</a> also define what behavior to use when certain states or properties, that do not have default values, are not provided.</p>
+	<section id="enumerated-attribute-values">
+		<h2>Enumerated Attribute Values</h2>
+		<p>When the ARIA attribute definition includes a table enumerating the attribute's allowed <span>values</span>, that attribute is an <a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute">enumerated attribute</a>. Each value in the table is a keyword for the attribute, mapping to a state of the same name. When the values table notates one of the values as "(default)", that default value is the <a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#invalid-value-default">invalid value default</a> for the attribute.</p>
+		<section class="informative" id="enumeration-example">
+			<h3>Example Enumerated Attribute Usage</h3>
+			<p>As noted in <a href="#typemapping">Mapping <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Value Types to Languages</a>, attributes are included in host languages, and the syntax for representation of enumerated value types is governed by the host language.</p>
+			<p>All enumerated attribute getters and setters use string values, including the boolean-like enumerated <a href="#valuetype_true-false">true/false</a> type.</p>
+			<aside class="example">
+
+<!-- ReSpec needs these examples to be unindented. -->
+<pre>// HTML hidden="" example (not aria-hidden="true")
+// Actual boolean type; defaults to false.
+
+// Note: Actual boolean assignment and return value.
+el.hidden = true;
+el.hidden; // true
+
+// Removal of content attribute results in missing value default: boolean false.
+el.removeAttribute("hidden");
+el.hidden; // false</pre>
+
+			</aside>
+			<aside class="example">
+
+<!-- ReSpec needs these examples to be unindented. -->
+<pre>// aria-busy example
+// true/false ~ enumerated boolean-like string; defaults to "false"
+
+// Note: String assignment and return value.
+el.ariaBusy = "true";
+el.ariaBusy; // "true"
+
+// Removal of content attribute results in missing value default: string "false".
+el.removeAttribute("aria-busy");
+el.ariaBusy; // "false"
+
+// Assignment of invalid "busy" value results in invalid value default: string "false".
+el.setAttribute("aria-busy", "busy");
+el.ariaBusy; // "false"</pre>
+
+			</aside>
+			<aside class="example">
+
+<!-- ReSpec needs these examples to be unindented. -->
+<pre>// aria-pressed example
+// Tristate ~ enumerated true/false/mixed/undefined string; defaults to "undefined".
+
+// A value of "true", "false", or "mixed" for aria-pressed on a button denotes a toggle button.
+button.setAttribute("aria-pressed", "true"); // Content attribute assignment.
+button.ariaPressed; // "true"
+button.ariaPressed = "false"; // DOM property assignment.
+button.ariaPressed; // "false"
+
+// Assignment of invalid "foo" value results in invalid value default, String "undefined".
+button.ariaPressed = "foo";
+button.ariaPressed; // "undefined" (Note: button is no longer a toggle button.)</pre>
+
+			</aside>
+		</section>
+	</section>
+	<section>
+		<h2>Translatable States and Properties</h2>
+		<p>The HTML specification states that other specifications can define <a href="https://html.spec.whatwg.org/multipage/dom.html#translatable-attributes">translatable attributes</a>. In order to be understandable by assistive technology users, the values of the following <a>states</a> and <a>properties</a> are <a href="https://html.spec.whatwg.org/multipage/dom.html#translatable-attributes">translatable attributes</a> and should be translated when a page is localized:</p>
+		<ul>
+			<li><pref>aria-label</pref></li>
+			<li><pref>aria-placeholder</pref></li>
+			<li><pref>aria-roledescription</pref></li>
+			<li><pref>aria-valuetext</pref></li>
+		</ul>
 	</section>
 	<section id="global_states">
 		<h2>Global States and Properties</h2>
-		<p>Some <a>states</a> and <a>properties</a> are applicable to all host language <a>elements</a> regardless of whether a <a>role</a> is applied. The following global states and properties are supported by all roles and by all base markup elements.</p>
+		<p>Some <a>states</a> and <a>properties</a> are applicable to all host language <a>elements</a> regardless of whether a <a>role</a> is applied. The following global states and properties are supported by all roles and by all base markup elements unless otherwise prohibited. If a role prohibits use of any global states or properties, those states or properties are listed as prohibited in the characteristics table included in the section that defines the role.</p>
 		<p class="placeholder">Placeholder for global states and properties</p>
-		<p>Global states and properties are applied to the role <rref>roletype</rref>, which is the base role, and therefore inherit into all roles. To facilitate reading, they are not explicitly identified as either supported or inherited states and properties in the specification. Instead, the inheritance is indicated by a link to this section.</p>
 	</section>
 	<section id="state_prop_taxonomy">
 		<h2>Taxonomy of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> States and Properties</h2>
@@ -8455,6 +10339,7 @@
 				<li><pref>aria-activedescendant</pref></li>
 				<li><pref>aria-colcount</pref></li>
 				<li><pref>aria-colindex</pref></li>
+				<li><pref>aria-colindextext</pref></li>
 				<li><pref>aria-colspan</pref></li>
 				<li><pref>aria-controls</pref></li>
 				<li><pref>aria-describedby</pref></li>
@@ -8466,6 +10351,7 @@
 				<li><pref>aria-posinset</pref></li>
 				<li><pref>aria-rowcount</pref></li>
 				<li><pref>aria-rowindex</pref></li>
+				<li><pref>aria-rowindextext</pref></li>
 				<li><pref>aria-rowspan</pref></li>
 				<li><pref>aria-setsize</pref></li>
 			</ul>
@@ -8478,12 +10364,15 @@
 		<div class="property" id="aria-activedescendant">
 			<pdef>aria-activedescendant</pdef>
 			<div class="property-description">
-				<p>Identifies the currently active element when DOM focus is on a <rref>composite</rref> widget, <rref>textbox</rref>, <rref>group</rref>, or <rref>application</rref>.</p>
-				<p>The <code>aria-activedescendant</code> property provides an alternative method of managing focus for interactive elements that may contain multiple focusable descendants, such as menus, grids, and toolbars. Instead of moving DOM focus among descendant elements, authors MAY set DOM focus on an <a>element</a> that supports <code>aria-activedescendant</code> and then use <code>aria-activedescendant</code> to refer to the element that is active.</p>
+				<p>Identifies the currently active element when DOM focus is on a <rref>composite</rref> widget, <rref>combobox</rref>, <rref>textbox</rref>, <rref>group</rref>, or <rref>application</rref>.</p>
+				<p>The <code>aria-activedescendant</code> property provides an alternative method of managing focus for interactive elements that may contain multiple focusable descendants, such as menus, grids, and toolbars. Instead of moving DOM focus among <a>owned</a> elements, authors MAY set DOM focus on a container <a>element</a> that supports <code>aria-activedescendant</code> and then use <code>aria-activedescendant</code> to refer to the element that is active.</p>
 				<p> Authors MUST ensure that one of the following two sets of conditions is met when setting the value of <code>aria-activedescendant</code> on an element with DOM focus:</p>
 				<ol>
-					<li>The value of <code>aria-activedescendant</code> refers to an element that is either a descendant of the element with DOM focus or is a logical descendant as indicated by the <pref>aria-owns</pref> attribute.</li>
-					<li>The element with DOM focus is a <rref>textbox</rref> with <pref>aria-controls</pref> referring to an element that supports <code>aria-activedescendant</code>, and the value of <code>aria-activedescendant</code> specified for the <code>textbox</code> refers to either a descendant of the element controlled by the <rref>textbox</rref> or is a logical descendant of that controlled element as indicated by the <pref>aria-owns</pref> attribute. For example, in a <rref>combobox</rref>, focus may remain on the <rref>textbox</rref> while the value of <code>aria-activedescendant</code> on the <rref>textbox</rref> element refers to a descendant of a popup <rref>listbox</rref> that is controlled by the <rref>textbox</rref>.</li>
+					<li>The value of <code>aria-activedescendant</code> refers to an <a>owned</a> element. An owned element is either a descendant of the element with DOM focus or a logical descendant as indicated by the <pref>aria-owns</pref> attribute.</li>
+					<li>
+            The element with DOM focus is a <rref>combobox</rref>, <rref>textbox</rref> or <rref>searchbox</rref> with <pref>aria-controls</pref> referring to an element that supports <code>aria-activedescendant</code>, and the value of <code>aria-activedescendant</code> refers to an owned element of the controlled element.
+            For example, in a <rref>combobox</rref>, focus may remain on the <rref>combobox</rref> while the value of <code>aria-activedescendant</code> on the <rref>combobox</rref> element refers to a descendant of a popup <rref>listbox</rref> that is controlled by the <rref>combobox</rref>.
+          </li>
 				</ol>
 				<p> Authors SHOULD also ensure that the currently active descendant is visible and in view (or scrolls into view) when focused.</p>
 			</div>
@@ -8498,7 +10387,7 @@
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><cite><a href="https://www.w3.org/TR/SVG2/"><abbr title="Scalable Vector Graphics">SVG</abbr></a></cite> [[SVG2]] and <cite><a href="https://www.w3.org/TR/dom/"><abbr title="Document Object Model">DOM</abbr></a></cite> [[DOM4]] active</td>
+						<td class="property-related"><cite><a href="https://www.w3.org/TR/SVG2/"><abbr title="Scalable Vector Graphics">SVG</abbr></a></cite> [[SVG2]] and <cite><a href="https://www.w3.org/TR/dom/"><abbr title="Document Object Model">DOM</abbr></a></cite> [[DOM]] active</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -8519,7 +10408,7 @@
 			<pdef>aria-atomic</pdef>
 			<div class="property-description">
 				<p>Indicates whether <a>assistive technologies</a> will present all, or only parts of, the changed region based on the change notifications defined by the <pref>aria-relevant</pref> attribute.</p>
-				<p>Both <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a> and the <cite><a href="https://www.w3.org/TR/dom/">Document Object Model</a></cite> [[DOM4]] provide events to allow the assistive technologies to determine changed areas of the document.</p>
+				<p>Both <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a> and the <cite><a href="https://www.w3.org/TR/dom/">Document Object Model</a></cite> [[DOM]] provide events to allow the assistive technologies to determine changed areas of the document.</p>
 				<p>When the content of a <a>live region</a> changes, user agents SHOULD examine the changed <a>element</a> and traverse the ancestors to find the first element with <pref>aria-atomic</pref> set, and apply the appropriate behavior for the cases below.</p>
 				<ol>
 					<li>If none of the ancestors have explicitly set <pref>aria-atomic</pref>, the default is that <pref>aria-atomic</pref> is <code>false</code>, and assistive technologies will only present the changed node to the user.</li>
@@ -8578,14 +10467,14 @@
 		<div class="property" id="aria-autocomplete">
 			<pdef>aria-autocomplete</pdef>
 			<div class="property-description">
-				<p>Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be presented if they are made.</p>
+				<p>Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a <rref>combobox</rref>, <rref>searchbox</rref>, or <rref>textbox</rref> and specifies how predictions would be presented if they were made.</p>
 				<p>The <code>aria-autocomplete</code> property describes the type of interaction model a <rref>textbox</rref>, <rref>searchbox</rref>, or <rref>combobox</rref> employs when dynamically helping users complete text input. It distinguishes between two models: the inline model (<code>aria-autocomplete="inline"</code>) that presents a value completion prediction inside the text input and the list model (<code>aria-autocomplete="list"</code>) that presents a collection of possible values in a separate element that pops up adjacent to the text input. It is possible for an input to offer both models at the same time (<code>aria-autocomplete="both"</code>).</p>
 				<p>The <code>aria-autocomplete</code> property is limited to describing predictive behaviors of an input element. Authors SHOULD either omit specifying a value for <code>aria-autocomplete</code> or set <code>aria-autocomplete</code> to <code>none</code> if an input element provides one or more input proposals where none of the proposals are dependent on the specific input provided by the user. For instance, a combobox where the value of <code>aria-autocomplete</code> would be <code>none</code> is a search field that displays suggested values by listing the 5 most recently used search terms without any filtering of the list based on the user's input. Elements with a role that supports <code>aria-autocomplete</code> have a default value for <code>aria-autocomplete</code> of <code>none</code>.</p>
 				<p>When an inline suggestion is made as a user types in an input, suggested text for completing the value of the field dynamically appears in the field after the input cursor, and the suggested value is accepted as the value of the input if the user performs an action that causes focus to leave the field. When an element has <code>aria-autocomplete</code> set to <code>inline</code> or <code>both</code>, authors SHOULD ensure that the automatically suggested portion of the text is presented as selected text. This enables assistive technologies to distinguish between a user's input and the automatic suggestion and, in the event that the suggestion is not the desired value, enables the user to easily delete the suggestion or replace it by continuing to type.</p>
 				<p> If an element has <code>aria-autocomplete</code> set to <code>list</code> or <code>both</code>, authors MUST ensure both of the following conditions are met:</p>
 				<ol>
 					<li>The element has a value specified for <pref>aria-controls</pref> that refers to the element that contains the collection of suggested values.</li>
-					<li>Either the element or a containing element with role <rref>combobox</rref> has a value for <pref>aria-haspopup</pref> that matches the role of the element that contains the collection of suggested values.</li>
+					<li>The element has a value for <pref>aria-haspopup</pref> that matches the role of the element that contains the collection of suggested values.</li>
 				</ol>
 				<p>Some implementations of the list model require the user to perform an action, such as moving focus to the suggestion with the <kbd>Down Arrow</kbd> or clicking on the suggestion, in order to choose the suggestion. In such implementations, authors MAY manage focus by either using <pref>aria-activedescendant</pref> if the collection container supports it or by moving DOM focus to the suggestion. However, other implementations of the list model automatically highlight one suggestion as the selected value that will be accepted when the field loses focus, e.g., when the user presses the <kbd>Tab</kbd> key or clicks on a different field. If an element has <code>aria-autocomplete</code> set to <code>list</code> or <code>both</code>, and if a suggestion is automatically selected as the user provides input, authors MUST ensure all the following conditions are met:</p>
 				<ol>
@@ -8606,7 +10495,7 @@
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related">XForms selection attribute in <a href="https://www.w3.org/TR/2006/REC-xforms-20060314/slice8.html#ui-selectMany">select</a></td>
+						<td class="property-related"> </td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -8646,6 +10535,64 @@
 					<tr>
 						<th class="value-name" scope="row"><strong class="default">none (default)</strong></th>
 						<td class="value-description">When a user is providing input, an automatic suggestion that attempts to predict how the user intends to complete the input is not displayed.</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div class="property" id="aria-brailleroledescription">
+			<pdef>aria-brailleroledescription</pdef>
+			<div class="property-description">
+				<p>Defines a human-readable, author-localized abbreviated description for the <a>role</a> of an <a>element</a>, which is intended to be converted into Braille. See related <pref>aria-roledescription</pref>.</p>
+				<p>Some <a>assistive technologies</a>, such as screen readers, present the role of an element as part of the user experience. Such assistive technologies typically localize the name of the role, and they may customize it as well. Users of these assistive technologies depend on the presentation of the role name, such as "region," "button," or "slider," for an understanding of the purpose of the element and, if it is a widget, how to interact with it.</p>
+				<p>The <code>aria-brailleroledescription</code> property gives authors the ability to override how <a>assistive technologies</a> localize and express the name of a role in Braille. Thus inappropriately using <code>aria-brailleroledescription</code> may inhibit users' ability to understand or interact with an element on braille interfaces. Authors SHOULD limit use of <code>aria-brailleroledescription</code> to clarifying the purpose of non-interactive container roles like <rref>group</rref> or <rref>region</rref>, or to providing a <em>more specific</em> description of a <rref>widget</rref> in a braille context.</p>
+				<p>Authors MUST NOT use <code>aria-brailleroledescription</code> without providing <code>aria-roledescription</code>. In general, <code>aria-brailleroledescription</code> should only be used in rare cases when a <code>aria-roledescription</code> is excessively verbose when rendered in Braille.</p>
+				<p> When using <code>aria-brailleroledescription</code>, authors SHOULD also ensure that:</p>
+				<ol>
+					<li>The element to which <code>aria-brailleroledescription</code> is applied has a valid <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role or has an implicit WAI-ARIA role semantic.</li>
+					<li>The value of <code>aria-brailleroledescription</code> is not empty or does not contain only whitespace characters.</li>
+					<li>The value of <code>aria-brailleroledescription</code> does not contain any characters in Unicode Braille Patterns (U+2800..U+28FF) or consists of only characters in Unicode Braille Patterns (U+2800..U+28FF) while not only containing Braille Pattern dots-0 (U+2800).</li>
+					<li>The value of <code>aria-brailleroledescription</code> should not be identical to the element's WAI-ARIA <code>aria-roledescription</code>, WAI-ARIA <code>role</code> or implicit WAI-ARIA role semantic.</li>
+				</ol>
+				<p class="note">Note that <a>Assistive Technologies</a> with braille support can convert <code>aria-roledescription</code> content to Braille. In addition, assistive technologies will be able to customize such braille output according to user preferences. Using only <code>aria-roledescription</code> is <strong>almost always</strong> the better user experience and authors are <strong>strongly discouraged</strong> from using <code>aria-brailleroledescription</code> to replicate <code>aria-roledescription</code>. Instead, <code>aria-brailleroledescription</code> is meant to be used only when <code>aria-roledescription</code> cannot provide an adequate braille representation, i.e., when a specialized braille description is very different from a text description converted to Braille. It is very important to note that when using <code>aria-brailleroledescription</code> authors are solely responsible to align the attribute value with the document language and clearly communicate the use of this attribute to the user. This is even more important when the value consists of Unicode Braille Patterns because <a>Assistive Technologies</a> will pass such content directly to the user without applying user specific braille translations; in general, authors are <strong>strongly discouraged</strong> from using Unicode Braille Patterns in <code>aria-brailleroledescription</code>.
+				</p>
+				<p>User agents MUST NOT expose the <code>aria-brailleroledescription</code> property if any of the following conditions exist:</p>
+				<ol>
+					<li>The element to which <code>aria-brailleroledescription</code> is applied does not have a valid WAI-ARIA <code>role</code> or does not have an implicit WAI-ARIA role semantic.</li>
+					<li>The value of <code>aria-brailleroledescription</code> is empty or contains only whitespace characters or contains only Braille Pattern dots-0 (U+2800).</li>
+					<li>The element to which <code>aria-brailleroledescription</code> is applied does not have a valid WAI-ARIA <code>aria-roledescription</code>.</li>
+				</ol>
+				<p><a>Assistive technologies</a> SHOULD use the value of <code>aria-brailleroledescription</code> when presenting the role of an element in Braille, but SHOULD NOT change other functionality based on the role of an element that has a value for <code>aria-brailleroledescription</code>. For example, an assistive technology that provides functions for navigating to the next <rref>region</rref> or <rref>button</rref> SHOULD allow those functions to navigate to regions and buttons that have an <code>aria-brailleroledescription</code>.</p>
+				<p><a>Assistive technologies</a> SHOULD expose the <code>aria-brailleroledescription</code> property as follows:</p>
+				<ol>
+					<li>If the value of <code>aria-brailleroledescription</code> does not contain characters in Unicode Braille Patterns (U+2800..U+28FF), translate the value according to the user's preferred translation table.</li>
+					<li>Otherwise, pass the value to the user without translation.</li>
+				</ol>
+				<p>The following example shows the use of <code>aria-brailleroledescription</code> to indicate that a button's description has a particular braille contraction.</p>
+				<pre class="example highlight">&lt;button aria-roledescription="planet" aria-brailleroledescription="pln" id="jupiter"&gt;
+&lt;img alt="jupiter" src="images/jupiter.jpg"/&gt;
+&lt;/button&gt;</pre>
+				<p>In the previous example, a braille display may display "pln Jupiter" in Braille rather than the verbose "planet Jupiter".</p>
+			</div>
+			<table class="property-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="property-applicability-head" scope="row">Used in Roles:</th>
+						<td class="property-applicability">All elements of the base markup</td>
+					</tr>
+					<tr>
+						<th class="property-descendants-head" scope="row">Inherits into Roles:</th>
+						<td class="property-descendants">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="property-value-head" scope="row">Value:</th>
+						<td class="property-value"><a href="#valuetype_string">string</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -8711,8 +10658,8 @@
 			<div class="state-description">
 				<p>Indicates the current "checked" <a>state</a> of checkboxes, radio buttons, and other <a>widgets</a>. See related <sref>aria-pressed</sref> and <sref>aria-selected</sref>.</p>
 				<p>The <sref>aria-checked</sref> <a>attribute</a> indicates whether the <a>element</a> is checked (<code>true</code>), unchecked (<code>false</code>), or represents a group of other elements that have a mixture of checked and unchecked <span>values</span> (<code>mixed</code>). Most inputs only support values of <code>true</code> and <code>false</code>, but the <code>mixed</code> value is supported by certain tri-state inputs such as a <rref>checkbox</rref> or <rref>menuitemcheckbox</rref>.</p>
-				<p>The <code>mixed</code> value is <em>not</em> supported on <rref>radio</rref>, <rref>menuitemradio</rref>, <rref>switch</rref> or any element that inherits from these in the <a>taxonomy</a>, and <a>user agents</a> MUST treat a <code>mixed</code> value as equivalent to <code>false</code> for those <a>roles</a>.</p>
-				<p>Examples using the <code>mixed</code> value of tri-state inputs are covered in <cite><a href="https://www.w3.org/TR/wai-aria-practices-1.1/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> [[WAI-ARIA-PRACTICES-1.1]]</p>
+				<p>The <code>mixed</code> value is <em>not</em> supported on <rref>radio</rref>, <rref>menuitemradio</rref>, <rref>switch</rref> or any element that inherits from these, and <a>user agents</a> MUST treat a <code>mixed</code> value as equivalent to <code>false</code> for those <a>roles</a>.</p>
+				<p>Examples using the <code>mixed</code> value of tri-state inputs are covered in the <cite><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite>.</p>
 			</div>
 			<table class="state-features">
 				<caption>Characteristics:</caption>
@@ -8764,7 +10711,7 @@
 						<td class="value-description">The element is checked.</td>
 					</tr>
 					<tr>
-						<th class="value-name" scope="row"><strong class="default">undefined (default)</strong></th>
+						<th class="value-name" scope="row"><strong class="default">undefined</strong> (default)</th>
 						<td class="value-description">The element does not support being checked.</td>
 					</tr>
 				</tbody>
@@ -8835,7 +10782,7 @@
 		<div class="property" id="aria-colindex">
 			<pdef>aria-colindex</pdef>
 			<div class="property-description">
-				<p>Defines an <a>element's</a> column index or position with respect to the total number of columns within a <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>. See related <pref>aria-colcount</pref> and <pref>aria-colspan</pref>.</p>
+				<p>Defines an <a>element's</a> column index or position with respect to the total number of columns within a <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>. See related <pref>aria-colindextext</pref>, <pref>aria-colcount</pref>, and <pref>aria-colspan</pref>.</p>
 				<p>If all of the columns are present in the <abbr title="Document Object Model">DOM</abbr>, it is not necessary to set this <a>attribute</a> as the <a>user agent</a> can automatically calculate the column index of each cell or <rref>gridcell</rref>. However, if only a portion of the columns is present in the <abbr title="Document Object Model">DOM</abbr> at a given moment, this attribute is needed to provide an explicit indication of the column of each cell or gridcell with respect to the full table.</p>
 				<p>Authors MUST set the <span>value</span> for <pref>aria-colindex</pref> to an integer greater than or equal to 1, greater than the <pref>aria-colindex</pref> value of any previous elements within the same row, and less than or equal to the number of columns in the full table. For a cell or gridcell which spans multiple columns, authors MUST set the value of <pref>aria-colindex</pref> to the start of the span.</p>
 				<p>If the set of columns which is present in the <abbr title="Document Object Model">DOM</abbr> is contiguous, and if there are no cells which span more than one row or column in that set, then authors MAY place <pref>aria-colindex</pref> on each row, setting the value to the index of the first column of the set. Otherwise, authors SHOULD place <pref>aria-colindex</pref> on all of the children or <a>owned</a> elements of each row.</p>
@@ -8943,6 +10890,42 @@
 					<tr>
 						<th class="property-value-head" scope="row">Value:</th>
 						<td class="property-value"><a href="#valuetype_integer">integer</a></td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div class="property" id="aria-colindextext">
+			<pdef>aria-colindextext</pdef>
+			<div class="property-description">
+				<p>Defines a human readable text alternative of <pref>aria-colindex</pref>. See related <pref>aria-rowindextext</pref>.</p>
+                                <p>Authors SHOULD only use <code>aria-colindextext</code> when the provided or calculated value of <pref>aria-colindex</pref> is not meaningful or does not reflect the displayed index, as is the case with spreadsheets and chess boards.</p>
+                                <p>Authors SHOULD NOT use <code>aria-colindextext</code> as a replacement for <pref>aria-colindex</pref> because some assistive technologies rely upon the numeric column index for the purpose of keeping track of the user's position or providing alternative table navigation.</p>
+                                <p class="note">Unlike <pref>aria-colindex</pref>, <code>aria-colindextext</code> is not a supported property of <rref>row</rref> because user agents have no way to reliably calculate <code>aria-colindextext</code> for the purpose of exposing its value on the <rref>cell</rref> or <rref>gridcell</rref>.</p>
+			</div>
+			<table class="property-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="property-related-head" scope="row">Related Concepts:</th>
+						<td class="property-related"> </td>
+					</tr>
+					<tr>
+						<th class="property-applicability-head" scope="row">Used in Roles:</th>
+						<td class="property-applicability">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="property-descendants-head" scope="row">Inherits into Roles:</th>
+						<td class="property-descendants">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="property-value-head" scope="row">Value:</th>
+						<td class="property-value"><a href="#valuetype_integer">string</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -9110,8 +11093,8 @@
 		<div class="property" id="aria-describedby">
 			<pdef>aria-describedby</pdef>
 			<div class="property-description">
-				<p>Identifies the <a>element</a> (or elements) that describes the <a>object</a>. See related <pref>aria-labelledby</pref>.</p>
-				<p>The <pref>aria-labelledby</pref> attribute is similar to the <pref>aria-describedby</pref> in that both reference other elements to calculate a text alternative, but a label should be concise, where a description is intended to provide more verbose information.</p>
+				<p>Identifies the <a>element</a> (or elements) that describes the <a>object</a>. See related <pref>aria-labelledby</pref> and <pref>aria-description</pref>.</p>
+				<p>The <pref>aria-labelledby</pref> attribute is similar to <pref>aria-describedby</pref> in that both reference other elements to calculate a text alternative, but a label should be concise, where a description is intended to provide more verbose information.</p>
 				<!-- keep previous sentence synced with the associated description in #aria-labelledby -->
 				<p>The element or elements referenced by the aria-describedby comprise the entire description. Include ID references to multiple elements if necessary, or enclose a set of elements (e.g., paragraphs) with the element referenced by the ID.</p>
 			</div>
@@ -9128,9 +11111,7 @@
 						<th class="property-related-head" scope="row">Related Concepts:</th>
 						<td class="property-related">
 							<ul>
-								<li>Hint or Help in <cite><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/">XForms</a></cite> [[XFORMS10]]</li>
-								<li>Label in XForms</li>
-								<li>Label in <cite><a href="https://www.w3.org/TR/2002/REC-xhtml1-20020801/"><abbr title="Hypertext Markup Language">HTML</abbr></a></cite> [[XHTML11]]</li>
+								<li><code>&lt;label&gt;</code> in [[HTML]]</li>
 								<li>online help</li>
 								<li><abbr title="Hypertext Markup Language">HTML</abbr> table cell headers</li>
 							</ul>
@@ -9151,13 +11132,63 @@
 				</tbody>
 			</table>
 		</div>
-                <div class="property" id="aria-details">
+		<div class="property" id="aria-description">
+			<pdef>aria-description</pdef>
+			<div class="property-description">
+				<p>Defines a string value that describes or annotates the current element. See related <pref>aria-describedby</pref>.</p>
+				<p>The <pref>aria-description</pref> attribute is similar to <pref>aria-label</pref> in that both provide a flat string to associate with the element, but a label should be concise, whereas a description is intended to provide more verbose information.</p>
+				<p>The purpose of <pref>aria-description</pref> is the same as that of <pref>aria-describedby</pref>. It provides the user with additional descriptive text for the object. The most common <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> mapping for a description is the <a>accessible description</a> property. User agents MUST give precedence to <pref>aria-describedby</pref> over <pref>aria-description</pref> when computing the accessible description property.</p>
+				<p>In cases where providing a visible description is not the desired user experience, authors MAY set the accessible description of the element using <pref>aria-description</pref>. However, if the description text is available in the DOM, authors SHOULD NOT use <pref>aria-description</pref>, but should use one of the following instead:</p>
+				<ul>
+					<li>Authors SHOULD use <pref>aria-describedby</pref> when the related description or annotation elements contain a simple, small description that is best experienced as a flat string, rather than by having the user navigate to them.</li>
+					<li>Authors SHOULD use <pref>aria-details</pref> when the related description or annotation elements contain useful semantics or structure, or there is a lot of content within them, making it difficult to experience as a flat string. Using <pref>aria-details</pref> will allow assistive technology users to visit the structured content and provide additional navigation commands, making it easier to understand the structure, or to experience the information in smaller pieces.</li>
+				</ul>
+			</div>
+			<table class="property-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="property-related-head" scope="row">Related Concepts:</th>
+						<td class="property-related"><code>title</code> attribute in [[HTML]]</td>
+					</tr>
+					<tr>
+						<th class="property-applicability-head" scope="row">Used in Roles:</th>
+						<td class="property-applicability">All elements of the base markup</td>
+					</tr>
+					<tr>
+						<th class="property-descendants-head" scope="row">Inherits into Roles:</th>
+						<td class="property-descendants">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="property-value-head" scope="row">Value:</th>
+						<td class="property-value"><a href="#valuetype_string">string</a></td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div class="property" id="aria-details">
 			<pdef>aria-details</pdef>
 			<div class="property-description">
-				<p>Identifies the <a>element</a> that provides a detailed, extended description for the <a>object</a>. See related <pref>aria-describedby</pref>.</p>
-				<p>The <code>aria-details</code> attribute references a single element that provides more detailed information than would normally be provided by <pref>aria-describedby</pref>. It enables <a>assistive technologies</a> to make users aware of the availability of an extended description as well as navigate to it. Authors SHOULD ensure the element referenced by <code>aria-details</code> is visible to all users.</p>
-				<p>Unlike elements referenced by <code>aria-describedby</code>, the element referenced by <code>aria-details</code> is not used in either the Accessible <a href="https://www.w3.org/TR/accname-aam-1.1/#mapping_additional_nd_name">Name Computation</a> or the Accessible <a href="https://www.w3.org/TR/accname-aam-1.1/#mapping_additional_nd_description">Description Computation</a> as defined in the Accessible Name and Description specification [[ACCNAME-AAM-1.1]]. Thus, the content of an element referenced by <code>aria-details</code> is not flattened to a string when presented to assistive technology users. This makes <code>aria-details</code> particularly useful when converting the information to a string would cause a loss of information or make the extended description more difficult to understand.</p>
-				<p>In some user agents, multiple reference relationships for descriptive information are not supported by the accessibility API. In such cases, if both <pref>aria-describedby</pref> and <code>aria-details</code> are provided on an element, <code>aria-details</code> takes precedence.</p>
+				<p>Identifies the <a>element</a> (or elements) that provide additional information related to the <a>object</a>. See related <pref>aria-describedby</pref>.</p>
+				<p>The <code>aria-details</code> property is for referencing elements that provide more detailed information than would normally be provided via <pref>aria-describedby</pref>. The presence of <code>aria-details</code> enables <a>assistive technologies</a> to make users aware of the availability of extended information and navigate to it. Authors SHOULD ensure that elements referenced by <code>aria-details</code> are visible to all users.</p>
+				<p>Assistive technologies MAY use the role of elements referenced by the <code>aria-details</code> property to help users understand the types of information associated with the element. Authors MAY convey the type of details associated with an element as follows:</p>
+				<ul>
+					<li>Comment: <code>aria-details</code> refers to an element with role <rref>comment</rref>.</li>
+					<li>Definition: <code>aria-details</code> is applied to an element with role <rref>term</rref> and refers to an element with role <rref>definition</rref>.</li>
+					<li>Footnote: <code>aria-details</code> refers to an element with role <code>doc-footnote</code>. This role is defined in [[DPUB-ARIA-1.0]].</li>
+					<li>Endnote: <code>aria-details</code> refers to an element with role <code>doc-endnote</code>. This role is defined in [[DPUB-ARIA-1.0]].</li>
+					<li>Description or general annotation: <code>aria-details</code> refers to an element with any other role.</li>
+				</ul>
+
+				<p>Unlike elements referenced by <code>aria-describedby</code>, elements referenced by <code>aria-details</code> are not used in the Accessible <a href="#mapping_additional_nd_description" class="accname">Description Computation</a> as defined in the Accessible Name and Description specification. Thus, the content of elements referenced by <code>aria-details</code> are not flattened to a string when presented to assistive technology users. This makes <code>aria-details</code> particularly useful when converting the information to a string would cause a loss of information or make the extended information more difficult to understand.</p>
+				<p>The <code>aria-details</code> property supports referring to multiple elements. For example, a paragraph in a document editor may reference multiple comments that are not related to each other. If a user agent relies on an accessibility API that does not support exposing multiple descriptive relations, the user agent SHOULD expose the relationship to the first element referenced by <code>aria-details</code>.</p>
+				<p>It is valid for an element to have both <code>aria-details</code> and a description specified with either <code>aria-describedby</code> or <code>aria-description</code>. If a user agent relies on an accessibility API that does not support exposing multiple descriptive relations, and if an element has both <code>aria-details</code> and <rref>aria-describedby</rref>, the user agent SHOULD expose the <code>aria-details</code> relation and the description string computed from the <rref>aria-describedby</rref> relationship.</p>
 				<p>A common use for <code>aria-details</code> is in digital publishing where an extended description needs to be conveyed in a book that requires structural markup or the embedding of other technology to provide illustrative content. The following example demonstrates this scenario.</p>
 				<pre class="example highlight">
                                 &lt;!-- Provision of an extended description --&gt;
@@ -9173,9 +11204,9 @@
                                     The following drawing illustrates an application of the Pythagorean Theorem when used to
                                     construct a skateboard ramp.
                                   &lt;/p&gt;
-                                  &lt;object data="skatebd-ramp.svg"  type="image/svg+xml"/&gt;
+                                  &lt;object data="skatebd-ramp.svg"  type="image/svg+xml"&gt;&lt;/object&gt;
                                   &lt;p&gt;
-                                    In this example you will notice a skateboard with a base and vertical board whose width
+                                    In this example you will notice a skateboard ramp with a base and vertical board whose width
                                     is the width of the ramp. To compute how long the ramp must be, simply calculate the
                                     base length, square it, sum it with the square of the height of the ramp, and take the
                                     square root of the sum.
@@ -9206,7 +11237,7 @@
 					</tr>
 					<tr>
 						<th class="property-value-head" scope="row">Value:</th>
-						<td class="property-value"><a href="#valuetype_idref">ID reference</a></td>
+						<td class="property-value"><a href="#valuetype_idref_list">ID reference list</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -9217,6 +11248,9 @@
 				<p>Indicates that the <a>element</a> is <a>perceivable</a> but disabled, so it is not editable or otherwise <a>operable</a>. See related <sref>aria-hidden</sref> and <pref>aria-readonly</pref>.</p>
 				<p>For example, irrelevant options in a radio group may be disabled. Disabled elements might not receive focus from the tab order. For some disabled elements, applications might choose not to support navigation to descendants. In addition to setting the <sref>aria-disabled</sref> attribute, authors SHOULD change the appearance (grayed out, etc.) to indicate that the item has been disabled.</p>
 				<p>The <a>state</a> of being disabled applies to the current element and all focusable descendant elements of the element on which the <sref>aria-disabled</sref> <a>attribute</a> is applied.</p>
+                <p class="note">While <sref>aria-disabled</sref> and proper scripting can successfully disable an element with role <rref>link</rref>, fully disabling a host language equivalent can be problematic. Authors are advised not to use <sref>aria-disabled</sref> on elements that cannot be disabled through features of the host language alone.</p>
+				<p class="note" title="Usage on columnheader, rowheader and row">While <sref>aria-disabled</sref> is currently supported on <rref>columnheader</rref>, <rref>rowheader</rref>, and <rref>row</rref>, in a future version the working group plans to prohibit its use on elements with any of those three roles except when they are in the context of a <rref>grid</rref> or <rref>treegrid</rref>.</p>
+				<p class="note">This state is being deprecated as a global state in ARIA 1.2. In future versions it will only be allowed on roles where it is specifically supported.</p>
 			</div>
 			<table class="state-features">
 				<caption>Characteristics:</caption>
@@ -9233,7 +11267,7 @@
 					</tr>
 					<tr>
 						<th class="state-applicability-head" scope="row">Used in Roles:</th>
-						<td class="state-applicability">All elements of the base markup</td>
+						<td class="state-applicability">Use as a global deprecated in ARIA 1.2</td>
 					</tr>
 					<tr>
 						<th class="state-descendants-head" scope="row">Inherits into Roles:</th>
@@ -9271,7 +11305,7 @@
 			  <p>[Deprecated in ARIA 1.1] Indicates what functions can be performed when a dragged object is released on the drop target.</p>
 			  <p class="note">The <code>aria-dropeffect</code> property is expected to be replaced by a new feature in a future version of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>. Authors are therefore advised to treat <code>aria-dropeffect</code> as <a>deprecated</a>.</p>
 			  <p>This <a>property</a> allows assistive technologies to convey the possible drag options available to users, including whether a pop-up menu of choices is provided by the application. Typically, drop effect functions can only be provided once an object has been grabbed for a drag operation as the drop effect functions available are dependent on the object being dragged.</p>
-				<p>More than one drop effect may be supported for a given <a>element</a>. Therefore, the value of this <a>attribute</a> is a space-delimited set of tokens indicating the possible effects, or <code>none</code> if there is no supported operation. In addition to setting the <pref>aria-dropeffect</pref> attribute, authors SHOULD show a visual indication of potential drop targets.</p>
+				<p>More than one drop effect may be supported for a given <a>element</a>. Therefore, the value of this <a>attribute</a> is a space-separated set of tokens indicating the possible effects, or <code>none</code> if there is no supported operation. In addition to setting the <pref>aria-dropeffect</pref> attribute, authors SHOULD show a visual indication of potential drop targets.</p>
 			</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>
@@ -9342,23 +11376,25 @@
 				<p>Identifies the <a>element</a> that provides an error message for an <a>object</a>. See related <sref>aria-invalid</sref> and <pref>aria-describedby</pref>.</p>
 				<p>The <code>aria-errormessage</code> attribute references another element that contains error message text. Authors MUST use <sref>aria-invalid</sref> in conjunction with <code>aria-errormessage</code>.</p>
 				<p>When the value of an object is not valid, <sref>aria-invalid</sref> is set to <code>true</code>, which indicates that the message contained by an element referenced by <code>aria-errormessage</code> is pertinent.</p>
-				<p>When an object is in a valid state, it has either <sref>aria-invalid</sref> set to <code>false</code> or it does not have the <sref>aria-invalid</sref> attribute. If a valid object has <code>aria-errormessage</code>, the element referenced by <code>aria-errormessage</code> is not rendered because the message it contains is not pertinent.</p>
-				<p>When <code>aria-errormessage</code> is pertinent, authors MUST ensure the content is not hidden so users can navigate to and examine the error message. Similarly, when <code>aria-errormessage</code> is not pertinent, authors MUST either ensure the content is not rendered or remove the <code>aria-errormessage</code> attribute or its value.</p>
+				<p>When an object is in a valid state, it has either <sref>aria-invalid</sref> set to <code>false</code> or it does not have the <sref>aria-invalid</sref> attribute. Authors MAY use <code>aria-errormessage</code> on an object that is currently valid, but only if the element referenced by <code>aria-errormessage</code> is <a>hidden</a>, because the message it contains is not pertinent.</p>
+				<p>When <code>aria-errormessage</code> is pertinent, authors MUST ensure the content is not hidden so users can navigate to and examine the error message. Similarly, when <code>aria-errormessage</code> is not pertinent, authors MUST either ensure the content is <a>hidden</a> or remove the <code>aria-errormessage</code> attribute or its value.</p>
 				<p>User agents MUST NOT expose <code>aria-errormessage</code> for an object with an <sref>aria-invalid</sref> value of <code>false</code>.</p>
 				<p>Authors MAY call attention to a newly rendered error message with a live region by either applying an <pref>aria-live</pref> property or using one of the <a href="#live_region_roles">live region roles</a>, such as <rref>alert</rref>. A live region is appropriate when an error message is displayed to users after they have provided an invalid value.</p>
-				<p>A typical message describes what is wrong and informs users what is required. For example, an error message might be, <q>Invalid time:  the time must be between 9:00 AM and 5:00 PM.</q> The following example code shows markup for an initial valid state and for a subsequent invalid state.  Note the changes to <sref>aria-invalid</sref> on the text input <a>object</a>, and to <pref>aria-live</pref> on the <a>element</a> containing the text of the error message:</p>
+				<p>A typical message describes what is wrong and informs users what is required. For example, an error message might be, <q>Invalid time: the time must be between 9:00 AM and 5:00 PM.</q> The following example code shows markup for an initial valid state and for a subsequent invalid state. Note the changes to <sref>aria-invalid</sref> on the text input <a>object</a>, and to <pref>aria-live</pref> on the <a>element</a> containing the text of the error message:</p>
 				<pre class="example highlight">
 				&lt;!-- Initial valid state --&gt;
 				&lt;label for="startTime"&gt; Please enter a start time for the meeting: &lt;/label&gt;
 				&lt;input id="startTime" type="text" aria-errormessage="msgID" value="" aria-invalid="false"&gt;
-				&lt;span id="msgID" aria-live="off" style="visibility:hidden"&gt; Invalid time:  the time must be between 9:00 AM and 5:00 PM" &lt;/span&gt;
+				&lt;span id="msgID" aria-live="assertive"&gt;&lt;span style="visibility:hidden"&gt;Invalid time: the time must be between 9:00 AM and 5:00 PM&lt;/span&gt;&lt;/span&gt;
 
 				&lt;!-- User has input an invalid value --&gt;
 				&lt;label for="startTime"&gt; Please enter a start time for the meeting: &lt;/label&gt;
 				&lt;input id="startTime" type="text" aria-errormessage="msgID" aria-invalid="true" value="11:30 PM" &gt;
-				&lt;span id="msgID" aria-live="assertive" style="visibility:visible"&gt; Invalid time:  the time must be between 9:00 AM and 5:00 PM" &lt;/span&gt;
+				&lt;span id="msgID" aria-live="assertive"&gt;&lt;span style="visibility:visible"&gt;Invalid time: the time must be between 9:00 AM and 5:00 PM&lt;/span&gt;&lt;/span&gt;
 				</pre>
-            </div>
+				<p class="note">This example uses <code>aria-live="assertive"</code> to indicate that assistive technologies should immediately announce the error message rather than completing other queued announcements first. This increases the likelihood that users are aware of the error message before they move focus out of the input.</p>
+				<p class="note">This state is being deprecated as a global state in ARIA 1.2. In future versions it will only be allowed on roles where it is specifically supported.</p>
+      		</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>
 				<thead>
@@ -9370,7 +11406,11 @@
 				<tbody>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
-						<td class="property-applicability">All elements of the base markup</td>
+						<td class="property-applicability">Use as a global deprecated in ARIA 1.2</td>
+					</tr>
+					<tr>
+							<th class="property-descendants-head" scope="row">Inherits into Roles:</th>
+							<td class="property-descendants">Placeholder</td>
 					</tr>
 					<tr>
 						<th class="property-value-head" scope="row">Value:</th>
@@ -9382,9 +11422,9 @@
 		<div class="state" id="aria-expanded">
 			<sdef>aria-expanded</sdef>
 			<div class="state-description">
-				<p>Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.</p>
-				<p>For example, this indicates whether a portion of a tree is expanded or collapsed. In other instances, this may be applied to page sections to mark expandable and collapsible regions that are flexible for managing content density. Simplifying the user interface by collapsing sections may improve usability for all, including those with cognitive or developmental disabilities.</p>
-				<p>If the element with the <sref>aria-expanded</sref> attribute controls the expansion of another grouping container that is not 'owned by' the element, the author SHOULD reference the container by using the <pref>aria-controls</pref> attribute.</p>
+				<p>Indicates whether a grouping element owned or controlled by this element is expanded or collapsed.</p>
+				<p>The <sref>aria-expanded</sref> attribute is applied to a focusable, interactive element that toggles visibility of content in another element. For example, it is applied to a parent <rref>treeitem</rref> to indicate whether its child branch of the tree is shown. Similarly, it can be applied to a <rref>button</rref> that controls visibility of a section of page content.</p>
+				<p>If a grouping container that can be expanded or collapsed is not <a>owned</a> by the element that has the <sref>aria-expanded</sref> attribute, the author SHOULD identify the controlling relationship by referencing the container from the element that has <sref>aria-expanded</sref> with the <pref>aria-controls</pref> property.</p>
 			</div>
 			<table class="state-features">
 				<caption>Characteristics:</caption>
@@ -9397,7 +11437,7 @@
 				<tbody>
 					<tr>
 						<th class="state-related-head" scope="row">Related Concepts:</th>
-						<td class="state-related">Tapered prompts in voice browsing. Switch in <cite><a href="https://www.w3.org/TR/SMIL3/"><abbr title="Synchronized Multimedia Integration Language">SMIL</abbr></a></cite> [[SMIL3]].</td>
+						<td class="state-related"></td>
 					</tr>
 					<tr>
 						<th class="state-applicability-head" scope="row">Used in Roles:</th>
@@ -9424,15 +11464,15 @@
 				<tbody>
 					<tr>
 						<th class="value-name" scope="row">false</th>
-						<td class="value-description">The element, or another grouping element it controls, is collapsed.</td>
+						<td class="value-description">The grouping element this element owns or controls is collapsed.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">true</th>
-						<td class="value-description">The element, or another grouping element it controls, is expanded.</td>
+						<td class="value-description">The grouping element this element owns or controls is expanded.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row"><strong class="default">undefined (default)</strong></th>
-						<td class="value-description">The element, or another grouping element it controls, is neither expandable nor collapsible; all its child elements are shown or there are no child elements.</td>
+						<td class="value-description">The element does not own or control a grouping element that is expandable.</td>
 					</tr>
 				</tbody>
 			</table>
@@ -9441,8 +11481,8 @@
 			<pdef>aria-flowto</pdef>
 			<div class="property-description">
 				<p>Identifies the next <a>element</a> (or elements) in an alternate reading order of content which, at the user's discretion, allows assistive technology to override the general default of reading in document source order.</p>
-				<p>When <pref>aria-flowto</pref> has a single IDREF, it allows <a>assistive technologies</a> to, at the user's request, forego normal document reading order and go to the targeted <a>object</a>. <!-- [No longer ref XHTML2] <pref>aria-flowto</pref> in subsequent elements would follow a process similar to <cite><a href="https://www.w3.org/TR/2006/WD-xhtml2-20060726/mod-hyperAttributes.html#adef_hyperAttributes_nextfocus">next focus in <abbr title="Extensible Hypertext Markup Language">XHTML</abbr>2</a></cite> ([[XHTML2]]). --> However, when <pref>aria-flowto</pref> is provided with multiple IDREFS, assistive technologies SHOULD present the referenced elements as path choices.</p>
-				<p>In the case of one or more IDREFS, <a>user agents</a> or assistive technologies SHOULD give the user the option of navigating to any of the targeted elements. The name of the path can be determined by the name of the target element of the <pref>aria-flowto</pref> <a>attribute</a>. <a>Accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a> can provide named path <a>relationships</a>.</p>
+				<p>When <pref>aria-flowto</pref> has a single ID reference, it allows <a>assistive technologies</a> to, at the user's request, forego normal document reading order and go to the targeted <a>object</a>. <!-- [No longer ref XHTML2] <pref>aria-flowto</pref> in subsequent elements would follow a process similar to <cite><a href="https://www.w3.org/TR/2006/WD-xhtml2-20060726/mod-hyperAttributes.html#adef_hyperAttributes_nextfocus">next focus in <abbr title="Extensible Hypertext Markup Language">XHTML</abbr>2</a></cite> ([[XHTML2]]). --> However, when <pref>aria-flowto</pref> is provided with multiple ID references, assistive technologies SHOULD present the referenced elements as path choices.</p>
+				<p>In the case of one or more ID references, <a>user agents</a> or assistive technologies SHOULD give the user the option of navigating to any of the targeted elements. The name of the path can be determined by the name of the target element of the <pref>aria-flowto</pref> <a>attribute</a>. <a>Accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a> can provide named path <a>relationships</a>.</p>
 			</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>
@@ -9538,10 +11578,16 @@
 			<div class="property-description">
 				<p>Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an <a>element</a>.</p>
 				<p>A popup element usually appears as a block of content that is on top of other content. Authors MUST ensure that the role of the element that serves as the container for the popup content is <rref>menu</rref>, <rref>listbox</rref>, <rref>tree</rref>, <rref>grid</rref>, or <rref>dialog</rref>, and that the value of <code>aria-haspopup</code> matches the role of the popup container.</p>
-        <p>For the popup element to be keyboard accessible, authors SHOULD ensure that the element that can trigger the popup is focusable, that there is a keyboard mechanism for opening the popup, and that the popup element manages focus of all its descendants as described in <a href="#managingfocus">Managing Focus</a>.</p>
-        <p>The <code>aria-haspopup</code> property is an enumerated type. <a>User agents</a> MUST treat any value of <code>aria-haspopup</code> that is not included in the list of allowed values, including an empty string, as if the value <code>false</code> had been provided. To provide backward compatibility with ARIA 1.0 content, user agents MUST treat an <code>aria-haspopup</code> value of <code>true</code> as equivalent to a value of <code>menu</code>.</p>
-        <p><a>Assistive technologies</a> SHOULD NOT expose the <code>aria-haspopup</code> property if it has a value of <code>false</code>.</p>
-        <p class="note">A <rref>tooltip</rref> is not considered to be a popup in this context.</p>
+				<p>For the popup element to be keyboard accessible, authors SHOULD ensure that the element that can trigger the popup is focusable, that there is a keyboard mechanism for opening the popup, and that the popup element manages focus of all its descendants as described in <a href="#managingfocus">Managing Focus</a>.</p>
+				<p>The <code>aria-haspopup</code> property is an enumerated type. <a>User agents</a> MUST treat any value of <code>aria-haspopup</code> that is not included in the list of allowed values, including an empty string, as if the value <code>false</code> had been provided. To provide backward compatibility with ARIA 1.0 content, user agents MUST treat an <code>aria-haspopup</code> value of <code>true</code> as equivalent to a value of <code>menu</code>.</p>
+				<p><a>Assistive technologies</a> SHOULD NOT expose the <code>aria-haspopup</code> property if it has a value of <code>false</code>.</p>
+				<p class="note">A <rref>tooltip</rref> is not considered to be a popup in this context.</p>
+				<p class="note"><code>aria-haspopup</code> is most relevant to use when there is a visual indicator in the element that triggers the popup.
+					For example, many controls styled with a downward pointing triangle, chevron, or ellipsis (three consecutive dots) have become standard visual indicators that a popup will display when the control is activated.
+					If some functional difference is relevant to display to a sighted user by means of a different visual style, that functional difference is usually relevant to convey to users of assistive technology.
+					If there is no visual indication that an element will trigger a popup, authors are advised to consider whether use of <code>aria-haspopup</code> is necessary, and avoid using it when it's not.
+				</p>
+				<p class="note">This property is being deprecated as a global property in ARIA 1.2. In future versions it will only be allowed on roles where it is specifically supported.</p>
 			</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>
@@ -9555,15 +11601,12 @@
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
 						<td class="property-related">
-							<ul>
-								<li><pref>aria-controls</pref></li>
-								<li><cite><a href="https://www.w3.org/TR/2002/REC-UAAG10-20021217/">User Agent Accessibility Guidelines</a></cite> [[UAAG10]] conditional content</li>
-							</ul>
+							<pref>aria-controls</pref>
 						</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
-						<td class="property-applicability">All elements of the base markup</td>
+						<td class="property-applicability">Use as a global deprecated in ARIA 1.2</td>
 					</tr>
 					<tr>
 						<th class="property-descendants-head" scope="row">Inherits into Roles:</th>
@@ -9620,12 +11663,9 @@
 			<div class="state-description">
 				<p>Indicates whether the <a>element</a> is exposed to an accessibility API. See related <sref>aria-disabled</sref>.</p>
 				<p>User agents determine an element's <a>hidden</a> status based on whether it is rendered, and the rendering is usually controlled by CSS. For example, an element whose <code>display</code> property is set to <code>none</code> is not rendered. An element is considered <a>hidden</a> if it, or any of its ancestors are not rendered or have their <code>aria-hidden</code> attribute value set to <code>true</code>.</p>
-				<pre class="example highlight lang-css">[aria-hidden="true"] { visibility: hidden; }</pre>
 				<p>Authors MAY, with caution, use aria-hidden to hide visibly rendered content from assistive technologies <em>only</em> if the act of hiding this content is intended to improve the experience for users of assistive technologies by removing redundant or extraneous content. Authors using aria-hidden to hide visible content from screen readers MUST ensure that identical or equivalent meaning and functionality is exposed to assistive technologies.</p>
 				<p class="note">Authors are advised to use extreme caution and consider a wide range of disabilities when hiding visibly rendered content from assistive technologies. For example, a sighted, dexterity-impaired individual may use voice-controlled assistive technologies to access a visual interface. If an author hides visible link text "Go to checkout" and exposes similar, yet non-identical link text "Check out now" to the accessibility API, the user may be unable to access the interface they perceive using voice control. Similar problems may also arise for screen reader users. For example, a sighted telephone support technician may attempt to have the blind screen reader user click the "Go to checkout" link, which they may be unable to find using a type-ahead item search ("Go to…").</p>
 				<p class="note">At the time of this writing, <code><sref>aria-hidden</sref>="false"</code> is known to work inconsistently in browsers. As future implementations improve, use caution and test thoroughly before relying on this approach.</p>
-				<p class="note">It is recommended that authors key visibility of elements off this attribute, rather than change visibility and separately update this <a>property</a>. <abbr title="Cascading Style Sheets">CSS</abbr> 2 introduced a way to <cite><a href="https://www.w3.org/TR/css3-selectors/#attribute-selectors">select on attribute values</a></cite> ([[CSS3-SELECTORS]]). The following <abbr title="Cascading Style Sheets">CSS</abbr> declaration makes content visible unless the <sref>aria-hidden</sref> attribute is <code>true</code>; scripts need only update the <span>value</span> of this attribute to change visibility:</p>
-				<pre class="example highlight lang-css">[aria-hidden="true"] { visibility: hidden; }</pre>
 			</div>
 			<table class="state-features">
 				<caption>Characteristics:</caption>
@@ -9685,6 +11725,7 @@
 				<p>If the value is computed to be invalid or out-of-range, the application author SHOULD set this <a>attribute</a> to <code>true</code>. <a>User agents</a> SHOULD inform the user of the error. Application authors SHOULD provide suggestions for corrections if they are known.</p>
 				<p>When the user attempts to submit data involving a field for which <pref>aria-required</pref> is <code>true</code>, authors MAY use the <sref>aria-invalid</sref> attribute to signal there is an error. However, if the user has not attempted to submit the form, authors SHOULD NOT set the <sref>aria-invalid</sref> attribute on required <a>widgets</a> simply because the user has not yet entered data.</p>
 				<p>For future expansion, the <sref>aria-invalid</sref> attribute is an enumerated type. Any value not recognized in the list of allowed <span>values</span> MUST be treated by user agents as if the value <code>true</code> had been provided. If the attribute is not present, or its value is <code>false</code>, or its value is an empty string, the default value of <code>false</code> applies.</p>
+				<p class="note">This state is being deprecated as a global state in ARIA 1.2. In future versions it will only be allowed on roles where it is specifically supported.</p>
 			</div>
 			<table class="state-features">
 				<caption>Characteristics:</caption>
@@ -9697,11 +11738,11 @@
 				<tbody>
 					<tr>
 						<th class="state-related-head" scope="row">Related Concepts:</th>
-						<td class="state-related"><cite><a href="https://www.w3.org/TR/xforms/">XForms</a></cite> [[XFORMS11]] <a href="https://www.w3.org/TR/xforms/#evt-invalid">'invalid' event</a>. This state is <code>true</code> if a form field is required but empty. However, the XForms <code>valid</code> property would be set to <code>false</code>.</td>
+						<td class="state-related"> </td>
 					</tr>
 					<tr>
 						<th class="state-applicability-head" scope="row">Used in Roles:</th>
-						<td class="state-applicability">All elements of the base markup</td>
+						<td class="state-applicability">Use as a global deprecated in ARIA 1.2</td>
 					</tr>
 					<tr>
 						<th class="state-descendants-head" scope="row">Inherits into Roles:</th>
@@ -9745,7 +11786,7 @@
 			<pdef>aria-keyshortcuts</pdef>
 			<div class="property-description">
 				<p>Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.</p>
-				<p>The value of the <code>aria-keyshortcuts</code> attribute is a space-delimited list of keyboard shortcuts that can be pressed to activate a command or textbox widget. The keys defined in the shortcuts represent the physical keys pressed and not the actual characters generated. Each keyboard shortcut consists of one or more tokens delimited by the plus sign ("+") representing zero or more modifier keys and exactly one non-modifier key that must be pressed simultaneously to activate the given shortcut.</p>
+				<p>The value of the <code>aria-keyshortcuts</code> attribute is a space-separated list of keyboard shortcuts that can be pressed to activate a command or textbox widget. The keys defined in the shortcuts represent the physical keys pressed and not the actual characters generated. Each keyboard shortcut consists of one or more tokens delimited by the plus sign ("+") representing zero or more modifier keys and exactly one non-modifier key that must be pressed simultaneously to activate the given shortcut.</p>
 				<p>Authors MUST specify modifier keys exactly according to the <a href="https://www.w3.org/TR/uievents-key/">UI Events KeyboardEvent key Values</a> spec [[!uievents-key]] - for example, "Alt", "Control", "Shift", "Meta", or "AltGraph". Note that Meta corresponds to the Command key, and Alt to the Option key, on Apple computers.</p>
 				<p>The valid names for non-modifier keys are any printable character such as "A", "B", "1", "2", "$", "Plus" for a plus sign, "Space" for the spacebar, or the names of any other non-modifier key specified in the <a href="https://www.w3.org/TR/uievents-key/">UI Events KeyboardEvent key Values</a> spec [[!uievents-key]] - for example, "Enter", "Tab", "ArrowRight", "PageDown", "Escape", or "F1". The use of "Space" for the spacebar is an exception to the <a href="https://www.w3.org/TR/uievents-key/">UI Events KeyboardEvent key Values</a> spec [[!uievents-key]] as the space or spacebar key is encoded as <code>'&#160;'</code> and would be treated as a whitespace character.</p>
 				<p>Authors MUST ensure modifier keys come first when they are part of a keyboard shortcut. Authors MUST ensure that required non-modifier keys come last when they are part of a shortcut. The order of the modifier keys is not otherwise significant, so "Alt+Shift+T" and "Shift+Alt+T" are equivalent, but "T+Shift+Alt" is not valid because all of the modifier keys don't come first, and "Alt" is not valid because it doesn't include at least one non-modifier key.</p>
@@ -9765,7 +11806,7 @@
 				</ul>
 				<p>User agents MUST NOT change keyboard behavior in response to the <code>aria-keyshortcuts</code> attribute. Authors MUST handle scripted keyboard events to process <code>aria-keyshortcuts</code>. The <code>aria-keyshortcuts</code> attribute exposes the existence of these shortcuts so that assistive technologies can communicate this information to users.</p>
 				<p>Authors SHOULD provide a way to expose keyboard shortcuts so that all users may discover them, such as through the use of a tooltip. Authors MUST ensure that <code>aria-keyshortcuts</code> applied to disabled elements are unavailable.</p>
-				<p>Authors SHOULD avoid implementing shortcut keys that inhibit operating system, user agent, or assistive technology functionality. This requires the author to carefully consider both which keys to assign and the contexts and conditions in which the keys are available to the user. For guidance, see the keyboard shortcuts section of the <cite><a href="https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_shortcuts"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices Guide</a></cite> [[WAI-ARIA-PRACTICES-1.1]].</p>
+				<p>Authors SHOULD avoid implementing shortcut keys that inhibit operating system, user agent, or assistive technology functionality. This requires the author to carefully consider both which keys to assign and the contexts and conditions in which the keys are available to the user. For guidance, see the keyboard shortcuts section of the <cite><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite>.</p>
 			</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>
@@ -9800,7 +11841,7 @@
 			<div class="property-description">
 				<p>Defines a string value that labels the current element. See related <pref>aria-labelledby</pref>.</p>
 				<p>The purpose of <pref>aria-label</pref> is the same as that of <pref>aria-labelledby</pref>. It provides the user with a recognizable name of the object. The most common <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> mapping for a label is the <a>accessible name</a> property.</p>
-				<p>If the label text is visible on screen, authors SHOULD use <pref>aria-labelledby</pref> and SHOULD NOT use <pref>aria-label</pref>. There may be instances where the name of an element cannot be determined programmatically from the content of the element, and there are cases where providing a visible label is not the desired user experience. Most host languages provide an attribute that could be used to name the element (e.g., the <a href="https://www.w3.org/TR/html5/dom.html#the-title-attribute"><code>title</code> attribute in <abbr title="Hypertext Markup Language">HTML</abbr></a>), yet this could present a browser tooltip. In the cases where a visible label or visible tooltip is undesirable, authors MAY set the accessible name of the element using <pref>aria-label</pref>. As required by the <a href="#textalternativecomputation">text alternative computation</a>, user agents give precedence to <pref>aria-labelledby</pref> over <pref>aria-label</pref> when computing the accessible name property.</p>
+				<p>If the label text is available in the DOM (i.e. typically visible text content), authors SHOULD use <pref>aria-labelledby</pref> and SHOULD NOT use <pref>aria-label</pref>. There may be instances where the name of an element cannot be determined programmatically from the DOM, and there are cases where referencing DOM content is not the desired user experience. Most host languages provide an attribute that could be used to name the element (e.g., the <code>title</code> attribute in [[HTML]]), yet this could present a browser tooltip. In the cases where DOM content or a tooltip is undesirable, authors MAY set the accessible name of the element using <pref>aria-label</pref>. As required by the <a href="#textalternativecomputation">accessible name and description computation</a>, user agents give precedence to <pref>aria-labelledby</pref> over <pref>aria-label</pref> when computing the accessible name property.</p>
 			</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>
@@ -9813,11 +11854,11 @@
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><a href="https://www.w3.org/TR/html5/dom.html#the-title-attribute"><abbr title="Hypertext Markup Language">HTML</abbr> <code>title</code></a></td>
+						<td class="property-related"> </td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
-						<td class="property-applicability">All elements of the base markup</td>
+						<td class="property-applicability">All elements of the base markup except for some roles or elements that prohibit its use</td>
 					</tr>
 					<tr>
 						<th class="property-descendants-head" scope="row">Inherits into Roles:</th>
@@ -9833,9 +11874,9 @@
 		<div class="property" id="aria-labelledby">
 			<pdef>aria-labelledby</pdef>
 			<div class="property-description">
-				<p>Identifies the <a>element</a> (or elements) that labels the current element. See related <pref>aria-describedby</pref>.</p>
+				<p>Identifies the <a>element</a> (or elements) that labels the current element. See related <pref>aria-label</pref> and <pref>aria-describedby</pref>.</p>
 				<p>The purpose of <pref>aria-labelledby</pref> is the same as that of <pref>aria-label</pref>. It provides the user with a recognizable name of the object. The most common <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> mapping for a label is the <a>accessible name</a> property.</p>
-				<p>If the interface is such that it is not possible to have a visible label on the screen, authors SHOULD use <pref>aria-label</pref> and SHOULD NOT use <pref>aria-labelledby</pref>. As required by the <a href="#textalternativecomputation">text alternative computation</a>, user agents give precedence to <pref>aria-labelledby</pref> over <pref>aria-label</pref> when computing the accessible name property.</p>
+				<p>If the interface is such that it is not possible to have a visible label on the screen, authors SHOULD use <pref>aria-label</pref> and SHOULD NOT use <pref>aria-labelledby</pref>. As required by the <a href="#textalternativecomputation">accessible name and description computation</a>, user agents give precedence to <pref>aria-labelledby</pref> over <pref>aria-label</pref> when computing the accessible name property.</p>
 				<p>The <pref>aria-labelledby</pref> attribute is similar to <pref>aria-describedby</pref> in that both reference other elements to calculate a text alternative, but a label should be concise, where a description is intended to provide more verbose information.</p>
 				<!-- keep previous sentence synced with the associated description in #aria-describedby -->
 				<p class="note">The expected spelling of this property in <abbr title="United States">U.S.</abbr> English is "labeledby." However, the <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> features to which this property is mapped have established the "labelledby" spelling. This property is spelled that way to match the convention and minimize the difficulty for developers.</p>
@@ -9851,8 +11892,58 @@
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><a href="https://www.w3.org/TR/html5/forms.html#the-label-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>label</code></a></td>
+						<td class="property-related"><code>&lt;label&gt;</code> in [[HTML]]</td>
 					</tr>
+					<tr>
+						<th class="property-applicability-head" scope="row">Used in Roles:</th>
+						<td class="property-applicability">All elements of the base markup except for some roles or elements that prohibit its use</td>
+					</tr>
+					<tr>
+						<th class="property-descendants-head" scope="row">Inherits into Roles:</th>
+						<td class="property-descendants">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="property-value-head" scope="row">Value:</th>
+						<td class="property-value"><a href="#valuetype_idref_list">ID reference list</a></td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div class="property" id="aria-braillelabel">
+			<pdef>aria-braillelabel</pdef>
+			<div class="property-description">
+				<p>Defines a string value that labels the current element, which is intended to be converted into Braille. See related <pref>aria-label</pref>.</p>
+				<p>The purpose of <pref>aria-braillelabel</pref> is similar to that of <pref>aria-label</pref>. It provides the user with a recognizable name of the object in Braille.</p>
+				<p>The <pref>aria-braillelabel</pref> property gives authors the ability to override how assistive technologies localize and express the accessible name of an element in Braille. Thus inappropriately using <pref>aria-braillelabel</pref> may inhibit users' ability to understand an element on braille interfaces. Authors SHOULD limit use of <pref>aria-braillelabel</pref> to instances where the name of an element when converted to Braille is not the desired user experience.</p>
+				<p> When using <code>aria-braillelabel</code>, authors SHOULD also ensure that:</p>
+				<ol>
+					<li>The element to which <code>aria-braillelabel</code> is applied has a valid accessible name.</li>
+					<li>The value of <code>aria-braillelabel</code> is not empty or does not contain only whitespace characters.</li>
+					<li>The value of <code>aria-braillelabel</code> does not contain any characters in Unicode Braille Patterns (U+2800..U+28FF) or consists of only characters in Unicode Braille Patterns (U+2800..U+28FF) while not containing only Braille Pattern dots-0 (U+2800).</li>
+					<li>The value of <code>aria-braillelabel</code> is not identical to the element's accessible name.</li>
+				</ol>
+				<p class="note">Note that <a>Assistive Technologies</a> with braille support can convert the accessible name to Braille. In addition, assistive technologies will be able to customize such braille output according to user preferences. Using only the accessible name, e.g., from content or via <code>aria-label</code> is <strong>almost always</strong> the better user experience and authors are <strong>strongly discouraged</strong> from using <code>aria-braillelabel</code> to replicate <code>aria-label</code>. Instead, <code>aria-braillelabel</code> is meant to be used only if the accessible name cannot provide an adequate braille representation, i.e., when a specialized braille description is very different from a text description converted to Braille. It is very important to note that when using <code>aria-braillelabel</code> authors are solely responsible to align the attribute value with the document language and clearly communicate the use of this attribute to the user. This is even more important when the value consists of Unicode Braille Patterns because <a>Assistive Technologies</a> will pass such content directly to the user without applying user specific braille translations; in general, authors are <strong>strongly discouraged</strong> from using Unicode Braille Patterns in <code>aria-braillelabel</code>.
+				</p>
+				<p><a>Assistive technologies</a> SHOULD use the value of <code>aria-braillelabel</code> when presenting the accessible name of an element in Braille, but SHOULD NOT change other functionality. For example, an assistive technology that provides aural rendering SHOULD use the accessible name.</p>
+				<p><a>Assistive technologies</a> SHOULD expose the <code>aria-braillelabel</code> property as follows:</p>
+				<ol>
+					<li>If the value of <code>aria-braillelabel</code> does not contain characters in Unicode Braille Patterns (U+2800..U+28FF), translate the value according to the user's preferred translation table.</li>
+					<li>Otherwise, pass the value to the user without translation.</li>
+				</ol>
+				<p>The following example shows the use of <code>aria-braillelabel</code> to customize a button's name in braille output.</p>
+				<pre class="example highlight">&lt;button aria-braillelabel="****"&gt;
+  &lt;img alt="4 stars" src="images/stars.jpg"&gt;
+&lt;/button&gt;</pre>
+				<p>In the previous example, a braille display may display "btn ****" in Braille rather than the verbose "btn gra 4 stars".</p>			</div>
+			<table class="property-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
 						<td class="property-applicability">All elements of the base markup</td>
@@ -9863,7 +11954,7 @@
 					</tr>
 					<tr>
 						<th class="property-value-head" scope="row">Value:</th>
-						<td class="property-value"><a href="#valuetype_idref_list">ID reference list</a></td>
+						<td class="property-value"><a href="#valuetype_string">string</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -9959,7 +12050,7 @@
 					</tr>
 					<tr>
 						<th class="value-name" scope="row"><strong class="default">off (default)</strong></th>
-						<td class="value-description">Indicates that updates to the region should not be presented to the user unless the used is currently focused on that region.</td>
+						<td class="value-description">Indicates that updates to the region should not be presented to the user unless the user is currently focused on that region.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">polite</th>
@@ -10192,7 +12283,7 @@
 			<pdef>aria-owns</pdef>
 			<div class="property-description">
 				<p>Identifies an <a>element</a> (or elements) in order to define a visual, functional, or contextual parent/child <a>relationship</a> between <abbr title="Document Object Model">DOM</abbr> elements where the DOM hierarchy cannot be used to represent the relationship. See related <pref>aria-controls</pref>.</p>
-				<p>The value of the <pref>aria-owns</pref> <a>attribute</a> is a space-separated list of IDREFS that reference one or more elements in the document by ID. The reason for adding <pref>aria-owns</pref> is to expose a parent/child contextual relationship to <a>assistive technologies</a> that is otherwise impossible to infer from the <abbr title="Document Object Model">DOM</abbr>.</p>
+				<p>The value of the <pref>aria-owns</pref> <a>attribute</a> is a space-separated ID reference list that references one or more elements in the document by ID. The reason for adding <pref>aria-owns</pref> is to expose a parent/child contextual relationship to <a>assistive technologies</a> that is otherwise impossible to infer from the <abbr title="Document Object Model">DOM</abbr>.</p>
 				<p>If an element has both <pref>aria-owns</pref> and  <abbr title="Document Object Model">DOM</abbr> children then the order of the child elements with respect to the parent/child relationship is the <abbr title="Document Object Model">DOM</abbr> children first, then the elements referenced in <pref>aria-owns</pref>. If the author intends that the <abbr title="Document Object Model">DOM</abbr> children are not first, then list the DOM children in <pref>aria-owns</pref> in the desired order. Authors SHOULD NOT use <pref>aria-owns</pref> as a replacement for the <abbr title="Document Object Model">DOM</abbr> hierarchy. If the relationship is represented in the DOM, do not use <pref>aria-owns</pref>. Authors MUST ensure that an element's ID is not specified in more than one other element's <pref>aria-owns</pref> attribute at any time. In other words, an element can have only one explicit owner.</p>
 			</div>
 			<table class="property-features">
@@ -10229,7 +12320,8 @@
 				<p>Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value. A hint could be a sample value or a brief description of the expected format.</p>
 				<p>Authors SHOULD NOT use <pref>aria-placeholder</pref> instead of a label as their purposes are different: The label indicates what kind of information is expected. The placeholder text is a hint about the expected value. See related <pref>aria-labelledby</pref> and <pref>aria-label</pref>.</p>
 				<p>Authors SHOULD present this hint to the user by displaying the hint text at any time the control's <span>value</span> is the empty string. This includes cases where the control first receives focus, and when users remove a previously-entered value.</p>
-				<p class="note">As is the case with the related <a href="https://www.w3.org/TR/html5/forms.html#attr-input-placeholder"><abbr title="Hypertext Markup Language">HTML</abbr> <code>placeholder</code></a> attribute, use of placeholder text as a replacement for a displayed label can reduce the accessibility and usability of the control for a range of users including older users and users with cognitive, mobility, fine motor skill or vision impairments. While the hint given by the control's label is shown at all times, the short hint given in the placeholder attribute is only shown before the user enters a value. Furthermore, placeholder text may be mistaken for a pre-filled value, and as commonly implemented the default color of the placeholder text provides insufficient contrast and the lack of a separate visible label reduces the size of the hit region available for setting focus on the control.</p>
+				<p class="note">As is the case with the related <code>placeholder</code> attribute in [[HTML]], use of placeholder text as a replacement for a displayed label can reduce the accessibility and usability of the control for a range of users including older users and users with cognitive, mobility, fine motor skill or vision impairments. While the hint given by the control's label is shown at all times, the short hint given in the placeholder attribute is only shown before the user enters a value. Furthermore, placeholder text may be mistaken for a pre-filled value, and as commonly implemented the default color of the placeholder text provides insufficient contrast and the lack of a separate visible label reduces the size of the hit region available for setting focus on the control.</p>
+				<p class="note">The following examples do not use the HTML <code>label</code> element as it cannot be used to label HTML elements with <code>contenteditable</code>.</p>
 				<p>The following example shows a <rref>searchbox</rref> in which the user has entered a value:</p>
 				<pre class="example highlight">
 &lt;span id="label"&gt;Birthday:&lt;/span&gt;
@@ -10252,7 +12344,7 @@
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><a href="https://www.w3.org/TR/html5/forms.html#attr-input-placeholder"><abbr title="Hypertext Markup Language">HTML</abbr> <code>placeholder</code></a></td>
+						<td class="property-related"><code>placeholder</code> attribute in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -10317,7 +12409,7 @@
 			<sdef>aria-pressed</sdef>
 			<div class="state-description">
 				<p>Indicates the current "pressed" <a>state</a> of toggle buttons. See related <sref>aria-checked</sref> and <sref>aria-selected</sref>.</p>
-				<p>Toggle buttons require a full press-and-release cycle to change their value. Activating it once changes the value to <code>true</code>, and activating it another time changes the value back to <code>false</code>. A value of <code>mixed</code> means that the values of more than one item controlled by the button do not all share the same value. Examples of mixed-state buttons are described in <cite><a href="https://www.w3.org/TR/wai-aria-practices-1.1/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> [[WAI-ARIA-PRACTICES-1.1]]. If the <a>attribute</a> is not present, the button is not a toggle button.</p>
+				<p>Toggle buttons require a full press-and-release cycle to change their value. Activating it once changes the value to <code>true</code>, and activating it another time changes the value back to <code>false</code>. A value of <code>mixed</code> means that the values of more than one item controlled by the button do not all share the same value.  If the <a>attribute</a> is not present, the button is not a toggle button.</p>
 				<p>The <sref>aria-pressed</sref> attribute is similar but not identical to the <sref>aria-checked</sref> attribute. Operating systems support <code>pressed</code> on buttons and <code>checked</code> on checkboxes.</p>
 			</div>
 			<table class="state-features">
@@ -10399,7 +12491,7 @@
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><cite><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/">XForms</a></cite> [[XFORMS10]] Readonly</td>
+						<td class="property-related"><code>readonly</code> attribute in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -10439,13 +12531,13 @@
 			<pdef>aria-relevant</pdef>
 			<div class="property-description">
 				<p>Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. See related <pref>aria-atomic</pref>.</p>
-				<p>The <a>attribute</a> is represented as a space delimited list of the following <span>values</span>: <code>additions</code>, <code>removals</code>, <code>text</code>; or a single catch-all value <code>all</code>.</p>
+				<p>The <a>attribute</a> is represented as a space-separated list of the following <span>values</span>: <code>additions</code>, <code>removals</code>, <code>text</code>; or a single catch-all value <code>all</code>.</p>
 				<p>This is used to describe <a>semantically</a> meaningful changes, as opposed to merely presentational ones. For example, nodes that are removed from the top of a log are merely removed for purposes of creating room for other entries, and the removal of them does not have meaning. However, in the case of a buddy list, removal of a buddy name indicates that they are no longer online, and this is a meaningful <a>event</a>. In that case <pref>aria-relevant</pref> will be set to <code>all</code>. When the <pref>aria-relevant</pref> attribute is not provided, the default value, <code>additions text</code>, indicates that text modifications and node additions are relevant, but that node removals are irrelevant.</p>
 				<p class="note"><pref>aria-relevant</pref> values of removals or all are to be used sparingly. Assistive technologies only need to be informed of content removal when its removal represents an important change, such as a buddy leaving a chat room.</p>
 				<p class="note">Text removals should only be considered relevant if one of the specified values is 'removals' or 'all'. For example, for a text change from 'foo' to 'bar' in a live region with a default <pref>aria-relevant</pref> value, the text addition ('bar') would be spoken, but the text removal ('foo') would not.</p>
 				<p><pref>aria-relevant</pref> is an optional attribute of live regions. This is a suggestion to <a>assistive technologies</a>, but assistive technologies are not required to present changes of all the relevant types.</p>
 				<p>When <pref>aria-relevant</pref> is not defined, an element's value is inherited from the nearest ancestor with a defined value. Although the value is a <a href="#valuetype_token_list">token list</a>, inherited values are not additive; the value provided on a descendant element completely overrides any inherited value from an ancestor element.</p>
-				<p>When text changes are denoted as relevant, user agents MUST monitor any descendant node change that affects the <a href="#textalternativecomputation">text alternative computation</a> of the live region as if the accessible name were determined from contents (<a href="#namecalculation">nameFrom: contents</a>). For example, a text change would be triggered if the HTML <code>alt</code> attribute of a contained image changed. However, no change would be triggered if there was a text change to a node outside the live region, even if that node was referenced (via <pref>aria-labelledby</pref>) by an element contained in the live region.</p>
+				<p>When text changes are denoted as relevant, user agents MUST monitor any descendant node change that affects the <a href="#textalternativecomputation">accessible name and description computation</a> of the live region as if the accessible name were determined from contents (<a href="#namecalculation">nameFrom: contents</a>). For example, a text change would be triggered if the HTML <code>alt</code> attribute of a contained image changed. However, no change would be triggered if there was a text change to a node outside the live region, even if that node was referenced (via <pref>aria-labelledby</pref>) by an element contained in the live region.</p>
 			</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>
@@ -10488,7 +12580,7 @@
 						<td class="value-description">Element nodes are added to the accessibility tree within the live region.</td>
 					</tr>
 					<tr>
-						<th class="value-name" scope="row"><strong class="default">additions text</strong></th>
+						<th class="value-name" scope="row"><strong class="default">additions text (default)</strong></th>
 						<td class="value-description">Equivalent to the combination of values, "additions text".</td>
 					</tr>
 					<tr>
@@ -10525,7 +12617,7 @@
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><a href="https://www.w3.org/TR/html5/forms.html#the-required-attribute"><abbr title="Hypertext Markup Language">HTML</abbr> <code>required</code></a></td>
+						<td class="property-related"><code>required</code> attribute in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -10575,7 +12667,8 @@
 				<p>User agents MUST NOT expose the <code>aria-roledescription</code> property if any of the following conditions exist:</p>
 				<ol>
 					<li>The element to which <code>aria-roledescription</code> is applied does not have a valid WAI-ARIA role or does not have an implicit WAI-ARIA role semantic.</li>
-					<li>The value of aria-roledescription is empty or contains only whitespace characters.</li>
+					<li>The element to which <code>aria-roledescription</code> is applied has an explicit or implicit WAI-ARIA role where <code>aria-roledescription</code> is <a href="#prohibitedattributes">prohibited</a>.</li>
+					<li>The value of <code>aria-roledescription</code> is empty or contains only whitespace characters.</li>
 				</ol>
 				<p><a>Assistive technologies</a> SHOULD use the value of <code>aria-roledescription</code> when presenting the role of an element, but SHOULD NOT change other functionality based on the role of an element that has a value for <code>aria-roledescription</code>. For example, an assistive technology that provides functions for navigating to the next <rref>region</rref> or <rref>button</rref> SHOULD allow those functions to navigate to regions and buttons that have an <code>aria-roledescription</code>.</p>
 				<p>The following two examples show the use of <code>aria-roledescription</code> to indicate that a non-interactive container is a "slide" in a web-based presentation application.</p>
@@ -10588,10 +12681,6 @@
 &lt;!-- remaining slide contents --&gt;
 &lt;/section&gt;</pre>
 				<p>In the previous examples, a screen reader user may hear "Quarterly Report, slide" rather than the more vague "Quarterly Report, region" or "Quarterly Report, group."</p>
-				<p>The following examples show the use of <code>aria-roledescription</code> to indicate that a <rref>button</rref> in a web-based email client is associated with an "attachment."</p>
-				<pre class="example highlight">&lt;div role="button" tabindex="0" aria-roledescription="attachment button"&gt;family_reunion.jpg&lt;/div&gt;</pre>
-				<pre class="example highlight">&lt;button aria-roledescription="attachment button"&gt;family_reunion.jpg&lt;/button&gt;</pre>
-				<p>In the previous two examples, because "button" is part of the localized description, a screen reader user should still understand how to interact with that control.</p>
 			</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>
@@ -10691,7 +12780,7 @@
 		<div class="property" id="aria-rowindex">
 			<pdef>aria-rowindex</pdef>
 			<div class="property-description">
-				<p>Defines an <a>element's</a> row index or position with respect to the total number of rows within a <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>. See related <pref>aria-rowcount</pref> and <pref>aria-rowspan</pref>.</p>
+				<p>Defines an <a>element's</a> row index or position with respect to the total number of rows within a <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>. See related <pref>aria-rowindextext</pref>, <pref>aria-rowcount</pref>, and <pref>aria-rowspan</pref>.</p>
 				<p>If all of the rows are present in the <abbr title="Document Object Model">DOM</abbr>, it is not necessary to set this <a>attribute</a> as the <a>user agent</a> can automatically calculate the index of each row. However, if only a portion of the rows is present in the <abbr title="Document Object Model">DOM</abbr> at a given moment, this attribute is needed to provide an explicit indication of each row's position with respect to the full table.</p>
 				<p>Authors MUST set the <span>value</span> for <pref>aria-rowindex</pref> to an integer greater than or equal to 1, greater than the <pref>aria-rowindex</pref> value of any previous rows, and less than or equal to the number of rows in the full table. For a cell or gridcell which spans multiple rows, authors MUST set the value of <pref>aria-rowindex</pref> to the start of the span.</p>
 				<p>Authors SHOULD place <pref>aria-rowindex</pref> on each row. Authors MAY also place <pref>aria-rowindex</pref> on all of the children or <a>owned elements</a> of each row.</p>
@@ -10784,6 +12873,42 @@
 					<tr>
 						<th class="property-value-head" scope="row">Value:</th>
 						<td class="property-value"><a href="#valuetype_integer">integer</a></td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div class="property" id="aria-rowindextext">
+			<pdef>aria-rowindextext</pdef>
+			<div class="property-description">
+				<p>Defines a human readable text alternative of <pref>aria-rowindex</pref>. See related <pref>aria-colindextext</pref>.</p>
+                                <p>Authors SHOULD only use <code>aria-rowindextext</code> when the provided or calculated value of <pref>aria-rowindex</pref> is not meaningful or does not reflect the displayed index, as can be seen in the game Battleship.</p>
+                                <p>Authors SHOULD NOT use <code>aria-rowindextext</code> as a replacement for <pref>aria-rowindex</pref> because some assistive technologies rely upon the numeric row index for the purpose of keeping track of the user's position or providing alternative table navigation.</p>
+				<p>Authors SHOULD place <code>aria-rowindextext</code> on each row. Authors MAY also place <code>aria-rowindextext</code> on all of the children or <a>owned elements</a> of each row.</p>
+			</div>
+			<table class="property-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="property-related-head" scope="row">Related Concepts:</th>
+						<td class="property-related"> </td>
+					</tr>
+					<tr>
+						<th class="property-applicability-head" scope="row">Used in Roles:</th>
+						<td class="property-applicability">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="property-descendants-head" scope="row">Inherits into Roles:</th>
+						<td class="property-descendants">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="property-value-head" scope="row">Value:</th>
+						<td class="property-value"><a href="#valuetype_integer">string</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -11017,7 +13142,7 @@
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><cite><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/">XForms</a></cite> [[XFORMS10]] range</td>
+						<td class="property-related"><code>&lt;range&gt;</code> element <code>max</code> attribute in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -11052,7 +13177,7 @@
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><cite><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/">XForms</a></cite> [[XFORMS10]] range</td>
+						<td class="property-related"><code>&lt;range&gt;</code> element <code>min</code> attribute in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -11078,7 +13203,7 @@
 				<p>The value of <pref>aria-valuenow</pref> is a decimal number. If the range is a set of numeric values, then <pref>aria-valuenow</pref> is one of those values. For example, if the range is [0, 1], a valid <pref>aria-valuenow</pref> is 0.5. A value outside the range, such as -2.5 or 1.1, is invalid.</p>
 				<p>For <rref>progressbar</rref> elements and <rref>scrollbar</rref> elements, assistive technologies SHOULD render the value to users as a percent, calculated as a position on the range from <pref>aria-valuemin</pref> to <pref>aria-valuemax</pref> if both are defined, otherwise the actual value with a percent indicator. For elements with role <rref>slider</rref> and <rref>spinbutton</rref>, assistive technologies SHOULD render the actual value to users.</p>
 				<p>When the rendered value cannot be accurately represented as a number, authors SHOULD use the <pref>aria-valuetext</pref> attribute in conjunction with <pref>aria-valuenow</pref> to provide a user-friendly representation of the range's current value. For example, a slider may have rendered values of <code>small</code>, <code>medium</code>, and <code>large</code>. In this case, the values of <pref>aria-valuetext</pref> would be one of the strings: <code>small</code>, <code>medium</code>, or <code>large</code>.</p>
-				<p class="note">If <rref>aria-valuetext</rref> is specified, assistive technologies render that instead of the value of <pref>aria-valuenow</pref>.</p>
+				<p class="note">If <pref>aria-valuetext</pref> is specified, assistive technologies render that instead of the value of <pref>aria-valuenow</pref>.</p>
 			</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>
@@ -11091,7 +13216,7 @@
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><cite><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/">XForms</a></cite> [[XFORMS10]] range, start</td>
+						<td class="property-related"><code>&lt;range&gt;</code> element <code>value</code> attribute in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -11115,7 +13240,7 @@
 				<p>This property is used, for example, on a range widget such as a slider or progress bar.</p>
 				<p>If the <pref>aria-valuetext</pref> attribute is set, authors SHOULD also set the <pref>aria-valuenow</pref> attribute, unless that value is unknown (for example, on an indeterminate <rref>progressbar</rref>).</p>
 				<p>Authors SHOULD only set the <pref>aria-valuetext</pref> attribute when the rendered value cannot be meaningfully represented as a number. For example, a slider may have rendered values of <code>small</code>, <code>medium</code>, and <code>large</code>. In this case, the values of <pref>aria-valuenow</pref> could range from 1 through 3, which indicate the position of each value in the value space, but the <pref>aria-valuetext</pref> would be one of the strings: <code>small</code>, <code>medium</code>, or <code>large</code>. If the <pref>aria-valuetext</pref> attribute is absent, the <a>assistive technologies</a> will rely solely on the <pref>aria-valuenow</pref> attribute for the current value.</p>
-				<p>If aria-valuetext is specified, assistive technologies SHOULD render that value instead of the value of <rref>aria-valuenow</rref>.</p>
+				<p>If <pref>aria-valuetext</pref> is specified, assistive technologies SHOULD render that value instead of the value of <pref>aria-valuenow</pref>.</p>
 			</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>
@@ -11128,7 +13253,7 @@
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><cite><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/">XForms</a></cite> [[XFORMS10]] range, start</td>
+						<td class="property-related"> </td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -11147,6 +13272,58 @@
 		</div>
 	</section>
 </section>
+<section class="normative" id="accessibility_tree">
+	<h1>Accessibility Tree</h1>
+	<p>The <a class="termref">accessibility tree</a> and the DOM tree are parallel structures. The <a>accessibility tree</a> includes the user interface objects of the <a>user agent</a> and the objects of the document. <a>Accessible objects</a> are created in the accessibility tree for every DOM element that should be exposed to an <a>assistive technology</a>, either because it may fire an accessibility <a>event</a> or because it has a <a>property</a>, <a>relationship</a> or feature which needs to be exposed.</p>
+	<section id="tree_exclusion">
+	  <h2>Excluding Elements from the Accessibility Tree</h2>
+	  <p>The following <a>elements</a> are not exposed via the <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> and user agents MUST NOT include them in the <a class="termref">accessibility tree</a>:</p>
+	  <ul>
+	    <li>Elements, including their descendent elements, that have host language semantics specifying that the element is not displayed, such as CSS <code>display:none</code>, <code>visibility:hidden</code>, or the HTML <code>hidden</code> attribute.</li>
+	    <li>Elements with <rref>none</rref> or <rref>presentation</rref> as the first role in the role attribute. However, their exclusion is conditional. In addition, the element's descendants and text content are generally included. These exceptions and conditions are documented in the <a href="#presentation">presentation (role)</a> section.</li>
+    </ul>
+	  <p>If not already excluded from the accessibility tree per the above rules, user agents SHOULD NOT include the following elements in the accessibility tree:</p>
+	  <ul>
+	    <li>Elements, including their descendants, that have <sref>aria-hidden</sref> set to <code>true</code>. In other words, <code>aria-hidden=&quot;true&quot;</code> on a parent overrides <code>aria-hidden=&quot;false&quot;</code> on descendants.</li>
+            <li>
+              <p>Any descendants of elements that have the characteristic &quot;<a href="#childrenArePresentational">Children Presentational: True</a>&quot; unless the descendant is not allowed to be presentational because it meets one of the conditions for exception described in <a href="#conflict_resolution_presentation_none">Presentational Roles Conflict Resolution</a>. However, the text content of any excluded descendants is included.</p>
+              <p>Elements with the following roles have the characteristic &quot;Children Presentational: True&quot;:</p>
+	        <ul>
+	          <li><rref>button</rref></li>
+	          <li><rref>checkbox</rref></li>
+	          <li><rref>img</rref></li>
+	          <li><rref>menuitemcheckbox</rref></li>
+	          <li><rref>menuitemradio</rref></li>
+	          <li><rref>meter</rref></li>
+	          <li><rref>option</rref></li>
+	          <li><rref>progressbar</rref></li>
+	          <li><rref>radio</rref></li>
+	          <li><rref>scrollbar</rref></li>
+	          <li><rref>separator</rref></li>
+	          <li><rref>slider</rref></li>
+	          <li><rref>switch</rref></li>
+	          <li><rref>tab</rref></li>
+		</ul>
+            </li>
+          </ul>
+	</section>
+	<section id="tree_inclusion">
+	  <h2>Including Elements in the Accessibility Tree</h2>
+          <p>If not excluded from the accessibility tree per the rules above in <a href="#tree_exclusion">Excluding Elements in the Accessibility Tree</a>, user agents MUST provide an <a>accessible object</a> in the <a>accessibility tree</a> for <abbr title="Document Object Model">DOM</abbr> <a>elements</a> that meet any of the following criteria:</p>
+          <ul>
+            <li>Elements that are not <a>hidden</a> and may fire an <a>accessibility <abbr title="Application Program Interface">API</abbr></a> <a>event</a>:
+              <ul>
+                <li>Elements that are <a>focusable</a> even if the element or one of its ancestor elements has its <sref>aria-hidden</sref> attribute set to <code>true</code>.</li>
+                <li>Elements that are a valid target of an <pref>aria-activedescendant</pref> attribute.</li>
+              </ul>
+	        </li>
+            <li>Elements that have an explicit role or a global <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> attribute and do not have <sref>aria-hidden</sref> set to <code>true</code>. (See <a href="#tree_exclusion">Excluding Elements in the Accessibility Tree</a> for additional guidance on <sref>aria-hidden</sref>.)</li>
+            <li>Elements that are not <a>hidden</a> and have an ID that is referenced by another element via a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> property.
+            <p class="note">Text equivalents for hidden referenced objects may still be used in the <a href="#mapping_additional_nd" class="accname">name and description computation</a> even when not included in the accessibility tree.</p>
+            </li>
+          </ul>
+	</section>
+</section>
 <section class="normative" id="host_languages">
 	<h1>Implementation in Host Languages</h1>
 	<p>The <a>roles</a>, <a>state</a>, and <a>properties</a> defined in this specification do not form a complete web language or format. They are intended to be used in the context of a host language. This section discusses how host languages are to implement <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>, to ensure that the markup specified here will integrate smoothly and effectively with the host language markup.</p>
@@ -11159,7 +13336,7 @@
 			<li>The attribute name MUST be <code>role</code>;</li>
 			<li>The attribute value MUST allow a token list as the value;</li>
 			<li>The appearance of the name literal of any concrete <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>role</a> as one of these tokens MUST NOT in and of itself make the attribute value illegal in the host-language syntax; and</li>
-			<li>The first name literal of a non-abstract <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role in the list of tokens in the role attribute defines the role according to which the user agent MUST process the element. User Agent processing for roles is defined in the <cite><a href="https://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings</a></cite> [[CORE-AAM-1.1]].</li>
+			<li>The first name literal of a non-abstract <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role in the list of tokens in the role attribute defines the role according to which the user agent MUST process the element. User Agent processing for roles is defined in the <cite><a href="" class="core-mapping">Core Accessibility API Mappings</a></cite> [[CORE-AAM-1.2]].</li>
 		</ul>
 	</section>
 	<section id="host_general_attrs">
@@ -11177,14 +13354,14 @@
 	</section>
 	<section id="host_general_focus">
 		<h2>Focus Navigation</h2>
-		<p>An implementing host language MUST provide support for the author to make all interactive elements focusable, that is, any renderable or event-receiving elements. An implementing host language MUST provide a facility to allow web authors to define whether these focusable, interactive elements appear in the default tab navigation order. The <code>tabindex</code> <a>attribute</a> in <abbr title="Hypertext Markup Language">HTML</abbr> 5 is an example of one implementation.</p>
+		<p>An implementing host language MUST provide support for the author to make all interactive elements focusable, that is, any renderable or event-receiving elements. An implementing host language MUST provide a facility to allow web authors to define whether these focusable, interactive elements appear in the default tab navigation order. The <code>tabindex</code> <a>attribute</a> in <abbr title="Hypertext Markup Language">HTML</abbr> is an example of one implementation.</p>
 	</section>
 	<section id="implicit_semantics">
 		<h2>Implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Semantics</h2>
 		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is designed to provide <a>semantic</a> information about objects when host languages lack native semantics for the object. <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is designed, however, to provide additional semantics for many host languages. Furthermore, host languages over time can evolve and provide new native features that correspond to WAI-ARIA features. Therefore, there are many situations in which <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics are redundant with host language semantics. </p>
 		<p>These host language features can be viewed as having &quot;implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics&quot;. User agent processing of features with implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics would be similar to the processing for the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> feature. The processing might not be identical because of lexical differences between the host language feature and the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> feature, but generally the user agent would expose the same information to the accessibility API. Features with implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics satisfy <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> structural requirements such as required owned elements, required states and properties, etc. and do not require explicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics to be provided. On elements with implicit WAI-ARIA roles, authors can also use WAI-ARIA states and properties supported by those roles <em>without</em> requiring explicit indication of the WAI-ARIA role.</p>
 		<p>For example, if an element with the functionality already exists, such as a checkbox or radio button, use the native semantics of the host language. <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> markup is only intended to be used to enhance the native semantics (e.g., indicating that the element is required with <pref>aria-required</pref>), or to change the semantics to a different purpose from the standard functionality of the element.</p>
-		<p>Implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics affect the conflict resolution procedures in the following section, Conflicts with Host Language Semantics. Therefore, implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics need to be defined in a normative specification, such as the host language specification or the <cite><a href="https://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings</a></cite> [[CORE-AAM-1.1]].</p>
+		<p>Implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics affect the conflict resolution procedures in the following section, Conflicts with Host Language Semantics. Therefore, implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics need to be defined in a normative specification, such as the host language specification or the <cite><a href="" class="core-mapping">Core Accessibility API Mappings</a></cite>.</p>
 	</section>
 	<section id="host_general_conflict">
 		<h2>Conflicts with Host Language Semantics</h2>
@@ -11193,10 +13370,11 @@
 		<p>Host languages can have features that have implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics corresponding to roles. When a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role is provided, user agents MUST use the semantic of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role for processing, not the native semantic, unless the role requires <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties whose attributes are explicitly forbidden on the native element by the host language. Values for roles do not conflict in the same way as values for states and properties (for example, the HTML 'checked' attribute and the 'aria-checked' attribute could have conflicting values), and authors are expected to have valid reason to provide a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role even on elements that would not normally be repurposed.</p>
 		<p>When <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties correspond to host language features that have the same <a href="#implicit_semantics">implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantic</a>, it can be particularly problematic to use the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> feature. If the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> feature and the host language feature are both provided but their values are not kept in sync, user agents and assistive technologies cannot know which value to use. Therefore, to prevent providing conflicting states and properties to assistive technologies, host languages MUST explicitly declare where the use of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attributes on each host language element conflicts with native attributes for that element. When a host language declares a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attribute to be in direct semantic conflict with a native attribute for a given element, user agents MUST ignore the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attribute and instead use the host language attribute with the same implicit semantic.</p>
 		<p>Host languages MAY document features that cannot be overridden with <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> (these are called "strong native semantics"). These can be features that have implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics, as well as features where the processing would be uncertain if the semantics were changed with <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>. Conformance checkers MAY signal an error or warning when a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role is used on elements with strong native semantics, but as described above, user agents MUST still use the value of the semantic of the WAI-ARIA role when exposing the element to accessibility APIs unless the native host language semantic is permanently presentational.</p>
-		<p>The opportunity for host languages to create exceptions to the WAI-ARIA override of native features is meant to avoid potential author errors or problems with intrinsic processing of host language features. Author errors could happen when a host language and WAI-ARIA provide similar but not identical features, where it might not be clear how changing one but not the other affects the accessibility API. Intrinsic processing refers to the way a feature is processed, beyond simple rendering and exposure to the Accessibility API, that cannot reasonably be changed in response to a ARIA feature, and would lead to unpredictable results were ARIA allowed. In these situations, there is good reason for host languages to limit the scope of WAI-ARIA. However, this provision does not give blanket permission for host languages to forbid the use of WAI-ARIA simply by documenting, feature by feature, that it may not be used. Host languages should create restrictions on the use of ARIA only when it is critical to effective processing of content.</p>
+		<p>The opportunity for host languages to create exceptions to the WAI-ARIA override of native features is meant to avoid potential author errors or problems with intrinsic processing of host language features. Author errors could happen when a host language and WAI-ARIA provide similar but not identical features, where it might not be clear how changing one but not the other affects the accessibility API. Intrinsic processing refers to the way a feature is processed, beyond simple rendering and exposure to the Accessibility API, that cannot reasonably be changed in response to an ARIA feature, and would lead to unpredictable results were ARIA allowed. In these situations, there is good reason for host languages to limit the scope of WAI-ARIA. However, this provision does not give blanket permission for host languages to forbid the use of WAI-ARIA simply by documenting, feature by feature, that it may not be used. Host languages should create restrictions on the use of ARIA only when it is critical to effective processing of content.</p>
 		<p>Certain ARIA features are critical to building a complete model in the accessibility API. Such features are not expected to conflict with native host language semantics (though they may complement them). Therefore, host languages MUST NOT declare strong native semantics that prevent use of the following ARIA features:</p>
 		<ul>
 			<li><pref>aria-describedby</pref></li>
+			<li><pref>aria-description</pref></li>
 			<li><pref>aria-label</pref></li>
 			<li><pref>aria-labelledby</pref></li>
 		</ul>
@@ -11216,134 +13394,308 @@
 		<p>State and property attributes are included in host languages, and therefore syntax for representation of their value types is governed by the host language. For each of the value types defined in <a href="#propcharacteristic_value">Value</a>, an appropriate value type from the host language is used. Recommended correspondences between <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> value types and various host language value types are listed in <a href="#typemapping">Mapping <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Value types to languages</a>. This is a non-normative mapping in order to accommodate new host languages supporting <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>.</p>
 		<p>The list value types&#8212;ID reference list and token list&#8212;allow more than one value of the given type to be provided. The values are separated by delimiter characters recognized by the host language for list attributes, such as space characters, commas, etc. Some languages may require a specific, single delimiter, while others may allow various delimiters.</p>
 		<p>Global states and properties are supported on any element in the host language. However, authors MUST only use non-global states and properties on elements with a role supporting the state or property; either defined as an explicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role, or as defined by the host language implicit WAI-ARIA semantic matching an appropriate WAI-ARIA role. When a role attribute is added to an element, the <a>semantics</a> and behavior of the element, including support for <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties, are augmented or overridden by the role behavior. User agents <strong>MUST</strong> ignore non-global states and properties used on an element without a role supporting the state or property; either defined as an explicit WAI-ARIA role, or as defined by the host language WAI-ARIA semantic matching an appropriate <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role. For example, the <pref>aria-valuetext</pref> attribute may be used on a <rref>progressbar</rref>.</p>
-		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles have associated states and properties that are qualified as "supported" or "required".  An example of a property <em>supported</em> by the <a class="role-reference" href="#combobox">combobox</a> role is <a class="property-reference" href="#aria-autocomplete">aria-autocomplete</a>.  The property is designated "supported" in this case because a given <code>combobox</code> might or might not implement auto completion.  In contrast, the <code>combobox</code> role <em>requires</em> the <a class="state-reference" href="#aria-expanded">aria-expanded</a> state in order to indicate that it is expandable.  Comboboxes have a descendant <code>listbox</code> that is either open or closed.  If the <code>listbox</code> is open, the <code>combobox</code> is in its expanded state; otherwise it is collapsed. </p>
+		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles have associated states and properties that are qualified as "supported" or "required".  An example of a property <em>supported</em> by the <a class="role-reference" href="#combobox">combobox</a> role is <a class="property-reference" href="#aria-autocomplete">aria-autocomplete</a>.  The property is designated "supported" in this case because a given <code>combobox</code> might or might not implement auto completion.  In contrast, the <code>combobox</code> role <em>requires</em> the <a class="state-reference" href="#aria-expanded">aria-expanded</a> state in order to indicate that it is expandable.  Comboboxes have a controlled popup element, such as a <code>listbox</code>, that is either open or closed.  If the <code>listbox</code> is open, the <code>combobox</code> is in its expanded state; otherwise it is collapsed. </p>
 		<p>When <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles are used, <em>supported</em> states and properties that are not present in the DOM are treated according to their default value. Keeping with the <code>combobox</code> example, a missing <code>aria-autocomplete</code> attribute is equivalent to <code>aria-autocomplete=&quot;none&quot;</code>, meaning the <code>combobox</code> does not offer auto completion.  </p>
 		<p>However, <em>required</em> states and properties that are absent are an author error. Missing required states and properties are treated as if they were present and have an implicit neutral value that is not necessarily their default value. For example, the default value of <code>aria-expanded</code> is <code>undefined</code>, meaning neither expandable nor collapsible.  But that does not apply to the case of a <code>combobox</code>. In this case, <code>aria-expanded</code> is needed to convey the expandable/collapsible nature of the <code>combobox</code>.  Thus, the implicit value of <code>aria-expanded</code> for the <code>combobox</code> role is <code>false</code>, meaning expandable (and currently collapsed).   The characteristics table associated with each WAI-ARIA role has an "<a href="#implictValueForRole">Implicit Value for Role</a>" entry that specifies the value of a state or property to use in the context of that role when the state or property is missing.  </p>
 		<p>Elements that have implicit WAI-ARIA semantics support the full set of WAI-ARIA states and properties supported by the corresponding role. Therefore, authors MAY omit the role when setting states and properties. The role is only needed when the implicit WAI-ARIA role of the element needs to be changed.</p>
-		<p>Sometimes states and properties are present in the DOM but have a zero-length string ("") as their value.  This is equivalent to their absence.  User agents SHOULD treat state and property attributes with a value of "" the same as they treat an absent attribute.  For supported states and properties, this corresponds to the default value, but if it is a required attribute, it signals an author error, and the implicit value for the role is used. </p>
+		<p>Sometimes states and properties are present in the DOM but have a zero-length string ("") as their value. Authors MAY specify a zero-length string ("") for any supported (but not required) state or property. User agents SHOULD treat state and property attributes with a value of "" the same as they treat an absent attribute.  For supported states and properties, this corresponds to the default value, but if it is a required attribute, it signals an author error, and the implicit value for the role is used. </p>
+		<section id="mapping_additional_relations_error_processing">
+	        <h3>ID Reference Error Processing</h3>
+	        <p><a>User agents</a> SHOULD ignore ID references that do not match the ID of another <a>element</a> in the same document.</p>
+	        <p>It is the web author's responsibility to ensure that IDs are unique. If more than one element has the same ID, the user agent SHOULD use the first element found with the given ID. The behavior will be the same as <code>getElementById</code>.</p>
+	        <p>If the same element is specified multiple times in a single <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> relation, user agents SHOULD return multiple pointers to the same <a>element</a>.</p>
+	        <p><pref>aria-activedescendant</pref> is defined as referencing only a single ID reference. Any <code>aria-activedescendant</code> value that does not match an existing ID reference exactly is an author error and will not match any element in the <abbr title="Document Object Model">DOM</abbr>.</p>
+        </section>
+	</section>
+	<section id="document-handling_css-selectors">
+		<h3>CSS Selectors</h3>
+		<p class="note">This section might be removed in a future version.</p>
+		<p>Support for <a class="termref">attribute</a> selectors MUST include <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> attributes. For example, <samp>.fooMenuItem[aria-haspopup=&quot;true&quot;]</samp> would select all <a class="termref">elements</a>  with class <code>fooMenuItem</code>, and <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> property <pref>aria-haspopup</pref> with value of <code>true</code>. The presentation MUST be updated for dynamic changes to <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> attributes. This allows authors to match styling with <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a>semantics</a>. </p>
+	</section>
+</section>
+<section id="document-handling_author-errors">
+	<h2>Handling Author Errors</h2>
+	<section id="document-handling_author-errors_roles">
+		<h3>Roles</h3>
+		<p>User agents are expected to perform validation of <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a>roles</a>.</p>
+		<p>As stated in the <a href="#role_definitions">Definition of Roles</a> section, it is considered an authoring error to use <a href="#abstract_roles">abstract roles</a> in content. User agents MUST NOT map abstract roles via the standard role mechanism of the accessibility <abbr title="application programming interface">API</abbr>.</p>
+		<p>If the <code>role</code> attribute contains no tokens matching the name of a non-abstract <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role, the user agent MUST treat the element as if no <a>role</a> had been provided. For example, <code>&lt;table&nbsp;role=&quot;foo&quot;&gt;</code> should be exposed in the same way as <code>&lt;table&gt;</code> and <code>&lt;input&nbsp;type=&quot;text&quot;&nbsp;role=&quot;structure&quot;&gt;</code> in the same way as <code>&lt;input&nbsp;type=&quot;text&quot;&gt;</code>.</p>
+	</section>
+	<section id="document-handling_author-errors_states-properties">
+		<h3>States and Properties</h3>
+			<p>In general, <a>user agents</a> do not do much validation of <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref">properties</a>. User agents MAY do some minor validation on request, such as making sure <a data-lt="valid idref">valid IDs</a> are specified for <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> relations, and enforcing things like <pref>aria-posinset</pref> being within 1 and <pref>aria-setsize</pref>, inclusive. User agents are not  responsible for logical validation, such as the following:</p>
+				<ol>
+					<li>Circular references created by relations, such as specifying that two <a>elements</a> own each other. </li>
+					<li>Correct usage with regard to <abbr title="Document Object Model">DOM</abbr> tree structure, such as an <a>element</a> being owned by more than one other element.</li>
+					<li>Elements with <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a>roles</a> correctly implement the  behavior of the specified role. For example, user agents do not verify that an element with a role of <rref>checkbox</rref> actually behaves like a checkbox.</li>
+					<li>Elements that do not correctly observe required child / parent role relationships or that appear elsewhere than in their required parent.</li>
+					<li>Determining whether <pref>aria-activedescendant</pref> actually points to an <a>owned</a> element of the container widget.</li>
+					<li>Determining implicit values of <pref>aria-setsize</pref> and <pref>aria-posinset</pref> when they are specified on some but not all the elements of the set.</li>
+				</ol>
+			<p>If the author specifies a non-numeric value for a decimal or integer value type, the user agent SHOULD do the following:</p>
+				<ul>
+				<li>When asked for the string version of the property, return the string if specified by the author.</li>
+				<li>When asked for the numeric version:
+					<ul>
+					<li>Follow the guidance in the <a href="#authorErrorDefaultValuesTable">Fallback values for missing required attributes</a> table below, if applicable. </li>
+					<li>Otherwise, return a fallback value of 0.0 for decimal value types and 0 for integer value types. </li>
+					</ul>
+				</li>
+				</ul>
+			<p>If a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> property contains an unknown or disallowed value, the user agent SHOULD expose to platform <a>accessibility APIs</a> as follows:</p>
+			<ul>
+				<li>When exposing as a platform accessibility API attribute, expose the unknown value &#8212; do not vet it against possible values. </li>
+				<li>When exposing as a platform <abbr title="application programming interface">API</abbr> Boolean state:
+				<ul>
+					<li>For values of &quot;&quot; (empty string),  &quot;undefined&quot; or no <a class="termref">attribute</a> present:
+					<ul>
+						<li>Follow the guidance in the <a href="#authorErrorDefaultValuesTable">Fallback values for missing required attributes</a> table below, if applicable. </li>
+						<li>Otherwise, treat as false. </li>
+					</ul>
+					</li>
+					<li>Treat any other value as true.</li>
+				</ul>
+				</li>
+				<li>Otherwise, ignore the value and treat the property as not present.</li>
+			</ul>
+			<p class="note">In <abbr title="User Interface Automation">UIA</abbr>, the user agent might leave the corresponding property set to &quot;unsupported.&quot;</p>
+			<p>User agents MUST NOT expose <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> attributes that reference unresolved IDs. For example:</p>
+			<ul>
+				<li>When the state or property has only one ID reference that cannot be resolved, treat as if the state or property is not present.</li>
+				<li>When the state or property has a list of ID references, ignore any that can't be resolved. If none in the list can be resolved, treat as if the state or property is not present.</li>
+			</ul>
+			<p>User Agents MUST NOT expose <pref>aria-roledescription</pref> when: </p>
+				<ul>
+					<li>The element it is applied to has an invalid <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role, or</li>
+					<li>The element does not have an implicit <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role</li>
+				</ul>
+			<p>If a required <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> attribute for a given role is missing, user agents SHOULD process the attribute as if the values given in the following table were provided.</p>
+			<table id="authorErrorDefaultValuesTable">
+			<caption>Fallback values for missing required attributes</caption>
+					<thead>
+						<tr>
+							<th><abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role</th>
+							<th>Required Attribute</th>
+							<th>Fallback value</th>
+						</tr>
+					</thead>
+			<tbody>
+				<tr>
+					<td><rref>checkbox</rref></td>
+					<td><sref>aria-checked</sref></td>
+					<td><code>false</code> </td>
+				</tr>
+				<tr>
+					<td><rref>combobox</rref></td>
+					<td><sref>aria-controls</sref></td>
+					<td>no mapping</td>
+				</tr>
+				<tr>
+					<td><rref>combobox</rref></td>
+					<td><sref>aria-expanded</sref></td>
+					<td><code>false</code></td>
+				</tr>
+				<tr>
+					<td><rref>heading</rref></td>
+					<td><pref>aria-level</pref></td>
+					<td><code>2</code></td>
+				</tr>
+				<tr>
+					<td><rref>menuitemcheckbox</rref></td>
+					<td><sref>aria-checked</sref></td>
+					<td><code>false</code> </td>
+				</tr>
+				<tr>
+					<td><rref>menuitemradio</rref></td>
+					<td><sref>aria-checked</sref></td>
+					<td><code>false</code> </td>
+				</tr>
+				<tr>
+					<td><rref>radio</rref></td>
+					<td><sref>aria-checked</sref></td>
+					<td><code>false</code> </td>
+				</tr>
+				<tr>
+					<td><rref>scrollbar</rref></td>
+					<td><pref>aria-controls</pref></td>
+					<td>no mapping</td>
+				</tr>
+				<tr>
+					<td><rref>scrollbar</rref></td>
+					<td><pref>aria-valuenow</pref></td>
+					<td>If missing or not a <a href="#valuetype_number">number</a>,<code>(aria-valuemax - aria-valuemin) / 2</code>. If present but less than <code>aria-valuemin</code>, the value of <code>aria-valuemin</code>. If present but greater than <code>aria-valuemax</code>, the value of <code>aria-valuemax</code>.</td>
+				</tr>
+				<tr>
+					<td><rref>separator</rref> (if focusable)</td>
+					<td><pref>aria-valuenow</pref></td>
+					<td>If missing or not a <a href="#valuetype_number">number</a>,<code>(aria-valuemax - aria-valuemin) / 2</code>. If present but less than <code>aria-valuemin</code>, the value of <code>aria-valuemin</code>. If present but greater than <code>aria-valuemax</code>, the value of <code>aria-valuemax</code>.</td>
+				</tr>
+				<tr>
+					<td><rref>slider</rref></td>
+					<td><pref>aria-valuenow</pref></td>
+					<td>If missing or not a <a href="#valuetype_number">number</a>,<code>(aria-valuemax - aria-valuemin) / 2</code>. If present but less than <code>aria-valuemin</code>, the value of <code>aria-valuemin</code>. If present but greater than <code>aria-valuemax</code>, the value of <code>aria-valuemax</code>. </td>
+				</tr>
+				<tr>
+					<td><rref>switch</rref></td>
+					<td><sref>aria-checked</sref></td>
+					<td><code>false</code> </td>
+				</tr>
+				<tr>
+					<td><rref>meter</rref></td>
+					<td><pref>aria-valuenow</pref></td>
+					<td>A value matching the implicit or explicitly set <code>aria-valuemin</code>.</td>
+				</tr>
+			</tbody>
+		</table>
+		<p class="note">Implicit Values for non-required states and properties appear in the characteristics table for each role. These are not considered fallback values so are not included here.</p>
 	</section>
 </section>
 <section id="idl-interface" class="normative">
 	<h2>IDL Interface</h2>
-	<p>Conforming user agents MUST implement the following IDL interfaces.</p>
-	<section id="AccessibilityRole" class="normative" data-dfn-for="AccessibilityRole" data-link-for="AccessibilityRole">
-		<h2>Interface Mixin <dfn>AccessibilityRole</dfn></h2>
+	<p>Conforming user agents MUST implement the following IDL interface.</p>
+	<section id="ARIAMixin" class="normative" data-dfn-for="ARIAMixin" data-link-for="ARIAMixin">
+		<h2>Interface Mixin <dfn>ARIAMixin</dfn></h2>
 		<pre class="idl">
-			interface mixin AccessibilityRole {
+			interface mixin ARIAMixin {
 				attribute DOMString? role;
+
+				<!-- attribute Element ariaActiveDescendantElement; -->
+				attribute DOMString ariaAtomic;
+				attribute DOMString ariaAutoComplete;
+				attribute DOMString ariaBusy;
+				attribute DOMString ariaChecked;
+				attribute DOMString ariaColCount;
+				attribute DOMString ariaColIndex;
+				attribute DOMString ariaColIndexText;
+				attribute DOMString ariaColSpan;
+				<!-- attribute FrozenArray&lt;Element&gt; ariaControlsElements; -->
+				attribute DOMString ariaCurrent;
+				<!-- attribute FrozenArray&lt;Element&gt; ariaDescribedByElements; -->
+				attribute DOMString ariaDescription;
+				<!-- attribute FrozenArray&lt;Element&gt; ariaDetailsElements; -->
+				attribute DOMString ariaDisabled;
+				<!-- attribute Element ariaErrorMessageElement; -->
+				attribute DOMString ariaExpanded;
+				<!-- attribute FrozenArray&lt;Element&gt; ariaFlowToElements; -->
+				attribute DOMString ariaHasPopup;
+				attribute DOMString ariaHidden;
+				attribute DOMString ariaInvalid;
+				attribute DOMString ariaKeyShortcuts;
+				attribute DOMString ariaLabel;
+				<!-- attribute FrozenArray&lt;Element&gt; ariaLabelledByElements; -->
+				attribute DOMString ariaLevel;
+				attribute DOMString ariaLive;
+				attribute DOMString ariaModal;
+				attribute DOMString ariaMultiLine;
+				attribute DOMString ariaMultiSelectable;
+				attribute DOMString ariaOrientation;
+				<!-- attribute FrozenArray&lt;Element&gt; ariaOwnsElements; -->
+				attribute DOMString ariaPlaceholder;
+				attribute DOMString ariaPosInSet;
+				attribute DOMString ariaPressed;
+				attribute DOMString ariaReadOnly;
+				<!-- attribute DOMString ariaRelevant; -->
+				attribute DOMString ariaRequired;
+				attribute DOMString ariaRoleDescription;
+				attribute DOMString ariaRowCount;
+				attribute DOMString ariaRowIndex;
+				attribute DOMString ariaRowIndexText;
+				attribute DOMString ariaRowSpan;
+				attribute DOMString ariaSelected;
+				attribute DOMString ariaSetSize;
+				attribute DOMString ariaSort;
+				attribute DOMString ariaValueMax;
+				attribute DOMString ariaValueMin;
+				attribute DOMString ariaValueNow;
+				attribute DOMString ariaValueText;
 			};
-			Element includes AccessibilityRole;
 		</pre>
-		<p>User agents MUST <a href="https://www.w3.org/TR/html52/infrastructure.html#reflecting-content-attributes-in-idl-attributes">reflect</a> the <code><dfn>role</dfn></code> content attribute as the <code>role</code> IDL attribute.</p>
+
+		<p>Interfaces that include <code>ARIAMixin</code> must provide the following algorithms:</p>
+
+		<ul>
+			<li><dfn><code>ARIAMixin</code> getter steps</dfn>, which take the host interface instance, IDL attribute name, and content attribute name, and must return a string value; and
+			<li><dfn><code>ARIAMixin</code> setter steps</dfn>, which take the host interface instance, IDL attribute name, content attribute name, and string value, and must return nothing.</li>
+		</ul>
+
+		<p>For every IDL attribute <var>idlAttribute</var> defined in <code>ARIAMixin</code>, on getting, it must perform the following steps:</p>
+
+		<ol>
+			<li><p>Let <var>contentAttribute</var> be the ARIA content attribute determined by looking up <var>idlAttribute</var> in the ARIA Attribute Correspondence table.</p></li>
+
+			<li><p>Return the result of running the <a><code>ARIAMixin</code> getter steps</a>, given this, <var>idlAttribute</var>, and <var>contentAttribute</var>.</p></li>
+		</ol>
+
+		<p>Similarly, on setting, it must perform the following steps:</p>
+
+		<ol>
+			<li><p>Let <var>contentAttribute</var> be the ARIA content attribute determined by looking up <var>idlAttribute</var> in the ARIA Attribute Correspondence table.</p></li>
+
+			<li><p>Run the <a><code>ARIAMixin</code> setter steps</a>, given this, <var>idlAttribute</var>, <var>contentAttribute</var>, and the given value.</p></li>
+		</ol>
+
+		<p class="note">This very general framework is motivated by the desire for different host interfaces, such as <code>Element</code> and <code>ElementInternals</code>, to give these IDL attributes different behaviors. The alternative is requiring each host interface to duplicate the IDL attributes independently, so that they can specify independent behaviors, but that comes with a high risk of them getting out of sync.</p>
 	</section>
 
-	<section id="AriaAttributes" class="normative" data-dfn-for="AriaAttributes" data-link-for="AriaAttributes">
-		<h2>Interface Mixin <dfn>AriaAttributes</dfn></h2>
-		<pre class="idl">
-			interface mixin AriaAttributes {
-				attribute DOMString? ariaActiveDescendant;
-				attribute DOMString? ariaAtomic;
-				attribute DOMString? ariaAutoComplete;
-				attribute DOMString? ariaBusy;
-				attribute DOMString? ariaChecked;
-				attribute DOMString? ariaColCount;
-				attribute DOMString? ariaColIndex;
-				attribute DOMString? ariaColSpan;
-				attribute DOMString? ariaControls;
-				attribute DOMString? ariaCurrent;
-				attribute DOMString? ariaDescribedBy;
-				attribute DOMString? ariaDetails;
-				attribute DOMString? ariaDisabled;
-				attribute DOMString? ariaErrorMessage;
-				attribute DOMString? ariaExpanded;
-				attribute DOMString? ariaFlowTo;
-				attribute DOMString? ariaHasPopup;
-				attribute DOMString? ariaHidden;
-				attribute DOMString? ariaInvalid;
-				attribute DOMString? ariaKeyShortcuts;
-				attribute DOMString? ariaLabel;
-				attribute DOMString? ariaLabelledBy;
-				attribute DOMString? ariaLevel;
-				attribute DOMString? ariaLive;
-				attribute DOMString? ariaModal;
-				attribute DOMString? ariaMultiLine;
-				attribute DOMString? ariaMultiSelectable;
-				attribute DOMString? ariaOrientation;
-				attribute DOMString? ariaOwns;
-				attribute DOMString? ariaPlaceholder;
-				attribute DOMString? ariaPosInSet;
-				attribute DOMString? ariaPressed;
-				attribute DOMString? ariaReadOnly;
-				attribute DOMString? ariaRelevant;
-				attribute DOMString? ariaRequired;
-				attribute DOMString? ariaRoleDescription;
-				attribute DOMString? ariaRowCount;
-				attribute DOMString? ariaRowIndex;
-				attribute DOMString? ariaRowSpan;
-				attribute DOMString? ariaSelected;
-				attribute DOMString? ariaSetSize;
-				attribute DOMString? ariaSort;
-				attribute DOMString? ariaValueMax;
-				attribute DOMString? ariaValueMin;
-				attribute DOMString? ariaValueNow;
-				attribute DOMString? ariaValueText;
-			};
-			Element includes AriaAttributes;
-		</pre>
-		<section id="reflection" class="normative">
-			<h2>ARIA Attribute Reflection</h2>
-			<p>User agents MUST <a href="https://www.w3.org/TR/html52/infrastructure.html#reflecting-content-attributes-in-idl-attributes">reflect</a> the following content attributes to each of the corresponding IDL attributes.</p>
-			<table>
-				<tr><th>IDL Attribute</th><th>Reflected ARIA Content Attribute</th></tr>
-				<tr><td><dfn>ariaActiveDescendant</dfn></td><td><pref>aria-activedescendant</pref></td></tr>
-				<tr><td><dfn>ariaAtomic</dfn></td><td><pref>aria-atomic</pref></td></tr>
-				<tr><td><dfn>ariaAutoComplete</dfn></td><td><pref>aria-autocomplete</pref></td></tr>
-				<tr><td><dfn>ariaBusy</dfn></td><td><sref>aria-busy</sref></td></tr>
-				<tr><td><dfn>ariaChecked</dfn></td><td><sref>aria-checked</sref></td></tr>
-				<tr><td><dfn>ariaColCount</dfn></td><td><pref>aria-colcount</pref></td></tr>
-				<tr><td><dfn>ariaColIndex</dfn></td><td><pref>aria-colindex</pref></td></tr>
-				<tr><td><dfn>ariaColSpan</dfn></td><td><pref>aria-colspan</pref></td></tr>
-				<tr><td><dfn>ariaControls</dfn></td><td><pref>aria-controls</pref></td></tr>
-				<tr><td><dfn>ariaCurrent</dfn></td><td><sref>aria-current</sref></td></tr>
-				<tr><td><dfn>ariaDescribedBy</dfn></td><td><pref>aria-describedby</pref></td></tr>
-				<tr><td><dfn>ariaDetails</dfn></td><td><pref>aria-details</pref></td></tr>
-				<tr><td><dfn>ariaDisabled</dfn></td><td><sref>aria-disabled</sref></td></tr>
-				<tr><td><dfn>ariaErrorMessage</dfn></td><td><pref>aria-errormessage</pref></td></tr>
-				<tr><td><dfn>ariaExpanded</dfn></td><td><sref>aria-expanded</sref></td></tr>
-				<tr><td><dfn>ariaFlowTo</dfn></td><td><pref>aria-flowto</pref></td></tr>
-				<tr><td><dfn>ariaHasPopup</dfn></td><td><pref>aria-haspopup</pref></td></tr>
-				<tr><td><dfn>ariaHidden</dfn></td><td><sref>aria-hidden</sref></td></tr>
-				<tr><td><dfn>ariaInvalid</dfn></td><td><sref>aria-invalid</sref></td></tr>
-				<tr><td><dfn>ariaKeyShortcuts</dfn></td><td><pref>aria-keyshortcuts</pref></td></tr>
-				<tr><td><dfn>ariaLabel</dfn></td><td><pref>aria-label</pref></td></tr>
-				<tr><td><dfn>ariaLabelledBy</dfn></td><td><pref>aria-labelledby</pref></td></tr>
-				<tr><td><dfn>ariaLevel</dfn></td><td><pref>aria-level</pref></td></tr>
-				<tr><td><dfn>ariaLive</dfn></td><td><pref>aria-live</pref></td></tr>
-				<tr><td><dfn>ariaModal</dfn></td><td><pref>aria-modal</pref></td></tr>
-				<tr><td><dfn>ariaMultiLine</dfn></td><td><pref>aria-multiline</pref></td></tr>
-				<tr><td><dfn>ariaMultiSelectable</dfn></td><td><pref>aria-multiselectable</pref></td></tr>
-				<tr><td><dfn>ariaOrientation</dfn></td><td><pref>aria-orientation</pref></td></tr>
-				<tr><td><dfn>ariaOwns</dfn></td><td><pref>aria-owns</pref></td></tr>
-				<tr><td><dfn>ariaPlaceholder</dfn></td><td><pref>aria-placeholder</pref></td></tr>
-				<tr><td><dfn>ariaPosInSet</dfn></td><td><pref>aria-posinset</pref></td></tr>
-				<tr><td><dfn>ariaPressed</dfn></td><td><sref>aria-pressed</sref></td></tr>
-				<tr><td><dfn>ariaReadOnly</dfn></td><td><pref>aria-readonly</pref></td></tr>
-				<tr><td><dfn>ariaRelevant</dfn></td><td><pref>aria-relevant</pref></td></tr>
-				<tr><td><dfn>ariaRequired</dfn></td><td><pref>aria-required</pref></td></tr>
-				<tr><td><dfn>ariaRoleDescription</dfn></td><td><pref>aria-roledescription</pref></td></tr>
-				<tr><td><dfn>ariaRowCount</dfn></td><td><pref>aria-rowcount</pref></td></tr>
-				<tr><td><dfn>ariaRowIndex</dfn></td><td><pref>aria-rowindex</pref></td></tr>
-				<tr><td><dfn>ariaRowSpan</dfn></td><td><pref>aria-rowspan</pref></td></tr>
-				<tr><td><dfn>ariaSelected</dfn></td><td><sref>aria-selected</sref></td></tr>
-				<tr><td><dfn>ariaSetSize</dfn></td><td><pref>aria-setsize</pref></td></tr>
-				<tr><td><dfn>ariaSort</dfn></td><td><pref>aria-sort</pref></td></tr>
-				<tr><td><dfn>ariaValueMax</dfn></td><td><pref>aria-valuemax</pref></td></tr>
-				<tr><td><dfn>ariaValueMin</dfn></td><td><pref>aria-valuemin</pref></td></tr>
-				<tr><td><dfn>ariaValueNow</dfn></td><td><pref>aria-valuenow</pref></td></tr>
-				<tr><td><dfn>ariaValueText</dfn></td><td><pref>aria-valuetext</pref></td></tr>
-			</table>
-			<p class="note">Note: Attributes <pref>aria-dropeffect</pref> and <sref>aria-grabbed</sref> were deprecated in ARIA 1.1 and do not have corresponding IDL attributes.</p>
-		</section>
+	<section id="accessibilityroleandproperties-correspondence" class="normative" data-dfn-for="ARIAMixin" data-link-for="ARIAMixin">
+		<h2>ARIA Attribute Correspondence</h2>
+		<p>The following table provides a correspondence between IDL attribute names and content attribute names, for use by <code>ARIAMixin</code>.</p>
+
+		<table>
+			<tr><th>IDL Attribute</th><th>Reflected ARIA Content Attribute</th></tr>
+			<tr><td><dfn>role</dfn></td><td><a href="#introrole">role</a></td></tr>
+			<!-- <tr><td><dfn>ariaActiveDescendantElement</dfn></td><td><pref>aria-activedescendant</pref></td></tr> -->
+			<tr><td><dfn>ariaAtomic</dfn></td><td><pref>aria-atomic</pref></td></tr>
+			<tr><td><dfn>ariaAutoComplete</dfn></td><td><pref>aria-autocomplete</pref></td></tr>
+			<tr><td><dfn>ariaBusy</dfn></td><td><sref>aria-busy</sref></td></tr>
+			<tr><td><dfn>ariaChecked</dfn></td><td><sref>aria-checked</sref></td></tr>
+			<tr><td><dfn>ariaColCount</dfn></td><td><pref>aria-colcount</pref></td></tr>
+			<tr><td><dfn>ariaColIndex</dfn></td><td><pref>aria-colindex</pref></td></tr>
+			<tr><td><dfn>ariaColIndexText</dfn></td><td><pref>aria-colindextext</pref></td></tr>
+			<tr><td><dfn>ariaColSpan</dfn></td><td><pref>aria-colspan</pref></td></tr>
+			<!-- <tr><td><dfn>ariaControlsElements</dfn></td><td><pref>aria-controls</pref></td></tr> -->
+			<tr><td><dfn>ariaCurrent</dfn></td><td><sref>aria-current</sref></td></tr>
+			<!-- <tr><td><dfn>ariaDescribedByElements</dfn></td><td><pref>aria-describedby</pref></td></tr> -->
+			<tr><td><dfn>ariaDescription</dfn></td><td><pref>aria-description</pref></td></tr>
+			<!-- <tr><td><dfn>ariaDetailsElements</dfn></td><td><pref>aria-details</pref></td></tr> -->
+			<tr><td><dfn>ariaDisabled</dfn></td><td><sref>aria-disabled</sref></td></tr>
+			<!-- <tr><td><dfn>ariaErrorMessageElement</dfn></td><td><pref>aria-errormessage</pref></td></tr> -->
+			<tr><td><dfn>ariaExpanded</dfn></td><td><sref>aria-expanded</sref></td></tr>
+			<!-- <tr><td><dfn>ariaFlowToElements</dfn></td><td><pref>aria-flowto</pref></td></tr> -->
+			<tr><td><dfn>ariaHasPopup</dfn></td><td><pref>aria-haspopup</pref></td></tr>
+			<tr><td><dfn>ariaHidden</dfn></td><td><sref>aria-hidden</sref></td></tr>
+			<tr><td><dfn>ariaInvalid</dfn></td><td><sref>aria-invalid</sref></td></tr>
+			<tr><td><dfn>ariaKeyShortcuts</dfn></td><td><pref>aria-keyshortcuts</pref></td></tr>
+			<tr><td><dfn>ariaLabel</dfn></td><td><pref>aria-label</pref></td></tr>
+			<!-- <tr><td><dfn>ariaLabelledByElements</dfn></td><td><pref>aria-labelledby</pref></td></tr> -->
+			<tr><td><dfn>ariaLevel</dfn></td><td><pref>aria-level</pref></td></tr>
+			<tr><td><dfn>ariaLive</dfn></td><td><pref>aria-live</pref></td></tr>
+			<tr><td><dfn>ariaModal</dfn></td><td><pref>aria-modal</pref></td></tr>
+			<tr><td><dfn>ariaMultiLine</dfn></td><td><pref>aria-multiline</pref></td></tr>
+			<tr><td><dfn>ariaMultiSelectable</dfn></td><td><pref>aria-multiselectable</pref></td></tr>
+			<tr><td><dfn>ariaOrientation</dfn></td><td><pref>aria-orientation</pref></td></tr>
+			<!-- <tr><td><dfn>ariaOwnsElements</dfn></td><td><pref>aria-owns</pref></td></tr> -->
+			<tr><td><dfn>ariaPlaceholder</dfn></td><td><pref>aria-placeholder</pref></td></tr>
+			<tr><td><dfn>ariaPosInSet</dfn></td><td><pref>aria-posinset</pref></td></tr>
+			<tr><td><dfn>ariaPressed</dfn></td><td><sref>aria-pressed</sref></td></tr>
+			<tr><td><dfn>ariaReadOnly</dfn></td><td><pref>aria-readonly</pref></td></tr>
+			<!-- <tr><td><dfn>ariaRelevant</dfn></td><td><pref>aria-relevant</pref></td></tr> -->
+			<tr><td><dfn>ariaRequired</dfn></td><td><pref>aria-required</pref></td></tr>
+			<tr><td><dfn>ariaRoleDescription</dfn></td><td><pref>aria-roledescription</pref></td></tr>
+			<tr><td><dfn>ariaRowCount</dfn></td><td><pref>aria-rowcount</pref></td></tr>
+			<tr><td><dfn>ariaRowIndex</dfn></td><td><pref>aria-rowindex</pref></td></tr>
+			<tr><td><dfn>ariaRowIndexText</dfn></td><td><pref>aria-rowindextext</pref></td></tr>
+			<tr><td><dfn>ariaRowSpan</dfn></td><td><pref>aria-rowspan</pref></td></tr>
+			<tr><td><dfn>ariaSelected</dfn></td><td><sref>aria-selected</sref></td></tr>
+			<tr><td><dfn>ariaSetSize</dfn></td><td><pref>aria-setsize</pref></td></tr>
+			<tr><td><dfn>ariaSort</dfn></td><td><pref>aria-sort</pref></td></tr>
+			<tr><td><dfn>ariaValueMax</dfn></td><td><pref>aria-valuemax</pref></td></tr>
+			<tr><td><dfn>ariaValueMin</dfn></td><td><pref>aria-valuemin</pref></td></tr>
+			<tr><td><dfn>ariaValueNow</dfn></td><td><pref>aria-valuenow</pref></td></tr>
+			<tr><td><dfn>ariaValueText</dfn></td><td><pref>aria-valuetext</pref></td></tr>
+		</table>
+		<p class="note">Note: Attributes <pref>aria-dropeffect</pref> and <sref>aria-grabbed</sref> were deprecated in ARIA 1.1 and do not have corresponding IDL attributes.</p>
+
 		<section class="informative" id="idl_attr_disambiguation">
 			<h3>Disambiguation Pattern</h3>
 			<p>Though specification authors may make exceptions to this pattern, the following rules were used to disambiguate names and case of the IDL attributes listed above.</p>
@@ -11361,8 +13713,25 @@
 			<ul>
 				<li><code>ariaPosInSet</code>: The <pref>aria-posinset</pref> attribute refers to an item's position in a set (two words: "in set") rather than the "inset" of an item from the beginning of the collection. Therefore the IDL attribute name is <code>ariaPosInSet</code> with the P, I, and second S capitalized, <em>not</em> <code>ariaPosInset</code>.</li>
 			</ul>
-			<p class="ednote">Editor's Note: Should we make an exception on the spelling of "placeholder" and capitalize the H anyway? Some developers will expect this to be <code>ariaPlaceHolder</code> despite the fact that it's not a hyphenated word.</p>
 		</section>
+	</section>
+
+	<section id="idl_element">
+		<h2><code>ARIAMixin</code> Mixed in to <code>Element</code></h2>
+
+		<p>User agents MUST include <code>ARIAMixin</code> on <code>Element</code>:</p>
+
+		<pre class="idl">
+			Element includes ARIAMixin;
+		</pre>
+
+		<p>For <code>Element</code>:</p>
+		<ul>
+			<li><p>The <a><code>ARIAMixin</code> getter steps</a> given <var>element</var>, <var>idlAttribute</var>, and <var>contentAttribute</var> are to return the result of the getter algorithm for <var>idlAttribute</var> <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect">reflecting</a> <var>contentAttribute</var> on <var>element</var>.</p></li>
+			<li><p>The <a><code>ARIAMixin</code> setter steps</a> given <var>element</var>, <var>idlAttribute</var>, <var>contentAttribute</var>, and <var>value</var> are to perform the setter algorithm for <var>idlAttribute</var> <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect">reflecting</a> <var>contentAttribute</var> on <var>element</var>, given <var>value</var>.</p></li>
+		</ul>
+
+		<p class="note">In practice, this means that, e.g., the <code>role</code> IDL on <code>Element</code> reflects the <code>role</code> content attribute; the <code>ariaValueMin</code> IDL attribute reflects the <code>aria-valuemin</code> content attribute; etc.</p>
 	</section>
 
 	<section class="informative" id="idl_example_usage">
@@ -11375,7 +13744,7 @@
     &lt;!-- Use semantic markup instead. This is just a retrofit example. --&gt;
 &lt;/div&gt;</pre>
 <pre>// Get a reference to the element.
-let el = document.getElementById('inaccessibleButton'); 
+let el = document.getElementById('inaccessibleButton');
 el.tabIndex = 0; // Make it focusable.
 
 // Set the role and label.
@@ -11402,149 +13771,61 @@ el.getAttribute("aria-label"); // Returns "Publish"</pre>
 	</section>
 
 </section>
-<section class="appendix informative" id="a_schemata">
-	<h1>Schemata</h1>
-	<p>WAI-ARIA roles, states, and properties are available in a number of machine-readable formats to support validation of content using WAI-ARIA attributes. WAI-ARIA is not finalized, however, so these files are subject to change without notice. <span class="todo">Todo: Remove disclaimers about not final at rec.</span></p>
-	<p>It is not appropriate to use these document types for live content. These are made available only for download, to support local use in development, evaluation, and validation tools. Using these versions directly from the W3C server could cause automatic blockage, preventing them from loading.</p>
-	<p>If it is necessary to use schemata in content, follow <a href="http://www.w3.org/blog/systeam/2008/02/08/w3c_s_excessive_dtd_traffic/">guidelines to avoid excessive DTD traffic</a>. For instance, use caching proxies to avoid fetching the schema each time it is used, or ensure software uses a local cache, such as with <a href="http://nwalsh.com/docs/articles/xml2003/">XML catalogs</a>.</p>
-	<section id="a_impl_roles">
-		<h3>Roles Implementation</h3>
-		<p>The taxonomy for WAI-ARIA expressed in RDF is available from <a href="http://www.w3.org/WAI/ARIA/schemata/aria-1.rdf">http://www.w3.org/WAI/ARIA/schemata/aria-1.rdf</a>.</p>
-	</section>
-	<section id="xhtml_mod">
-		<h3><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Attributes Module</h3>
-		<p>This module declares the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>attributes</a> as a module that can be included in a modularized <abbr title="Document Type Definition">DTD</abbr>. A sample XHTML DTD using this module follows. Note the WAI-ARIA attributes are in no namespace, and the attribute name begins with "aria-" to reduce the likelihood of collision with existing attributes.</p>
-		<p>This module is available from <a href="http://www.w3.org/MarkUp/DTD/aria-attributes-1.mod">http://www.w3.org/MarkUp/DTD/aria-attributes-1.mod</a>.</p>
-	</section>
-	<section id="xhtml_dtd">
-		<h3><abbr title="Extensible Hypertext Markup Language">XHTML</abbr> plus <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <abbr title="Document Type Definition">DTD</abbr></h3>
-		<p>This <abbr title="Document Type Definition">DTD</abbr> extends <abbr title="Extensible Hypertext Markup Language">XHTML</abbr> 1.1 and adds the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>state</a> and <a>property</a> <a>attributes</a> to all its <a>elements</a>. In order to provide broader keyboard support and conform with the Focus Navigation section above, it also adds the <code>tabindex</code> attribute to a wider set of elements. </p>
-		<p>This is not a formal document type and may be obsoleted by future formal XHTML DTDs that support WAI-ARIA.</p>
-		<p>The XHTML 1.1 plus WAI-ARIA DTD is available from <a href="http://www.w3.org/WAI/ARIA/schemata/xhtml-aria-1.dtd">http://www.w3.org/WAI/ARIA/schemata/xhtml-aria-1.dtd</a>.</p>
-		<p>Documents written using this XHTML Family markup language can be validated using the above DTD. If a document author wants to facilitate such validation, they can include the following declaration at the top of their document: </p>
-		<pre>&lt;!DOCTYPE html PUBLIC &quot;-//W3C//DTD XHTML+ARIA 1.0//EN&quot;
-  &quot;http://www.w3.org/WAI/ARIA/schemata/xhtml-aria-1.dtd&quot;&gt;</pre>
-		<p>However, note that when this DOCTYPE is present in a document, most user agents treat the document as generic XML rather than HTML. This causes them to be unable to support named character entities defined by the DTD (e.g., &amp;copy;). Therefore, authors need to avoid use of named entities outside of the <cite><a href="https://www.w3.org/TR/xml11/#sec-predefined-ent">predefined entities in XML</a></cite> ([[XML11]], Section 4.6).</p>
-		<p>To avoid the above problem, authors can omit the above DOCTYPE statement. This causes user agents to treat the document as generic HTML with named character entity support as well as built-in ARIA support. However, it causes user agents to enter &quot;quirks&quot; mode which affects CSS rendering, and causes conformance checkers to fail the document due to the added ARIA attributes. </p>
-		<p>To avoid the issues of named character entity support and quirks mode, authors can instead use the following generic DOCTYPE declaration for HTML: </p>
-		<pre>&lt;!DOCTYPE html&gt;</pre>
-		<p>However, this still does not guarantee that documents will be validated by conformance checkers.</p>
-	</section>
-	<section id="xhtml-aria_cat">
-		<h3>SGML Open Catalog Entry for XHTML+ARIA</h3>
-		<p>This section contains the SGML Open Catalog-format definition [[SGML-CATALOG]] of the public identifiers for XHTML+ARIA 1.0.</p>
-		<pre>-- .......................................................................... --
--- File catalog  ............................................................ --
-
---  XHTML+ARIA Catalog Data File
-
-	Revision:  $Revision: 1.40 $
-
-	See "Entity Management", SGML Open Technical Resolution 9401 for detailed
-	information on supplying and using catalog data. This document is available
-	from OASIS at URL:
-
-		&lt;http://www.oasis-open.org/html/tr9401.html&gt;
-
---
-
--- .......................................................................... --
--- SGML declaration associated with XHTML  .................................. --
-
-OVERRIDE YES
-
-SGMLDECL "xml1.dcl"
-
--- :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: --
-
--- XHTML+ARIA modules          .............................................. --
-
-
-PUBLIC "-//W3C//DTD XHTML+ARIA 1.0//EN" "xhtml-aria-1.dtd"
-
-
-PUBLIC "-//W3C//ENTITIES XHTML ARIA Attributes 1.0//EN" "aria-attributes-1.mod"
-
--- End of catalog data  ..................................................... --
--- .......................................................................... --
-</pre>
-	</section>
-	<section id="xhtml_schema_mod">
-		<h3><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Attributes <abbr title="Extensible Markup Language">XML</abbr> Schema Module</h3>
-		<p>This module declares the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>attributes</a> as an <abbr title="Extensible Markup Language">XML</abbr> Schema module that can be included in a modularized schema. Note the WAI-ARIA attributes are in no namespace, and the attribute name begins with "aria-" to reduce the likelihood of collision with existing attributes.</p>
-		<p>This module is available from <a href="http://www.w3.org/MarkUp/SCHEMA/aria-attributes-1.xsd">http://www.w3.org/MarkUp/SCHEMA/aria-attributes-1.xsd</a>.</p>
-	</section>
-	<section id="html_dtd">
-		<h3><abbr title="Accessible Rich Internet Applications">HTML 4.01 plus WAI-ARIA DTD</abbr></h3>
-		<p>This standalone DTD adds WAI-ARIA <a>state</a> and <a>property</a> <a>attributes</a> to all <a>elements</a> in HTML 4.01, as well as a <code>role</code> attribute. In order to provide broader keyboard support, it also adds the <code>tabindex</code> attribute to a wider set of elements. </p>
-		<p>The DTD is based on the HTML 4.01 Transitional DTD, and includes all entity references needed to make it a standalone file. <em>This is not an official W3C DTD</em> and should be considered a derivative work of HTML 4.01.</p>
-		<p>Documents written using this markup language can be validated using the above DTD. If a document author wants to facilitate such validation, they can include the following declaration at the top of their document: </p>
-		<pre>&lt;!DOCTYPE html PUBLIC &quot;-//W3C//DTD HTML+ARIA 1.0//EN&quot;
-	&quot;http://www.w3.org/WAI/ARIA/schemata/html4-aria-1.dtd&quot;&gt;</pre>
-		<p> However, note that when this DOCTYPE is present in a document, most user agents treat the document as generic XML rather than HTML. This causes them to be unable to support named character entities defined by the DTD (e.g., &amp;copy;). Therefore, authors need to avoid use of named entities outside of the <cite><a href="https://www.w3.org/TR/xml/#sec-predefined-ent">predefined entities in XML</a></cite> ([[XML11]], Section 4.6). </p>
-		<p> To avoid the above problem, authors can omit the above DOCTYPE statement. This causes user agents to treat the document as generic HTML with named character entity support as well as built-in ARIA support. However, it causes user agents to enter &quot;quirks&quot; mode which affects CSS rendering, and causes conformance checkers to fail the document due to the added ARIA attributes. </p>
-		<p>To avoid the issues of named character entity support and quirks mode, authors can instead use the following generic DOCTYPE declaration for HTML: </p>
-		<pre>&lt;!DOCTYPE html&gt;</pre>
-		<p>However, this still does not guarantee that documents will be validated by conformance checkers.</p>
-		<p>The <a href="http://www.w3.org/html/wg/">HTML Working Group</a> is incorporating WAI-ARIA into <a href="https://www.w3.org/TR/html5/">HTML5</a>. Official support for WAI-ARIA in HTML will be provided in that specification. This DTD is made available <em>only</em> as a bridging solution for applications requiring DTD validation but not using HTML 5.</p>
-		<p>This module is available from <a href="http://www.w3.org/WAI/ARIA/schemata/html4-aria-1.dtd">http://www.w3.org/WAI/ARIA/schemata/html4-aria-1.dtd</a>.</p>
-	</section>
-</section>
 <section class="informative appendix" id="typemapping">
 	<h2>Mapping WAI-ARIA Value types to languages</h2>
-	<p class="note">The HTML 5 column of the table below is advisory. Guidance on use of WAI-ARIA state and properties in HTML 5 is provided in <a href="https://www.w3.org/TR/html51/dom.html#state-and-property-attributes">State and Property Attributes</a> ([[HTML51]], section 3.2.7.3.2).</p>
-	<p class="note">The suggested mappings for true/false values in HTML 5 use <a href="https://www.w3.org/TR/html5/infrastructure.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of <code>true</code> and <code>false</code>, instead of using the HTML 5 boolean value type. <!--@@ can't rely on attribute absence because of default value in true/false/undefined case.--></p>
-	<p>The table below provides recommended mappings between WAI-ARIA state and property types and attribute types from HTML 5, <cite><a href="https://www.w3.org/TR/xmlschema11-2/"><abbr title="Extensible Markup Language">XML</abbr> Schema Datatypes</a></cite> [[XMLSCHEMA11-2]], SVG, and SGML.</p>
+	<p class="note">The HTML column of the table below is advisory. Guidance on use of WAI-ARIA state and properties in HTML is provided in <a href="https://www.w3.org/TR/html-aria/#allowed-aria-roles-states-and-properties">Allowed ARIA roles, states and properties  </a> ([[HTML-ARIA]].</p>
+	<p class="note">The suggested mappings for true/false values in HTML use <a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of <code>true</code> and <code>false</code>, instead of using the HTML boolean value type. <!--@@ can't rely on attribute absence because of default value in true/false/undefined case.--></p>
+	<p>The table below provides recommended mappings between WAI-ARIA state and property types and attribute types from [[HTML]], <cite><a href="https://www.w3.org/TR/xmlschema11-2/"><abbr title="Extensible Markup Language">XML</abbr> Schema Datatypes</a></cite> [[XMLSCHEMA11-2]], [[SVG2]], and SGML.</p>
 	<p>Languages not listed below might have appropriate value types defined in the language. If they do not, we recommend XML Schema Datatypes for general purpose XML languages. Documents using DTDs instead of schemas will not be able to validate automatically and require additional processing on WAI-ARIA attributes.</p>
 	<table>
 		<tr>
 			<th scope="col">WAI-ARIA type</th>
-			<th scope="col">HTML 5</th>
+			<th scope="col">HTML</th>
 			<th scope="col">XML Schema</th>
 		</tr>
 		<tr>
 			<td>true/false</td>
-			<td><a href="https://www.w3.org/TR/html5/infrastructure.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of &quot;true&quot; and &quot;false&quot;</td>
+			<td><a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of &quot;true&quot; and &quot;false&quot;</td>
 			<td><a href="https://www.w3.org/TR/xmlschema11-2/#boolean">boolean</a></td>
 		</tr>
 		<tr>
 			<td>true/false/undefined</td>
-			<td><a href="https://www.w3.org/TR/html5/infrastructure.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of <code>true</code>, <code>false</code>, and <code>undefined</code></td>
+			<td><a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of <code>true</code>, <code>false</code>, and <code>undefined</code></td>
 			<td><a href="https://www.w3.org/TR/xmlschema11-2/#NMTOKEN">NMTOKEN</a> with an <a href="https://www.w3.org/TR/xmlschema11-2/#NMTOKEN">enumeration constraint</a> allowing values of <code>true</code>, <code>false</code>, and <code>undefined</code></td>
 		</tr>
 		<tr>
 			<td>tristate</td>
-			<td><a href="https://www.w3.org/TR/html5/infrastructure.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of &quot;true&quot;, &quot;false&quot;, and &quot;mixed&quot;</td>
+			<td><a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of &quot;true&quot;, &quot;false&quot;, and &quot;mixed&quot;</td>
 			<td><a href="https://www.w3.org/TR/xmlschema11-2/#NMTOKEN">NMTOKEN</a> with an <a href="https://www.w3.org/TR/xmlschema11-2/#NMTOKEN">enumeration constraint</a> allowing values of &quot;true&quot;, &quot;false&quot;, and &quot;mixed&quot;</td>
 		</tr>
 		<tr>
 			<td>number</td>
-			<td><a href="https://www.w3.org/TR/html5/infrastructure.html#floating-point-numbers">Floating-point numbers</a></td>
+			<td><a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#floating-point-numbers">Floating-point numbers</a></td>
 			<td><a href="https://www.w3.org/TR/xmlschema11-2/#decimal">decimal</a></td>
 		</tr>
 		<tr>
 			<td>integer</td>
-			<td><a href="https://www.w3.org/TR/html5/infrastructure.html#non-negative-integers">Non-negative integer</a></td>
+			<td><a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#floating-point-numbers">Non-negative integer</a></td>
 			<td><a href="https://www.w3.org/TR/xmlschema11-2/#integer">integer</a></td>
 		</tr>
 		<tr>
 			<td>token</td>
-			<td><a href="https://www.w3.org/TR/html5/infrastructure.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a></td>
+			<td><a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a></td>
 			<td><a href="https://www.w3.org/TR/xmlschema11-2/#NMTOKEN">NMTOKEN</a> with an <a href="https://www.w3.org/TR/xmlschema11-2/#NMTOKEN">enumeration constraint</a> allowing values listed in the state or property definition</td>
 		</tr>
 		<tr>
 			<td>token list</td>
-			<td><a href="https://www.w3.org/TR/html5/infrastructure.html#space-separated-tokens">Space-separated tokens</a></td>
+			<td><a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#space-separated-tokens">Space-separated tokens</a></td>
 			<td><a href="https://www.w3.org/TR/xmlschema11-2/#NMTOKENS">NMTOKENS</a> with an <a href="https://www.w3.org/TR/xmlschema11-2/#NMTOKEN">enumeration constraint</a> allowing values listed in the state or property definition</td>
 		</tr>
 		<tr>
 			<td>ID reference</td>
-			<td>The value of a defined <a href="https://www.w3.org/TR/html5/dom.html#the-id-attribute">id attribute</a> on another element</td>
+			<td>The value of a defined <a href="https://html.spec.whatwg.org/multipage/dom.html#the-id-attribute">id attribute</a> on another element</td>
 			<td><a href="https://www.w3.org/TR/xmlschema11-2/#IDREF">IDREF</a></td>
 		</tr>
 		<tr>
 			<td>ID reference list</td>
-			<td>The value of one or more defined <a href="https://www.w3.org/TR/html5/dom.html#the-id-attribute">id attributes</a> on other element(s), represented as <a href="https://www.w3.org/TR/html5/infrastructure.html#space-separated-tokens">Space-separated tokens</a></td>
+			<td>The value of one or more defined <a href="https://html.spec.whatwg.org/multipage/dom.html#the-id-attribute">id attributes</a> on other element(s), represented as <a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#space-separated-tokens">Space-separated tokens</a></td>
 			<td><a href="https://www.w3.org/TR/xmlschema11-2/#IDREFS">IDREFS</a></td>
 		</tr>
 		<tr>
@@ -11557,21 +13838,85 @@ PUBLIC "-//W3C//ENTITIES XHTML ARIA Attributes 1.0//EN" "aria-attributes-1.mod"
 <section class="appendix" id="changelog">
 	<h2>Change Log</h2>
 	<section>
+		<h2>Substantive changes targetted for the 1.3 release</h2>
+		<ul>
+			<li>11-Mar-2020: Add <pref>aria-braillelabel</pref></li>
+			<li>13-Feb-2020: Role <rref>suggestion</rref> added</li>
+			<li>11-Feb-2020: Update <pref>aria-details</pref> to allow multiple IDrefs</li>
+			<li>11-Feb-2020: Role <rref>comment</rref> added</li>
+			<li>16-Jan-2020: Add <pref>aria-description</pref></li>
+			<li>15-Jan-2020: Role <rref>mark</rref>: Added</li>
+			<li>14-Oct-2019: Add <pref>aria-brailleroledescription</pref></li>
+
+		</ul>
 		<h2>Substantive changes since the last public working draft</h2>
 		<ul>
 			<!-- EdNote: After each WD publish, move contents of this list into the next one below. -->
-			<li>21-Jun-2018: Allow group as child of listbox</li>
-			<li>21-Jun-2018: Resolve inconsistencies around group ownevership of menuitem, menuitemcheckbox and menuitemradio</li>
-			<li>31-May-2018: Add <rref>blockquote</rref>, <rref>caption</rref>, and <rref>paragraph</rref> roles.</li>
-			<li>01-Apr-2018: Added ARIA IDL Section (JavaScript interfaces).</li>
-			<li>06-Dec-2017: Make <sref>aria-expanded</sref> a supported state of <rref>menuitem</rref>. This change also makes it a supported property of <rref>menuitemcheckbox</rref> and <rref>menuitemradio</rref> via inheritance.</li>
-			<li>06-Dec-2017: When aria-errormessage is not pertinent, authors MUST either ensure the content is not rendered or remove the aria-errormessage attribute or its value. User agents MUST NOT expose <code>aria-errormessage</code> for an object with an <sref>aria-invalid</sref> value of <code>false</code>.</li>
+			<li>16-Jul-2020: Update to define owned and container for</li>
+			<li>09-Jul-2020: Re-add <pref>aria-haspopup</pref> on links</li>
+			<li>25-Jun-2020: Remove multiple inheritance from <rref>menuitemcheckbox</rref> and <rref>menuitemradio</rref></li>
+			<li>15-May-2020: Remove nullable from IDL DOMStrings, add enumerated attributes prose and examples, and remove ariaRelevant IDL until Issue #1267 can be resolved.</li>
+			<li>07-May-2020: Deprecate <sref>aria-disabled</sref>, <pref>aria-errormessage</pref>, <pref>aria-haspopup</pref> and <sref>aria-invalid</sref> as globals rather than removing them.</li>
+			<li>21-Apr-2020: Require user agents to expose a value for <rref>combobox</rref> elements</li>
+			<li>03-Apr-2020: Clarify default values</li>
+			<li>03-Apr-2020: Revise <rref>meter</rref> authoring advice</li>
+			<li>26-Mar-2020: remove recommendation to use <code>role="none presentation"</code></li>
+			<li>26-Mar-2020: Add info about layout and bounds to <rref>generic</rref></li>
+			<li>04-Mar-2020: prohibit <pref>aria-roledescription</pref> on <rref>generic</rref></li>
+			<li>03-Mar-2020: Clean up of Presentational roles conflict resolution section</li>
+            <li>20-Feb-2020: Update <rref>combobox</rref> to remove aria-multiline reference</li>
+			<li>01-Nov-2019: Modify <rref>combobox</rref> to new ARIA 1.2 pattern.</li>
+			<li>25-Oct-2019: Modify <rref>caption</rref> authoring advice</li>
+			<li>22-Oct-2019: Change <sref>aria-disabled</sref>, <pref>aria-errormessage</pref>, <pref>aria-haspopup</pref> and <sref>aria-invalid</sref> from global to widget specific.</li>
+			<li>22-Oct-2019: Clarify use of <rref>alertdialog</rref> and <rref>alert</rref> roles</li>
+			<li>22-Oct-2019: remove <pref>aria-level</pref> from <rref>tablist</rref></li>
+			<li>18-Oct-2019: Remove references to taxonomy file</li>
+			<li>18-Oct-2019: Remove implicit value from <sref>aria-checked</sref> on <rref>checkbox</rref></li>
+			<li>11-Oct-2019: Deprecate <rref>directory</rref> role</li>
+			<li>11-Oct-2019: Make <rref>form</rref> role accessible name required true</li>
+			<li>11-Oct-2019: Remove allowance of <rref>group</rref> in <rref>list</rref></li>
+            <li>09-Oct-2019: Add missing implicit value for <rref>progressbar</rref></li>
+			<li>09-Oct-2019: Remove accessible name required from <rref>log</rref> and <rref>timer</rref></li>
+			<li>22-Aug-2019: Remove <pref>aria-level</pref> from <rref>grid</rref></li>
+			<li>23-Jul-2019: Add <rref>generic</rref> role</li>
+			<li>11-Jul-2019: Remove advice against changing roles</li>
+			<li>11-Jul-2019: Set Accessible Name Required to false on <rref>gridcell</rref></li>
+			<li>11-Jul-2019: Add <rref>associationlist</rref>, <rref>associationlistitemkey</rref>, and <rref>associationlistitemvalue</rref> roles</li>
+			<li>28-Jun-2019: Prohibits Labeling of <rref>caption</rref>, <rref>code</rref>, <rref>deletion</rref>, <rref>emphasis</rref>, <rref>insertion</rref>, <rref>paragraph</rref>, <rref>presentation</rref>, <rref>strong</rref>, <rref>subscript</rref>, <rref>superscript</rref></li>
+			<li>25 Jun-2019: Add <pref>aria-rowindextext</pref> and <pref>aria-colindextext</pref> properties</li>
+			<li>04-Jun-2019: Make <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> supported, rather than required, properties of focusable <rref>separator</rref>, <rref>slider</rref>, and <rref>scrollbar</rref>. Make <pref>aria-orientation</pref> a supported, rather than required, property of <rref>scrollbar</rref>.</li>
+			<li>02-May-2019: Add <rref>strong</rref> and <rref>emphasis</rref> roles</li>
+			<li>02-May-2019: Add <pref>aria-required</pref> as a supported property of <rref>checkbox</rref></li>
+			<li>02-May-2019: Add <rref>code</rref> role</li>
+			<li>02-May-2019: Add <sref>aria-expanded</sref> support to <rref>application</rref> and <rref>checkbox</rref> roles.</li>
+			<li>02-May-2019: Remove <sref>aria-expanded</sref> support from the following roles: <rref>alert</rref>, <rref>alertdialog</rref>, <rref>article</rref>, <rref>banner</rref>, <rref>blockquote</rref>, <rref>caption</rref>, <rref>cell</rref>, <rref>complementary</rref>, <rref>contentinfo</rref>, <rref>definition</rref>, <rref>deletion</rref>, <rref>dialog</rref>, <rref>directory</rref>, <rref>feed</rref>, <rref>figure</rref>, <rref>form</rref>, <rref>grid</rref>, <rref>group</rref>, <rref>heading</rref>, <rref>img</rref>, <rref>insertion</rref>, <rref>label</rref>, <rref>landmark</rref>, <rref>legend</rref>, <rref>list</rref>, <rref>listitem</rref>, <rref>log</rref>, <rref>main</rref>, <rref>marquee</rref>, <rref>math</rref>, <rref>menu</rref>, <rref>menubar</rref>, <rref>navigation</rref>, <rref>note</rref>, <rref>paragraph</rref>, <rref>radiogroup</rref>, <rref>region</rref>, <rref>search</rref>, <rref>select</rref>, <rref>status</rref>, <rref>subscript</rref>, <rref>superscript</rref>, <rref>table</rref>, <rref>tabpanel</rref>, <rref>term</rref>, <rref>time</rref>, <rref>timer</rref>, <rref>toolbar</rref>, <rref>tooltip</rref>, <rref>tree</rref>, <rref>treegrid</rref>.</li>
+			<li>11-Apr-2019: Add <rref>legend</rref> role</li>
+			<li>11-Apr-2019: Remove children-presentational=true from <rref>math</rref> role</li>
+			<li>10-Apr-2019: Add <rref>label</rref> role</li>
+			<li>10-Apr-2019: Add <rref>time</rref> role</li>
+			<li>27-Mar-2019: Add Translatable States and Properties Section</li>
+			<li>21-Feb-2019: Add <rref>subscript</rref> and <rref>superscript</rref> roles.</li>
+			<li>07-Feb-2019: Remove contents as a supported name source for <rref>rowgroup</rref>.</li>
+			<li>01-Feb-2019: Add <rref>meter</rref>> role.</li>
+			<li>31-Jan-2019: Change the superclass of <rref>range</rref> from widget to structure.</li>
+			<li>23-Jan-2019: Removed Default value of <sref>aria-checked</sref> from <rref>menuitemcheckbox</rref> and <rref>menuitemradio</rref> roles</li>
+			<li>09-Jan-2019: Removed Default value of <sref>aria-checked</sref> from <rref>switch</rref> and <rref>checkbox</rref> roles</li>
 		</ul>
 	</section>
 	<section>
 		<h2>Substantive changes since the <a href="https://www.w3.org/TR/wai-aria-1.1/">WAI-ARIA 1.1 Recommendation</a></h2>
 		<ul>
 			<!-- EdNote: After each WD publish, move contents of the previous list into this one. -->
+			<li>05-Oct-2018: Role <rref>spinbutton</rref>: Change the default value of <pref>aria-valuenow</pref> from <code>0</code> to "there is no current value." Also add <pref>aria-valuetext</pref> as a supported property.</li>
+			<li>05-Oct-2018: Role <rref>spinbutton</rref>: allow empty values, no min, no max, and structure with sibling steppers</li>
+			<li>21-Aug-2018: Correct normative language in <rref>rowheader</rref> to be consistent with required states and properties.</li>
+			<li>21-Aug-2018: Allow <sref>aria-posinset</sref> and <sref>aria-setsize</sref> on <rref>row</rref> when used in a <rref>treegrid</rref>.</li>
+			<li>21-Jun-2018: Allow <rref>group</rref> as child of <rref>listbox</rref>.</li>
+			<li>21-Jun-2018: Resolve inconsistencies around group ownership of <rref>menuitem</rref>, <rref>menuitemcheckbox</rref> and <rref>menuitemradio</rref>.</li>
+			<li>31-May-2018: Add <rref>blockquote</rref>, <rref>caption</rref>, and <rref>paragraph</rref> roles.</li>
+			<li>01-Apr-2018: Added ARIA IDL Section (JavaScript interfaces).</li>
+			<li>06-Dec-2017: Make <sref>aria-expanded</sref> a supported state of <rref>menuitem</rref>. This change also makes it a supported property of <rref>menuitemcheckbox</rref> and <rref>menuitemradio</rref> via inheritance.</li>
+			<li>06-Dec-2017: When aria-errormessage is not pertinent, authors MUST either ensure the content is not rendered or remove the aria-errormessage attribute or its value. User agents MUST NOT expose <code>aria-errormessage</code> for an object with an <sref>aria-invalid</sref> value of <code>false</code>.</li>
 		</ul>
 	</section>
 </section>
@@ -11586,6 +13931,12 @@ PUBLIC "-//W3C//ENTITIES XHTML ARIA Attributes 1.0//EN" "aria-attributes-1.mod"
 	<p class="placeholder">Placeholder for quick reference table</p>
 </section>
 -->
-<div data-include='common/acknowledgements.html' data-oninclude='fixIncludes' data-include-replace='true'></div>
+	<section class="appendix informative section" id="acknowledgements">
+		<h3>Acknowledgments</h3>
+		<p>The following people contributed to the development of this document.</p>
+		<div data-include="common/acknowledgements/aria-wg-active.html" data-include-replace="true"></div>
+		<div data-include="common/acknowledgements/aria-contributors.html" data-include-replace="true"></div>
+		<div data-include="common/acknowledgements/funders.html" data-include-replace="true"></div>
+	</section>
 </body>
 </html>


### PR DESCRIPTION
For issue #700, made the following changes to the option role section in index.html:

1. Remove sentence from description that states there is an default value of false fore aria-selected on option elements.
2. Remove aria-selected from required states and properties row of attributes table.
3. Add aria-selected to supported row of attributes table.
4. Remove default value for aria-selected from implicit values row of attributes table.

Note: This cascades to treeitem so that aria-selected is not required on treeitem.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/799.html" title="Last updated on Oct 11, 2020, 2:19 AM UTC (de84a1f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/799/ff8cd29...de84a1f.html" title="Last updated on Oct 11, 2020, 2:19 AM UTC (de84a1f)">Diff</a>