### PR TITLE
Issue504 description list roles

### DIFF
--- a/index.html
+++ b/index.html
@@ -3783,8 +3783,8 @@
 		<div class="role" id="list">
 			<rdef>list</rdef>
 			<div class="role-description">
-				<p>A <rref>section</rref> containing <rref>listitem</rref>, <rref>listitemterm</rref> and <rref>listitemdescripion</rref> elements. See related <rref>listbox</rref>.</p>
-				<p>Lists contain children whose <a>role</a> is <rref>listitem</rref>, <rref>listitemterm</rref> and <rref>listitemdescripion</rref> or elements whose <a>role</a> is <rref>group</rref> which in turn contains children whose <a>role</a> is <rref>listitem</rref>.</p>
+				<p>A <rref>section</rref> containing <rref>listitem</rref>, <rref>listitemdescripion</rref> and <rref>listitemterm</rref> elements. See related <rref>listbox</rref>.</p>
+				<p>Lists contain children whose <a>role</a> is <rref>listitem</rref>, <rref>listitemdescripion</rref> and <rref>listitemterm</rref>, or elements whose <a>role</a> is <rref>group</rref> which in turn contains children whose <a>role</a> is <rref>listitem</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -659,15 +659,15 @@
 			<ul>
 				<li><rref>application</rref></li>
 				<li><rref>article</rref></li>
+        <li><rref>associationlist</rref></li>
+        <li><rref>associationlistitemkey</rref></li>
+        <li><rref>associationlistitemvalue</rref></li>
 				<li><rref>blockquote</rref></li>
 				<li><rref>caption</rref></li>
 				<li><rref>cell</rref></li>
 				<li><rref>columnheader</rref></li>
 				<li><rref>definition</rref></li>
         <li><rref>deletion</rref></li>
-        <li><rref>descriptionitem</rref></li>
-        <li><rref>descriptionlist</rref></li>
-        <li><rref>descriptionterm</rref></li>
 				<li><rref>directory</rref></li>
 				<li><rref>document</rref></li>
 				<li><rref>feed</rref></li>
@@ -1086,7 +1086,276 @@
 				</tbody>
 			</table>
 		</div>
-		<div class="role" id="banner">
+    <div class="role" id="associationlist">
+      <rdef>associationlist</rdef>
+      <div class="role-description">
+        <p>A <rref>section</rref> containing <rref>associationlistitemkey</rref> and <rref>associationlistitemvalue</rref> elements.</p>
+
+        <p>Association lists contain children whose <a>role</a> is <rref>associationlistitemkey</rref> and <rref>associationlistitemvalue</rref> to represent a list of key items each having one or more values.</p>
+
+        <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>associationlist</code>:</p>
+        <ul>
+          <li>MUST only use an element with role <rref>associationlistitemkey</rref> as the first child in the description list.</li>
+          <li>Each element with role <rref>associationlistitemkey</rref> SHOULD have at least one following sibling element with role <rref>associationlistitemvalue</rref>.</li>
+        </ul>
+
+      </div>
+      <table class="role-features">
+        <caption>Characteristics:</caption>
+        <thead>
+          <tr>
+            <th scope="col">Characteristic</th>
+            <th scope="col">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th class="role-abstract-head" scope="row">Is Abstract:</th>
+            <td class="role-abstract"> </td>
+          </tr>
+          <tr>
+            <th class="role-parent-head" scope="row">Superclass Role:</th>
+            <td class="role-parent"><rref>section</rref></td>
+          </tr>
+          <tr>
+            <th class="role-children-head" scope="row">Subclass Roles:</th>
+            <td class="role-children">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-base-head" scope="row">Base Concept:</th>
+            <td class="role-base">
+                <a href="https://www.w3.org/TR/html5/grouping-content.html#the-dl-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dl</code></a>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-related-head" scope="row">Related Concepts:</th>
+            <td class="role-related"> </td>
+          </tr>
+          <tr>
+            <th class="role-scope-head" scope="row">Required Context Role:</th>
+            <td class="role-scope"> </td>
+          </tr>
+          <tr>
+            <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+            <td class="role-mustcontain">
+              <ul>
+                <li><rref>associationlistitemvalue</rref></li>
+                <li><rref>associationlistitemkey</rref></li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-required-properties-head">Required States and Properties:</th>
+            <td class="role-required-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
+            <td class="role-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+            <td class="role-inherited">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-namefrom-head" scope="row">Name From:</th>
+            <td class="role-namefrom">author</td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+            <td class="role-namerequired"> </td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+            <td class="role-namerequired-inherited"> </td>
+          </tr>
+          <tr>
+            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+            <td class="role-childpresentational"> </td>
+          </tr>
+          <tr>
+            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+            <td class="role-presentational-inherited"> </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="role" id="associationlistitemkey">
+      <rdef>associationlistitemkey</rdef>
+      <div class="role-description">
+        <p>A single key in an association list.</p>
+
+        <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>associationlistitemkey</code>:</p>
+        <ul>
+          <li>MUST be contained in an element whose <a>role</a> is <rref>associationlist</rref>.</li>
+          <li>SHOULD be followed by one or more sibling <a>elements</a> whose <a>role</a> is <rref>associationlistitemvalue</rref>.</li>
+          <li>MAY be followed by one or more sibling elements whose role is also <rref>associationlistitemkey</rref>.</li>
+        </ul>
+
+      </div>
+      <table class="role-features">
+        <caption>Characteristics:</caption>
+        <thead>
+          <tr>
+            <th scope="col">Characteristic</th>
+            <th scope="col">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th class="role-abstract-head" scope="row">Is Abstract:</th>
+            <td class="role-abstract"> </td>
+          </tr>
+          <tr>
+            <th class="role-parent-head" scope="row">Superclass Role:</th>
+            <td class="role-parent"><rref>section</rref></td>
+          </tr>
+          <tr>
+            <th class="role-children-head" scope="row">Subclass Roles:</th>
+            <td class="role-children">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-base-head" scope="row">Base Concept:</th>
+            <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dt-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dt</code></a></td>
+          </tr>
+          <tr>
+            <th class="role-related-head" scope="row">Related Concepts:</th>
+            <td class="role-related"><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-common-elements-item">XForms item</a></td>
+          </tr>
+          <tr>
+            <th class="role-scope-head" scope="row">Required Context Role:</th>
+            <td class="role-scope"><rref>list</rref></td>
+          </tr>
+          <tr>
+            <th class="role-required-properties-head">Required States and Properties:</th>
+            <td class="role-required-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
+            <td class="role-properties">
+              <ul>
+                <li><pref>aria-level</pref></li>
+                <li><pref>aria-posinset</pref></li>
+                <li><pref>aria-setsize</pref></li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+            <td class="role-inherited">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-namefrom-head" scope="row">Name From:</th>
+            <td class="role-namefrom">author</td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+            <td class="role-namerequired"> </td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+            <td class="role-namerequired-inherited"> </td>
+          </tr>
+          <tr>
+            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+            <td class="role-childpresentational"> </td>
+          </tr>
+          <tr>
+            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+            <td class="role-presentational-inherited"> </td>
+          </tr>
+        </tbody>
+      </table>
+    <div class="role" id="associationlistitemvalue">
+      <rdef>associationlistitemvalue</rdef>
+      <div class="role-description">
+        <p>A single description in a description list.</p>
+
+        <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>associationlistitemvalue</code>:</p>
+        <ul>
+          <li>MUST be contained in an element whose <a>role</a> is <rref>associationlist</rref>.</li>
+          <li>SHOULD have a preceeding sibling <a>element</a> whose <a>role</a> is <rref>associationlistitemkey</rref>.</li>
+          <li>MAY be followed by one or more sibling elements whose role is also <rref>associationlistitemvalue</rref>.</li>
+        </ul>
+
+      </div>
+      <table class="role-features">
+        <caption>Characteristics:</caption>
+        <thead>
+          <tr>
+            <th scope="col">Characteristic</th>
+            <th scope="col">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th class="role-abstract-head" scope="row">Is Abstract:</th>
+            <td class="role-abstract"> </td>
+          </tr>
+          <tr>
+            <th class="role-parent-head" scope="row">Superclass Role:</th>
+            <td class="role-parent"><rref>section</rref></td>
+          </tr>
+          <tr>
+            <th class="role-children-head" scope="row">Subclass Roles:</th>
+            <td class="role-children">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-base-head" scope="row">Base Concept:</th>
+            <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dd-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dd</code></a></td>
+          </tr>
+          <tr>
+            <th class="role-related-head" scope="row">Related Concepts:</th>
+            <td class="role-related"><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-common-elements-item">XForms item</a></td>
+          </tr>
+          <tr>
+            <th class="role-scope-head" scope="row">Required Context Role:</th>
+            <td class="role-scope"><rref>list</rref></td>
+          </tr>
+          <tr>
+            <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+            <td class="role-mustcontain"> </td>
+          </tr>
+          <tr>
+            <th class="role-required-properties-head">Required States and Properties:</th>
+            <td class="role-required-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
+            <td class="role-properties">
+              <ul>
+                <li><pref>aria-posinset</pref></li>
+                <li><pref>aria-setsize</pref></li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+            <td class="role-inherited">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-namefrom-head" scope="row">Name From:</th>
+            <td class="role-namefrom">author</td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+            <td class="role-namerequired"> </td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+            <td class="role-namerequired-inherited"> </td>
+          </tr>
+          <tr>
+            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+            <td class="role-childpresentational"> </td>
+          </tr>
+          <tr>
+            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+            <td class="role-presentational-inherited"> </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    </div>		<div class="role" id="banner">
 			<rdef>banner</rdef>
 			<div class="role-description">
 				<p>A region that contains mostly site-oriented content, rather than page-specific content.</p>
@@ -2291,277 +2560,7 @@
         </tbody>
       </table>
     </div>
-    <div class="role" id="descriptionitem">
-      <rdef>descriptionitem</rdef>
-      <div class="role-description">
-        <p>A single description in a description list.</p>
 
-        <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>descriptionitem</code>:</p>
-        <ul>
-          <li>MUST be contained in an element whose <a>role</a> is <rref>descriptionlist</rref>.</li>
-          <li>SHOULD have a preceeding sibling <a>element</a> whose <a>role</a> is <rref>descriptionterm</rref>.</li>
-          <li>MAY be followed by one or more sibling elements whose role is also <rref>descriptionitem</rref>.</li>
-        </ul>
-
-      </div>
-      <table class="role-features">
-        <caption>Characteristics:</caption>
-        <thead>
-          <tr>
-            <th scope="col">Characteristic</th>
-            <th scope="col">Value</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th class="role-abstract-head" scope="row">Is Abstract:</th>
-            <td class="role-abstract"> </td>
-          </tr>
-          <tr>
-            <th class="role-parent-head" scope="row">Superclass Role:</th>
-            <td class="role-parent"><rref>section</rref></td>
-          </tr>
-          <tr>
-            <th class="role-children-head" scope="row">Subclass Roles:</th>
-            <td class="role-children">Placeholder</td>
-          </tr>
-          <tr>
-            <th class="role-base-head" scope="row">Base Concept:</th>
-            <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dd-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dd</code></a></td>
-          </tr>
-          <tr>
-            <th class="role-related-head" scope="row">Related Concepts:</th>
-            <td class="role-related"><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-common-elements-item">XForms item</a></td>
-          </tr>
-          <tr>
-            <th class="role-scope-head" scope="row">Required Context Role:</th>
-            <td class="role-scope"><rref>list</rref></td>
-          </tr>
-          <tr>
-            <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
-            <td class="role-mustcontain"> </td>
-          </tr>
-          <tr>
-            <th class="role-required-properties-head">Required States and Properties:</th>
-            <td class="role-required-properties"> </td>
-          </tr>
-          <tr>
-            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
-            <td class="role-properties">
-              <ul>
-                <li><pref>aria-level</pref></li>
-                <li><pref>aria-posinset</pref></li>
-                <li><pref>aria-setsize</pref></li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
-            <td class="role-inherited">Placeholder</td>
-          </tr>
-          <tr>
-            <th class="role-namefrom-head" scope="row">Name From:</th>
-            <td class="role-namefrom">author</td>
-          </tr>
-          <tr>
-            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-            <td class="role-namerequired"> </td>
-          </tr>
-          <tr>
-            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
-            <td class="role-namerequired-inherited"> </td>
-          </tr>
-          <tr>
-            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
-            <td class="role-childpresentational"> </td>
-          </tr>
-          <tr>
-            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
-            <td class="role-presentational-inherited"> </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    <div class="role" id="descriptionlist">
-      <rdef>descriptionlist</rdef>
-      <div class="role-description">
-        <p>A <rref>section</rref> containing <rref>descriptionitem</rref> and <rref>descriptionterm</rref> elements.</p>
-
-        <p>Description lists contain children whose <a>role</a> is <rref>descriptionterm</rref> and <rref>descriptionitem</rref> to represent a list of terms each having one or more descriptions.</p>
-
-        <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>descriptionlist</code>:</p>
-        <ul>
-          <li>MUST only use an element with role <rref>descriptionterm</rref> as the first child in the description list.</li>
-          <li>Each element with role <rref>descriptionterm</rref> SHOULD have at least one following sibling element with role <rref>descriptionitem</rref>.</li>
-        </ul>
-
-      </div>
-      <table class="role-features">
-        <caption>Characteristics:</caption>
-        <thead>
-          <tr>
-            <th scope="col">Characteristic</th>
-            <th scope="col">Value</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th class="role-abstract-head" scope="row">Is Abstract:</th>
-            <td class="role-abstract"> </td>
-          </tr>
-          <tr>
-            <th class="role-parent-head" scope="row">Superclass Role:</th>
-            <td class="role-parent"><rref>section</rref></td>
-          </tr>
-          <tr>
-            <th class="role-children-head" scope="row">Subclass Roles:</th>
-            <td class="role-children">Placeholder</td>
-          </tr>
-          <tr>
-            <th class="role-base-head" scope="row">Base Concept:</th>
-            <td class="role-base">
-                <a href="https://www.w3.org/TR/html5/grouping-content.html#the-dl-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dl</code></a>
-            </td>
-          </tr>
-          <tr>
-            <th class="role-related-head" scope="row">Related Concepts:</th>
-            <td class="role-related"> </td>
-          </tr>
-          <tr>
-            <th class="role-scope-head" scope="row">Required Context Role:</th>
-            <td class="role-scope"> </td>
-          </tr>
-          <tr>
-            <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
-            <td class="role-mustcontain">
-              <ul>
-                <li><rref>descriptionitem</rref></li>
-                <li><rref>descriptionterm</rref></li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <th class="role-required-properties-head">Required States and Properties:</th>
-            <td class="role-required-properties"> </td>
-          </tr>
-          <tr>
-            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
-            <td class="role-properties"> </td>
-          </tr>
-          <tr>
-            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
-            <td class="role-inherited">Placeholder</td>
-          </tr>
-          <tr>
-            <th class="role-namefrom-head" scope="row">Name From:</th>
-            <td class="role-namefrom">author</td>
-          </tr>
-          <tr>
-            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-            <td class="role-namerequired"> </td>
-          </tr>
-          <tr>
-            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
-            <td class="role-namerequired-inherited"> </td>
-          </tr>
-          <tr>
-            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
-            <td class="role-childpresentational"> </td>
-          </tr>
-          <tr>
-            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
-            <td class="role-presentational-inherited"> </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    <div class="role" id="descriptionterm">
-      <rdef>descriptionterm</rdef>
-      <div class="role-description">
-        <p>A single term in a description list.</p>
-
-        <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>descriptionterm</code>:</p>
-        <ul>
-          <li>MUST be contained in an element whose <a>role</a> is <rref>descriptionlist</rref>.</li>
-          <li>SHOULD be followed by one or more sibling <a>elements</a> whose <a>role</a> is <rref>descriptionitem</rref>.</li>
-          <li>MAY be followed by one or more sibling elements whose role is also <rref>descriptionterm</rref>.</li>
-        </ul>
-
-      </div>
-      <table class="role-features">
-        <caption>Characteristics:</caption>
-        <thead>
-          <tr>
-            <th scope="col">Characteristic</th>
-            <th scope="col">Value</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th class="role-abstract-head" scope="row">Is Abstract:</th>
-            <td class="role-abstract"> </td>
-          </tr>
-          <tr>
-            <th class="role-parent-head" scope="row">Superclass Role:</th>
-            <td class="role-parent"><rref>section</rref></td>
-          </tr>
-          <tr>
-            <th class="role-children-head" scope="row">Subclass Roles:</th>
-            <td class="role-children">Placeholder</td>
-          </tr>
-          <tr>
-            <th class="role-base-head" scope="row">Base Concept:</th>
-            <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dt-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dt</code></a></td>
-          </tr>
-          <tr>
-            <th class="role-related-head" scope="row">Related Concepts:</th>
-            <td class="role-related"><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-common-elements-item">XForms item</a></td>
-          </tr>
-          <tr>
-            <th class="role-scope-head" scope="row">Required Context Role:</th>
-            <td class="role-scope"><rref>list</rref></td>
-          </tr>
-          <tr>
-            <th class="role-required-properties-head">Required States and Properties:</th>
-            <td class="role-required-properties"> </td>
-          </tr>
-          <tr>
-            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
-            <td class="role-properties">
-              <ul>
-                <li><pref>aria-level</pref></li>
-                <li><pref>aria-posinset</pref></li>
-                <li><pref>aria-setsize</pref></li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
-            <td class="role-inherited">Placeholder</td>
-          </tr>
-          <tr>
-            <th class="role-namefrom-head" scope="row">Name From:</th>
-            <td class="role-namefrom">author</td>
-          </tr>
-          <tr>
-            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-            <td class="role-namerequired"> </td>
-          </tr>
-          <tr>
-            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
-            <td class="role-namerequired-inherited"> </td>
-          </tr>
-          <tr>
-            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
-            <td class="role-childpresentational"> </td>
-          </tr>
-          <tr>
-            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
-            <td class="role-presentational-inherited"> </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
 		<div class="role" id="dialog">
 			<rdef>dialog</rdef>
 			<div class="role-description">

--- a/index.html
+++ b/index.html
@@ -3783,8 +3783,8 @@
 		<div class="role" id="list">
 			<rdef>list</rdef>
 			<div class="role-description">
-				<p>A <rref>section</rref> containing <rref>listitem</rref> elements. See related <rref>listbox</rref>.</p>
-				<p>Lists contain children whose <a>role</a> is <rref>listitem</rref>, or elements whose <a>role</a> is <rref>group</rref> which in turn contains children whose <a>role</a> is <rref>listitem</rref>.</p>
+				<p>A <rref>section</rref> containing <rref>listitem</rref>, <rref>listitemterm</rref> and <rref>listitemdescripion</rref> elements. See related <rref>listbox</rref>.</p>
+				<p>Lists contain children whose <a>role</a> is <rref>listitem</rref>, <rref>listitemterm</rref> and <rref>listitemdescripion</rref> or elements whose <a>role</a> is <rref>group</rref> which in turn contains children whose <a>role</a> is <rref>listitem</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -3830,6 +3830,8 @@
 							<ul>
 								<li><rref>group</rref> <abbr title="containing" class="symbol">→</abbr> <rref>listitem</rref></li>
 								<li><rref>listitem</rref></li>
+                <li><rref>listitemterm</rref></li>
+                <li><rref>listitemdescripion</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -4067,11 +4069,11 @@
 				</tbody>
 			</table>
 		</div>
-    <div class="role" id="listitemterm">
-      <rdef>listitemterm</rdef>
+    <div class="role" id="listitemdescription">
+      <rdef>listitemdescription</rdef>
       <div class="role-description">
-        <p>A single item in a list or directory.</p>
-        <p>Authors MUST ensure <a>elements</a> whose <a>role</a> is <code>listitem</code> are contained in, or owned by, an <a>element</a> whose <a>role</a> is <rref>list</rref>, or an <a>element</a> whose <a>role</a> is <rref>group</rref> which in turn is contained or owned by an <a>element</a> whose <a>role</a> is <rref>list</rref>.</p>
+        <p>Represents a single description in a list of terms and descriptions.</p>
+        <p>Authors MUST ensure <a>elements</a> whose <a>role</a> is <code>listitemdescription</code> are contained in a <rref>list</rref>.</p>
       </div>
       <table class="role-features">
         <caption>Characteristics:</caption>
@@ -4096,7 +4098,7 @@
           </tr>
           <tr>
             <th class="role-base-head" scope="row">Base Concept:</th>
-            <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dt-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dt</code></a></td>
+            <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dd-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dd</code></a></td>
           </tr>
           <tr>
             <th class="role-related-head" scope="row">Related Concepts:</th>
@@ -4104,12 +4106,7 @@
           </tr>
           <tr>
             <th class="role-scope-head" scope="row">Required Context Role:</th>
-            <td class="role-scope">
-              <ul>
-                <li><rref>group</rref></li>
-                <li><rref>list</rref></li>
-              </ul>
-            </td>
+            <td class="role-scope"><rref>list</rref></td>
           </tr>
           <tr>
             <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
@@ -4156,11 +4153,11 @@
         </tbody>
       </table>
     </div>
-    <div class="role" id="listitemdescription">
-      <rdef>listitemdescription</rdef>
+    <div class="role" id="listitemterm">
+      <rdef>listitemterm</rdef>
       <div class="role-description">
-        <p>A single item in a list or directory.</p>
-        <p>Authors MUST ensure <a>elements</a> whose <a>role</a> is <code>listitem</code> are contained in, or owned by, an <a>element</a> whose <a>role</a> is <rref>list</rref>, or an <a>element</a> whose <a>role</a> is <rref>group</rref> which in turn is contained or owned by an <a>element</a> whose <a>role</a> is <rref>list</rref>.</p>
+        <p>Represents a single term in a list of terms and descriptions.</p>
+        <p>Authors MUST ensure <a>elements</a> whose <a>role</a> is <code>listitemterm</code> are contained in <rref>list</rref>.</p>
       </div>
       <table class="role-features">
         <caption>Characteristics:</caption>
@@ -4185,7 +4182,7 @@
           </tr>
           <tr>
             <th class="role-base-head" scope="row">Base Concept:</th>
-            <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dd-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dd</code></a></td>
+            <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dt-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dt</code></a></td>
           </tr>
           <tr>
             <th class="role-related-head" scope="row">Related Concepts:</th>
@@ -4193,16 +4190,7 @@
           </tr>
           <tr>
             <th class="role-scope-head" scope="row">Required Context Role:</th>
-            <td class="role-scope">
-              <ul>
-                <li><rref>group</rref></li>
-                <li><rref>list</rref></li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
-            <td class="role-mustcontain"> </td>
+            <td class="role-scope"><rref>list</rref></td>
           </tr>
           <tr>
             <th class="role-required-properties-head">Required States and Properties:</th>

--- a/index.html
+++ b/index.html
@@ -1182,7 +1182,7 @@
     <div class="role" id="associationlistitemkey">
       <rdef>associationlistitemkey</rdef>
       <div class="role-description">
-        <p>A single key in an association list.</p>
+        <p>A single key item in an association list.</p>
 
         <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>associationlistitemkey</code>:</p>
         <ul>
@@ -1265,10 +1265,11 @@
           </tr>
         </tbody>
       </table>
+    </div>
     <div class="role" id="associationlistitemvalue">
       <rdef>associationlistitemvalue</rdef>
       <div class="role-description">
-        <p>A single description in a description list.</p>
+        <p>A single value item in an association list.</p>
 
         <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>associationlistitemvalue</code>:</p>
         <ul>
@@ -1355,7 +1356,7 @@
         </tbody>
       </table>
     </div>
-    </div>		<div class="role" id="banner">
+		<div class="role" id="banner">
 			<rdef>banner</rdef>
 			<div class="role-description">
 				<p>A region that contains mostly site-oriented content, rather than page-specific content.</p>

--- a/index.html
+++ b/index.html
@@ -677,8 +677,8 @@
         <li><rref>legend</rref></li>
 				<li><rref>list</rref></li>
 				<li><rref>listitem</rref></li>
-        <li><rref>listitemterm</rref></li>
         <li><rref>listitemdescription</rref></li>
+        <li><rref>listitemterm</rref></li>
 				<li><rref>math</rref></li>
 				<li><rref>none</rref></li>
 				<li><rref>note</rref></li>

--- a/index.html
+++ b/index.html
@@ -531,6 +531,7 @@
 						<li>author: name comes from values provided by the author in explicit markup features such as the <pref>aria-label</pref> attribute, the <pref>aria-labelledby</pref> attribute, or the host language labeling mechanism, such as the <code>alt</code> or <code>title</code> attributes in <abbr title="Hypertext Markup Language">HTML</abbr>, with HTML <code>title</code> attribute having the lowest precedence for specifying a text alternative.</li>
 						<li>contents: name comes from the text value of the <a>element</a> node. Although this may be allowed in addition to "author" in some <a>roles</a>, this is used in content only if higher priority "author" features are not provided. Priority is defined by the <a href="https://www.w3.org/TR/accname-aam-1.1/#mapping_additional_nd_te">accessible name and description computation</a> algorithm.  [[ACCNAME-1.1]]</li>
             <li>encapsulation: name comes from the text value of the <a>element</a> node with role <code>label</code> that is the closest ancestor. Although "encapsulation" may be allowed in addition to "author" and "contents" in some <a>roles</a>, "encapsulation" is used only if higher priority "author" features are not provided. Priority is defined by the <a href="https://www.w3.org/TR/accname-aam-1.1/#mapping_additional_nd_te">accessible name and description computation</a> algorithm.  [[ACCNAME-1.1]]</li>
+            <li>legend: name comes from the text value of the first descendant <a>element</a> node with the role of <code>legend</code>.  Although "legend" may be allowed in addition to "author" in some <a>roles</a>, "legend" is used in content only if higher priority "author" features are not provided. Priority is defined by the <a href="https://www.w3.org/TR/accname-aam-1.1/#mapping_additional_nd_te">accessible name and description computation</a> algorithm.  [[ACCNAME-1.1]]</li>
 					</ol>
 				</dd>
 			</dl>
@@ -673,6 +674,7 @@
 				<li><rref>img</rref></li>
         <li><rref>insertion</rref></li>
         <li><rref>label</rref></li>
+        <li><rref>legend</rref></li>
 				<li><rref>list</rref></li>
 				<li><rref>listitem</rref></li>
 				<li><rref>math</rref></li>
@@ -3045,7 +3047,12 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom">
+              <ul>
+                <li>author</li>
+                <li>legend</li>
+              </ul>
+            </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -3570,6 +3577,114 @@
 				</tbody>
 			</table>
 		</div>
+    <div class="role" id="legend">
+      <rdef>legend</rdef>
+      <div class="role-description">
+        <p>A visible name or caption for a group of related user interface components.</p>
+
+        <p>A element with role <code>legend</code> element can provide an accessible name for elements with grouping roles if it is progammatically associated with the element.  Authors MAY associate an element with role <code>legend</code> with an element by using one of two methods:</p>
+
+        <ul>
+          <li>legend: The element contains an element with role <code>legend</code> element.  If the element contains more than one element with role <code>legend</code>, only the first descendant element with role <code>legend</code> is used for computing the accessible name.</li>
+          <li>reference: The element eith role <code>legend</code> is referenced by the element it names via the <pref>aria-labelledby</pref> attribute.</li>
+        </ul>
+
+        <p>The legend method of naming is supported only if the element being named has one of the following grouping roles:</p>
+
+        <ul>
+          <li><pref>group</pref></li>
+          <li><pref>radiogroup</pref> </li>
+        </ul>
+
+        <p>Authors SHOULD ensure that:</p>
+
+        <ul>
+          <li>All elements with role <code>legend</code> are associated with one or more elements with grouping roles.</li>
+          <li>When an element with role <code>legend</code> is activated by touch or a pointer, focus moves to the first focusable element in the associated group of user interface components.
+
+        </p>
+      </div>
+      <table class="role-features">
+        <caption>Characteristics:</caption>
+        <thead>
+          <tr>
+            <th scope="col">Characteristic</th>
+            <th scope="col">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th class="role-abstract-head" scope="row">Is Abstract:</th>
+            <td class="role-abstract"> </td>
+          </tr>
+          <tr>
+            <th class="role-parent-head" scope="row">Superclass Role:</th>
+            <td class="role-parent">
+              <ul>
+                <li><rref>section</rref></li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-children-head" scope="row">Subclass Roles:</th>
+            <td class="role-children"></td>
+          </tr>
+          <tr>
+            <th class="role-base-head" scope="row">Base Concept:</th>
+            <td class="role-base"><a href="https://www.w3.org/TR/html5/sec-forms.html#the-legend-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>legend</code></a></td>
+          </tr>
+          <tr>
+            <th class="role-related-head" scope="row">Related Concepts:</th>
+            <td class="role-related"> </td>
+          </tr>
+          <tr>
+            <th class="role-scope-head" scope="row">Required Context Role:</th>
+            <td class="role-scope"><rref></rref></td>
+          </tr>
+          <tr>
+            <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+            <td class="role-mustcontain"> </td>
+          </tr>
+          <tr>
+            <th class="role-required-properties-head">Required States and Properties:</th>
+            <td class="role-required-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
+            <td class="role-properties"></td>
+          </tr>
+          <tr>
+            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+            <td class="role-inherited">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-namefrom-head" scope="row">Name From:</th>
+            <td class="role-namefrom">
+              <ul>
+                <li>contents</li>
+                <li>author</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+            <td class="role-namerequired">True</td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+            <td class="role-namerequired-inherited"> </td>
+          </tr>
+          <tr>
+            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+            <td class="role-childpresentational"> </td>
+          </tr>
+          <tr>
+            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+            <td class="role-presentational-inherited"> </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
 		<div class="role" id="link">
 			<rdef>link</rdef>
 			<div class="role-description">
@@ -5747,7 +5862,12 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom">
+              <ul>
+                <li>author</li>
+                <li>legend</li>
+              </ul>
+            </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>

--- a/index.html
+++ b/index.html
@@ -2387,7 +2387,7 @@
       <div class="role-description">
         <p>A <rref>section</rref> containing <rref>descriptionitem</rref> and <rref>descriptionterm</rref> elements.</p>
 
-        <p>Description lists contain children whose <a>role</a> is <rref>descriptionitem</rref> and <rref>descriptionterm</rref> to represent a list of terms each having one or more descriptions.</p>
+        <p>Description lists contain children whose <a>role</a> is <rref>descriptionterm</rref> and <rref>descriptionitem</rref> to represent a list of terms each having one or more descriptions.</p>
 
         <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>descriptionlist</code>:</p>
         <ul>

--- a/index.html
+++ b/index.html
@@ -4049,7 +4049,7 @@
 				</tbody>
 			</table>
 		</div>
-  <div class="role" id="list">
+    <div class="role" id="list">
       <rdef>list</rdef>
       <div class="role-description">
         <p>A <rref>section</rref> containing <rref>listitem</rref> elements. See related <rref>listbox</rref>.</p>
@@ -4066,7 +4066,7 @@
         <tbody>
           <tr>
             <th class="role-abstract-head" scope="row">Is Abstract:</th>
-            <td class="role-abstract"> </td>
+            <td class="role-abstract"> </td>
           </tr>
           <tr>
             <th class="role-parent-head" scope="row">Superclass Role:</th>
@@ -4087,11 +4087,11 @@
           </tr>
           <tr>
             <th class="role-related-head" scope="row">Related Concepts:</th>
-            <td class="role-related"> </td>
+            <td class="role-related"> </td>
           </tr>
           <tr>
             <th class="role-scope-head" scope="row">Required Context Role:</th>
-            <td class="role-scope"> </td>
+            <td class="role-scope"> </td>
           </tr>
           <tr>
             <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
@@ -4104,11 +4104,11 @@
           </tr>
           <tr>
             <th class="role-required-properties-head">Required States and Properties:</th>
-            <td class="role-required-properties"> </td>
+            <td class="role-required-properties"> </td>
           </tr>
           <tr>
             <th class="role-properties-head" scope="row">Supported States and Properties:</th>
-            <td class="role-properties"> </td>
+            <td class="role-properties"> </td>
           </tr>
           <tr>
             <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -4120,19 +4120,19 @@
           </tr>
           <tr>
             <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-            <td class="role-namerequired"> </td>
+            <td class="role-namerequired"> </td>
           </tr>
           <tr>
             <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
-            <td class="role-namerequired-inherited"> </td>
+            <td class="role-namerequired-inherited"> </td>
           </tr>
           <tr>
             <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
-            <td class="role-childpresentational"> </td>
+            <td class="role-childpresentational"> </td>
           </tr>
           <tr>
             <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
-            <td class="role-presentational-inherited"> </td>
+            <td class="role-presentational-inherited"> </td>
           </tr>
         </tbody>
       </table>

--- a/index.html
+++ b/index.html
@@ -3602,9 +3602,8 @@
 
         <ul>
           <li>All elements with role <code>legend</code> are associated with one or more elements with grouping roles.</li>
-          <li>When an element with role <code>legend</code> is activated by touch or a pointer, focus moves to the first focusable element in the associated group of user interface components.
-
-        </p>
+          <li>When an element with role <code>legend</code> is activated by touch or a pointer, focus moves to the first focusable element in the associated group of user interface components.</li>
+        </ul>
       </div>
       <table class="role-features">
         <caption>Characteristics:</caption>
@@ -3785,6 +3784,8 @@
 			<div class="role-description">
 				<p>A <rref>section</rref> containing <rref>listitem</rref>, <rref>listitemdescripion</rref> and <rref>listitemterm</rref> elements. See related <rref>listbox</rref>.</p>
 				<p>Lists contain children whose <a>role</a> is <rref>listitem</rref>, <rref>listitemdescripion</rref> and <rref>listitemterm</rref>, or elements whose <a>role</a> is <rref>group</rref> which in turn contains children whose <a>role</a> is <rref>listitem</rref>.</p>
+
+        <p>Authors MUST only include <a>elements</a> whose roles are <rref>listitemdescripion</rref> and <rref>listitemterm</rref> for description lists and the first item in the description list MUST be an <a>element</a> whose role is <rref>listitemterm</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4073,7 +4074,13 @@
       <rdef>listitemdescription</rdef>
       <div class="role-description">
         <p>A single description in a list of terms and descriptions.</p>
-        <p>Authors MUST ensure <a>elements</a> whose <a>role</a> is <code>listitemdescription</code> are contained in a <rref>list</rref>.</p>
+
+        <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>listitemdescription</code>:</p>
+        <ul>
+          <li>MUST be contained in a <rref>list</rref>.</li>
+          <li>SHOULD have a preceeding sibling <a>element</a> whose <a>role</a> is <code>listitemterm</code>.</li>
+        </ul>
+
       </div>
       <table class="role-features">
         <caption>Characteristics:</caption>
@@ -4157,7 +4164,13 @@
       <rdef>listitemterm</rdef>
       <div class="role-description">
         <p>A single term in a list of terms and descriptions.</p>
-        <p>Authors MUST ensure <a>elements</a> whose <a>role</a> is <code>listitemterm</code> are contained in a <rref>list</rref>.</p>
+
+        <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>listitemterm</code>:</p>
+        <ul>
+          <li>MUST be contained in a <rref>list</rref>.</li>
+          <li>SHOULD be followed by one or more sibling <a>elements</a> whose <a>role</a> is <code>listitemdescription</code>.</li>
+        </ul>
+
       </div>
       <table class="role-features">
         <caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -2407,86 +2407,86 @@
 				</tbody>
 			</table>
 		</div>
-		<div class="role" id="definition">
-			<rdef>definition</rdef>
-			<div class="role-description">
+    <div class="role" id="definition">
+      <rdef>definition</rdef>
+      <div class="role-description">
         <p>A definition of a term or concept. See related <rref>term</rref>.</p>
-				<p>Authors SHOULD identify the <a>element</a> being defined by giving that element a role of <rref>term</rref> and referencing it with the <pref>aria-labelledby</pref> <a>attribute</a>.</p>
-			</div>
-			<table class="role-features">
-				<caption>Characteristics:</caption>
-				<thead>
-					<tr>
-						<th scope="col">Characteristic</th>
-						<th scope="col">Value</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<th class="role-abstract-head" scope="row">Is Abstract:</th>
-						<td class="role-abstract"> </td>
-					</tr>
-					<tr>
-						<th class="role-parent-head" scope="row">Superclass Role:</th>
-						<td class="role-parent"><rref>section</rref></td>
-					</tr>
-					<tr>
-						<th class="role-children-head" scope="row">Subclass Roles:</th>
-						<td class="role-children">Placeholder</td>
-					</tr>
-					<tr>
-						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"> </td>
-					</tr>
-					<tr>
-						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related">
+        <p>Authors SHOULD identify the <a>element</a> being defined by giving that element a role of <rref>term</rref> and referencing it with the <pref>aria-labelledby</pref> <a>attribute</a>.</p>
+      </div>
+      <table class="role-features">
+        <caption>Characteristics:</caption>
+        <thead>
+          <tr>
+            <th scope="col">Characteristic</th>
+            <th scope="col">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th class="role-abstract-head" scope="row">Is Abstract:</th>
+            <td class="role-abstract"> </td>
+          </tr>
+          <tr>
+            <th class="role-parent-head" scope="row">Superclass Role:</th>
+            <td class="role-parent"><rref>section</rref></td>
+          </tr>
+          <tr>
+            <th class="role-children-head" scope="row">Subclass Roles:</th>
+            <td class="role-children">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-base-head" scope="row">Base Concept:</th>
+            <td class="role-base"> </td>
+          </tr>
+          <tr>
+            <th class="role-related-head" scope="row">Related Concepts:</th>
+            <td class="role-related">
               <a href="https://www.w3.org/TR/html5/text-level-semantics.html#the-dfn-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dfn</code></a>
-						</td>
-					</tr>
-					<tr>
-						<th class="role-scope-head" scope="row">Required Context Role:</th>
-						<td class="role-scope"> </td>
-					</tr>
-					<tr>
-						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
-						<td class="role-mustcontain"> </td>
-					</tr>
-					<tr>
-						<th class="role-required-properties-head">Required States and Properties:</th>
-						<td class="role-required-properties"> </td>
-					</tr>
-					<tr>
-						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"> </td>
-					</tr>
-					<tr>
-						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
-						<td class="role-inherited">Placeholder</td>
-					</tr>
-					<tr>
-						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
-					</tr>
-					<tr>
-						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-						<td class="role-namerequired"> </td>
-					</tr>
-					<tr>
-						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
-						<td class="role-namerequired-inherited"> </td>
-					</tr>
-					<tr>
-						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
-						<td class="role-childpresentational"> </td>
-					</tr>
-					<tr>
-						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
-						<td class="role-presentational-inherited"> </td>
-					</tr>
-				</tbody>
-			</table>
-		</div>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-scope-head" scope="row">Required Context Role:</th>
+            <td class="role-scope"> </td>
+          </tr>
+          <tr>
+            <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+            <td class="role-mustcontain"> </td>
+          </tr>
+          <tr>
+            <th class="role-required-properties-head">Required States and Properties:</th>
+            <td class="role-required-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
+            <td class="role-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+            <td class="role-inherited">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-namefrom-head" scope="row">Name From:</th>
+            <td class="role-namefrom">author</td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+            <td class="role-namerequired"> </td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+            <td class="role-namerequired-inherited"> </td>
+          </tr>
+          <tr>
+            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+            <td class="role-childpresentational"> </td>
+          </tr>
+          <tr>
+            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+            <td class="role-presentational-inherited"> </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
     <div class="role" id="deletion">
       <rdef>deletion</rdef>
       <div class="role-description">
@@ -8309,86 +8309,85 @@
 				</tbody>
 			</table>
 		</div>
-		<div class="role" id="term">
-			<rdef>term</rdef>
-			<div class="role-description">
-				<p>A word or phrase with a corresponding definition. See related <rref>definition</rref>.</p>
-				<p>The <code>term</code> role is used to explicitly identify a word or phrase for which a <rref>definition</rref> has been provided by the author or is expected to be provided by the user.</p>
-        <p>Authors SHOULD provide a reference to an element with role <rref>term</rref> from each related element with role <rref>defintion</rref> using the <pref>aria-labelledby</pref> <a>attribute</a>.</p>
-				<p>Authors SHOULD NOT use the <code>term</code> role on interactive elements such as links because doing so could prevent users of <a>assistive technologies</a> from interacting with those elements.</p>
-			</div>
-			<table class="role-features">
-				<caption>Characteristics:</caption>
-				<thead>
-					<tr>
-						<th scope="col">Characteristic</th>
-						<th scope="col">Value</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<th class="role-abstract-head" scope="row">Is Abstract:</th>
-						<td class="role-abstract"> </td>
-					</tr>
-					<tr>
-						<th class="role-parent-head" scope="row">Superclass Role:</th>
-						<td class="role-parent"><rref>section</rref></td>
-					</tr>
-					<tr>
-						<th class="role-children-head" scope="row">Subclass Roles:</th>
-						<td class="role-children">Placeholder</td>
-					</tr>
-					<tr>
-						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"> </td>
-					</tr>
-					<tr>
-						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"></td>
-					</tr>
-					<tr>
-						<th class="role-scope-head" scope="row">Required Context Role:</th>
-						<td class="role-scope"> </td>
-					</tr>
-					<tr>
-						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
-						<td class="role-mustcontain"> </td>
-					</tr>
-					<tr>
-						<th class="role-required-properties-head">Required States and Properties:</th>
-						<td class="role-required-properties"> </td>
-					</tr>
-					<tr>
-						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"> </td>
-					</tr>
-					<tr>
-						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
-						<td class="role-inherited">Placeholder</td>
-					</tr>
-					<tr>
-						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
-					</tr>
-					<tr>
-						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-						<td class="role-namerequired"> </td>
-					</tr>
-					<tr>
-						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
-						<td class="role-namerequired-inherited"> </td>
-					</tr>
-					<tr>
-						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
-						<td class="role-childpresentational"> </td>
-					</tr>
-					<tr>
-						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
-						<td class="role-presentational-inherited"> </td>
-					</tr>
-				</tbody>
-			</table>
-		</div>
+    <div class="role" id="term">
+      <rdef>term</rdef>
+      <div class="role-description">
+        <p>A word or phrase with a corresponding definition. See related <rref>definition</rref>.</p>
+        <p>The <code>term</code> role is used to explicitly identify a word or phrase for which a <rref>definition</rref> has been provided by the author or is expected to be provided by the user.</p>
+        <p>Authors SHOULD NOT use the <code>term</code> role on interactive elements such as links because doing so could prevent users of <a>assistive technologies</a> from interacting with those elements.</p>
+      </div>
+      <table class="role-features">
+        <caption>Characteristics:</caption>
+        <thead>
+          <tr>
+            <th scope="col">Characteristic</th>
+            <th scope="col">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th class="role-abstract-head" scope="row">Is Abstract:</th>
+            <td class="role-abstract"> </td>
+          </tr>
+          <tr>
+            <th class="role-parent-head" scope="row">Superclass Role:</th>
+            <td class="role-parent"><rref>section</rref></td>
+          </tr>
+          <tr>
+            <th class="role-children-head" scope="row">Subclass Roles:</th>
+            <td class="role-children">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-base-head" scope="row">Base Concept:</th>
+            <td class="role-base"> </td>
+          </tr>
+          <tr>
+            <th class="role-related-head" scope="row">Related Concepts:</th>
+            <td class="role-related"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dt-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dt</code></a></td>
+          </tr>
+          <tr>
+            <th class="role-scope-head" scope="row">Required Context Role:</th>
+            <td class="role-scope"> </td>
+          </tr>
+          <tr>
+            <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+            <td class="role-mustcontain"> </td>
+          </tr>
+          <tr>
+            <th class="role-required-properties-head">Required States and Properties:</th>
+            <td class="role-required-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
+            <td class="role-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+            <td class="role-inherited">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-namefrom-head" scope="row">Name From:</th>
+            <td class="role-namefrom">author</td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+            <td class="role-namerequired"> </td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+            <td class="role-namerequired-inherited"> </td>
+          </tr>
+          <tr>
+            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+            <td class="role-childpresentational"> </td>
+          </tr>
+          <tr>
+            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+            <td class="role-presentational-inherited"> </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
 <!-- FIXME: This is commented out because the ARIA Working Group agreed to move the text role to ARIA 2.0,
      but we've not branched for 1.1 yet. Once we have branched, this entire section should be deleted from
      the 1.1 branch and uncommented for the master branch.

--- a/index.html
+++ b/index.html
@@ -4157,7 +4157,7 @@
       <rdef>listitemterm</rdef>
       <div class="role-description">
         <p>Represents a single term in a list of terms and descriptions.</p>
-        <p>Authors MUST ensure <a>elements</a> whose <a>role</a> is <code>listitemterm</code> are contained in <rref>list</rref>.</p>
+        <p>Authors MUST ensure <a>elements</a> whose <a>role</a> is <code>listitemterm</code> are contained in a <rref>list</rref>.</p>
       </div>
       <table class="role-features">
         <caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -677,6 +677,8 @@
         <li><rref>legend</rref></li>
 				<li><rref>list</rref></li>
 				<li><rref>listitem</rref></li>
+        <li><rref>listitemterm</rref></li>
+        <li><rref>listitemdescription</rref></li>
 				<li><rref>math</rref></li>
 				<li><rref>none</rref></li>
 				<li><rref>note</rref></li>
@@ -4065,6 +4067,184 @@
 				</tbody>
 			</table>
 		</div>
+    <div class="role" id="listitemterm">
+      <rdef>listitemterm</rdef>
+      <div class="role-description">
+        <p>A single item in a list or directory.</p>
+        <p>Authors MUST ensure <a>elements</a> whose <a>role</a> is <code>listitem</code> are contained in, or owned by, an <a>element</a> whose <a>role</a> is <rref>list</rref>, or an <a>element</a> whose <a>role</a> is <rref>group</rref> which in turn is contained or owned by an <a>element</a> whose <a>role</a> is <rref>list</rref>.</p>
+      </div>
+      <table class="role-features">
+        <caption>Characteristics:</caption>
+        <thead>
+          <tr>
+            <th scope="col">Characteristic</th>
+            <th scope="col">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th class="role-abstract-head" scope="row">Is Abstract:</th>
+            <td class="role-abstract"> </td>
+          </tr>
+          <tr>
+            <th class="role-parent-head" scope="row">Superclass Role:</th>
+            <td class="role-parent"><rref>section</rref></td>
+          </tr>
+          <tr>
+            <th class="role-children-head" scope="row">Subclass Roles:</th>
+            <td class="role-children">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-base-head" scope="row">Base Concept:</th>
+            <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dt-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dt</code></a></td>
+          </tr>
+          <tr>
+            <th class="role-related-head" scope="row">Related Concepts:</th>
+            <td class="role-related"><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-common-elements-item">XForms item</a></td>
+          </tr>
+          <tr>
+            <th class="role-scope-head" scope="row">Required Context Role:</th>
+            <td class="role-scope">
+              <ul>
+                <li><rref>group</rref></li>
+                <li><rref>list</rref></li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+            <td class="role-mustcontain"> </td>
+          </tr>
+          <tr>
+            <th class="role-required-properties-head">Required States and Properties:</th>
+            <td class="role-required-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
+            <td class="role-properties">
+              <ul>
+                <li><pref>aria-level</pref></li>
+                <li><pref>aria-posinset</pref></li>
+                <li><pref>aria-setsize</pref></li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+            <td class="role-inherited">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-namefrom-head" scope="row">Name From:</th>
+            <td class="role-namefrom">author</td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+            <td class="role-namerequired"> </td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+            <td class="role-namerequired-inherited"> </td>
+          </tr>
+          <tr>
+            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+            <td class="role-childpresentational"> </td>
+          </tr>
+          <tr>
+            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+            <td class="role-presentational-inherited"> </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="role" id="listitemdescription">
+      <rdef>listitemdescription</rdef>
+      <div class="role-description">
+        <p>A single item in a list or directory.</p>
+        <p>Authors MUST ensure <a>elements</a> whose <a>role</a> is <code>listitem</code> are contained in, or owned by, an <a>element</a> whose <a>role</a> is <rref>list</rref>, or an <a>element</a> whose <a>role</a> is <rref>group</rref> which in turn is contained or owned by an <a>element</a> whose <a>role</a> is <rref>list</rref>.</p>
+      </div>
+      <table class="role-features">
+        <caption>Characteristics:</caption>
+        <thead>
+          <tr>
+            <th scope="col">Characteristic</th>
+            <th scope="col">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th class="role-abstract-head" scope="row">Is Abstract:</th>
+            <td class="role-abstract"> </td>
+          </tr>
+          <tr>
+            <th class="role-parent-head" scope="row">Superclass Role:</th>
+            <td class="role-parent"><rref>section</rref></td>
+          </tr>
+          <tr>
+            <th class="role-children-head" scope="row">Subclass Roles:</th>
+            <td class="role-children">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-base-head" scope="row">Base Concept:</th>
+            <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dd-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dd</code></a></td>
+          </tr>
+          <tr>
+            <th class="role-related-head" scope="row">Related Concepts:</th>
+            <td class="role-related"><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-common-elements-item">XForms item</a></td>
+          </tr>
+          <tr>
+            <th class="role-scope-head" scope="row">Required Context Role:</th>
+            <td class="role-scope">
+              <ul>
+                <li><rref>group</rref></li>
+                <li><rref>list</rref></li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+            <td class="role-mustcontain"> </td>
+          </tr>
+          <tr>
+            <th class="role-required-properties-head">Required States and Properties:</th>
+            <td class="role-required-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
+            <td class="role-properties">
+              <ul>
+                <li><pref>aria-level</pref></li>
+                <li><pref>aria-posinset</pref></li>
+                <li><pref>aria-setsize</pref></li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+            <td class="role-inherited">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-namefrom-head" scope="row">Name From:</th>
+            <td class="role-namefrom">author</td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+            <td class="role-namerequired"> </td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+            <td class="role-namerequired-inherited"> </td>
+          </tr>
+          <tr>
+            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+            <td class="role-childpresentational"> </td>
+          </tr>
+          <tr>
+            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+            <td class="role-presentational-inherited"> </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
 		<div class="role" id="log">
 			<rdef>log</rdef>
 			<div class="role-description">

--- a/index.html
+++ b/index.html
@@ -1095,7 +1095,7 @@
 
         <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>associationlist</code>:</p>
         <ul>
-          <li>MUST only use an element with role <rref>associationlistitemkey</rref> as the first child in the description list.</li>
+          <li>MUST only use an element with role <rref>associationlistitemkey</rref> as the first child in the <code>associationlist</code>.</li>
           <li>Each element with role <rref>associationlistitemkey</rref> SHOULD have at least one following sibling element with role <rref>associationlistitemvalue</rref>.</li>
         </ul>
 

--- a/index.html
+++ b/index.html
@@ -2441,7 +2441,10 @@
           <tr>
             <th class="role-related-head" scope="row">Related Concepts:</th>
             <td class="role-related">
-              <a href="https://www.w3.org/TR/html5/text-level-semantics.html#the-dfn-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dfn</code></a>
+              <ul>
+                <li><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dd-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dd</code></a></li>
+                <li><a href="https://www.w3.org/TR/html5/text-level-semantics.html#the-dfn-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dfn</code></a></li>
+              </ul>
             </td>
           </tr>
           <tr>

--- a/index.html
+++ b/index.html
@@ -1139,8 +1139,8 @@
             <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
             <td class="role-mustcontain">
               <ul>
-                <li><rref>associationlistitemvalue</rref></li>
-                <li><rref>associationlistitemkey</rref></li>
+								<li><rref>associationlistitemkey</rref></li>
+								<li><rref>associationlistitemvalue</rref></li>
               </ul>
             </td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -665,6 +665,9 @@
 				<li><rref>columnheader</rref></li>
 				<li><rref>definition</rref></li>
         <li><rref>deletion</rref></li>
+        <li><rref>descriptionitem</rref></li>
+        <li><rref>descriptionlist</rref></li>
+        <li><rref>descriptionterm</rref></li>
 				<li><rref>directory</rref></li>
 				<li><rref>document</rref></li>
 				<li><rref>feed</rref></li>
@@ -677,8 +680,6 @@
         <li><rref>legend</rref></li>
 				<li><rref>list</rref></li>
 				<li><rref>listitem</rref></li>
-        <li><rref>listitemdescription</rref></li>
-        <li><rref>listitemterm</rref></li>
 				<li><rref>math</rref></li>
 				<li><rref>none</rref></li>
 				<li><rref>note</rref></li>
@@ -2293,6 +2294,275 @@
         </tbody>
       </table>
     </div>
+    <div class="role" id="descriptionitem">
+      <rdef>descriptionitem</rdef>
+      <div class="role-description">
+        <p>A single description in a description list.</p>
+
+        <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>descriptionitem</code>:</p>
+        <ul>
+          <li>MUST be contained in a element whose <a>role</a> is <rref>descriptionlist</rref>.</li>
+          <li>SHOULD have a preceeding sibling <a>element</a> whose <a>role</a> is <rref>descriptionterm</rref>.</li>
+        </ul>
+
+      </div>
+      <table class="role-features">
+        <caption>Characteristics:</caption>
+        <thead>
+          <tr>
+            <th scope="col">Characteristic</th>
+            <th scope="col">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th class="role-abstract-head" scope="row">Is Abstract:</th>
+            <td class="role-abstract"> </td>
+          </tr>
+          <tr>
+            <th class="role-parent-head" scope="row">Superclass Role:</th>
+            <td class="role-parent"><rref>section</rref></td>
+          </tr>
+          <tr>
+            <th class="role-children-head" scope="row">Subclass Roles:</th>
+            <td class="role-children">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-base-head" scope="row">Base Concept:</th>
+            <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dd-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dd</code></a></td>
+          </tr>
+          <tr>
+            <th class="role-related-head" scope="row">Related Concepts:</th>
+            <td class="role-related"><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-common-elements-item">XForms item</a></td>
+          </tr>
+          <tr>
+            <th class="role-scope-head" scope="row">Required Context Role:</th>
+            <td class="role-scope"><rref>list</rref></td>
+          </tr>
+          <tr>
+            <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+            <td class="role-mustcontain"> </td>
+          </tr>
+          <tr>
+            <th class="role-required-properties-head">Required States and Properties:</th>
+            <td class="role-required-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
+            <td class="role-properties">
+              <ul>
+                <li><pref>aria-level</pref></li>
+                <li><pref>aria-posinset</pref></li>
+                <li><pref>aria-setsize</pref></li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+            <td class="role-inherited">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-namefrom-head" scope="row">Name From:</th>
+            <td class="role-namefrom">author</td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+            <td class="role-namerequired"> </td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+            <td class="role-namerequired-inherited"> </td>
+          </tr>
+          <tr>
+            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+            <td class="role-childpresentational"> </td>
+          </tr>
+          <tr>
+            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+            <td class="role-presentational-inherited"> </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="role" id="descriptionlist">
+      <rdef>descriptionlist</rdef>
+      <div class="role-description">
+        <p>A <rref>section</rref> containing <rref>descriptionitem</rref> and <rref>descriptionterm</rref> elements.</p>
+
+        <p>Description lists contain children whose <a>role</a> is <rref>descriptionitem</rref> and <rref>descriptionterm</rref> to represent a list of terms each having one or more descriptions.</p>
+
+        <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>descriptionlist</code>:</p>
+        <ul>
+          <li>MUST only use an element with role <rref>descriptionterm</rref> as the first child in the description list.</li>
+          <li>Each element with role <rref>descriptionterm</rref> SHOULD have at least one following sibling element with role <rref>descriptionitem</rref>.</li>
+        </ul>
+
+      </div>
+      <table class="role-features">
+        <caption>Characteristics:</caption>
+        <thead>
+          <tr>
+            <th scope="col">Characteristic</th>
+            <th scope="col">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th class="role-abstract-head" scope="row">Is Abstract:</th>
+            <td class="role-abstract"> </td>
+          </tr>
+          <tr>
+            <th class="role-parent-head" scope="row">Superclass Role:</th>
+            <td class="role-parent"><rref>section</rref></td>
+          </tr>
+          <tr>
+            <th class="role-children-head" scope="row">Subclass Roles:</th>
+            <td class="role-children">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-base-head" scope="row">Base Concept:</th>
+            <td class="role-base">
+                <a href="https://www.w3.org/TR/html5/grouping-content.html#the-dl-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dl</code></a>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-related-head" scope="row">Related Concepts:</th>
+            <td class="role-related"> </td>
+          </tr>
+          <tr>
+            <th class="role-scope-head" scope="row">Required Context Role:</th>
+            <td class="role-scope"> </td>
+          </tr>
+          <tr>
+            <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+            <td class="role-mustcontain">
+              <ul>
+                <li><rref>descriptionitem</rref></li>
+                <li><rref>descriptionterm</rref></li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-required-properties-head">Required States and Properties:</th>
+            <td class="role-required-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
+            <td class="role-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+            <td class="role-inherited">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-namefrom-head" scope="row">Name From:</th>
+            <td class="role-namefrom">author</td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+            <td class="role-namerequired"> </td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+            <td class="role-namerequired-inherited"> </td>
+          </tr>
+          <tr>
+            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+            <td class="role-childpresentational"> </td>
+          </tr>
+          <tr>
+            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+            <td class="role-presentational-inherited"> </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="role" id="descriptionterm">
+      <rdef>descriptionterm</rdef>
+      <div class="role-description">
+        <p>A single term in a description list.</p>
+
+        <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>descriptionterm</code>:</p>
+        <ul>
+          <li>MUST be contained in a element whose <a>role</a> is <rref>descriptionlist</rref>.</li>
+          <li>SHOULD be followed by one or more sibling <a>elements</a> whose <a>role</a> is <rref>descriptionitem</rref>.</li>
+        </ul>
+
+      </div>
+      <table class="role-features">
+        <caption>Characteristics:</caption>
+        <thead>
+          <tr>
+            <th scope="col">Characteristic</th>
+            <th scope="col">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th class="role-abstract-head" scope="row">Is Abstract:</th>
+            <td class="role-abstract"> </td>
+          </tr>
+          <tr>
+            <th class="role-parent-head" scope="row">Superclass Role:</th>
+            <td class="role-parent"><rref>section</rref></td>
+          </tr>
+          <tr>
+            <th class="role-children-head" scope="row">Subclass Roles:</th>
+            <td class="role-children">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-base-head" scope="row">Base Concept:</th>
+            <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dt-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dt</code></a></td>
+          </tr>
+          <tr>
+            <th class="role-related-head" scope="row">Related Concepts:</th>
+            <td class="role-related"><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-common-elements-item">XForms item</a></td>
+          </tr>
+          <tr>
+            <th class="role-scope-head" scope="row">Required Context Role:</th>
+            <td class="role-scope"><rref>list</rref></td>
+          </tr>
+          <tr>
+            <th class="role-required-properties-head">Required States and Properties:</th>
+            <td class="role-required-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
+            <td class="role-properties">
+              <ul>
+                <li><pref>aria-level</pref></li>
+                <li><pref>aria-posinset</pref></li>
+                <li><pref>aria-setsize</pref></li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+            <td class="role-inherited">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-namefrom-head" scope="row">Name From:</th>
+            <td class="role-namefrom">author</td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+            <td class="role-namerequired"> </td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+            <td class="role-namerequired-inherited"> </td>
+          </tr>
+          <tr>
+            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+            <td class="role-childpresentational"> </td>
+          </tr>
+          <tr>
+            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+            <td class="role-presentational-inherited"> </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
 		<div class="role" id="dialog">
 			<rdef>dialog</rdef>
 			<div class="role-description">
@@ -3779,99 +4049,94 @@
 				</tbody>
 			</table>
 		</div>
-		<div class="role" id="list">
-			<rdef>list</rdef>
-			<div class="role-description">
-				<p>A <rref>section</rref> containing <rref>listitem</rref>, <rref>listitemdescription</rref> and <rref>listitemterm</rref> elements. See related <rref>listbox</rref>.</p>
-
-				<p>Lists contain children whose <a>role</a> is <rref>listitem</rref>, <rref>listitemdescription</rref> and <rref>listitemterm</rref>, or elements whose <a>role</a> is <rref>group</rref> which in turn contains children whose <a>role</a> is <rref>listitem</rref>.</p>
-
-        <p>Authors MUST only include <a>elements</a> whose roles are <rref>listitemdescription</rref> and <rref>listitemterm</rref> for description lists and the first item in the description list MUST be an <a>element</a> whose role is <rref>listitemterm</rref>.</p>
-			</div>
-			<table class="role-features">
-				<caption>Characteristics:</caption>
-				<thead>
-					<tr>
-						<th scope="col">Characteristic</th>
-						<th scope="col">Value</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<th class="role-abstract-head" scope="row">Is Abstract:</th>
-						<td class="role-abstract"> </td>
-					</tr>
-					<tr>
-						<th class="role-parent-head" scope="row">Superclass Role:</th>
-						<td class="role-parent"><rref>section</rref></td>
-					</tr>
-					<tr>
-						<th class="role-children-head" scope="row">Subclass Roles:</th>
-						<td class="role-children">Placeholder</td>
-					</tr>
-					<tr>
-						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base">
-							<ul>
-								<li><a href="https://www.w3.org/TR/html5/grouping-content.html#the-ol-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>ol</code></a></li>
-								<li><a href="https://www.w3.org/TR/html5/grouping-content.html#the-ul-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>ul</code></a></li>
-							</ul>
-						</td>
-					</tr>
-					<tr>
-						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"> </td>
-					</tr>
-					<tr>
-						<th class="role-scope-head" scope="row">Required Context Role:</th>
-						<td class="role-scope"> </td>
-					</tr>
-					<tr>
-						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
-						<td class="role-mustcontain">
-							<ul>
-								<li><rref>group</rref> <abbr title="containing" class="symbol">→</abbr> <rref>listitem</rref></li>
-								<li><rref>listitem</rref></li>
-                <li><rref>listitemterm</rref></li>
-                <li><rref>listitemdescription</rref></li>
-							</ul>
-						</td>
-					</tr>
-					<tr>
-						<th class="role-required-properties-head">Required States and Properties:</th>
-						<td class="role-required-properties"> </td>
-					</tr>
-					<tr>
-						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"> </td>
-					</tr>
-					<tr>
-						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
-						<td class="role-inherited">Placeholder</td>
-					</tr>
-					<tr>
-						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
-					</tr>
-					<tr>
-						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-						<td class="role-namerequired"> </td>
-					</tr>
-					<tr>
-						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
-						<td class="role-namerequired-inherited"> </td>
-					</tr>
-					<tr>
-						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
-						<td class="role-childpresentational"> </td>
-					</tr>
-					<tr>
-						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
-						<td class="role-presentational-inherited"> </td>
-					</tr>
-				</tbody>
-			</table>
-		</div>
+  <div class="role" id="list">
+      <rdef>list</rdef>
+      <div class="role-description">
+        <p>A <rref>section</rref> containing <rref>listitem</rref> elements. See related <rref>listbox</rref>.</p>
+        <p>Lists contain children whose <a>role</a> is <rref>listitem</rref>, or elements whose <a>role</a> is <rref>group</rref> which in turn contains children whose <a>role</a> is <rref>listitem</rref>.</p>
+      </div>
+      <table class="role-features">
+        <caption>Characteristics:</caption>
+        <thead>
+          <tr>
+            <th scope="col">Characteristic</th>
+            <th scope="col">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th class="role-abstract-head" scope="row">Is Abstract:</th>
+            <td class="role-abstract"> </td>
+          </tr>
+          <tr>
+            <th class="role-parent-head" scope="row">Superclass Role:</th>
+            <td class="role-parent"><rref>section</rref></td>
+          </tr>
+          <tr>
+            <th class="role-children-head" scope="row">Subclass Roles:</th>
+            <td class="role-children">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-base-head" scope="row">Base Concept:</th>
+            <td class="role-base">
+              <ul>
+                <li><a href="https://www.w3.org/TR/html5/grouping-content.html#the-ol-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>ol</code></a></li>
+                <li><a href="https://www.w3.org/TR/html5/grouping-content.html#the-ul-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>ul</code></a></li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-related-head" scope="row">Related Concepts:</th>
+            <td class="role-related"> </td>
+          </tr>
+          <tr>
+            <th class="role-scope-head" scope="row">Required Context Role:</th>
+            <td class="role-scope"> </td>
+          </tr>
+          <tr>
+            <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+            <td class="role-mustcontain">
+              <ul>
+                <li><rref>group</rref> <abbr title="containing" class="symbol">→</abbr> <rref>listitem</rref></li>
+                <li><rref>listitem</rref></li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th class="role-required-properties-head">Required States and Properties:</th>
+            <td class="role-required-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
+            <td class="role-properties"> </td>
+          </tr>
+          <tr>
+            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+            <td class="role-inherited">Placeholder</td>
+          </tr>
+          <tr>
+            <th class="role-namefrom-head" scope="row">Name From:</th>
+            <td class="role-namefrom">author</td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+            <td class="role-namerequired"> </td>
+          </tr>
+          <tr>
+            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+            <td class="role-namerequired-inherited"> </td>
+          </tr>
+          <tr>
+            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+            <td class="role-childpresentational"> </td>
+          </tr>
+          <tr>
+            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+            <td class="role-presentational-inherited"> </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
 		<div class="role" id="listbox">
 			<rdef>listbox</rdef>
 			<div class="role-description">
@@ -4071,182 +4336,6 @@
 				</tbody>
 			</table>
 		</div>
-    <div class="role" id="listitemdescription">
-      <rdef>listitemdescription</rdef>
-      <div class="role-description">
-        <p>A single description in a list of terms and descriptions.</p>
-
-        <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>listitemdescription</code>:</p>
-        <ul>
-          <li>MUST be contained in a <rref>list</rref>.</li>
-          <li>SHOULD have a preceeding sibling <a>element</a> whose <a>role</a> is <rref>listitemterm</rref>.</li>
-        </ul>
-
-      </div>
-      <table class="role-features">
-        <caption>Characteristics:</caption>
-        <thead>
-          <tr>
-            <th scope="col">Characteristic</th>
-            <th scope="col">Value</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th class="role-abstract-head" scope="row">Is Abstract:</th>
-            <td class="role-abstract"> </td>
-          </tr>
-          <tr>
-            <th class="role-parent-head" scope="row">Superclass Role:</th>
-            <td class="role-parent"><rref>section</rref></td>
-          </tr>
-          <tr>
-            <th class="role-children-head" scope="row">Subclass Roles:</th>
-            <td class="role-children">Placeholder</td>
-          </tr>
-          <tr>
-            <th class="role-base-head" scope="row">Base Concept:</th>
-            <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dd-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dd</code></a></td>
-          </tr>
-          <tr>
-            <th class="role-related-head" scope="row">Related Concepts:</th>
-            <td class="role-related"><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-common-elements-item">XForms item</a></td>
-          </tr>
-          <tr>
-            <th class="role-scope-head" scope="row">Required Context Role:</th>
-            <td class="role-scope"><rref>list</rref></td>
-          </tr>
-          <tr>
-            <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
-            <td class="role-mustcontain"> </td>
-          </tr>
-          <tr>
-            <th class="role-required-properties-head">Required States and Properties:</th>
-            <td class="role-required-properties"> </td>
-          </tr>
-          <tr>
-            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
-            <td class="role-properties">
-              <ul>
-                <li><pref>aria-level</pref></li>
-                <li><pref>aria-posinset</pref></li>
-                <li><pref>aria-setsize</pref></li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
-            <td class="role-inherited">Placeholder</td>
-          </tr>
-          <tr>
-            <th class="role-namefrom-head" scope="row">Name From:</th>
-            <td class="role-namefrom">author</td>
-          </tr>
-          <tr>
-            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-            <td class="role-namerequired"> </td>
-          </tr>
-          <tr>
-            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
-            <td class="role-namerequired-inherited"> </td>
-          </tr>
-          <tr>
-            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
-            <td class="role-childpresentational"> </td>
-          </tr>
-          <tr>
-            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
-            <td class="role-presentational-inherited"> </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    <div class="role" id="listitemterm">
-      <rdef>listitemterm</rdef>
-      <div class="role-description">
-        <p>A single term in a list of terms and descriptions.</p>
-
-        <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>listitemterm</code>:</p>
-        <ul>
-          <li>MUST be contained in a <rref>list</rref>.</li>
-          <li>SHOULD be followed by one or more sibling <a>elements</a> whose <a>role</a> is <rref>listitemdescription</rref>.</li>
-        </ul>
-
-      </div>
-      <table class="role-features">
-        <caption>Characteristics:</caption>
-        <thead>
-          <tr>
-            <th scope="col">Characteristic</th>
-            <th scope="col">Value</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th class="role-abstract-head" scope="row">Is Abstract:</th>
-            <td class="role-abstract"> </td>
-          </tr>
-          <tr>
-            <th class="role-parent-head" scope="row">Superclass Role:</th>
-            <td class="role-parent"><rref>section</rref></td>
-          </tr>
-          <tr>
-            <th class="role-children-head" scope="row">Subclass Roles:</th>
-            <td class="role-children">Placeholder</td>
-          </tr>
-          <tr>
-            <th class="role-base-head" scope="row">Base Concept:</th>
-            <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dt-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dt</code></a></td>
-          </tr>
-          <tr>
-            <th class="role-related-head" scope="row">Related Concepts:</th>
-            <td class="role-related"><a href="https://www.w3.org/TR/2007/REC-xforms-20071029/#ui-common-elements-item">XForms item</a></td>
-          </tr>
-          <tr>
-            <th class="role-scope-head" scope="row">Required Context Role:</th>
-            <td class="role-scope"><rref>list</rref></td>
-          </tr>
-          <tr>
-            <th class="role-required-properties-head">Required States and Properties:</th>
-            <td class="role-required-properties"> </td>
-          </tr>
-          <tr>
-            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
-            <td class="role-properties">
-              <ul>
-                <li><pref>aria-level</pref></li>
-                <li><pref>aria-posinset</pref></li>
-                <li><pref>aria-setsize</pref></li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
-            <td class="role-inherited">Placeholder</td>
-          </tr>
-          <tr>
-            <th class="role-namefrom-head" scope="row">Name From:</th>
-            <td class="role-namefrom">author</td>
-          </tr>
-          <tr>
-            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-            <td class="role-namerequired"> </td>
-          </tr>
-          <tr>
-            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
-            <td class="role-namerequired-inherited"> </td>
-          </tr>
-          <tr>
-            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
-            <td class="role-childpresentational"> </td>
-          </tr>
-          <tr>
-            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
-            <td class="role-presentational-inherited"> </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
 		<div class="role" id="log">
 			<rdef>log</rdef>
 			<div class="role-description">

--- a/index.html
+++ b/index.html
@@ -3782,11 +3782,11 @@
 		<div class="role" id="list">
 			<rdef>list</rdef>
 			<div class="role-description">
-				<p>A <rref>section</rref> containing <rref>listitem</rref>, <rref>listitemdescripion</rref> and <rref>listitemterm</rref> elements. See related <rref>listbox</rref>.</p>
+				<p>A <rref>section</rref> containing <rref>listitem</rref>, <rref>listitemdescription</rref> and <rref>listitemterm</rref> elements. See related <rref>listbox</rref>.</p>
 
-				<p>Lists contain children whose <a>role</a> is <rref>listitem</rref>, <rref>listitemdescripion</rref> and <rref>listitemterm</rref>, or elements whose <a>role</a> is <rref>group</rref> which in turn contains children whose <a>role</a> is <rref>listitem</rref>.</p>
+				<p>Lists contain children whose <a>role</a> is <rref>listitem</rref>, <rref>listitemdescription</rref> and <rref>listitemterm</rref>, or elements whose <a>role</a> is <rref>group</rref> which in turn contains children whose <a>role</a> is <rref>listitem</rref>.</p>
 
-        <p>Authors MUST only include <a>elements</a> whose roles are <rref>listitemdescripion</rref> and <rref>listitemterm</rref> for description lists and the first item in the description list MUST be an <a>element</a> whose role is <rref>listitemterm</rref>.</p>
+        <p>Authors MUST only include <a>elements</a> whose roles are <rref>listitemdescription</rref> and <rref>listitemterm</rref> for description lists and the first item in the description list MUST be an <a>element</a> whose role is <rref>listitemterm</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -3833,7 +3833,7 @@
 								<li><rref>group</rref> <abbr title="containing" class="symbol">→</abbr> <rref>listitem</rref></li>
 								<li><rref>listitem</rref></li>
                 <li><rref>listitemterm</rref></li>
-                <li><rref>listitemdescripion</rref></li>
+                <li><rref>listitemdescription</rref></li>
 							</ul>
 						</td>
 					</tr>

--- a/index.html
+++ b/index.html
@@ -2140,7 +2140,7 @@
 		<div class="role" id="definition">
 			<rdef>definition</rdef>
 			<div class="role-description">
-				<p>A definition of a term or concept. See related <rref>term</rref>.</p>
+        <p>A definition of a term or concept. See related <rref>term</rref>.</p>
 				<p>Authors SHOULD identify the <a>element</a> being defined by giving that element a role of <rref>term</rref> and referencing it with the <pref>aria-labelledby</pref> <a>attribute</a>.</p>
 			</div>
 			<table class="role-features">
@@ -2171,10 +2171,7 @@
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
 						<td class="role-related">
-							<ul>
-								<li><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dd-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dd</code></a></li>
-								<li><a href="https://www.w3.org/TR/html5/text-level-semantics.html#the-dfn-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dfn</code></a></li>
-							</ul>
+              <a href="https://www.w3.org/TR/html5/text-level-semantics.html#the-dfn-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dfn</code></a>
 						</td>
 					</tr>
 					<tr>
@@ -2301,8 +2298,9 @@
 
         <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>descriptionitem</code>:</p>
         <ul>
-          <li>MUST be contained in a element whose <a>role</a> is <rref>descriptionlist</rref>.</li>
+          <li>MUST be contained in an element whose <a>role</a> is <rref>descriptionlist</rref>.</li>
           <li>SHOULD have a preceeding sibling <a>element</a> whose <a>role</a> is <rref>descriptionterm</rref>.</li>
+          <li>MAY be followed by one or more sibling elements whose role is also <rref>descriptionitem</rref>.</li>
         </ul>
 
       </div>
@@ -2484,8 +2482,9 @@
 
         <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>descriptionterm</code>:</p>
         <ul>
-          <li>MUST be contained in a element whose <a>role</a> is <rref>descriptionlist</rref>.</li>
+          <li>MUST be contained in an element whose <a>role</a> is <rref>descriptionlist</rref>.</li>
           <li>SHOULD be followed by one or more sibling <a>elements</a> whose <a>role</a> is <rref>descriptionitem</rref>.</li>
+          <li>MAY be followed by one or more sibling elements whose role is also <rref>descriptionterm</rref>.</li>
         </ul>
 
       </div>
@@ -8315,6 +8314,7 @@
 			<div class="role-description">
 				<p>A word or phrase with a corresponding definition. See related <rref>definition</rref>.</p>
 				<p>The <code>term</code> role is used to explicitly identify a word or phrase for which a <rref>definition</rref> has been provided by the author or is expected to be provided by the user.</p>
+        <p>Authors SHOULD provide a reference to an element with role <rref>term</rref> from each related element with role <rref>defintion</rref> using the <pref>aria-labelledby</pref> <a>attribute</a>.</p>
 				<p>Authors SHOULD NOT use the <code>term</code> role on interactive elements such as links because doing so could prevent users of <a>assistive technologies</a> from interacting with those elements.</p>
 			</div>
 			<table class="role-features">
@@ -8344,7 +8344,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dt-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dt</code></a></td>
+						<td class="role-related"></td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>

--- a/index.html
+++ b/index.html
@@ -4072,7 +4072,7 @@
     <div class="role" id="listitemdescription">
       <rdef>listitemdescription</rdef>
       <div class="role-description">
-        <p>Represents a single description in a list of terms and descriptions.</p>
+        <p>A single description in a list of terms and descriptions.</p>
         <p>Authors MUST ensure <a>elements</a> whose <a>role</a> is <code>listitemdescription</code> are contained in a <rref>list</rref>.</p>
       </div>
       <table class="role-features">
@@ -4156,7 +4156,7 @@
     <div class="role" id="listitemterm">
       <rdef>listitemterm</rdef>
       <div class="role-description">
-        <p>Represents a single term in a list of terms and descriptions.</p>
+        <p>A single term in a list of terms and descriptions.</p>
         <p>Authors MUST ensure <a>elements</a> whose <a>role</a> is <code>listitemterm</code> are contained in a <rref>list</rref>.</p>
       </div>
       <table class="role-features">

--- a/index.html
+++ b/index.html
@@ -4066,7 +4066,7 @@
         <tbody>
           <tr>
             <th class="role-abstract-head" scope="row">Is Abstract:</th>
-            <td class="role-abstract"> </td>
+            <td class="role-abstract"> </td>
           </tr>
           <tr>
             <th class="role-parent-head" scope="row">Superclass Role:</th>
@@ -4087,11 +4087,11 @@
           </tr>
           <tr>
             <th class="role-related-head" scope="row">Related Concepts:</th>
-            <td class="role-related"> </td>
+            <td class="role-related"> </td>
           </tr>
           <tr>
             <th class="role-scope-head" scope="row">Required Context Role:</th>
-            <td class="role-scope"> </td>
+            <td class="role-scope"> </td>
           </tr>
           <tr>
             <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
@@ -4104,11 +4104,11 @@
           </tr>
           <tr>
             <th class="role-required-properties-head">Required States and Properties:</th>
-            <td class="role-required-properties"> </td>
+            <td class="role-required-properties"> </td>
           </tr>
           <tr>
             <th class="role-properties-head" scope="row">Supported States and Properties:</th>
-            <td class="role-properties"> </td>
+            <td class="role-properties"> </td>
           </tr>
           <tr>
             <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -4120,19 +4120,19 @@
           </tr>
           <tr>
             <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-            <td class="role-namerequired"> </td>
+            <td class="role-namerequired"> </td>
           </tr>
           <tr>
             <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
-            <td class="role-namerequired-inherited"> </td>
+            <td class="role-namerequired-inherited"> </td>
           </tr>
           <tr>
             <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
-            <td class="role-childpresentational"> </td>
+            <td class="role-childpresentational"> </td>
           </tr>
           <tr>
             <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
-            <td class="role-presentational-inherited"> </td>
+            <td class="role-presentational-inherited"> </td>
           </tr>
         </tbody>
       </table>

--- a/index.html
+++ b/index.html
@@ -3783,6 +3783,7 @@
 			<rdef>list</rdef>
 			<div class="role-description">
 				<p>A <rref>section</rref> containing <rref>listitem</rref>, <rref>listitemdescripion</rref> and <rref>listitemterm</rref> elements. See related <rref>listbox</rref>.</p>
+
 				<p>Lists contain children whose <a>role</a> is <rref>listitem</rref>, <rref>listitemdescripion</rref> and <rref>listitemterm</rref>, or elements whose <a>role</a> is <rref>group</rref> which in turn contains children whose <a>role</a> is <rref>listitem</rref>.</p>
 
         <p>Authors MUST only include <a>elements</a> whose roles are <rref>listitemdescripion</rref> and <rref>listitemterm</rref> for description lists and the first item in the description list MUST be an <a>element</a> whose role is <rref>listitemterm</rref>.</p>
@@ -4078,7 +4079,7 @@
         <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>listitemdescription</code>:</p>
         <ul>
           <li>MUST be contained in a <rref>list</rref>.</li>
-          <li>SHOULD have a preceeding sibling <a>element</a> whose <a>role</a> is <code>listitemterm</code>.</li>
+          <li>SHOULD have a preceeding sibling <a>element</a> whose <a>role</a> is <rref>listitemterm</rref>.</li>
         </ul>
 
       </div>
@@ -4168,7 +4169,7 @@
         <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>listitemterm</code>:</p>
         <ul>
           <li>MUST be contained in a <rref>list</rref>.</li>
-          <li>SHOULD be followed by one or more sibling <a>elements</a> whose <a>role</a> is <code>listitemdescription</code>.</li>
+          <li>SHOULD be followed by one or more sibling <a>elements</a> whose <a>role</a> is <rref>listitemdescription</rref>.</li>
         </ul>
 
       </div>


### PR DESCRIPTION
Proposal for role parity for description list is to create two new roles `listitemdescription` and `listitemterm` which would be children of a list.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/951.html" title="Last updated on Jul 1, 2019, 4:20 PM UTC (6c64374)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/951/834a8ba...6c64374.html" title="Last updated on Jul 1, 2019, 4:20 PM UTC (6c64374)">Diff</a>