### PR TITLE
Delete editor's note about placeholder.

### DIFF
--- a/index.html
+++ b/index.html
@@ -12281,7 +12281,6 @@
 			<ul>
 				<li><code>ariaPosInSet</code>: The <pref>aria-posinset</pref> attribute refers to an item's position in a set (two words: "in set") rather than the "inset" of an item from the beginning of the collection. Therefore the IDL attribute name is <code>ariaPosInSet</code> with the P, I, and second S capitalized, <em>not</em> <code>ariaPosInset</code>.</li>
 			</ul>
-			<p class="ednote">Editor's Note: Should we make an exception on the spelling of "placeholder" and capitalize the H anyway? Some developers will expect this to be <code>ariaPlaceHolder</code> despite the fact that it's not a hyphenated word.</p>
 		</section>
 	</section>
 


### PR DESCRIPTION
According to multiple dictionaries, placeholder is a single word, and so should not be camelCased.