### PR TITLE
update introduction sentence to option role

### DIFF
--- a/index.html
+++ b/index.html
@@ -5756,7 +5756,7 @@
 		<div class="role" id="option">
 			<rdef>option</rdef>
 			<div class="role-description">
-				<p>A selectable item in a <rref>select</rref> list.</p>
+				<p>A selectable item in a <rref>listbox</rref>.</p>
 				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>option</code> are contained in, or owned by, an element with the <a>role</a>  <rref>listbox</rref> or <rref>group</rref>. Options not associated with a <rref>listbox</rref> might not be correctly mapped to an <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a>.</p>
 				<p>Elements with the role <code>option</code> have an implicit <sref>aria-selected</sref> value of <code>false</code>.</p>
 			</div>

--- a/index.html
+++ b/index.html
@@ -5757,7 +5757,7 @@
 			<rdef>option</rdef>
 			<div class="role-description">
 				<p>A selectable item in a <rref>listbox</rref>.</p>
-				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>option</code> are contained in, or owned by, an element with the <a>role</a>  <rref>listbox</rref> or <rref>group</rref>. Options not associated with a <rref>listbox</rref> might not be correctly mapped to an <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a>.</p>
+				<p>Authors MUST ensure <a>elements</a> with <a>role</a> <code>option</code> are contained in, or owned by, an element with the <a>role</a>  <rref>listbox</rref> or <rref>group</rref> within a <code>listbox</code>. Options not associated with a <rref>listbox</rref> might not be correctly mapped to an <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a>.</p>
 				<p>Elements with the role <code>option</code> have an implicit <sref>aria-selected</sref> value of <code>false</code>.</p>
 			</div>
 			<table class="role-features">


### PR DESCRIPTION
closes #809

An `option` belongs within a `listbox` or a `group` within a `listbox`.  This PR aims to make that more apparent by better indicating that, and removing the ambiguity by saying `option` can be a child of the `select` abstract role, which encompasses more than its HTML namesake.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1087.html" title="Last updated on Oct 8, 2019, 2:12 AM UTC (a6b890b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1087/ff73742...a6b890b.html" title="Last updated on Oct 8, 2019, 2:12 AM UTC (a6b890b)">Diff</a>