### PR TITLE
clarify that modal requires an accessible name

### DIFF
--- a/index.html
+++ b/index.html
@@ -2726,7 +2726,7 @@
 			<div class="role-description">
 				<p>A dialog is a descendant window of the primary window of a web application. For <abbr title="Hypertext Markup Language">HTML</abbr> pages, the primary application window is the entire web document, i.e., the <code>body</code> element.</p>
 				<p>Dialogs are most often used to prompt the user to enter or respond to information. A dialog that is designed to interrupt workflow is usually modal. See related <rref>alertdialog</rref>.</p>
-<p>Authors SHOULD provide a dialog label, which can be done with the <pref>aria-label</pref> or <pref>aria-labelledby</pref> attribute.</p>
+				<p>Authors MUST provide an accessible name for a dialog, which can be done with the <pref>aria-label</pref> or <pref>aria-labelledby</pref> attribute.</p>
 				<p>Authors SHOULD ensure that all dialogs (both modal and non-modal) have at least one focusable descendant element. Authors SHOULD focus an element in the modal dialog when it is displayed, and authors SHOULD manage focus of modal dialogs.</p>
 				<p class="note">In the description of this role, the term "web application" does not refer to the <rref>application</rref> role, which specifies specific assistive technology behaviors.</p>
 			</div>


### PR DESCRIPTION
The use of the word "label" is confusing, and dialogs require an accessible name.
That is a MUST, not a SHOULD.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WilcoFiers/aria/pull/1180.html" title="Last updated on Jan 29, 2020, 8:24 AM UTC (d6efd55)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1180/6ec58d5...WilcoFiers:d6efd55.html" title="Last updated on Jan 29, 2020, 8:24 AM UTC (d6efd55)">Diff</a>