### PR TITLE
Fix typo in aria-live description

### DIFF
--- a/index.html
+++ b/index.html
@@ -9961,7 +9961,7 @@
 					</tr>
 					<tr>
 						<th class="value-name" scope="row"><strong class="default">off (default)</strong></th>
-						<td class="value-description">Indicates that updates to the region should not be presented to the user unless the used is currently focused on that region.</td>
+						<td class="value-description">Indicates that updates to the region should not be presented to the user unless the user is currently focused on that region.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">polite</th>


### PR DESCRIPTION
There was a typo in the description of aria-live="off"; "unless the used" should be "unless the user".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nicolas17/aria/pull/822.html" title="Last updated on Oct 15, 2018, 2:02 PM GMT (3e236fa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/822/43321f8...nicolas17:3e236fa.html" title="Last updated on Oct 15, 2018, 2:02 PM GMT (3e236fa)">Diff</a>