### PR TITLE
Editorial nits in role-description for group

### DIFF
--- a/index.html
+++ b/index.html
@@ -2862,10 +2862,10 @@
 		<div class="role" id="group">
 			<rdef>group</rdef>
 			<div class="role-description">
-				<p>A set of user interface <a>objects</a> which are not intended to be included in a page summary or table of contents by <a>assistive technologies</a>.</p>
-				<p>Contrast with <rref>region</rref> which is a grouping of user interface objects that will be included in a page summary or table of contents.</p>
-				<p>Authors SHOULD use a <code>group</code> to form logical collection of items in a <a>widget</a> such as children in a tree widget forming a collection of siblings in a hierarchy, or a collection of items having the same container in a directory. However, when a <code>group</code> is used in the context of list, authors MUST limit its children to <rref>listitem</rref> elements. Therefore, proper handling of <code>group</code> by authors and assistive technologies is determined by the context in which it is provided.</p>
-				<p>Authors MAY nest <code>group</code> elements. If a section is significant enough to warrant inclusion in the web page's table of contents, the author SHOULD assign the section a <a>role</a> of <rref>region</rref> or a <a href="#landmark_roles">standard landmark role</a>.</p>
+				<p>A set of user interface <a>objects</a> that is not intended to be included in a page summary or table of contents by <a>assistive technologies</a>.</p>
+				<p>Contrast with <rref>region</rref>, which is a grouping of user interface objects that will be included in a page summary or table of contents.</p>
+				<p>Authors SHOULD use a <code>group</code> to form a logical collection of items in a <a>widget</a>, such as children in a tree widget forming a collection of siblings in a hierarchy, or a collection of items having the same container in a directory. However, when a <code>group</code> is used in the context of a <rref>list</rref>, authors MUST limit its children to <rref>listitem</rref> elements. Therefore, proper handling of <code>group</code> by authors and assistive technologies is determined by the context in which it is provided.</p>
+				<p>Authors MAY nest <code>group</code> elements. If a section is significant enough to warrant inclusion in the web page's table of contents, the author SHOULD assign it a <a>role</a> of <rref>region</rref> or a <a href="#landmark_roles">standard landmark role</a>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>


### PR DESCRIPTION
- plural "which are" should be singular "that is"
- missing commas (before "which" and before "such as")
- missing "a" before "a list" and missing rref for list
- simplify "the section" to "it" because already used in sentence


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/810.html" title="Last updated on Aug 24, 2018, 6:29 PM GMT (73b9f8b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/810/ee93646...73b9f8b.html" title="Last updated on Aug 24, 2018, 6:29 PM GMT (73b9f8b)">Diff</a>