### PR TITLE
prohibit aria-roledescription from role=generic

### DIFF
--- a/index.html
+++ b/index.html
@@ -3360,9 +3360,10 @@
 							<ul>
 								<li><pref>aria-label</pref></li>
 								<li><pref>aria-labelledby</pref></li>
-							</ul>					
+								<li><pref>aria-roledescription</pref></li>
+							</ul>
 						</td>
-					</tr>						
+					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
 						<td class="role-namefrom">prohibited</td>

--- a/index.html
+++ b/index.html
@@ -12137,6 +12137,7 @@
 				<p>User agents MUST NOT expose the <code>aria-roledescription</code> property if any of the following conditions exist:</p>
 				<ol>
 					<li>The element to which <code>aria-roledescription</code> is applied does not have a valid WAI-ARIA role or does not have an implicit WAI-ARIA role semantic.</li>
+					<li>The element to which <code>aria-roledescription</code> is applied has an explicit or implicit WAI-ARIA role where <code>aria-roledescription</code> is <a href="#prohibitedattributes">prohibited</a>.</li>
 					<li>The value of <code>aria-roledescription</code> is empty or contains only whitespace characters.</li>
 				</ol>
 				<p><a>Assistive technologies</a> SHOULD use the value of <code>aria-roledescription</code> when presenting the role of an element, but SHOULD NOT change other functionality based on the role of an element that has a value for <code>aria-roledescription</code>. For example, an assistive technology that provides functions for navigating to the next <rref>region</rref> or <rref>button</rref> SHOULD allow those functions to navigate to regions and buttons that have an <code>aria-roledescription</code>.</p>

--- a/index.html
+++ b/index.html
@@ -3303,7 +3303,6 @@
 				<p>Contrast with <rref>group</rref>, which semantically groups its descendants in a named container.</p>
 				<p>A <code>generic</code> can provide a limited number of accessible states and properties for its descendants, such as <pref>aria-live</pref> attributes. This differentiates it from the <rref>presentation</rref> role.</p>
 				<p>The <code>generic</code> role is intended for implementors of User Agents. Authors SHOULD NOT use this role in content.</p>
-				<p class="ednote">A triage of global properties is pending. This will reduce the number of inherited states and properties in the characteristics table below. For details, see <a href="https://github.com/w3c/aria/issues/999">issue #999</a>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -3357,7 +3357,6 @@
 						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
 						<td class="role-disallowed">
 							<ul>
-								<li><pref>aria-brailleroledescription</pref></li>
 								<li><pref>aria-label</pref></li>
 								<li><pref>aria-labelledby</pref></li>
 								<li><pref>aria-roledescription</pref></li>

--- a/index.html
+++ b/index.html
@@ -3358,6 +3358,7 @@
 						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
 						<td class="role-disallowed">
 							<ul>
+								<li><pref>aria-brailleroledescription</pref></li>
 								<li><pref>aria-label</pref></li>
 								<li><pref>aria-labelledby</pref></li>
 								<li><pref>aria-roledescription</pref></li>
@@ -3970,7 +3971,7 @@
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties"> </td>
-					</tr>					
+					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
 						<td class="role-inherited">Placeholder</td>


### PR DESCRIPTION
closes #1140, pending answering [comment about note](https://github.com/w3c/aria/issues/1140#issuecomment-568189345)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1142.html" title="Last updated on Mar 4, 2020, 12:48 AM UTC (5c5bd92)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1142/db5a8c5...5c5bd92.html" title="Last updated on Mar 4, 2020, 12:48 AM UTC (5c5bd92)">Diff</a>