### PR TITLE
Correct mistake in aria-description applicability

### DIFF
--- a/index.html
+++ b/index.html
@@ -10811,7 +10811,7 @@
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
-						<td class="property-applicability">All elements of the base markup except for some roles or elements that prohibit its use</td>
+						<td class="property-applicability">All elements of the base markup</td>
 					</tr>
 					<tr>
 						<th class="property-descendants-head" scope="row">Inherits into Roles:</th>


### PR DESCRIPTION
The aria-description property should apply to the same elements that aria-describedby applies to, which is all elements of the base markup.

Closes #1186.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1193.html" title="Last updated on Feb 6, 2020, 9:59 PM UTC (625549a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1193/7193e40...625549a.html" title="Last updated on Feb 6, 2020, 9:59 PM UTC (625549a)">Diff</a>