### PR TITLE
Remove implicit value of aria-level from heading role

### DIFF
--- a/index.html
+++ b/index.html
@@ -3146,10 +3146,6 @@
 						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
 						<td class="role-presentational-inherited"> </td>
 					</tr>
-					<tr>
-						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
-						<td class="implicit-values">Default for <pref>aria-level</pref> is <code class="default">2</code>.</td>
-					</tr>
 				</tbody>
 			</table>
 		</div>

--- a/index.html
+++ b/index.html
@@ -3070,7 +3070,7 @@
 			<rdef>heading</rdef>
 			<div class="role-description">
 				<p>A heading for a section of the page.</p>
-				<p>Often, <code>heading</code> elements will be referenced with the <pref>aria-labelledby</pref> <a>attribute</a> of the section for which they serve as a heading. If headings are organized into a logical outline, the <pref>aria-level</pref> attribute is used to indicate the nesting level.</p>
+				<p>Often, <code>heading</code> elements will be referenced with the <pref>aria-labelledby</pref> <a>attribute</a> of the section for which they serve as a heading. To ensure headings are organized into a logical outline, authors MUST use the <pref>aria-level</pref> attribute to indicate the proper nesting level.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>


### PR DESCRIPTION
Addresses issue #854


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/melanierichards/aria/pull/942.html" title="Last updated on Apr 25, 2019, 3:57 AM UTC (490eb68)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/942/78b9178...melanierichards:490eb68.html" title="Last updated on Apr 25, 2019, 3:57 AM UTC (490eb68)">Diff</a>