### PR TITLE
Remove redundant paragraph from Presentational Roles Conflict Resolution section #837

### DIFF
--- a/index.html
+++ b/index.html
@@ -5041,7 +5041,7 @@
 				<section id="conflict_resolution_presentation_none">
 					<h5>Presentational Roles Conflict Resolution</h5>
 					<p>There are a number of ways presentational role conflicts are resolved.</p>
-					<p>Host languages elements, having implicit presentational roles for which no roles, may be applied, MUST never be exposed to in the accessibility tree. With this exception, user agents MUST always expose global WAI-ARIA states and properties to accessibility APIs. In this case, the user agent ignores the <code>presentation</code> role and exposes the element according to its implicit native semantics. However, user agents MUST ignore any non-global, role-specific WAI-ARIA states and properties, unless it is on an inherited presentational role where an explicit role is applied.</p>
+					<p>Host languages elements having implicit presentational roles for which no roles may be applied MUST never be exposed in the accessibility tree, with this exception: user agents MUST always expose global WAI-ARIA states and properties to accessibility APIs. In this case, the user agent ignores the <code>presentation</code> role and exposes the element according to its implicit native semantics. However, user agents MUST ignore any non-global, role-specific WAI-ARIA states and properties, unless it is on an inherited presentational role where an explicit role is applied.</p>
 					<p>For example, <pref>aria-haspopup</pref> is a global attribute and would always be applied; <pref>aria-level</pref> is not a global attribute and would therefore only apply if the element was not in a presentational state.</p>
 					<pre class="example highlight">
 						<span class="comment">&lt;!-- 1. [role="presentation"] is ignored due to the global aria-haspopup property. --&gt;</span>
@@ -5051,7 +5051,6 @@
 					</pre>
 					<p>Explicit roles on a descendant or <a>owned</a> element override the inherited role of <code>presentation</code>, and cause the owned element to behave as any other element with an explicit role. If the action of exposing the implicit role causes the accessibility tree to be malformed, the expected results are undefined and the user agent MAY resort to an internal recovery mechanism to repair the accessibility tree.</p>
 					<p>If an element with a role of presentation is focusable, or otherwise interactive, user agents MUST ignore the normal effect of the role and expose the element with implicit native semantics, in order to ensure that the element is both <a>understandable</a> and <a>operable</a>.</p>
-					<p>User agents MUST always expose global WAI-ARIA states and properties to accessibility APIs, even if an element has an explicit or inherited role of presentation. In this case, the user agent ignores the <code>presentation</code> role and exposes the element according to its implicit native semantics. However, user agents MUST ignore any non-global, role-specific WAI-ARIA states and properties, unless it is on an inherited presentational role where an explicit role is applied.</p>
 				</section>
 			</div>
 			<table class="role-features">


### PR DESCRIPTION
Fixes #837 
Removed 2nd instance of redundant paragraph.
Also removed some commas and an extraneous 'to' in the first instance of the paragraph.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/838.html" title="Last updated on Nov 8, 2018, 4:08 AM GMT (8aaccae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/838/0ce46ea...8aaccae.html" title="Last updated on Nov 8, 2018, 4:08 AM GMT (8aaccae)">Diff</a>