### PR TITLE
fix two typos

### DIFF
--- a/index.html
+++ b/index.html
@@ -6242,12 +6242,11 @@
 				<p>An <a>element</a> that displays the progress status for tasks that take a long time.</p>
 				<p>A progressbar indicates that the user's request has been received and the application is making progress toward completing the requested action.</p>
 				<p>Authors MAY set <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> to indicate the minimum and maximum progress indicator values. Otherwise, their implicit values follow the same rules as <code>&lt;input[type="range"]&gt;</code> in [[HTML]]:</p>
-					<ul>
-						<li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero).</li>
-						<li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100.</li>
-					</ul>
-				</p>
-				<p>The author SHOULD supply a <span>value</span> for <pref>aria-valuenow</pref> unless the value is indeterminate, in which case the author SHOULD omit the <pref>aria-valuenow</pref> attribute. 
+				<ul>
+					<li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero).</li>
+					<li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100.</li>
+				</ul>
+				<p>The author SHOULD supply a <span>value</span> for <pref>aria-valuenow</pref> unless the value is indeterminate, in which case the author SHOULD omit the <pref>aria-valuenow</pref> attribute.
 				Authors SHOULD update this value when the visual progress indicator is updated. If the <code>progressbar</code> is describing the loading progress of a particular region of a page, the author SHOULD use <pref>aria-describedby</pref> to point to the status, and set the <sref>aria-busy</sref> attribute to <code>true</code> on the region until it is finished loading. It is not possible for the user to alter the value of a <code>progressbar</code> because it is always read-only.</p>
 				<p class="note">Assistive technologies generally will render the value of <pref>aria-valuenow</pref> as a percent of a range between the value of <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref>, unless <pref>aria-valuetext</pref> is specified.</p>
 			</div>

--- a/index.html
+++ b/index.html
@@ -1648,7 +1648,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related">&lt;caption&gt;</code> in [[HTML]] <br> <code>&lt;figcaption&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;caption&gt;</code> in [[HTML]] <br> <code>&lt;figcaption&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -13380,7 +13380,7 @@ el.getAttribute("aria-label"); // Returns "Publish"</pre>
 			<li>27-Mar-2019: Add Translatable States and Properties Section</li>
 			<li>21-Feb-2019: Add <rref>subscript</rref> and <rref>superscript</rref> roles.</li>
 			<li>07-Feb-2019: Remove contents as a supported name source for <rref>rowgroup</rref>.</li>
-			<li>01-Feb-2019: Add <rref>meter</rref>> role.</li>
+			<li>01-Feb-2019: Add <rref>meter</rref> role.</li>
 			<li>31-Jan-2019: Change the superclass of <rref>range</rref> from widget to structure.</li>
 			<li>23-Jan-2019: Removed Default value of <sref>aria-checked</sref> from <rref>menuitemcheckbox</rref> and <rref>menuitemradio</rref> roles</li>
 			<li>09-Jan-2019: Removed Default value of <sref>aria-checked</sref> from <rref>switch</rref> and <rref>checkbox</rref> roles</li>


### PR DESCRIPTION
* fix related concepts of `caption` to add an opening `<code>` tag to the source that was: `&lt;caption&gt;</code> in [HTML]` .
* remove extra “>” from the `<rref>meter</rref>` end tag in the changelog.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1124.html" title="Last updated on Dec 7, 2019, 2:48 PM UTC (0ab869f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1124/f519fca...0ab869f.html" title="Last updated on Dec 7, 2019, 2:48 PM UTC (0ab869f)">Diff</a>