### PR TITLE
Editorial: remove list around Name From for tree

### DIFF
--- a/index.html
+++ b/index.html
@@ -7989,11 +7989,7 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">
-							<ul>
-								<li>author</li>
-							</ul>
-						</td>
+						<td class="role-namefrom">author</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>


### PR DESCRIPTION
Resolves #889 
NameFromContent list was being generated automatically in aria.js and if there is a list in Name From was adding to name from content list.
Checked this was the only one which was broken


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/890.html" title="Last updated on Jan 23, 2019, 10:01 PM UTC (4f52154)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/890/8a2f10b...4f52154.html" title="Last updated on Jan 23, 2019, 10:01 PM UTC (4f52154)">Diff</a>