### PR TITLE
inconsistency nit: replace "&#160;" (nbsp) with " " (space)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4146,7 +4146,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related">&#160;</td>
+						<td class="role-related"> </td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -8096,7 +8096,7 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties">&#160;</td>
+						<td class="role-properties"> </td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>


### PR DESCRIPTION
replace `&#160;` (same as `&nbsp;`) with " " (regular space) in a couple of rows in the landmark and section characteristics tables. This has no effect on the generated document (i.e. those rows are still not rendered, which is the desired behavior). This would simply make the document source a tiny bit more consistent (i.e. space is used in every other case to represent an empty row), and therefore a tiny bit easier to parse (which some folks were talking about doing). :)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1146.html" title="Last updated on Jan 7, 2020, 3:48 PM UTC (7c5b396)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1146/f519fca...7c5b396.html" title="Last updated on Jan 7, 2020, 3:48 PM UTC (7c5b396)">Diff</a>