### PR TITLE
fixed term and definition related concepts, added an aditional authori…

### DIFF
--- a/index.html
+++ b/index.html
@@ -2138,7 +2138,7 @@
 			<rdef>definition</rdef>
 			<div class="role-description">
 				<p>A definition of a term or concept. See related <rref>term</rref>.</p>
-				<p>Authors SHOULD identify the <a>element</a> being defined by giving that element a role of <rref>term</rref> and referencing it with the <pref>aria-labelledby</pref> <a>attribute</a> or making the element with role of <rref>term</rref> a descendant of the element with with role <code>definition</code>.</p>
+				<p>Authors SHOULD identify the <a>element</a> being defined by giving that element a role of <rref>term</rref> and referencing it with the <pref>aria-labelledby</pref> <a>attribute</a> or by making the element with role <rref>term</rref> a descendant of the element with role <code>definition</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -2138,7 +2138,7 @@
 			<rdef>definition</rdef>
 			<div class="role-description">
 				<p>A definition of a term or concept. See related <rref>term</rref>.</p>
-				<p>Authors SHOULD identify the <a>element</a> being defined by giving that element a role of <rref>term</rref> and referencing it with the <pref>aria-labelledby</pref> <a>attribute</a>.</p>
+				<p>Authors SHOULD identify the <a>element</a> being defined by giving that element a role of <rref>term</rref> and referencing it with the <pref>aria-labelledby</pref> <a>attribute</a> or making the element with role of <rref>term</rref> a descendant of the element with with role <code>definition</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -2164,15 +2164,6 @@
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
 						<td class="role-base"> </td>
-					</tr>
-					<tr>
-						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related">
-							<ul>
-								<li><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dd-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dd</code></a></li>
-								<li><a href="https://www.w3.org/TR/html5/text-level-semantics.html#the-dfn-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dfn</code></a></li>
-							</ul>
-						</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -8073,7 +8064,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dt-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dt</code></a></td>
+						<td class="role-related"><a href="https://www.w3.org/TR/html5/textlevel-semantics.html#the-dfn-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dfn</code></a></td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>


### PR DESCRIPTION
fixed term and definition related concepts, added an additional authoring options for creating a relationship between `definition` and `term` roles.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/971.html" title="Last updated on May 21, 2019, 11:30 PM UTC (905d47f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/971/a8e3167...905d47f.html" title="Last updated on May 21, 2019, 11:30 PM UTC (905d47f)">Diff</a>