### PR TITLE
Fix issue #553: rowgroup role-description of required context roles mismatches characteristics table

### DIFF
--- a/index.html
+++ b/index.html
@@ -5854,7 +5854,7 @@
 			<div class="role-description">
 				<p>A structure containing one or more row elements in a tabular container.</p>
 				<p>The <code>rowgroup</code> role establishes a <a>relationship</a> between <a>owned</a> <rref>row</rref> elements. It is a structural equivalent to the <code>thead</code>, <code>tfoot</code>, and <code>tbody</code> elements in an <abbr title="Hypertext Markup Language">HTML</abbr> <code>table</code> <a>element</a>.</p>
-				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>rowgroup</code> are contained in, or <a>owned</a> by, an element with the role <rref>table</rref> or <rref>grid</rref>.</p>
+				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>rowgroup</code> are contained in, or <a>owned</a> by, an element with the role <rref>grid</rref>, <rref>table</rref>, or <rref>treegrid</rref>.</p>
 				<p class="note">The <code>rowgroup</code> role exists, in part, to support role symmetry in HTML, and allows for the propagation of presentation inheritance on HTML <code>table</code> elements with an explicit <code>presentation</code> role applied.</p>
 				<p class="note">This role does not differentiate between types of row groups (e.g., <code>thead</code> vs. <code>tbody</code>), but an issue has been raised for <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 2.0.</p>
 			</div>


### PR DESCRIPTION
Per #553: The `rowgroup` description states that it *MUST* be owned by a `grid` or `table`, but the characteristics table for the `rowgroup` says that in addition to `grid` and `table`, a `treegrid` is an acceptable context role. Since `treegrid`'s definition is consistent in saying that a `treegrid` is a `grid` and `rowgroup`s are valid within it, this seems like it's just an omission in the role-description text.