### PR TITLE
Editorial: Merge redundant points in Handling Author Errors section #845

### DIFF
--- a/index.html
+++ b/index.html
@@ -11983,10 +11983,10 @@
 			<p>In general, <a>user agents</a> do not do much validation of <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref">properties</a>. User agents MAY do some minor validation on request, such as making sure <a data-lt="valid idref">valid IDs</a> are specified for <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> relations, and enforcing things like <pref>aria-posinset</pref> being within 1 and <pref>aria-setsize</pref>, inclusive. User agents are not  responsible for logical validation, such as the following:</p>
 				<ol>
 					<li>Circular references created by relations, such as specifying that two <a>elements</a> own each other. </li>
-					<li>Correct usage with regard to <abbr title="Document Object Model">DOM</abbr> tree structure, such as an <pref>aria-activedescendant</pref> being a <abbr title="Document Object Model">DOM</abbr>-descendant of the element with the  relation.</li>
+					<li>Correct usage with regard to <abbr title="Document Object Model">DOM</abbr> tree structure, such as an <a>element</a> being owned by more than one other element.</li>
 					<li>Elements with <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a>roles</a> correctly implement the  behavior of the specified role. For example, user agents do not verify that an element with a role of <rref>checkbox</rref> actually behaves like a checkbox.</li>
 					<li>Elements that do not correctly observe required child / parent role relationships or that appear elsewhere than in their required parent.</li>
-					<li>Determining whether <pref>aria-activedescendant</pref> actually points to a descendant or another owned element.</li>
+					<li>Determining whether <pref>aria-activedescendant</pref> actually points to a <abbr title="Document Object Model">DOM</abbr> descendant or owned element.</li>
 					<li>Determining implicit values of <pref>aria-setsize</pref> and <pref>aria-posinset</pref> when they are specified on some but not all the elements of the set.</li>
 				</ol>
 			<p>If the author specifies a non-numeric value for a decimal or integer value type, the user agent SHOULD do the following:</p>


### PR DESCRIPTION
Reworded Point 2 using a different example that does not intersect with Point 5, as follows:

Point 2. Correct usage with regard to DOM tree structure, such as an element being owned by more than one other element.

Point 5. Determining whether aria-activedescendant actually points to a DOM descendant or owned element.