### PR TITLE
fix(grid): removes aria-level from grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -3437,7 +3437,6 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
-								<li><pref>aria-level</pref></li>
 								<li><pref>aria-multiselectable</pref></li>
 								<li><pref>aria-readonly</pref></li>
 							</ul>


### PR DESCRIPTION
Closes #743


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1029.html" title="Last updated on Aug 22, 2019, 6:23 PM UTC (77b047a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1029/83779c4...77b047a.html" title="Last updated on Aug 22, 2019, 6:23 PM UTC (77b047a)">Diff</a>