### PR TITLE
Remove outdated Related Concepts links

### DIFF
--- a/index.html
+++ b/index.html
@@ -935,7 +935,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/di-gloss/#def-delivery-unit">Device Independence Delivery Unit</a></td>
+						<td class="role-related"> </td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2281,7 +2281,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;menuitem&gt;</code></a> in [[HTML]]</td>
+						<td class="role-related"> </td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2835,7 +2835,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="http://www.daisy.org/z3986/2005/Z3986-2005.html#Guide"><abbr title="Digital Accessible Information System">DAISY</abbr> Guide</a></td>
+						<td class="role-related"> </td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2914,7 +2914,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/di-gloss/#def-delivery-unit">Device Independence Delivery Unit</a></td>
+						<td class="role-related"> </td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -5174,7 +5174,6 @@
 						<td class="role-related">
 							<ul>
 								<li><rref>list</rref></li>
-								<li><a href="https://docs.oracle.com/javase/10/docs/api/javax/accessibility/AccessibleRole.html#MENU"><abbr title="Java Accessibility Application Programing Interface">JAPI</abbr> MENU</a></li>
 							</ul>
 						</td>
 					</tr>
@@ -5369,8 +5368,6 @@
 						<th class="role-related-head" scope="row">Related Concepts:</th>
 						<td class="role-related">
 							<ul>
-								<li><a href="https://docs.oracle.com/javase/10/docs/api/javax/accessibility/AccessibleRole.html#MENU_ITEM">MENU_ITEM</a> in <abbr title="Java Accessibility Application Programing Interface">JAPI</abbr></li>
-								<li><code>&lt;menuitem&gt;</code></a> in [[HTML]]</li>
 								<li><rref>listitem</rref></li>
 								<li><rref>option</rref></li>
 							</ul>
@@ -6716,12 +6713,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related">
-							<ul>
-								<li><a href="https://www.w3.org/TR/xhtml-role/#s_role_module_attributes"><abbr title="Extensible Hypertext Markup Language">XHTML</abbr> role</a></li>
-								<li><a href="http://dublincore.org/documents/2012/06/14/dcmi-terms/">Dublin Core type</a></li>
-							</ul>
-						</td>
+						<td class="role-related"> </td>
 					</tr>
 					<tr>
 						<th class="role-required-properties-head">Required States and Properties:</th>
@@ -8634,7 +8626,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="http://www.daisy.org/z3986/2005/Z3986-2005.html#Guide"><abbr title="Digital Accessible Information System">DAISY</abbr> Guide</a></td>
+						<td class="role-related"> </td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>

--- a/index.html
+++ b/index.html
@@ -5171,11 +5171,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related">
-							<ul>
-								<li><rref>list</rref></li>
-							</ul>
-						</td>
+						<td class="role-related"><rref>list</rref></td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>


### PR DESCRIPTION
Resolves #1114, removes all links mentioned in the issue.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1125.html" title="Last updated on Dec 5, 2019, 8:59 PM UTC (355daec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1125/f519fca...355daec.html" title="Last updated on Dec 5, 2019, 8:59 PM UTC (355daec)">Diff</a>