### PR TITLE
remove aria-level from tablist

### DIFF
--- a/index.html
+++ b/index.html
@@ -8585,7 +8585,6 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
-								<li><pref>aria-level</pref></li>
 								<li><pref>aria-multiselectable</pref></li>
 								<li><pref>aria-orientation</pref></li>
 							</ul>


### PR DESCRIPTION
closes #915 (if accepted or denied).  This PR removes `aria-level` from `tablist`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1079.html" title="Last updated on Oct 4, 2019, 4:38 PM UTC (f188c82)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1079/ff73742...f188c82.html" title="Last updated on Oct 4, 2019, 4:38 PM UTC (f188c82)">Diff</a>