### PR TITLE
Remove contents as a supported name source for rowgroup

### DIFF
--- a/index.html
+++ b/index.html
@@ -5921,12 +5921,7 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">
-							<ul>
-								<li>contents</li>
-								<li>author</li>
-							</ul>
-						</td>
+						<td class="role-namefrom">author</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>


### PR DESCRIPTION
Addresses issue #896.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/897.html" title="Last updated on Feb 2, 2019, 1:35 AM UTC (c75f5c5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/897/e434828...c75f5c5.html" title="Last updated on Feb 2, 2019, 1:35 AM UTC (c75f5c5)">Diff</a>