### PR TITLE
update caption role for 1.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -1636,10 +1636,14 @@
 		<div class="role" id="caption">
 			<rdef>caption</rdef>
 			<div class="role-description">
-				<p>A visible name or caption for a figure, table or grid in the page.</p>
-				<p>A <code>caption</code> SHOULD be a direct child of the figure, table or grid it is used to name. If a child of a table or grid the <code>caption</code> SHOULD be the first child. If a child of a figure the <code>caption</code> SHOULD be the first or last child.</p>
-				<p>Authors SHOULD reference the element with role <code>caption</code> by setting <pref>aria-labelledby</pref> on the parent element.</p>
-				<p>If a <code>caption</code> contains content that would serve as both a name and description to the parent element, authors MAY use <pref>aria-labelledby</pref> to reference an element within the <code>caption</code> to produce a concise accessible name, and <pref>aria-describedby</pref> to reference the descriptive content.</p>
+				<p>Visible content that names, and may also describe, a <rref>figure</rref>, <rref>table</rref>, or <rref>grid</rref>.</p>
+				<p>When using <code>caption</code> authors SHOULD ensure:</p>
+				<ul>
+					<li>The <code>caption</code> is a direct child of a <rref>figure</rref>, <rref>table</rref>, or <rref>grid</rref>.</li>
+					<li>The <code>caption</code> is the first child of a <rref>table</rref> or <rref>grid</rref>.</li>
+					<li>The <code>caption</code> is the first or last child of a <rref>figure</rref>.</li>
+				</ul>
+				<p>Authors SHOULD set <pref>aria-labelledby</pref> on the parent <code>figure</code>, <code>table</code>, or <code>grid</code> to reference the element with role <code>caption</code>. However, if a <code>caption</code> contains content that serves as both a name and description for its parent, authors MAY instead set <pref>aria-labelledby</pref> to reference an element within the <code>caption</code> that contains a concise name, and set <pref>aria-describedby</pref> to reference an element within the <code>caption</code> that contains the descriptive content.</p>
 
 				<pre class="example highlight">
 					&lt;div role="table" aria-labelledby="name" aria-describedby="desc"&gt;

--- a/index.html
+++ b/index.html
@@ -1639,6 +1639,19 @@
 				<p>A visible name or caption for a figure, table or grid in the page.</p>
 				<p>A <code>caption</code> SHOULD be a direct child of the figure, table or grid it is used to name. If a child of a table or grid the <code>caption</code> SHOULD be the first child. If a child of a figure the <code>caption</code> SHOULD be the first or last child.</p>
 				<p>Authors SHOULD reference the element with role <code>caption</code> by setting <pref>aria-labelledby</pref> on the parent element.</p>
+				<p>If a <code>caption</code> contains content that would serve as both a name and description to the parent element, authors MAY use <pref>aria-labelledby</pref> to reference an element within the <code>caption</code> to produce a concise accessible name, and <pref>aria-describedby</pref> to reference the descriptive content.</p>
+
+				<pre class="example highlight">
+					&lt;div role="table" aria-labelledby="name" aria-describedby="desc"&gt;
+				    &lt;div role="caption"&gt;
+				      &lt;div id="name"&gt;Contest Entrants&lt;/div&gt;
+				      &lt;div id="desc"&gt;
+				        This table shows the total number of entrants (500) the
+				        contest accepted over the past four weeks.
+				      &lt;/div&gt;
+				    &lt;/div&gt;
+				    &lt;!-- ... --&gt;
+				</pre>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -1637,7 +1637,7 @@
 			<rdef>caption</rdef>
 			<div class="role-description">
 				<p>On-screen descriptive text for a figure or table in the page.</p>
-				<p>Authors SHOULD reference the element with role <code>caption</code> by setting <pref>aria-describedby</pref> on the figure or table.</p>
+				<p>Authors SHOULD reference the element with role <code>caption</code> by setting <pref>aria-labelledby</pref> on the figure or table.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -1636,8 +1636,9 @@
 		<div class="role" id="caption">
 			<rdef>caption</rdef>
 			<div class="role-description">
-				<p>On-screen descriptive text for a figure or table in the page.</p>
-				<p>Authors SHOULD reference the element with role <code>caption</code> by setting <pref>aria-labelledby</pref> on the figure or table.</p>
+				<p>A visible name or caption for a figure, table or grid in the page.</p>
+				<p>A <code>caption</code> SHOULD be a direct child of the figure, table or grid it is used to name. If a child of a table or grid the <code>caption</code> SHOULD be the first child. If a child of a figure the <code>caption</code> SHOULD be the first or last child.</p>
+				<p>Authors SHOULD reference the element with role <code>caption</code> by setting <pref>aria-labelledby</pref> on the parent element.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -1666,11 +1667,17 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;figcaption&gt;</code> in [[HTML]]<br />&lt;caption&gt;</code> in [[HTML]]</td>
+						<td class="role-related">&lt;caption&gt;</code> in [[HTML]] <br> <code>&lt;figcaption&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
-						<td class="role-scope"> </td>
+						<td class="role-scope"> 
+							<ul>
+								<li><rref>figure</rref></li>
+								<li><rref>grid</rref></li>
+								<li><rref>table</rref></li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>


### PR DESCRIPTION
closes #1085

a `caption` and `figcaption` are meant to provide an accessible name to their parent `table` and `figure` respectively.

This PR changes the current direction to set `aria-describedby` on the parent element to `aria-labelledby` to better match how a `caption` should be used.

Additionally, this PR looks to close #901 as well.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1086.html" title="Last updated on Oct 22, 2019, 4:01 PM UTC (a0922ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1086/ff73742...a0922ac.html" title="Last updated on Oct 22, 2019, 4:01 PM UTC (a0922ac)">Diff</a>