### PR TITLE
clean up of heading definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -3697,7 +3697,7 @@
 			<rdef>heading</rdef>
 			<div class="role-description">
 				<p>A heading for a section of the page.</p>
-				<p>To ensure headings are organized into a logical outline, authors MUST use the <pref>aria-level</pref> attribute to indicate the proper nesting level.</p>
+				<p>To ensure elements with a role of <rref>heading</rref> are organized into a logical outline, authors MUST use the <pref>aria-level</pref> attribute to indicate the proper nesting level.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -3697,7 +3697,7 @@
 			<rdef>heading</rdef>
 			<div class="role-description">
 				<p>A heading for a section of the page.</p>
-				<p>Often, <code>heading</code> elements will be referenced with the <pref>aria-labelledby</pref> <a>attribute</a> of the section for which they serve as a heading. To ensure headings are organized into a logical outline, authors MUST use the <pref>aria-level</pref> attribute to indicate the proper nesting level.</p>
+				<p>To ensure headings are organized into a logical outline, authors MUST use the <pref>aria-level</pref> attribute to indicate the proper nesting level.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>


### PR DESCRIPTION
removing content that would be better exposed as authoring guidance / is not necessarily what should “often” happen.

closes #1166


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1167.html" title="Last updated on Jan 23, 2020, 9:37 PM UTC (f337769)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1167/18522e3...f337769.html" title="Last updated on Jan 23, 2020, 9:37 PM UTC (f337769)">Diff</a>