### PR TITLE
Name Not Required on gridcell

### DIFF
--- a/index.html
+++ b/index.html
@@ -3137,7 +3137,7 @@
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-						<td class="role-namerequired">True</td>
+						<td class="role-namerequired"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>


### PR DESCRIPTION
makes Accessible Name Required: false on gridcell.

Resolves #993


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1004.html" title="Last updated on Jun 26, 2019, 6:35 PM UTC (4d2bebc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1004/55a66bc...4d2bebc.html" title="Last updated on Jun 26, 2019, 6:35 PM UTC (4d2bebc)">Diff</a>