### PR TITLE
Properties should use pref not rref

### DIFF
--- a/index.html
+++ b/index.html
@@ -12730,7 +12730,7 @@
 				<p>The value of <pref>aria-valuenow</pref> is a decimal number. If the range is a set of numeric values, then <pref>aria-valuenow</pref> is one of those values. For example, if the range is [0, 1], a valid <pref>aria-valuenow</pref> is 0.5. A value outside the range, such as -2.5 or 1.1, is invalid.</p>
 				<p>For <rref>progressbar</rref> elements and <rref>scrollbar</rref> elements, assistive technologies SHOULD render the value to users as a percent, calculated as a position on the range from <pref>aria-valuemin</pref> to <pref>aria-valuemax</pref> if both are defined, otherwise the actual value with a percent indicator. For elements with role <rref>slider</rref> and <rref>spinbutton</rref>, assistive technologies SHOULD render the actual value to users.</p>
 				<p>When the rendered value cannot be accurately represented as a number, authors SHOULD use the <pref>aria-valuetext</pref> attribute in conjunction with <pref>aria-valuenow</pref> to provide a user-friendly representation of the range's current value. For example, a slider may have rendered values of <code>small</code>, <code>medium</code>, and <code>large</code>. In this case, the values of <pref>aria-valuetext</pref> would be one of the strings: <code>small</code>, <code>medium</code>, or <code>large</code>.</p>
-				<p class="note">If <rref>aria-valuetext</rref> is specified, assistive technologies render that instead of the value of <pref>aria-valuenow</pref>.</p>
+				<p class="note">If <pref>aria-valuetext</pref> is specified, assistive technologies render that instead of the value of <pref>aria-valuenow</pref>.</p>
 			</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>
@@ -12767,7 +12767,7 @@
 				<p>This property is used, for example, on a range widget such as a slider or progress bar.</p>
 				<p>If the <pref>aria-valuetext</pref> attribute is set, authors SHOULD also set the <pref>aria-valuenow</pref> attribute, unless that value is unknown (for example, on an indeterminate <rref>progressbar</rref>).</p>
 				<p>Authors SHOULD only set the <pref>aria-valuetext</pref> attribute when the rendered value cannot be meaningfully represented as a number. For example, a slider may have rendered values of <code>small</code>, <code>medium</code>, and <code>large</code>. In this case, the values of <pref>aria-valuenow</pref> could range from 1 through 3, which indicate the position of each value in the value space, but the <pref>aria-valuetext</pref> would be one of the strings: <code>small</code>, <code>medium</code>, or <code>large</code>. If the <pref>aria-valuetext</pref> attribute is absent, the <a>assistive technologies</a> will rely solely on the <pref>aria-valuenow</pref> attribute for the current value.</p>
-				<p>If aria-valuetext is specified, assistive technologies SHOULD render that value instead of the value of <rref>aria-valuenow</rref>.</p>
+				<p>If aria-valuetext is specified, assistive technologies SHOULD render that value instead of the value of <pref>aria-valuenow</pref>.</p>
 			</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -12767,7 +12767,7 @@
 				<p>This property is used, for example, on a range widget such as a slider or progress bar.</p>
 				<p>If the <pref>aria-valuetext</pref> attribute is set, authors SHOULD also set the <pref>aria-valuenow</pref> attribute, unless that value is unknown (for example, on an indeterminate <rref>progressbar</rref>).</p>
 				<p>Authors SHOULD only set the <pref>aria-valuetext</pref> attribute when the rendered value cannot be meaningfully represented as a number. For example, a slider may have rendered values of <code>small</code>, <code>medium</code>, and <code>large</code>. In this case, the values of <pref>aria-valuenow</pref> could range from 1 through 3, which indicate the position of each value in the value space, but the <pref>aria-valuetext</pref> would be one of the strings: <code>small</code>, <code>medium</code>, or <code>large</code>. If the <pref>aria-valuetext</pref> attribute is absent, the <a>assistive technologies</a> will rely solely on the <pref>aria-valuenow</pref> attribute for the current value.</p>
-				<p>If aria-valuetext is specified, assistive technologies SHOULD render that value instead of the value of <pref>aria-valuenow</pref>.</p>
+				<p>If <pref>aria-valuetext</pref> is specified, assistive technologies SHOULD render that value instead of the value of <pref>aria-valuenow</pref>.</p>
 			</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1148.html" title="Last updated on Jan 9, 2020, 9:17 PM UTC (bfe78d4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1148/f519fca...bfe78d4.html" title="Last updated on Jan 9, 2020, 9:17 PM UTC (bfe78d4)">Diff</a>