### PR TITLE
revise meter authoring advice

### DIFF
--- a/index.html
+++ b/index.html
@@ -5050,7 +5050,7 @@
 					<li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero).</li>
 					<li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100.</li>
 				</ul>
-				<p>If authors do not set <code>aria-valuemin</code> and <code>aria-valuemax</code>, the value of <pref>aria-valuenow</pref> MUST NOT fall below or exceed the implicit <code>aria-valuemin</code> and <code>aria-valuemax</code> values, respectively.
+				<p>The value of <pref>aria-valuenow</pref> MUST NOT fall below or exceed the computed values of <code>aria-valuemin</code> and <code>aria-valuemax</code>, respectively.</p>
 				<p>Authors SHOULD NOT use the <code>meter</code> role to indicate progress; the <rref>progressbar</rref> role exists to address that need.</p>
 				<p class="note">Presently, there are no <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> properties corresponding to the <code>low</code>, <code>optimum</code>, and <code>high</code> attributes supported on the <code>&lt;meter&gt;</code> element in [[HTML]]. The addition of these properties will be considered for ARIA version 1.3.</p>
 			</div>

--- a/index.html
+++ b/index.html
@@ -5045,9 +5045,14 @@
 			<rdef>meter</rdef>
 			<div class="role-description">
 				<p>An <a>element</a> that represents a scalar measurement within a known range, or a fractional value. See related <rref>progressbar</rref>.</p>
-				<p>Authors MUST NOT use the <code>meter</code> role to represent a value whose minimum and maximum values are unknown. In addition, authors MUST use <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> to make the minimum and maximum values available to assistive technologies.</p>
+				<p>Authors MAY set <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> to make the minimum and maximum values available to assistive technologies. Otherwise, their implicit values follow the same rules as <code>&lt;input[type="range"]&gt;</code> in [[HTML]]:</p>
+				<ul>
+					<li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero).</li>
+					<li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100.</li>
+				</ul>
+				<p>If authors do not set <code>aria-valuemin</code> and <code>aria-valuemax</code>, the value of <pref>aria-valuenow</pref> MUST NOT fall below or exceed the implicit <code>aria-valuemin</code> and <code>aria-valuemax</code> values, respectively.
 				<p>Authors SHOULD NOT use the <code>meter</code> role to indicate progress; the <rref>progressbar</rref> role exists to address that need.</p>
-				<p class="note">At the present time, there are no <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> properties corresponding to the <code>low</code>, <code>optimum</code>, and <code>high</code> attributes supported on the <code>&lt;meter&gt;</code> element in [[HTML]]. The addition of these properties will be considered for ARIA version 1.3.</p>
+				<p class="note">Presently, there are no <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> properties corresponding to the <code>low</code>, <code>optimum</code>, and <code>high</code> attributes supported on the <code>&lt;meter&gt;</code> element in [[HTML]]. The addition of these properties will be considered for ARIA version 1.3.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -5088,13 +5093,7 @@
 					</tr>
 					<tr>
 						<th class="role-required-properties-head">Required States and Properties:</th>
-						<td class="role-required-properties">
-							<ul>
-								<li><pref>aria-valuemax</pref></li>
-								<li><pref>aria-valuemin</pref></li>
-								<li><pref>aria-valuenow</pref></li>
-							</ul>
-						</td>
+						<td class="role-required-properties"><pref>aria-valuenow</pref></td>
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
@@ -5128,6 +5127,13 @@
 					<tr>
 						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
 						<td class="role-presentational-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
+						<td class="implicit-values">
+							Default for <pref>aria-valuemin</pref> is <code class="default">0</code>. <br/>
+							Default for <pref>aria-valuemax</pref> is <code class="default">100</code>.
+						</td>
 					</tr>
 				</tbody>
 			</table>
@@ -13089,6 +13095,11 @@
 					<td><rref>spinbutton</rref></td>
 					<td><pref>aria-valuenow</pref></td>
 					<td><code>0</code></td>
+				</tr>
+				<tr>
+					<td><rref>meter</rref></td>
+					<td><pref>aria-valuenow</pref></td>
+					<td>A value matching the implicit or explicitly set <code>aria-valuemin</code>.</td>
 				</tr>
 			</tbody>
 		</table>

--- a/index.html
+++ b/index.html
@@ -5045,7 +5045,7 @@
 			<rdef>meter</rdef>
 			<div class="role-description">
 				<p>An <a>element</a> that represents a scalar measurement within a known range, or a fractional value. See related <rref>progressbar</rref>.</p>
-				<p>Authors MAY set <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> to make the minimum and maximum values available to assistive technologies. Otherwise, their implicit values follow the same rules as <code>&lt;input[type="range"]&gt;</code> in [[HTML]]:</p>
+				<p>Authors MAY set <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> to indicate the minimum and maximum values for the <code>meter</code>. Otherwise, their implicit values follow the same rules as <code>&lt;input[type="range"]&gt;</code> in [[HTML]]:</p>
 				<ul>
 					<li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero).</li>
 					<li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100.</li>


### PR DESCRIPTION
closes #1123 

to have similar authoring expectations to HTML’s meter element, the authoring adivce for the meter role is updated to remove the requirement for aria-valuemin and max, and instead indicate these attributes should have implicit defult values, similar to progressbar.

removes aria-valuemax and min from the required states and properties row of the characteristics table, and moves them to an Implicit Value for Role row.

Adds meter’s required aria-valuenow to the Fallback values for missing required attributes table


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1129.html" title="Last updated on Mar 5, 2020, 2:08 PM UTC (892de76)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1129/f519fca...892de76.html" title="Last updated on Mar 5, 2020, 2:08 PM UTC (892de76)">Diff</a>