### PR TITLE
aria-expanded: revise definition and change applicability for issue 681

### DIFF
--- a/index.html
+++ b/index.html
@@ -10194,8 +10194,8 @@
 		<div class="state" id="aria-expanded">
 			<sdef>aria-expanded</sdef>
 			<div class="state-description">
-				<p>Indicates whether a grouping element owned or controled by this element is expanded or collapsed.</p>
-				<p>The <sref>aria-expanded</sref> attribute is applied to a focusable, interactive element that toggles visibility of content in another element. For example, it is applied to a parent <rref>treeitem</rref> to indicate whether its child branch of the tree is shown. Similarly, it can be applied to a<rref>button</rref> that controls visibility of a section of page content.</p>
+				<p>Indicates whether a grouping element owned or controlled by this element is expanded or collapsed.</p>
+				<p>The <sref>aria-expanded</sref> attribute is applied to a focusable, interactive element that toggles visibility of content in another element. For example, it is applied to a parent <rref>treeitem</rref> to indicate whether its child branch of the tree is shown. Similarly, it can be applied to a <rref>button</rref> that controls visibility of a section of page content.</p>
 				<p>If a grouping container that can be expanded or collapsed is not 'owned by' the element that has the <sref>aria-expanded</sref> attribute, the author SHOULD identify the controlling relationship by referencing the container from the element that has <sref>aria-expanded</sref> with the <pref>aria-controls</pref> property.</p>
 			</div>
 			<table class="state-features">

--- a/index.html
+++ b/index.html
@@ -10196,7 +10196,7 @@
 			<div class="state-description">
 				<p>Indicates whether a grouping element owned or controlled by this element is expanded or collapsed.</p>
 				<p>The <sref>aria-expanded</sref> attribute is applied to a focusable, interactive element that toggles visibility of content in another element. For example, it is applied to a parent <rref>treeitem</rref> to indicate whether its child branch of the tree is shown. Similarly, it can be applied to a <rref>button</rref> that controls visibility of a section of page content.</p>
-				<p>If a grouping container that can be expanded or collapsed is not 'owned by' the element that has the <sref>aria-expanded</sref> attribute, the author SHOULD identify the controlling relationship by referencing the container from the element that has <sref>aria-expanded</sref> with the <pref>aria-controls</pref> property.</p>
+				<p>If a grouping container that can be expanded or collapsed is not <a>owned</a> by the element that has the <sref>aria-expanded</sref> attribute, the author SHOULD identify the controlling relationship by referencing the container from the element that has <sref>aria-expanded</sref> with the <pref>aria-controls</pref> property.</p>
 			</div>
 			<table class="state-features">
 				<caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -10209,7 +10209,7 @@
 				<tbody>
 					<tr>
 						<th class="state-related-head" scope="row">Related Concepts:</th>
-						<td class="state-related">Tapered prompts in voice browsing. Switch in <cite><a href="https://www.w3.org/TR/SMIL3/"><abbr title="Synchronized Multimedia Integration Language">SMIL</abbr></a></cite> [[SMIL3]].</td>
+						<td class="state-related"></td>
 					</tr>
 					<tr>
 						<th class="state-applicability-head" scope="row">Used in Roles:</th>

--- a/index.html
+++ b/index.html
@@ -969,7 +969,12 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"><pref>aria-activedescendant</pref></td>
+						<td class="role-properties">
+            <ul>
+              <li><pref>aria-activedescendant</pref></li>
+              <li><sref>aria-expanded</sref></li>
+            </ul>
+            </td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>

--- a/index.html
+++ b/index.html
@@ -1564,6 +1564,7 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
+                <li><sref>aria-expanded</sref></li>
 								<li><pref>aria-readonly</pref></li>
 							</ul>
 						</td>
@@ -2500,7 +2501,7 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"><sref>aria-expanded</sref></td>
+						<td class="role-properties"></td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -2950,6 +2951,7 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
+                <li><sref>aria-expanded</sref></li>
 								<li><pref>aria-readonly</pref></li>
 								<li><pref>aria-required</pref></li>
 								<li><sref>aria-selected</sref></li>
@@ -3934,6 +3936,7 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
+                <li><sref>aria-expanded</sref></li>
 								<li><pref>aria-multiselectable</pref></li>
 								<li><pref>aria-readonly</pref></li>
 								<li><pref>aria-required</pref></li>
@@ -6207,6 +6210,7 @@
 						<td class="role-properties">
 							<ul>
 								<li><pref>aria-colindex</pref></li>
+                <li><sref>aria-expanded</sref></li>
 								<li><pref>aria-level</pref></li>
                 <li><pref>aria-posinset</pref></li>
 								<li><pref>aria-rowindex</pref></li>
@@ -6347,7 +6351,7 @@
 				<p>The <rref>rowheader</rref> role can be used to identify a cell as a header for a row in a <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>. The rowheader establishes a <a>relationship</a> between it and all cells in the corresponding row. It is a structural equivalent to setting <code>scope="row"</code> on an <abbr title="Hypertext Markup Language">HTML</abbr> <code>th</code> <a>element</a>.</p>
 				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>rowheader</code> are contained in, or <a>owned</a> by, an element with the role <rref>row</rref>.</p>
 				<p>Applying the <sref>aria-selected</sref> state on a rowheader MUST NOT cause the user agent to automatically propagate the <sref>aria-selected</sref> state to all the cells in the corresponding row. An author MAY choose to propagate selection in this manner depending on the specific application.</p>
-				<p>While the <code>rowheader</code> role can be used in both interactive grids and non-interactive tables, the use of <pref>aria-readonly</pref> and <pref>aria-required</pref> is only applicable to interactive elements. Therefore, authors SHOULD NOT use <pref>aria-required</pref> or <pref>aria-readonly</pref> in a <code>rowheader</code> that descends from a <rref>table</rref>, and user agents SHOULD NOT expose either property to <a>assistive technologies</a> unless the <code>rowheader</code> descends from a <rref>grid</rref> or <rref>treegrid</rref>.</p>
+				<p>While the <code>rowheader</code> role can be used in both interactive grids and non-interactive tables, the use of <sref>aria-expanded</sref>, <pref>aria-readonly</pref>, and <pref>aria-required</pref> is only applicable to interactive elements. Therefore, authors SHOULD NOT use <sref>aria-expanded</sref>, <pref>aria-readonly</pref>, or<pref>aria-required</pref> in a <code>rowheader</code> that descends from a <rref>table</rref>, and user agents SHOULD NOT expose these properties to <a>assistive technologies</a> unless the <code>rowheader</code> descends from a <rref>grid</rref> or <rref>treegrid</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -6398,7 +6402,12 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"><pref>aria-sort</pref></td>
+						<td class="role-properties">
+              <ul>
+                <li><sref>aria-expanded</sref></li>
+                <li><pref>aria-sort</pref></li>
+              </ul>
+            </td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -6741,7 +6750,7 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"><sref>aria-expanded</sref></td>
+						<td class="role-properties"></td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -6811,7 +6820,7 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"><sref>aria-expanded</sref></td>
+						<td class="role-properties"></td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -7728,6 +7737,7 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
+                <li><sref>aria-expanded</sref></li>
 								<li><pref>aria-posinset</pref></li>
 								<li><sref>aria-selected</sref></li>
 								<li><pref>aria-setsize</pref></li>
@@ -8938,7 +8948,7 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"> </td>
+						<td class="role-properties"><sref>aria-expanded</sref></td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -9090,12 +9100,7 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties">
-							<ul>
-								<li><sref>aria-expanded</sref></li>
-								<li><pref>aria-modal</pref></li>
-							</ul>
-						</td>
+						<td class="role-properties"><pref>aria-modal</pref></td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -10189,9 +10194,9 @@
 		<div class="state" id="aria-expanded">
 			<sdef>aria-expanded</sdef>
 			<div class="state-description">
-				<p>Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.</p>
-				<p>For example, this indicates whether a portion of a tree is expanded or collapsed. In other instances, this may be applied to page sections to mark expandable and collapsible regions that are flexible for managing content density. Simplifying the user interface by collapsing sections may improve usability for all, including those with cognitive or developmental disabilities.</p>
-				<p>If the element with the <sref>aria-expanded</sref> attribute controls the expansion of another grouping container that is not 'owned by' the element, the author SHOULD reference the container by using the <pref>aria-controls</pref> attribute.</p>
+				<p>Indicates whether a grouping element owned or controled by this element is expanded or collapsed.</p>
+				<p>The <sref>aria-expanded</sref> attribute is applied to a focusable, interactive element that toggles visibility of content in another element. For example, it is applied to a parent <rref>treeitem</rref> to indicate whether its child branch of the tree is shown. Similarly, it can be applied to a<rref>button</rref> that controls visibility of a section of page content.</p>
+				<p>If a grouping container that can be expanded or collapsed is not 'owned by' the element that has the <sref>aria-expanded</sref> attribute, the author SHOULD identify the controlling relationship by referencing the container from the element that has <sref>aria-expanded</sref> with the <pref>aria-controls</pref> property.</p>
 			</div>
 			<table class="state-features">
 				<caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -10236,15 +10236,15 @@
 				<tbody>
 					<tr>
 						<th class="value-name" scope="row">false</th>
-						<td class="value-description">The element, or another grouping element it controls, is collapsed.</td>
+						<td class="value-description">The grouping element this element owns or controls is collapsed.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">true</th>
-						<td class="value-description">The element, or another grouping element it controls, is expanded.</td>
+						<td class="value-description">The grouping element this element owns or controls is expanded.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row"><strong class="default">undefined (default)</strong></th>
-						<td class="value-description">The element, or another grouping element it controls, is neither expandable nor collapsible; all its child elements are shown or there are no child elements.</td>
+						<td class="value-description">The element does not own or control a grouping element that is expandable.</td>
 					</tr>
 				</tbody>
 			</table>


### PR DESCRIPTION
Resolves issue #681 by:
* Revising aria-expanded definition to state it aria-expanded belongs on interactive, focusable, controlling element.
* Rewording normative authors SHOULD to clarify when aria-controls should be used.
* Trimming unnecessary content from aria-expanded description related to grouping mechanisms and the benefits of collapsing content.
* Removing support from document, section, sectionhead, and window.
* Restoring support to following subclass roles that were effected by removals: gridcell, listbox (for issue #722), row, rowheader, tab, and treeitem.
* Adding support for checkbox.

Thus, support is removed from the roles listed below that do not act as interactive, focusable, controlling mechanisms for expansion:

alert
alertdialog
article
banner
blockquote
caption
cell
complementary
contentinfo
definition
deletion
dialog
directory
feed
figure
form
grid
group
heading
img
insertion
label
landmark
legend
list
listitem
log
main
marquee
math
menu
menubar
navigation
note
paragraph
radiogroup
region
search
select
status
subscript
superscript
table
tabpanel
term
time
timer
toolbar
tooltip
tree
treegrid

### Link to preview these changes

[raw.githack view of branch](https://raw.githack.com/w3c/aria/issue681-aria-expanded-scope/index.html#aria-expanded)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/972.html" title="Last updated on May 2, 2019, 5:36 PM UTC (31d6a53)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/972/a8e3167...31d6a53.html" title="Last updated on May 2, 2019, 5:36 PM UTC (31d6a53)">Diff</a>