### PR TITLE
remove confusing "(see structure)" from menuitemradio superclass

### DIFF
--- a/index.html
+++ b/index.html
@@ -5559,7 +5559,7 @@
 						<th class="role-parent-head" scope="row">Superclass Role:</th>
 						<td class="role-parent">
 							<ul>
-								<li><rref>menuitemcheckbox</rref> (see structure)</li>
+								<li><rref>menuitemcheckbox</rref></li>
 								<li><rref>radio</rref></li>
 							</ul>
 						</td>


### PR DESCRIPTION
Closes #1144


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1145.html" title="Last updated on Jan 7, 2020, 12:43 AM UTC (d6f3dfa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1145/f519fca...d6f3dfa.html" title="Last updated on Jan 7, 2020, 12:43 AM UTC (d6f3dfa)">Diff</a>