### PR TITLE
Add treegrid to the list of context roles for caption

### DIFF
--- a/index.html
+++ b/index.html
@@ -1601,14 +1601,14 @@
 		<div class="role" id="caption">
 			<rdef>caption</rdef>
 			<div class="role-description">
-				<p>Visible content that names, and may also describe, a <rref>figure</rref>, <rref>table</rref>, or <rref>grid</rref>.</p>
+				<p>Visible content that names, and may also describe, a <rref>figure</rref>, <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>.</p>
 				<p>When using <code>caption</code> authors SHOULD ensure:</p>
 				<ul>
-					<li>The <code>caption</code> is a direct child of a <rref>figure</rref>, <rref>table</rref>, or <rref>grid</rref>.</li>
-					<li>The <code>caption</code> is the first child of a <rref>table</rref> or <rref>grid</rref>.</li>
+					<li>The <code>caption</code> is a direct child of a <rref>figure</rref>, <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>.</li>
+					<li>The <code>caption</code> is the first child of a <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>.</li>
 					<li>The <code>caption</code> is the first or last child of a <rref>figure</rref>.</li>
 				</ul>
-				<p>Authors SHOULD set <pref>aria-labelledby</pref> on the parent <code>figure</code>, <code>table</code>, or <code>grid</code> to reference the element with role <code>caption</code>. However, if a <code>caption</code> contains content that serves as both a name and description for its parent, authors MAY instead set <pref>aria-labelledby</pref> to reference an element within the <code>caption</code> that contains a concise name, and set <pref>aria-describedby</pref> to reference an element within the <code>caption</code> that contains the descriptive content.</p>
+				<p>Authors SHOULD set <pref>aria-labelledby</pref> on the parent <code>figure</code>, <code>table</code>, <code>grid</code>, or <rref>treegrid</rref> to reference the element with role <code>caption</code>. However, if a <code>caption</code> contains content that serves as both a name and description for its parent, authors MAY instead set <pref>aria-labelledby</pref> to reference an element within the <code>caption</code> that contains a concise name, and set <pref>aria-describedby</pref> to reference an element within the <code>caption</code> that contains the descriptive content.</p>
 
 				<pre class="example highlight">
 					&lt;div role="table" aria-labelledby="name" aria-describedby="desc"&gt;
@@ -1653,11 +1653,12 @@
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
-						<td class="role-scope"> 
+						<td class="role-scope">
 							<ul>
 								<li><rref>figure</rref></li>
 								<li><rref>grid</rref></li>
 								<li><rref>table</rref></li>
+								<li><rref>treegrid</rref></li>
 							</ul>
 						</td>
 					</tr>


### PR DESCRIPTION
Resolves #1168, adds `treegrid` to the role description and list of required context roles for `caption`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1171.html" title="Last updated on Jan 24, 2020, 10:30 PM UTC (8823fdf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1171/6ec58d5...8823fdf.html" title="Last updated on Jan 24, 2020, 10:30 PM UTC (8823fdf)">Diff</a>