### PR TITLE
Fix HTML syntax errors in the source

### DIFF
--- a/common/acknowledgements.html
+++ b/common/acknowledgements.html
@@ -1,7 +1,7 @@
 <section class="appendix informative section" id="acknowledgements">
 	<h3>Acknowledgments</h3>
 	<p>The following people contributed to the development of this document.</p>
-	<div data-include="acknowledgements/aria-wg-active.html" data-include-replace="true"/>
-	<div data-include="acknowledgements/aria-contributors.html" data-include-replace="true"/>
-	<div data-include="acknowledgements/funders.html" data-include-replace="true"/>
+	<div data-include="acknowledgements/aria-wg-active.html" data-include-replace="true"></div>
+	<div data-include="acknowledgements/aria-contributors.html" data-include-replace="true"></div>
+	<div data-include="acknowledgements/funders.html" data-include-replace="true"></div>
 </section>

--- a/common/acknowledgements.html
+++ b/common/acknowledgements.html
@@ -1,7 +1,7 @@
 <section class="appendix informative section" id="acknowledgements">
 	<h3>Acknowledgments</h3>
 	<p>The following people contributed to the development of this document.</p>
-	<div data-include="acknowledgements/aria-wg-active.html" data-include-replace="true"></div>
-	<div data-include="acknowledgements/aria-contributors.html" data-include-replace="true"></div>
-	<div data-include="acknowledgements/funders.html" data-include-replace="true"></div>
+	<div data-include="acknowledgements/aria-wg-active.html" data-include-replace="true"/>
+	<div data-include="acknowledgements/aria-contributors.html" data-include-replace="true"/>
+	<div data-include="acknowledgements/funders.html" data-include-replace="true"/>
 </section>

--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-<!--?xml version='1.0' encoding='UTF-8'?-->
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
 <head>
@@ -577,7 +576,7 @@
 	<section id="roles_categorization">
 		<h2>Categorization of Roles</h2>
 		<p>To support the current user scenario, this specification categorizes <a>roles</a> that define user interface <a>widgets</a> (sliders, tree controls, etc.) and those that define page structure (sections, navigation, etc.). Note that some assistive technologies provide special modes of interaction for regions marked with role <code>application</code> or <code>document</code>.</p>
-		<div class="img" id="rdf_model"><a href="img/rdf_model"><img alt="Class diagram of the relationships described in the role data model" src="img/rdf_model_sm.png" longdesc="img/rdf_model.html" width="600" height="269" /></a>
+		<div class="img" id="rdf_model"><a href="img/rdf_model"><img alt="Class diagram of the relationships described in the role data model" src="img/rdf_model_sm.png" width="600" height="269" /></a>
 			<p>Class diagram of the relationships described in the role data model.</p>
 			<p><a href="img/rdf_model.svg"><abbr title="Scalable Vector Graphics">SVG</abbr> class diagram</a> | <a href="img/rdf_model.png"><abbr title="Portable Network Graphics">PNG</abbr> class diagram</a> | <a href="img/rdf_model.html">Class diagram description</a></p>
 		</div>


### PR DESCRIPTION
* `<div/>` is invalid, it needs the full end tag.
* Remove `longdesc` (invalid & redundant with the link).
* Remove unneccessary comment before the doctype.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/981.html" title="Last updated on May 22, 2019, 8:35 AM UTC (ee73e38)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/981/8194d29...ee73e38.html" title="Last updated on May 22, 2019, 8:35 AM UTC (ee73e38)">Diff</a>