### PR TITLE
Change the superclass of range from widget to structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -5161,7 +5161,12 @@
 					</tr>
 					<tr>
 						<th class="role-parent-head" scope="row">Superclass Role:</th>
-						<td class="role-parent"><rref>range</rref></td>
+						<td class="role-parent">
+							<ul>
+								<li><rref>range</rref></li>
+								<li><rref>widget</rref></li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-children-head" scope="row">Subclass Roles:</th>
@@ -5401,7 +5406,7 @@
 		<div class="role" id="range">
 			<rdef>range</rdef>
 			<div class="role-description">
-				<p>An input representing a range of values that can be set by the user.</p>
+				<p>A structure representing a range of values that can be set by the user.</p>
 				<p class="note"><code>range</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
 			</div>
 			<table class="role-features">
@@ -5419,7 +5424,7 @@
 					</tr>
 					<tr>
 						<th class="role-parent-head" scope="row">Superclass Role:</th>
-						<td class="role-parent"><rref>widget</rref></td>
+						<td class="role-parent"><rref>structure</rref></td>
 					</tr>
 					<tr>
 						<th class="role-children-head" scope="row">Subclass Roles:</th>
@@ -5979,9 +5984,12 @@
 					</tr>
 					<tr>
 						<th class="role-parent-head" scope="row">Superclass Role:</th>
-						<td class="role-parent"><ul>
-							<li><rref>range</rref></li>
-						</ul></td>
+						<td class="role-parent">
+							<ul>
+								<li><rref>range</rref></li>
+								<li><rref>widget</rref></li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-children-head" scope="row">Subclass Roles:</th>

--- a/index.html
+++ b/index.html
@@ -5406,7 +5406,7 @@
 		<div class="role" id="range">
 			<rdef>range</rdef>
 			<div class="role-description">
-				<p>A structure representing a range of values that can be set by the user.</p>
+				<p>An element representing a range of values that can be set by the user.</p>
 				<p class="note"><code>range</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
 			</div>
 			<table class="role-features">
@@ -11826,6 +11826,7 @@ PUBLIC "-//W3C//ENTITIES XHTML ARIA Attributes 1.0//EN" "aria-attributes-1.mod"
 		<h2>Substantive changes since the last public working draft</h2>
 		<ul>
 			<!-- EdNote: After each WD publish, move contents of this list into the next one below. -->
+			<li>31-Jan-2019: Change the superclass of range from widget to structure.</li>
 			<li>23-Jan-2019: Removed Default value of aria-checked from manuitemcheckbox and menuitemradio roles</li>
 			<li>09-Jan-2019: Removed Default value of aria-checked from switch and checkbox roles</li>
 		</ul>


### PR DESCRIPTION
This is needed to support the aria-value* attributes on non-interative,
and potentially static objects such as a meter.

Because range now subclasses structure, we need to use multiple inheritance
with the widget roles which subclass range. Those roles are: progressbar,
scrollbar, slider, and spinbutton. The latter two already subclass both range
and input thus no further change is needed. Progressbar and scrollbar now
subclass both range and widget.

Addresses github issue #892.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/894.html" title="Last updated on Jan 31, 2019, 7:07 PM UTC (0d6f4d5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/894/60a9063...0d6f4d5.html" title="Last updated on Jan 31, 2019, 7:07 PM UTC (0d6f4d5)">Diff</a>