### PR TITLE
Move aria-level on heading role from required section to supported section

### DIFF
--- a/index.html
+++ b/index.html
@@ -3028,11 +3028,11 @@
 					</tr>
 					<tr>
 						<th class="role-required-properties-head">Required States and Properties:</th>
-						<td class="role-required-properties"><pref>aria-level</pref></td>
+						<td class="role-required-properties"> </td>
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"> </td>
+						<td class="role-properties"><pref>aria-level</pref></td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -3065,7 +3065,7 @@
 					</tr>
 					<tr>
 						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
-						<td class="implicit-values">Default for <pref>aria-level</pref> is <code class="default">2</code>.</td>
+						<td class="implicit-values">Fallback for <pref>aria-level</pref> is <code class="default">2</code>.</td>
 					</tr>
 				</tbody>
 			</table>
@@ -11830,6 +11830,7 @@ PUBLIC "-//W3C//ENTITIES XHTML ARIA Attributes 1.0//EN" "aria-attributes-1.mod"
 		<h2>Substantive changes since the last public working draft</h2>
 		<ul>
 			<!-- EdNote: After each WD publish, move contents of this list into the next one below. -->
+			<li>09-Jan-2019: Move aria-level on heading from required section to supported section.</li>
 			<li>05-Oct-2018: Role <rref>spinbutton</rref>: Change the default value of <pref>aria-valuenow</pref> from <code>0</code> to "there is no current value." Also add <pref>aria-valuetext</pref> as a supported property.</li>
 			<li>05-Oct-2018: Role <rref>spinbutton</rref>: allow empty values, no min, no max, and structure with sibling steppers</li>
 			<li>21-Aug-2018: Correct normative language in <rref>rowheader</rref> to be consistent with required states and properties.</li>


### PR DESCRIPTION
Fixes #854

A couple areas where I'd like to get feedback, please! :

* We're thinking of these "default" values as a repair technique rather than a default, so under the implicit values section I changed the language from "default" to "fallback". This introduces an inconsistency, do we want to keep the old language or update other implicit value sections?
* Another point there is do we just want to point people over to the fallback table instead of keeping the value inline (inline seems handy for the reader)
* The fallback table is prefaced with "Fallback values for missing required attributes". This is out of scope for this PR, but maybe we should modify the language here as we're using these fallback values for more than just missing required attributes. I don't think we're tracking this (though it could be referenced in another issue and I just missed it), but if people agree, I can open an issue for that change.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/melanierichards/aria/pull/880.html" title="Last updated on Jan 10, 2019, 4:56 PM UTC (52b576f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/880/2e2ccef...melanierichards:52b576f.html" title="Last updated on Jan 10, 2019, 4:56 PM UTC (52b576f)">Diff</a>