### PR TITLE
clarify “rendering” of aria-errormessage

### DIFF
--- a/index.html
+++ b/index.html
@@ -494,7 +494,7 @@
 				<h3>Prohibited States and Properties</h3>
 				<p>List of states and properties that are prohibited on a <a>role</a>. Authors MUST NOT specify a prohibited state or property.</p>
 				<p class="note">A host language attribute with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> would also prohibit a state or property in this section. </p>
-			</section>		
+			</section>
 		<section id="mustContain">
 			<h3>Required Owned Elements</h3>
 			<dl class="runin">
@@ -10833,11 +10833,11 @@
 				<p>Identifies the <a>element</a> that provides an error message for an <a>object</a>. See related <sref>aria-invalid</sref> and <pref>aria-describedby</pref>.</p>
 				<p>The <code>aria-errormessage</code> attribute references another element that contains error message text. Authors MUST use <sref>aria-invalid</sref> in conjunction with <code>aria-errormessage</code>.</p>
 				<p>When the value of an object is not valid, <sref>aria-invalid</sref> is set to <code>true</code>, which indicates that the message contained by an element referenced by <code>aria-errormessage</code> is pertinent.</p>
-				<p>When an object is in a valid state, it has either <sref>aria-invalid</sref> set to <code>false</code> or it does not have the <sref>aria-invalid</sref> attribute. If a valid object has <code>aria-errormessage</code>, the element referenced by <code>aria-errormessage</code> is not rendered because the message it contains is not pertinent.</p>
-				<p>When <code>aria-errormessage</code> is pertinent, authors MUST ensure the content is not hidden so users can navigate to and examine the error message. Similarly, when <code>aria-errormessage</code> is not pertinent, authors MUST either ensure the content is not rendered or remove the <code>aria-errormessage</code> attribute or its value.</p>
+				<p>When an object is in a valid state, it has either <sref>aria-invalid</sref> set to <code>false</code> or it does not have the <sref>aria-invalid</sref> attribute. Authors MAY use <code>aria-errormessage</code> on an object that is currently valid, but only if the element referenced by <code>aria-errormessage</code> is <a>hidden</a>, because the message it contains is not pertinent.</p>
+				<p>When <code>aria-errormessage</code> is pertinent, authors MUST ensure the content is not hidden so users can navigate to and examine the error message. Similarly, when <code>aria-errormessage</code> is not pertinent, authors MUST either ensure the content is <a>hidden</a> or remove the <code>aria-errormessage</code> attribute or its value.</p>
 				<p>User agents MUST NOT expose <code>aria-errormessage</code> for an object with an <sref>aria-invalid</sref> value of <code>false</code>.</p>
 				<p>Authors MAY call attention to a newly rendered error message with a live region by either applying an <pref>aria-live</pref> property or using one of the <a href="#live_region_roles">live region roles</a>, such as <rref>alert</rref>. A live region is appropriate when an error message is displayed to users after they have provided an invalid value.</p>
-				<p>A typical message describes what is wrong and informs users what is required. For example, an error message might be, <q>Invalid time:  the time must be between 9:00 AM and 5:00 PM.</q> The following example code shows markup for an initial valid state and for a subsequent invalid state.  Note the changes to <sref>aria-invalid</sref> on the text input <a>object</a>, and to <pref>aria-live</pref> on the <a>element</a> containing the text of the error message:</p>
+				<p>A typical message describes what is wrong and informs users what is required. For example, an error message might be, <q>Invalid time: the time must be between 9:00 AM and 5:00 PM.</q> The following example code shows markup for an initial valid state and for a subsequent invalid state. Note the changes to <sref>aria-invalid</sref> on the text input <a>object</a>, and to <pref>aria-live</pref> on the <a>element</a> containing the text of the error message:</p>
 				<pre class="example highlight">
 				&lt;!-- Initial valid state --&gt;
 				&lt;label for="startTime"&gt; Please enter a start time for the meeting: &lt;/label&gt;
@@ -10849,7 +10849,7 @@
 				&lt;input id="startTime" type="text" aria-errormessage="msgID" aria-invalid="true" value="11:30 PM" &gt;
 				&lt;span id="msgID" aria-live="assertive"&gt;&lt;span style="visibility:visible"&gt;Invalid time: the time must be between 9:00 AM and 5:00 PM&lt;/span&gt;&lt;/span&gt;
 				</pre>
-            </div>
+      </div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>
 				<thead>
@@ -12905,7 +12905,7 @@
 				</ul>
 				</li>
 				<li>Otherwise, ignore the value and treat the property as not present.</li>
-			</ul>	
+			</ul>
 			<p class="note">In <abbr title="User Interface Automation">UIA</abbr>, the user agent might leave the corresponding property set to &quot;unsupported.&quot;</p>
 			<p>User agents MUST NOT expose <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> attributes that reference unresolved IDs. For example:</p>
 			<ul>


### PR DESCRIPTION
closes #796 by updating the text per recommendation in the issue.

change wording from “not rendered” to hidden, and link to hidden’s definition.  This creates consistency with other parts of the `aria-errormessage`’s description where the term “hidden” is already used.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1098.html" title="Last updated on Oct 15, 2019, 1:11 PM UTC (7d5db28)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1098/2048cb5...7d5db28.html" title="Last updated on Oct 15, 2019, 1:11 PM UTC (7d5db28)">Diff</a>