### PR TITLE
removes the old default aria-checked value from properties table

### DIFF
--- a/index.html
+++ b/index.html
@@ -1908,10 +1908,6 @@
 						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
 						<td class="role-presentational-inherited"> </td>
 					</tr>
-						<tr>
-							<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
-							<td class="implicit-values">Default for <sref>aria-checked</sref> is <code class="default">false</code>.</td>
-						</tr>
 				</tbody>
 			</table>
 		</div>

--- a/index.html
+++ b/index.html
@@ -10195,7 +10195,7 @@
 				</thead>
 				<tbody>
 					<tr>
-						<th class="value-name" scope="row"><strong class="default">false (default)</strong></th>
+						<th class="value-name" scope="row">false</th>
 						<td class="value-description">The element supports being checked but is not currently checked.</td>
 					</tr>
 					<tr>
@@ -10208,7 +10208,7 @@
 						<td class="value-description">The element is checked.</td>
 					</tr>
 					<tr>
-						<th class="value-name" scope="row">undefined</th>
+						<th class="value-name" scope="row"><strong class="default">undefined</strong> (default)</th>
 						<td class="value-description">The element does not support being checked.</td>
 					</tr>
 				</tbody>

--- a/index.html
+++ b/index.html
@@ -1908,6 +1908,10 @@
 						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
 						<td class="role-presentational-inherited"> </td>
 					</tr>
+					<tr>
+						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
+						<td class="implicit-values"></td>
+					</tr>
 				</tbody>
 			</table>
 		</div>

--- a/index.html
+++ b/index.html
@@ -10195,7 +10195,7 @@
 				</thead>
 				<tbody>
 					<tr>
-						<th class="value-name" scope="row">false</th>
+						<th class="value-name" scope="row"><strong class="default">false (default)</strong></th>
 						<td class="value-description">The element supports being checked but is not currently checked.</td>
 					</tr>
 					<tr>
@@ -10206,10 +10206,6 @@
 					<tr>
 						<th class="value-name" scope="row">true</th>
 						<td class="value-description">The element is checked.</td>
-					</tr>
-					<tr>
-						<th class="value-name" scope="row"><strong class="default">undefined (default)</strong></th>
-						<td class="value-description">The element does not support being checked.</td>
 					</tr>
 				</tbody>
 			</table>

--- a/index.html
+++ b/index.html
@@ -10207,6 +10207,10 @@
 						<th class="value-name" scope="row">true</th>
 						<td class="value-description">The element is checked.</td>
 					</tr>
+					<tr>
+						<th class="value-name" scope="row">undefined</th>
+						<td class="value-description">The element does not support being checked.</td>
+					</tr>
 				</tbody>
 			</table>
 		</div>


### PR DESCRIPTION
closes #826

removes the previous default state of undefined for the default state of “false” from the properties table, fully closing this issue.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1069.html" title="Last updated on Oct 16, 2019, 10:16 PM UTC (d415409)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1069/2b5a43e...d415409.html" title="Last updated on Oct 16, 2019, 10:16 PM UTC (d415409)">Diff</a>