### PR TITLE
fix Children Pres. for math

### DIFF
--- a/index.html
+++ b/index.html
@@ -5121,7 +5121,7 @@
 					</tr>
 					<tr>
 						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
-						<td class="role-childpresentational">False</td>
+						<td class="role-childpresentational">True</td>
 					</tr>
 					<tr>
 						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>


### PR DESCRIPTION
According to section 7.1, math is intended to have "children presentational: True". This PR fixes that. Alternatively, 7.1 could be updated, but this seemed like the right way this was supposed to work.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WilcoFiers/aria/pull/1172.html" title="Last updated on Jan 25, 2020, 8:23 PM UTC (1a97ee2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1172/6ec58d5...WilcoFiers:1a97ee2.html" title="Last updated on Jan 25, 2020, 8:23 PM UTC (1a97ee2)">Diff</a>