### PR TITLE
Additional considerations regarding mapping implementation

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -121,7 +121,9 @@
 					<p>The normative documents produced by this Working Group fall into two categories: ARIA specifications and Accessibility API Mapping specifications.</p>
 					<ul>
 						<li>For ARIA specifications, implementability and interoperability will be demonstrated by having at least two independent implementations of each of feature defined in that specification.</li>
-						<li>For every platform with mappings in an Accessibility API Mapping specification, at least one implementation of 75% of the mappings being tested on that platform will demonstrate implementability on that platform. Multiple implementations of each platform are not required because some platforms have only one implementation. For features that are not platform-specific, passing test results in at least two different implementations will be documented to demonstrate implementability.</li>
+						<li>For every platform with mappings in an Accessibility API Mapping specification, at least one implementation of 75% of the mappings being tested on that platform will demonstrate implementability on that platform. Multiple implementations of each platform are not required because some platforms have only one implementation. For features that are not platform-specific, passing test results in at least two different implementations will be documented to demonstrate implementability.
+							No platform will be dropped out of the specification without prior consultation with that platform's owners. Every effort will be made to take member organizations' schedules into account and to ensure all platforms are included.
+						</li>
 					</ul>
 					<p> Modules that reach <a href="https://www.w3.org/2018/Process-20180201/#rec-publication">W3C Recommendation</a>, are considered successful when all of the following are present:</p>
 					<ul>


### PR DESCRIPTION
This adds to the charter:
[[
No platform will be dropped out of the specification without prior consultation with that platform's owners. Every effort will be made to take member organizations' schedules into account and to ensure all platforms are included. 
]]
