### PR TITLE
term/definition should use aria-details instead of aria-labelledby

### DIFF
--- a/index.html
+++ b/index.html
@@ -2567,7 +2567,7 @@
       <rdef>definition</rdef>
       <div class="role-description">
         <p>A definition of a term or concept. See related <rref>term</rref>.</p>
-        <p>Authors SHOULD identify the <a>element</a> being defined and assign that element a role of <rref>term</rref>. In addition, authors SHOULD set <pref>aria-details</pref> on the <rref>term</rref>, pointing to the relevant <code>definition</code>.</p>
+        <p>Authors SHOULD identify the <a>element</a> being defined and assign that element a role of <rref>term</rref>. In addition, authors SHOULD set <pref>aria-details</pref> on the <rref>term</rref>, pointing to the related <code>definition</code>.</p>
       </div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -2567,7 +2567,7 @@
       <rdef>definition</rdef>
       <div class="role-description">
         <p>A definition of a term or concept. See related <rref>term</rref>.</p>
-        <p>Authors SHOULD identify the <a>element</a> being defined and assign that element a role of <rref>term</rref>. In addition, authors SHOULD set <pref>aria-details</pref> on the <rref>term</rref>, pointing to the related <code>definition</code>.</p>
+        <p>Authors MUST identify the <a>element</a> being defined and assign that element a role of <rref>term</rref>.</p>
       </div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -2615,8 +2615,17 @@
 						<td class="role-inherited">Placeholder</td>
 					</tr>
 					<tr>
+						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
+						<td class="role-disallowed">
+							<ul>
+								<li><pref>aria-label</pref></li>
+								<li><pref>aria-labelledby</pref></li>
+							</ul>
+					 </td>
+					</tr>
+					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom">prohibited</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -8772,7 +8781,7 @@
 			<rdef>term</rdef>
 			<div class="role-description">
 				<p>A word or phrase with a corresponding definition. See related <rref>definition</rref>.</p>
-				<p>The <code>term</code> role is used to explicitly identify a word or phrase for which a <rref>definition</rref> has been provided by the author or is expected to be provided by the user. Where a matching <rref>definition</rref> exists, authors SHOULD set <pref>aria-details</pref> on the <code>term</code>, pointing to the <rref>definition</rref>.</p>
+				<p>The <code>term</code> role is used to explicitly identify a word or phrase for which a <rref>definition</rref> has been provided by the author or is expected to be provided by the user. Where a matching <rref>definition</rref> exists, authors MUST set <pref>aria-details</pref> on the <code>term</code>, pointing to the <rref>definition</rref>.</p>
 				<p>Authors SHOULD NOT use the <code>term</code> role on interactive elements such as links because doing so could prevent users of <a>assistive technologies</a> from interacting with those elements.</p>
 			</div>
 			<table class="role-features">

--- a/index.html
+++ b/index.html
@@ -2567,7 +2567,7 @@
       <rdef>definition</rdef>
       <div class="role-description">
         <p>A definition of a term or concept. See related <rref>term</rref>.</p>
-        <p>Authors SHOULD identify the <a>element</a> being defined and assign that element a role of <rref>term</rref>. In addition, authors should set <pref>aria-details</pref> on the <rref>term</rref>, pointing to the relevant <code>definition</code>.</p></p>
+        <p>Authors SHOULD identify the <a>element</a> being defined and assign that element a role of <rref>term</rref>. In addition, authors SHOULD set <pref>aria-details</pref> on the <rref>term</rref>, pointing to the relevant <code>definition</code>.</p></p>
       </div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -8772,7 +8772,7 @@
 			<rdef>term</rdef>
 			<div class="role-description">
 				<p>A word or phrase with a corresponding definition. See related <rref>definition</rref>.</p>
-				<p>The <code>term</code> role is used to explicitly identify a word or phrase for which a <rref>definition</rref> has been provided by the author or is expected to be provided by the user. Where a matching <rref>definition</rref> exists, authors should set <pref>aria-details</pref> on the <code>term</code>, pointing to the <rref>definition</rref>.</p>
+				<p>The <code>term</code> role is used to explicitly identify a word or phrase for which a <rref>definition</rref> has been provided by the author or is expected to be provided by the user. Where a matching <rref>definition</rref> exists, authors SHOULD set <pref>aria-details</pref> on the <code>term</code>, pointing to the <rref>definition</rref>.</p>
 				<p>Authors SHOULD NOT use the <code>term</code> role on interactive elements such as links because doing so could prevent users of <a>assistive technologies</a> from interacting with those elements.</p>
 			</div>
 			<table class="role-features">

--- a/index.html
+++ b/index.html
@@ -8825,8 +8825,17 @@
 						<td class="role-inherited">Placeholder</td>
 					</tr>
 					<tr>
+						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
+						<td class="role-disallowed">
+							<ul>
+								<li><pref>aria-label</pref></li>
+								<li><pref>aria-labelledby</pref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom">prohibited</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>

--- a/index.html
+++ b/index.html
@@ -8780,8 +8780,8 @@
 		<div class="role" id="term">
 			<rdef>term</rdef>
 			<div class="role-description">
-				<p>A word or phrase with a corresponding definition. See related <rref>definition</rref>.</p>
-				<p>The <code>term</code> role is used to explicitly identify a word or phrase for which a <rref>definition</rref> has been provided by the author or is expected to be provided by the user. Where a matching <rref>definition</rref> exists, authors MUST set <pref>aria-details</pref> on the <code>term</code>, pointing to the <rref>definition</rref>.</p>
+				<p>A word or phrase with an optional corresponding definition. See related <rref>definition</rref>.</p>
+				<p>The <code>term</code> role is used to explicitly identify a word or phrase for which a <rref>definition</rref> has been provided by the author or is expected to be provided by the user. Where a matching <rref>definition</rref> exists, authors MUST set <pref>aria-details</pref> on the <code>term</code>, pointing to the <rref>definition</rref>. Otherwie, <pref>aria-details</pref> MUST point to a form or control that take user input that provides the definition.</p>
 				<p>Authors SHOULD NOT use the <code>term</code> role on interactive elements such as links because doing so could prevent users of <a>assistive technologies</a> from interacting with those elements.</p>
 			</div>
 			<table class="role-features">

--- a/index.html
+++ b/index.html
@@ -2568,6 +2568,7 @@
       <div class="role-description">
         <p>A definition of a term or concept. See related <rref>term</rref>.</p>
         <p>Authors MUST identify the <a>element</a> being defined and assign that element a role of <rref>term</rref>.</p>
+        <p>Authors SHOULD NOT use the <code>definition</code> role on interactive elements such as form controls because doing so could prevent users of assistive technologies from interacting with those elements.</p>
       </div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -8781,7 +8782,7 @@
 			<rdef>term</rdef>
 			<div class="role-description">
 				<p>A word or phrase with an optional corresponding definition. See related <rref>definition</rref>.</p>
-				<p>The <code>term</code> role is used to explicitly identify a word or phrase for which a <rref>definition</rref> has been provided by the author or is expected to be provided by the user. If a definition, or a form to enter the definition, is visible, authors SHOULD set aria-details to point to the related element.</p>
+				<p>The <code>term</code> role is used to explicitly identify a word or phrase for which a <rref>definition</rref> has been provided by the author or is expected to be provided by the user. If there is an existing <rref>definition</rref>, or a form or form control to enter a definition, authors SHOULD set <pref>aria-details</pref> to point to the related element.</p>
 				<p>Authors SHOULD NOT use the <code>term</code> role on interactive elements such as links because doing so could prevent users of <a>assistive technologies</a> from interacting with those elements.</p>
 			</div>
 			<table class="role-features">

--- a/index.html
+++ b/index.html
@@ -8781,7 +8781,7 @@
 			<rdef>term</rdef>
 			<div class="role-description">
 				<p>A word or phrase with an optional corresponding definition. See related <rref>definition</rref>.</p>
-				<p>The <code>term</code> role is used to explicitly identify a word or phrase for which a <rref>definition</rref> has been provided by the author or is expected to be provided by the user. Where a matching <rref>definition</rref> exists, authors MUST set <pref>aria-details</pref> on the <code>term</code>, pointing to the <rref>definition</rref>. Otherwise, <pref>aria-details</pref> MUST point to a form or control that takes user input to provide the definiton</p>
+				<p>The <code>term</code> role is used to explicitly identify a word or phrase for which a <rref>definition</rref> has been provided by the author or is expected to be provided by the user. If a definition, or a form to enter the definition, is visible, authors SHOULD set aria-details to point to the related element.</p>
 				<p>Authors SHOULD NOT use the <code>term</code> role on interactive elements such as links because doing so could prevent users of <a>assistive technologies</a> from interacting with those elements.</p>
 			</div>
 			<table class="role-features">

--- a/index.html
+++ b/index.html
@@ -8781,7 +8781,7 @@
 			<rdef>term</rdef>
 			<div class="role-description">
 				<p>A word or phrase with an optional corresponding definition. See related <rref>definition</rref>.</p>
-				<p>The <code>term</code> role is used to explicitly identify a word or phrase for which a <rref>definition</rref> has been provided by the author or is expected to be provided by the user. Where a matching <rref>definition</rref> exists, authors MUST set <pref>aria-details</pref> on the <code>term</code>, pointing to the <rref>definition</rref>. Otherwie, <pref>aria-details</pref> MUST point to a form or control that take user input that provides the definition.</p>
+				<p>The <code>term</code> role is used to explicitly identify a word or phrase for which a <rref>definition</rref> has been provided by the author or is expected to be provided by the user. Where a matching <rref>definition</rref> exists, authors MUST set <pref>aria-details</pref> on the <code>term</code>, pointing to the <rref>definition</rref>. Otherwise, <pref>aria-details</pref> MUST point to a form or control, allowing a user to provide the definition.</p>
 				<p>Authors SHOULD NOT use the <code>term</code> role on interactive elements such as links because doing so could prevent users of <a>assistive technologies</a> from interacting with those elements.</p>
 			</div>
 			<table class="role-features">

--- a/index.html
+++ b/index.html
@@ -2567,7 +2567,7 @@
       <rdef>definition</rdef>
       <div class="role-description">
         <p>A definition of a term or concept. See related <rref>term</rref>.</p>
-        <p>Authors SHOULD identify the <a>element</a> being defined and assign that element a role of <rref>term</rref>. In addition, authors SHOULD set <pref>aria-details</pref> on the <rref>term</rref>, pointing to the relevant <code>definition</code>.</p></p>
+        <p>Authors SHOULD identify the <a>element</a> being defined and assign that element a role of <rref>term</rref>. In addition, authors SHOULD set <pref>aria-details</pref> on the <rref>term</rref>, pointing to the relevant <code>definition</code>.</p>
       </div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -2567,7 +2567,7 @@
       <rdef>definition</rdef>
       <div class="role-description">
         <p>A definition of a term or concept. See related <rref>term</rref>.</p>
-        <p>Authors SHOULD identify the <a>element</a> being defined by giving that element a role of <rref>term</rref> and referencing it with the <pref>aria-details</pref> <a>attribute</a> or by making the element with role <rref>term</rref> a descendant of the element with role <code>definition</code>.</p>
+        <p>Authors SHOULD identify the <a>element</a> being defined and assign that element a role of <rref>term</rref>. In addition, authors should set <pref>aria-details</pref> on the <rref>term</rref>, pointing to the relevant <code>definition</code>.</p></p>
       </div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -8772,7 +8772,7 @@
 			<rdef>term</rdef>
 			<div class="role-description">
 				<p>A word or phrase with a corresponding definition. See related <rref>definition</rref>.</p>
-				<p>The <code>term</code> role is used to explicitly identify a word or phrase for which a <rref>definition</rref> has been provided by the author or is expected to be provided by the user.</p>
+				<p>The <code>term</code> role is used to explicitly identify a word or phrase for which a <rref>definition</rref> has been provided by the author or is expected to be provided by the user. Where a matching <rref>definition</rref> exists, authors should set <pref>aria-details</pref> on the <code>term</code>, pointing to the <rref>definition</rref>.</p>
 				<p>Authors SHOULD NOT use the <code>term</code> role on interactive elements such as links because doing so could prevent users of <a>assistive technologies</a> from interacting with those elements.</p>
 			</div>
 			<table class="role-features">

--- a/index.html
+++ b/index.html
@@ -2564,11 +2564,11 @@
 			</table>
 		</div>
 		<div class="role" id="definition">
-			<rdef>definition</rdef>
-			<div class="role-description">
-				<p>A definition of a term or concept. See related <rref>term</rref>.</p>
-				<p>Authors SHOULD identify the <a>element</a> being defined by giving that element a role of <rref>term</rref> and referencing it with the <pref>aria-labelledby</pref> <a>attribute</a> or by making the element with role <rref>term</rref> a descendant of the element with role <code>definition</code>.</p>
-			</div>
+      <rdef>definition</rdef>
+      <div class="role-description">
+        <p>A definition of a term or concept. See related <rref>term</rref>.</p>
+        <p>Authors SHOULD identify the <a>element</a> being defined by giving that element a role of <rref>term</rref> and referencing it with the <pref>aria-details</pref> <a>attribute</a> or by making the element with role <rref>term</rref> a descendant of the element with role <code>definition</code>.</p>
+      </div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
 				<thead>

--- a/index.html
+++ b/index.html
@@ -2564,12 +2564,12 @@
 			</table>
 		</div>
 		<div class="role" id="definition">
-      <rdef>definition</rdef>
-      <div class="role-description">
-        <p>A definition of a term or concept. See related <rref>term</rref>.</p>
-        <p>Authors MUST identify the <a>element</a> being defined and assign that element a role of <rref>term</rref>.</p>
-        <p>Authors SHOULD NOT use the <code>definition</code> role on interactive elements such as form controls because doing so could prevent users of assistive technologies from interacting with those elements.</p>
-      </div>
+      		<rdef>definition</rdef>
+      		<div class="role-description">
+        		<p>A definition of a term or concept. See related <rref>term</rref>.</p>
+        		<p>Authors MUST identify the <a>element</a> being defined and assign that element a role of <rref>term</rref>.</p>
+        		<p>Authors SHOULD NOT use the <code>definition</code> role on interactive elements such as form controls because doing so could prevent users of assistive technologies from interacting with those elements.</p>
+      		</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
 				<thead>


### PR DESCRIPTION
Relates to issue #749 

A definition should not change the accessible name of a term, and thus aria-labelledby is inappropriate. Rather, a definition is an annotation and should use aria-details.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1147.html" title="Last updated on Feb 11, 2020, 11:15 PM UTC (6187596)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1147/f519fca...6187596.html" title="Last updated on Feb 11, 2020, 11:15 PM UTC (6187596)">Diff</a>