### PR TITLE
Remove references to SMIL #973

### DIFF
--- a/index.html
+++ b/index.html
@@ -6743,11 +6743,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related">
-							<ul>
-								<li><a href="https://www.w3.org/TR/SMIL3/smil-timing.html#edef-par"><abbr title="Synchronized Multimedia Integration Language">SMIL</abbr> par</a></li>
-							</ul>
-						</td>
+						<td class="role-related"> </td>
 					</tr>
 					<tr>
 						<th class="role-required-properties-head">Required States and Properties:</th>


### PR DESCRIPTION
Fixes #973 
The Normative references section is updated with script, now that SMIL3 is no longer referenced.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/974.html" title="Last updated on May 2, 2019, 6:17 PM UTC (78d4e57)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/974/47a5882...78d4e57.html" title="Last updated on May 2, 2019, 6:17 PM UTC (78d4e57)">Diff</a>