### PR TITLE
Editorial: Fix invalid HTML markup in an example

### DIFF
--- a/index.html
+++ b/index.html
@@ -9446,7 +9446,7 @@
                                     The following drawing illustrates an application of the Pythagorean Theorem when used to
                                     construct a skateboard ramp.
                                   &lt;/p&gt;
-                                  &lt;object data="skatebd-ramp.svg"  type="image/svg+xml"/&gt;
+                                  &lt;object data="skatebd-ramp.svg"  type="image/svg+xml"&gt;&lt;/object&gt;
                                   &lt;p&gt;
                                     In this example you will notice a skateboard with a base and vertical board whose width
                                     is the width of the ramp. To compute how long the ramp must be, simply calculate the


### PR DESCRIPTION
The `/>` syntax is invalid for the `object` element.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/912.html" title="Last updated on Feb 27, 2019, 1:25 PM UTC (74ead4b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/912/c21d084...74ead4b.html" title="Last updated on Feb 27, 2019, 1:25 PM UTC (74ead4b)">Diff</a>