### PR TITLE
Related concepts for region: HTML section

### DIFF
--- a/index.html
+++ b/index.html
@@ -6717,9 +6717,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related">
-						    <rref>section</rref>
-						</td>
+						<td class="role-related"><code>&lt;section&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>


### PR DESCRIPTION
The "Related concepts" for `region` role was referring to ARIA `section` (abstract role), but it should be referring to HTML `section` element.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1189.html" title="Last updated on Feb 4, 2020, 4:10 AM UTC (f596adb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1189/876c754...f596adb.html" title="Last updated on Feb 4, 2020, 4:10 AM UTC (f596adb)">Diff</a>