### PR TITLE
Clarify the role of default values

### DIFF
--- a/index.html
+++ b/index.html
@@ -450,7 +450,7 @@
 		</section>
 		<section id="requiredState">
 			<h3>Required States and Properties</h3>
-			<p><a>States</a> and <a>properties</a> specifically required for the <a>role</a> and subclass roles. Content authors MUST provide a non-empty <span>value</span> for required states and properties, except if current value is the default for that state or property for the role. Content authors MUST NOT use the value <code>undefined</code> for required states and properties, unless <code>undefined</code> is an explicitly-supported value of that state or property.</p>
+			<p><a>States</a> and <a>properties</a> specifically required for the <a>role</a> and subclass roles. Content authors MUST provide a non-empty <span>value</span> for required states and properties. Content authors MUST NOT use the value <code>undefined</code> for required states and properties, unless <code>undefined</code> is an explicitly-supported value of that state or property.</p>
 			<p>When an <a>object</a> inherits from multiple ancestors and one ancestor indicates that property is supported while another ancestor indicates that it is required, the property is required in the inheriting object.</p>
 			<p class="note">A host language attribute with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> fulfills this requirement.</p>
 		</section>

--- a/index.html
+++ b/index.html
@@ -450,13 +450,13 @@
 		</section>
 		<section id="requiredState">
 			<h3>Required States and Properties</h3>
-			<p><a>States</a> and <a>properties</a> specifically required for the <a>role</a> and subclass roles. Content authors MUST provide a non-empty <span>value</span> for required states and properties. Content authors MUST NOT use the value <code>undefined</code> for required states and properties, unless <code>undefined</code> is an explicitly-supported value of that state or property.</p>
+			<p><a>States</a> and <a>properties</a> specifically required for the <a>role</a> and subclass roles. Content authors MUST provide a non-empty <span>value</span> for required states and properties, except if current value is the default for that state or property for the role. Content authors MUST NOT use the value <code>undefined</code> for required states and properties, unless <code>undefined</code> is an explicitly-supported value of that state or property.</p>
 			<p>When an <a>object</a> inherits from multiple ancestors and one ancestor indicates that property is supported while another ancestor indicates that it is required, the property is required in the inheriting object.</p>
 			<p class="note">A host language attribute with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> fulfills this requirement.</p>
 		</section>
 		<section id="supportedState">
 			<h3>Supported States and Properties</h3>
-			<p><a>States</a> and <a>properties</a> specifically applicable to the <a>role</a> and child roles. <a>User agents</a> MUST map all supported states and properties for the role to an accessibility API. Content authors MAY provide <span>values</span> for supported states and properties, but need not in some cases where default values are sufficient.</p>
+			<p><a>States</a> and <a>properties</a> specifically applicable to the <a>role</a> and child roles. <a>User agents</a> MUST map all supported states and properties for the role to an accessibility API. If the state or property is undefined, and it has a default value for the role, <a>User agents</a> MUST use the default value. Content authors MAY provide <span>values</span> for supported states and properties, but need not in some cases where default values are sufficient.</p>
 			<p class="note">A host language attribute with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> fulfills this requirement.</p>
 		</section>
 		<section id="inheritedattributes">

--- a/index.html
+++ b/index.html
@@ -456,7 +456,7 @@
 		</section>
 		<section id="supportedState">
 			<h3>Supported States and Properties</h3>
-			<p><a>States</a> and <a>properties</a> specifically applicable to the <a>role</a> and child roles. <a>User agents</a> MUST map all supported states and properties for the role to an accessibility API. If the state or property is undefined, and it has a default value for the role, <a>User agents</a> MUST use the default value. Content authors MAY provide <span>values</span> for supported states and properties, but need not in some cases where default values are sufficient.</p>
+			<p><a>States</a> and <a>properties</a> specifically applicable to the <a>role</a> and child roles. <a>User agents</a> MUST map all supported states and properties for the role to an accessibility API. If the state or property is undefined, and it has a default value for the role, <a>user agents</a> MUST use the default value. Content authors MAY provide <span>values</span> for supported states and properties, but need not in some cases where default values are sufficient.</p>
 			<p class="note">A host language attribute with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> fulfills this requirement.</p>
 		</section>
 		<section id="inheritedattributes">

--- a/index.html
+++ b/index.html
@@ -456,7 +456,7 @@
 		</section>
 		<section id="supportedState">
 			<h3>Supported States and Properties</h3>
-			<p><a>States</a> and <a>properties</a> specifically applicable to the <a>role</a> and child roles. <a>User agents</a> MUST map all supported states and properties for the role to an accessibility API. If the state or property is undefined, and it has a default value for the role, <a>user agents</a> MUST use the default value. Content authors MAY provide <span>values</span> for supported states and properties, but need not in some cases where default values are sufficient.</p>
+			<p><a>States</a> and <a>properties</a> specifically applicable to the <a>role</a> and child roles. Content authors MAY provide <span>values</span> for supported states and properties, but need not in cases where default values are sufficient. <a>User agents</a> MUST map all supported states and properties for the role to an accessibility API. If the state or property is undefined and it has a default value for the role, <a>user agents</a> SHOULD expose the default value.</p>
 			<p class="note">A host language attribute with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> fulfills this requirement.</p>
 		</section>
 		<section id="inheritedattributes">


### PR DESCRIPTION
We worked on this in the [ACT rules community group](https://act-rules.github.io/rules/4e8ab6), where we noticed there were some inconsistencies on how AT handled the defaults. It would help to be more explicit about the role of default values.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#supportedState
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 27, 2020, 9:03 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2FWilcoFiers%2Faria%2Ff413b6bbdcb4b8ab4f7d1348422f94f95f191ad3%2Findex.html%3FisPreview%3Dtrue)

```
waiting for function failed: timeout 30000ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/aria%231163.)._
</details>
