### PR TITLE
Explicitly mention "searchbox" at aria-activedescendant

### DIFF
--- a/index.html
+++ b/index.html
@@ -10084,7 +10084,7 @@
 				<ol>
 					<li>The value of <code>aria-activedescendant</code> refers to an element that is either a descendant of the element with DOM focus or is a logical descendant as indicated by the <pref>aria-owns</pref> attribute.</li>
 					<li>
-            The element with DOM focus is a <rref>combobox</rref> or <rref>textbox</rref> with <pref>aria-controls</pref> referring to an element that supports <code>aria-activedescendant</code>, and the value of <code>aria-activedescendant</code> refers to either a descendant of the controlled element or is a logical descendant of that controlled element as indicated by the <pref>aria-owns</pref> attribute.
+            The element with DOM focus is a <rref>combobox</rref>, <rref>textbox</rref> or <rref>searchbox</rref> with <pref>aria-controls</pref> referring to an element that supports <code>aria-activedescendant</code>, and the value of <code>aria-activedescendant</code> refers to either a descendant of the controlled element or is a logical descendant of that controlled element as indicated by the <pref>aria-owns</pref> attribute.
             For example, in a <rref>combobox</rref>, focus may remain on the <rref>combobox</rref> while the value of <code>aria-activedescendant</code> on the <rref>combobox</rref> element refers to a descendant of a popup <rref>listbox</rref> that is controlled by the <rref>combobox</rref>.
           </li>
 				</ol>


### PR DESCRIPTION
Since it is not explicitly defined that this property is inherited from textbox to searchbox, searchbox should be mentioned


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#aria-activedescendant
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JAWS-test2/aria/pull/1184.html#aria-activedescendant" title="Last updated on Jan 29, 2020, 5:30 PM UTC (bba7d40)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1184/6ec58d5...JAWS-test2:bba7d40.html" title="Last updated on Jan 29, 2020, 5:30 PM UTC (bba7d40)">Diff</a>