### PR TITLE
remove stray /a> after HTML link

### DIFF
--- a/index.html
+++ b/index.html
@@ -2154,7 +2154,7 @@
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
 						<td class="role-related">
-							<code>&lt;select&gt;</code> in [[HTML]]/a>
+							<code>&lt;select&gt;</code> in [[HTML]]
 						</td>
 					</tr>
 					<tr>


### PR DESCRIPTION
removes the “/a>” from the following in the combobox characteristics table:
>`<code>&lt;select&gt;</code>` in [[HTML]]/a>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1077.html" title="Last updated on Oct 2, 2019, 6:24 PM UTC (1f2d11a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1077/d5d2883...1f2d11a.html" title="Last updated on Oct 2, 2019, 6:24 PM UTC (1f2d11a)">Diff</a>