### PR TITLE
initial draft for role="generic" issue #699

### DIFF
--- a/index.html
+++ b/index.html
@@ -3276,7 +3276,7 @@
 			<div class="role-description">
 				<p>A nameless container <a>element</a> that has no semantic meaning on its own.</p>
 				<p>Contrast with <rref>group</rref>, which semantically groups its descendants in a named container.</p>
-				<p>A <code>generic</code> can provide a limited number of accessible states and properties for its descendants, such as <sref>aria-hidden</sref> and <pref>aria-live</pref>. This differentiates it from the <rref>presentation</rref> role.</p>
+				<p>A <code>generic</code> can provide a limited number of accessible states and properties for its descendants, such as <pref>aria-live</pref> attributes. This differentiates it from the <rref>presentation</rref> role.</p>
 				<p>The <code>generic</code> role is intended for implementors of User Agents. Authors SHOULD NOT use this role in content.</p>
 				<p class="ednote">A triage of global properties is pending. This will reduce the number of inherited states and properties in the characteristics table below. For details, see <a href="https://github.com/w3c/aria/issues/999">issue #999</a>.</p>
 			</div>

--- a/index.html
+++ b/index.html
@@ -3277,7 +3277,7 @@
 				<p>A nameless container <a>element</a> that has no semantic meaning on its own.</p>
 				<p>Contrast with <rref>group</rref>, which semantically groups its descendants in a named container.</p>
 				<p>A <code>generic</code> can provide a limited number of accessible states and properties for its descendants, such as <sref>aria-hidden</sref> and <pref>aria-live</pref>.</p>
-				<p class="note"><code>generic</code> is a role used for the ontology. With the exception of providing <code>generic</code> <abbr title="Hypertext Markup Language">HTML</abbr> <a href="https://html.spec.whatwg.org/multipage/custom-elements.html">Custom Elements</a>, authors should not use this role in content.</p>
+				<p class="note"><code>generic</code> role is intended for implementors of User Agents. Authors should not use this role in content.</p>
 				<p class="ednote">A triage of global properties is pending. This will reduce the number of inherited states and properties in the characteristics table below. For details, see <a href="https://github.com/w3c/aria/issues/999">issue #999</a>.</p>
 			</div>
 			<table class="role-features">

--- a/index.html
+++ b/index.html
@@ -3277,7 +3277,7 @@
 				<p>A nameless container <a>element</a> that has no semantic meaning on its own.</p>
 				<p>Contrast with <rref>group</rref>, which semantically groups its descendants in a named container.</p>
 				<p>A <code>generic</code> can provide a limited number of accessible states and properties for its descendants, such as <sref>aria-hidden</sref> and <pref>aria-live</pref>.</p>
-				<p class="note"><code>generic</code> is a superclass role used for the ontology. With the exception of providing <code>generic</code> <abbr title="Hypertext Markup Language">HTML</abbr> <a href="https://html.spec.whatwg.org/multipage/custom-elements.html">Custom Elements</a>, authors should not use this role in content.</p>
+				<p class="note"><code>generic</code> is a role used for the ontology. With the exception of providing <code>generic</code> <abbr title="Hypertext Markup Language">HTML</abbr> <a href="https://html.spec.whatwg.org/multipage/custom-elements.html">Custom Elements</a>, authors should not use this role in content.</p>
 				<p class="ednote">A triage of global properties is pending. This will reduce the number of inherited states and properties in the characteristics table below. For details, see <a href="https://github.com/w3c/aria/issues/999">issue #999</a>.</p>
 			</div>
 			<table class="role-features">

--- a/index.html
+++ b/index.html
@@ -3277,7 +3277,7 @@
 				<p>A nameless container <a>element</a> that has no semantic meaning on its own.</p>
 				<p>Contrast with <rref>group</rref>, which semantically groups its descendants in a named container.</p>
 				<p>A <code>generic</code> can provide a limited number of accessible states and properties for its descendants, such as <sref>aria-hidden</sref> and <pref>aria-live</pref>.</p>
-				<p class="note"><code>generic</code> is a superclass role used for the ontology. With the exception of providing <code>generic</code> <a href="https://html.spec.whatwg.org/multipage/custom-elements.html">Custom Elements</a>, authors should not use this role in content.</p>
+				<p class="note"><code>generic</code> is a superclass role used for the ontology. With the exception of providing <code>generic</code> <abbr title="Hypertext Markup Language">HTML</abbr> <a href="https://html.spec.whatwg.org/multipage/custom-elements.html">Custom Elements</a>, authors should not use this role in content.</p>
 				<p class="ednote">A triage of global properties is pending. This will reduce the number of inherited states and properties in the characteristics table below. For details, see <a href="https://github.com/w3c/aria/issues/999">issue #999</a>.</p>
 			</div>
 			<table class="role-features">

--- a/index.html
+++ b/index.html
@@ -3329,7 +3329,6 @@
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
 						<td class="role-inherited">Placeholder</td>
 					</tr>
-					<!-- see pr #985
 					<tr>
 						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
 						<td class="role-disallowed">
@@ -3338,8 +3337,7 @@
 								<li><pref>aria-labelledby</pref></li>
 							</ul>					
 						</td>
-					</tr>
-					-->
+					</tr>						
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
 						<td class="role-namefrom">prohibited</td>

--- a/index.html
+++ b/index.html
@@ -3276,7 +3276,7 @@
 			<div class="role-description">
 				<p>A nameless container <a>element</a> that has no semantic meaning on its own.</p>
 				<p>Contrast with <rref>group</rref>, which semantically groups its descendants in a named container.</p>
-				<p>A <code>generic</code> can provide a limited number of accessible states and properties for its descendants, such as <sref>aria-hidden</sref> and <pref>aria-live</pref>.</p>
+				<p>A <code>generic</code> can provide a limited number of accessible states and properties for its descendants, such as <sref>aria-hidden</sref> and <pref>aria-live</pref>. This differentiates it from the <rref>presentation</rref> role.</p>
 				<p class="note"><code>generic</code> role is intended for implementors of User Agents. Authors should not use this role in content.</p>
 				<p class="ednote">A triage of global properties is pending. This will reduce the number of inherited states and properties in the characteristics table below. For details, see <a href="https://github.com/w3c/aria/issues/999">issue #999</a>.</p>
 			</div>

--- a/index.html
+++ b/index.html
@@ -3274,8 +3274,11 @@
 		<div class="role" id="generic">
 			<rdef>generic</rdef>
 			<div class="role-description">
-				<p>A nameless container <a>element</a> that has no semantic meaning on its own, but can provide accessible states and properties for its descendants.</p>
+				<p>A nameless container <a>element</a> that has no semantic meaning on its own.</p>
 				<p>Contrast with <rref>group</rref>, which semantically groups its descendants in a named container.</p>
+				<p>A <code>generic</code> can provide a limited number of accessible states and properties for its descendants, such as <sref>aria-hidden</sref> and <pref>aria-live</pref>.</p>
+				<p class="note"><code>generic</code> is a superclass role used for the ontology. With the exception of providing <code>generic</code> <a href="https://html.spec.whatwg.org/multipage/custom-elements.html">Custom Elements</a>, authors should not use this role in content.</p>
+				<p class="ednote">A triage of global properties is pending. This will reduce the number of inherited states and properties in the characteristics table below. For details, see <a href="https://github.com/w3c/aria/issues/999">issue #999</a>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -3277,7 +3277,7 @@
 				<p>A nameless container <a>element</a> that has no semantic meaning on its own.</p>
 				<p>Contrast with <rref>group</rref>, which semantically groups its descendants in a named container.</p>
 				<p>A <code>generic</code> can provide a limited number of accessible states and properties for its descendants, such as <sref>aria-hidden</sref> and <pref>aria-live</pref>. This differentiates it from the <rref>presentation</rref> role.</p>
-				<p class="note"><code>generic</code> role is intended for implementors of User Agents. Authors should not use this role in content.</p>
+				<p>The <code>generic</code> role is intended for implementors of User Agents. Authors SHOULD NOT use this role in content.</p>
 				<p class="ednote">A triage of global properties is pending. This will reduce the number of inherited states and properties in the characteristics table below. For details, see <a href="https://github.com/w3c/aria/issues/999">issue #999</a>.</p>
 			</div>
 			<table class="role-features">

--- a/index.html
+++ b/index.html
@@ -672,7 +672,7 @@
 			</ul>
 		</section>
 		<section id="document_structure_roles">
-			<h3>Document Structure</h3>
+			<h3>Document Structure Roles</h3>
 			<p>The following <a>roles</a> describe structures that organize content in a page. Document structures are not usually interactive.</p>
 			<ul>
 				<li><rref>application</rref></li>
@@ -691,6 +691,7 @@
 				<li><rref>emphasis</rref></li>
 				<li><rref>feed</rref></li>
 				<li><rref>figure</rref></li>
+				<li><rref>generic</rref></li>
 				<li><rref>group</rref></li>
 				<li><rref>heading</rref></li>
 				<li><rref>img</rref></li>
@@ -3254,6 +3255,95 @@
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
 						<td class="role-namerequired"> </td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational"> </td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div class="role" id="generic">
+			<rdef>generic</rdef>
+			<div class="role-description">
+				<p>A nameless container <a>element</a> that has no semantic meaning on its own, but can provide accessible states and properties for its descendants.</p>
+				<p>Contrast with <rref>group</rref>, which semantically groups its descendants in a named container.</p>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent"><rref>structure</rref></td>
+					</tr>
+					<tr>
+						<th class="role-children-head" scope="row">Subclass Roles:</th>
+						<td class="role-children">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"> </td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"><a href="https://www.w3.org/TR/html/grouping-content.html#the-div-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>div</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-span-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>span</code></a></td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Context Role:</th>
+						<td class="role-scope"> </td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<!-- see pr #985
+					<tr>
+						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
+						<td class="role-disallowed">
+							<ul>
+								<li><pref>aria-label</pref></li>
+								<li><pref>aria-labelledby</pref></li>
+							</ul>					
+						</td>
+					</tr>
+					-->
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">prohibited</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>


### PR DESCRIPTION
issue #699.

Notes & Questions for `block` and `inline` generic roles draft:
1. Used **Superclass Role** as `roletype` for both (should it be `structure`?)
2. Listed  **Related Concepts** as `HTML div/span` (should we also list `CSS display:block/display:inline`? or maybe list those under **Base Concept**? or not at all?)
3. Added both to **Document Structure Roles** category (or should they be categorized in a new "Generic Roles" category)?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/805.html" title="Last updated on Jul 19, 2019, 3:38 PM UTC (3e48334)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/805/9649112...3e48334.html" title="Last updated on Jul 19, 2019, 3:38 PM UTC (3e48334)">Diff</a>