### PR TITLE
Editorial: remove 5 from "HTML 5"

### DIFF
--- a/index.html
+++ b/index.html
@@ -13035,7 +13035,7 @@
 	  <p>The following <a>elements</a> are not exposed via the <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> and user agents MUST NOT include them in the <a class="termref">accessibility tree</a>:</p>
 	  <ul>
 	    <li>Elements with <rref>none</rref> or <rref>presentation</rref> as the first role in the role attribute. However, their exclusion is conditional and depends on other factors. In addition, the element's descendants and text content are generally included. These exceptions and conditions are documented in the <a href="#conflict_resolution_presentation_none">Presentational Roles Conflict Resolution</a> section.</li>
-	    <li>Elements, including their descendent elements, that have host language semantics specifying that the element is not displayed, such as CSS <code>display:none</code>, <code>visibility:hidden</code>, or the HTML 5 <code>hidden</code> attribute.</li>
+	    <li>Elements, including their descendent elements, that have host language semantics specifying that the element is not displayed, such as CSS <code>display:none</code>, <code>visibility:hidden</code>, or the HTML <code>hidden</code> attribute.</li>
           </ul>
 	  <p>If not already excluded from the accessibility tree per the above rules, user agents SHOULD NOT include the following elements in the accessibility tree:</p>
 	  <ul>
@@ -13106,7 +13106,7 @@
 	</section>
 	<section id="host_general_focus">
 		<h2>Focus Navigation</h2>
-		<p>An implementing host language MUST provide support for the author to make all interactive elements focusable, that is, any renderable or event-receiving elements. An implementing host language MUST provide a facility to allow web authors to define whether these focusable, interactive elements appear in the default tab navigation order. The <code>tabindex</code> <a>attribute</a> in <abbr title="Hypertext Markup Language">HTML</abbr> 5 is an example of one implementation.</p>
+		<p>An implementing host language MUST provide support for the author to make all interactive elements focusable, that is, any renderable or event-receiving elements. An implementing host language MUST provide a facility to allow web authors to define whether these focusable, interactive elements appear in the default tab navigation order. The <code>tabindex</code> <a>attribute</a> in <abbr title="Hypertext Markup Language">HTML</abbr> is an example of one implementation.</p>
 	</section>
 	<section id="implicit_semantics">
 		<h2>Implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Semantics</h2>


### PR DESCRIPTION
Purely editorial (I did not create an issue for this).
We already changed all instances of "HTML5" to HTML.
It seems these 2 instances were missed, possibly because of the space character, or maybe they were pulled in from somewhere else after the previous PR was merged.
Regardless, HTML is just HTML now.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1196.html" title="Last updated on Feb 12, 2020, 10:35 PM UTC (86fc661)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1196/f15fd3f...86fc661.html" title="Last updated on Feb 12, 2020, 10:35 PM UTC (86fc661)">Diff</a>