### PR TITLE
don't recommend role="none presentation"

### DIFF
--- a/index.html
+++ b/index.html
@@ -5793,7 +5793,7 @@
 				<div class="note" id="role-none-note-none">
 					<h5>Note regarding the ARIA 1.1 <code>none</code> role.</h5>
 					<p>In ARIA 1.1, the working group introduced <code>none</code> as a synonym to the <rref>presentation</rref> role, due to author confusion surrounding the intended meaning of the word "presentation" or "presentational." Many individuals erroneously consider <code>role="presentation"</code> to be synonymous with <code>aria-hidden="true"</code>, and we believe <code>role="none"</code> conveys the actual meaning more unambiguously.</p>
-					<p>Until implementations include sufficient support for <code>role="none"</code>, web authors are advised to use the <rref>presentation</rref> role alone <code>role="presentation"</code> or redundantly as a fallback to the <code>none</code> role <code>role="none presentation"</code>.</p>
+					<p>Until implementations include sufficient support for <code>role="none"</code>, web authors are advised to use the <rref>presentation</rref> role alone <code>role="presentation"</code>.</p>
 				</div>
 			</div>
 		</div>

--- a/index.html
+++ b/index.html
@@ -5793,7 +5793,6 @@
 				<div class="note" id="role-none-note-none">
 					<h5>Note regarding the ARIA 1.1 <code>none</code> role.</h5>
 					<p>In ARIA 1.1, the working group introduced <code>none</code> as a synonym to the <rref>presentation</rref> role, due to author confusion surrounding the intended meaning of the word "presentation" or "presentational." Many individuals erroneously consider <code>role="presentation"</code> to be synonymous with <code>aria-hidden="true"</code>, and we believe <code>role="none"</code> conveys the actual meaning more unambiguously.</p>
-					<p>Until implementations include sufficient support for <code>role="none"</code>, web authors are advised to use the <rref>presentation</rref> role alone <code>role="presentation"</code>.</p>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
This is not a good way to use graceful degradation. Fallback roles themselves aren't supported consistently. If something doesn't support role=none, it doesn't support fallback roles either.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#none
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WilcoFiers/aria/pull/1181.html#none" title="Last updated on Mar 5, 2020, 6:33 PM UTC (59e8352)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1181/6ec58d5...WilcoFiers:59e8352.html" title="Last updated on Mar 5, 2020, 6:33 PM UTC (59e8352)">Diff</a>