### PR TITLE
revise Owned Element term & Required Context Role

### DIFF
--- a/common/terms.html
+++ b/common/terms.html
@@ -136,11 +136,11 @@
     </dd>
     <dt><dfn data-lt="owned element|owned|owned element's|owned elements">Owned Element</dfn></dt>
     <dd>
-      <p>An 'owned element' is any <abbr title="Document Object Model">DOM</abbr> descendant of the <a>element</a>, any element specified as a child via <pref>aria-owns</pref>, or any <abbr title="Document Object Model">DOM</abbr> descendant of the owned child. 'Owned elements' can have specific <a href="#scope">required context roles</a> in relation to their <a class="termref" href="#dfn-owning">owning elements</a>.</p>
+      <p>An 'owned element' is any <abbr title="Document Object Model">DOM</abbr> descendant of the <a>element</a>, any element specified as a child via <pref>aria-owns</pref>, or any <abbr title="Document Object Model">DOM</abbr> descendant of the owned child. 'Owned elements' can have specific <a href="#scope">required context roles</a> in relation to their <a class="termref" href="#dfn-owning-element">owning elements</a>.</p>
     </dd>
     <dt><dfn data-lt="owning element|owning">Owning Element</dfn></dt>
     <dd>
-      <p>An 'owning element' is any <abbr title="Document Object Model">DOM</abbr> ancestor of the <a>element</a>, or any element with an <pref>aria-owns</pref> attribute which references the ID of the   element. </p>
+      <p>An 'owning element' is any <abbr title="Document Object Model">DOM</abbr> ancestor of the <a>element</a>, or any element with an <pref>aria-owns</pref> attribute which references the ID of the element. 'Owning elements' can have specific <a href="#mustContain">required owned roles</a> in relation to their <a class="termref" href="#dfn-owned-element">owned elements</a>.</p>
     </dd>
     <dt><dfn>Perceivable</dfn></dt>
     <dd>

--- a/common/terms.html
+++ b/common/terms.html
@@ -136,7 +136,7 @@
     </dd>
     <dt><dfn data-lt="owned element|owned|owned element's|owned elements">Owned Element</dfn></dt>
     <dd>
-      <p>An 'owned element' is any <abbr title="Document Object Model">DOM</abbr> descendant of the <a>element</a>, any element specified as a child via <pref>aria-owns</pref>, or any <abbr title="Document Object Model">DOM</abbr> descendant of the owned child.</p>
+      <p>An 'owned element' is any <abbr title="Document Object Model">DOM</abbr> descendant of the <a>element</a>, any element specified as a child via <pref>aria-owns</pref>, or any <abbr title="Document Object Model">DOM</abbr> descendant of the owned child. An 'owned element' can require specific <a href="#scope">required context roles</a> in relation to their <a class="termref" href="#dfn-owning">owning elements</a>.</p>
     </dd>
     <dt><dfn data-lt="owning element|owning">Owning Element</dfn></dt>
     <dd>

--- a/common/terms.html
+++ b/common/terms.html
@@ -136,7 +136,7 @@
     </dd>
     <dt><dfn data-lt="owned element|owned|owned element's|owned elements">Owned Element</dfn></dt>
     <dd>
-      <p>An 'owned element' is any <abbr title="Document Object Model">DOM</abbr> descendant of the <a>element</a>, any element specified as a child via <pref>aria-owns</pref>, or any <abbr title="Document Object Model">DOM</abbr> descendant of the owned child. An 'owned element' can require specific <a href="#scope">required context roles</a> in relation to their <a class="termref" href="#dfn-owning">owning elements</a>.</p>
+      <p>An 'owned element' is any <abbr title="Document Object Model">DOM</abbr> descendant of the <a>element</a>, any element specified as a child via <pref>aria-owns</pref>, or any <abbr title="Document Object Model">DOM</abbr> descendant of the owned child. 'Owned elements' can have specific <a href="#scope">required context roles</a> in relation to their <a class="termref" href="#dfn-owning">owning elements</a>.</p>
     </dd>
     <dt><dfn data-lt="owning element|owning">Owning Element</dfn></dt>
     <dd>

--- a/common/terms.html
+++ b/common/terms.html
@@ -140,7 +140,7 @@
     </dd>
     <dt><dfn data-lt="owning element|owning">Owning Element</dfn></dt>
     <dd>
-      <p>An 'owning element' is any <a>element</a> with an <pref>aria-owns</pref> attribute that references the ID of the element or any of its <abbr title="Document Object Model">DOM</abbr> ancestors, or if the element does not have an ancestor that is referenced by an <pref>aria-owns</pref> attribute then any <abbr title="Document Object Model">DOM</abbr> ancestor of the <a>element</a>. 'Owning elements' can have specific <a href="#mustContain">required owned roles</a> in relation to their <a class="termref" href="#dfn-owned-element">owned elements</a>.</p>
+      <p>An 'owning element' is any <a>element</a> with an <pref>aria-owns</pref> attribute that references either the ID of the element or any of its <abbr title="Document Object Model">DOM</abbr> ancestors, or if the element does not have an ancestor that is referenced by an <pref>aria-owns</pref> attribute then any <abbr title="Document Object Model">DOM</abbr> ancestor of the <a>element</a>. 'Owning elements' can have specific <a href="#mustContain">required owned roles</a> in relation to their <a class="termref" href="#dfn-owned-element">owned elements</a>.</p>
     </dd>
     <dt><dfn>Perceivable</dfn></dt>
     <dd>

--- a/common/terms.html
+++ b/common/terms.html
@@ -136,11 +136,11 @@
     </dd>
     <dt><dfn data-lt="owned element|owned|owned element's|owned elements">Owned Element</dfn></dt>
     <dd>
-      <p>An 'owned element' is any <abbr title="Document Object Model">DOM</abbr> descendant of the <a>element</a> unless the <abbr title="Document Object Model">DOM</abbr> descendant is the target of an <pref>aria-owns</pref> relation, any element specified as a child via <pref>aria-owns</pref>, or any <abbr title="Document Object Model">DOM</abbr> descendant of the owned child. 'Owned elements' can have specific <a href="#scope">required context roles</a> in relation to their <a class="termref" href="#dfn-owning-element">owning elements</a>.</p>
+      <p>An 'owned element' is any <abbr title="Document Object Model">DOM</abbr> descendant of the <a>element</a> unless the <abbr title="Document Object Model">DOM</abbr> descendant or any of its ancestors is the target of an <pref>aria-owns</pref> relation, any element specified as a child via <pref>aria-owns</pref>, or any <abbr title="Document Object Model">DOM</abbr> descendant of the owned child. 'Owned elements' can have specific <a href="#scope">required context roles</a> in relation to their <a class="termref" href="#dfn-owning-element">owning elements</a>.</p>
     </dd>
     <dt><dfn data-lt="owning element|owning">Owning Element</dfn></dt>
     <dd>
-      <p>An 'owning element' is any <abbr title="Document Object Model">DOM</abbr> ancestor of the <a>element</a>, or any element with an <pref>aria-owns</pref> attribute which references the ID of the element. 'Owning elements' can have specific <a href="#mustContain">required owned roles</a> in relation to their <a class="termref" href="#dfn-owned-element">owned elements</a>.</p>
+      <p>An 'owning element' is any <a>element</a> with an <pref>aria-owns</pref> attribute that references the ID of the element or any of its <abbr title="Document Object Model">DOM</abbr> ancestors, or if the element does not have an ancestor that is referenced by an <pref>aria-owns</pref> attribute then any <abbr title="Document Object Model">DOM</abbr> ancestor of the <a>element</a>. 'Owning elements' can have specific <a href="#mustContain">required owned roles</a> in relation to their <a class="termref" href="#dfn-owned-element">owned elements</a>.</p>
     </dd>
     <dt><dfn>Perceivable</dfn></dt>
     <dd>

--- a/common/terms.html
+++ b/common/terms.html
@@ -136,7 +136,7 @@
     </dd>
     <dt><dfn data-lt="owned element|owned|owned element's|owned elements">Owned Element</dfn></dt>
     <dd>
-      <p>An 'owned element' is any <abbr title="Document Object Model">DOM</abbr> descendant of the <a>element</a>, any element specified as a child via <pref>aria-owns</pref>, or any <abbr title="Document Object Model">DOM</abbr> descendant of the owned child. 'Owned elements' can have specific <a href="#scope">required context roles</a> in relation to their <a class="termref" href="#dfn-owning-element">owning elements</a>.</p>
+      <p>An 'owned element' is any <abbr title="Document Object Model">DOM</abbr> descendant of the <a>element</a> unless the <abbr title="Document Object Model">DOM</abbr> descendant is the target of an <pref>aria-owns</pref> relation, any element specified as a child via <pref>aria-owns</pref>, or any <abbr title="Document Object Model">DOM</abbr> descendant of the owned child. 'Owned elements' can have specific <a href="#scope">required context roles</a> in relation to their <a class="termref" href="#dfn-owning-element">owning elements</a>.</p>
     </dd>
     <dt><dfn data-lt="owning element|owning">Owning Element</dfn></dt>
     <dd>

--- a/index.html
+++ b/index.html
@@ -477,31 +477,26 @@
 		</section>
 		<section id="scope">
 			<h3>Required Context Role</h3>
-			<p>The required context role defines the owning container where this <a>role</a> is allowed. If a role has a required context, authors MUST ensure that the element is contained inside (or <a>owned</a> by) an element with the required context role. There can be no other intermixed containing elements unless those elements are explicitly set as presentational, e.g. with a <rref>none</rref> role.</p>
+			<p>The required context role defines the owning container where this <a>role</a> is allowed. If a role has a required context, authors MUST ensure that any element with that role is contained inside (or <a>owned</a> by) an element with the required context role. There can be no other intermixed containing elements unless those elements are explicitly set as presentational, e.g. with role <rref>presentation</rref> or <rref>none</rref>.</p>
 			<p>For example, an element with role <code>listitem</code> is only meaningful when contained inside (or owned by) an element with role <code>list</code>, as demonstrated by the following code snippet.</p>
-			<div class="example">
-				<pre class="highlight">
-          &lt;div role="list" aria-owns="owned_item">
-            &lt;div role="listitem">Direct child of the list.&lt;/div>
-            &lt;div role="none">
-              &lt;div role="listitem">Descendant contained by a presentational element.&lt;/div>
-            &lt;/div>
+			<pre class="example highlight">
+        &lt;!-- 1. These listitem elements meet the required context role expectations. --&gt;
+        &lt;div role="list" aria-owns="owned_item">
+          &lt;div role="listitem">Direct child of the list.&lt;/div>
+          &lt;div role="none">
+            &lt;div role="listitem">Descendant contained by a presentational element.&lt;/div>
           &lt;/div>
-          &lt;div role="listitem" id="owned_item">List item that is "owned" by its sibling "list".&lt;/div>
-        </pre>
-      </div>
-
-      <p>The following example shows <code>listitem</code> elements that do not meet the required context role expectations.</p>
-      <div class="example">
-        <pre class="highlight">
-          &lt;div role="list">
-            &lt;div>
-              &lt;div role="listitem">...&lt;/div>
-            &lt;/div>
+        &lt;/div>
+        &lt;div role="listitem" id="owned_item">List item that is owned by its sibling list.&lt;/div>
+        
+        &lt;!-- 2. These listitem elements DO NOT meet the required context role expectations. --&gt;
+        &lt;div role="list">
+          &lt;div>
+            &lt;div role="listitem">Descendant with intervening non-presentational element.&lt;/div>
           &lt;/div>
-          &lt;div role="listitem">...&lt;/div>
-				</pre>
-			</div>
+        &lt;/div>
+        &lt;div role="listitem">List item that is not owned by a list.&lt;/div>
+			</pre>
 			<p class="note">A role that has 'required context role' does not imply the reverse relationship. While an element with the given role needs to appear within an element of the listed role(s) in order to be meaningful, elements of the listed roles do not always need descendant elements of the given role in order to be meaningful. See <a href="#mustContain">required owned elements</a> for requirements about elements that require presence of a given descendant to be processed properly.</p>
 			<p class="note">An element with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> fulfills this requirement.</p>
 		</section>

--- a/index.html
+++ b/index.html
@@ -477,13 +477,13 @@
 		</section>
 		<section id="scope">
 			<h3>Required Context Role</h3>
-			<p>The required context role defines the owning container where this <a>role</a> is allowed. If a role has a required context, authors MUST ensure that an element with the role is contained inside (or <a>owned</a> by) an element with the required context role, with no other intermixed containing elements with non-presentational roles.</p>
+			<p>The required context role defines the owning container where this <a>role</a> is allowed. If a role has a required context, authors MUST ensure that the element is contained inside (or <a>owned</a> by) an element with the required context role. There can be no other intermixed containing elements unless those elements are explicitly set as presentational, e.g. with a <rref>none</rref> role.</p>
 			<p>For example, an element with role <code>listitem</code> is only meaningful when contained inside (or owned by) an element with role <code>list</code>, as demonstrated by the following code snippet.</p>
 			<div class="example">
 				<pre class="highlight">
           &lt;div role="list" aria-owns="owned_item">
             &lt;div role="listitem">Direct child of the list.&lt;/div>
-            &lt;div role="presentation">
+            &lt;div role="none">
               &lt;div role="listitem">Descendant contained by a presentational element.&lt;/div>
             &lt;/div>
           &lt;/div>

--- a/index.html
+++ b/index.html
@@ -477,7 +477,31 @@
 		</section>
 		<section id="scope">
 			<h3>Required Context Role</h3>
-			<p>The required context role defines the owning container where this <a>role</a> is allowed. If a role has a required context, authors MUST ensure that an element with the role is contained inside (or <a>owned</a> by) an element with the required context role. For example, an element with role <code>listitem</code> is only meaningful when contained inside (or owned by) an element with role <code>list</code>.</p>
+			<p>The required context role defines the owning container where this <a>role</a> is allowed. If a role has a required context, authors MUST ensure that an element with the role is contained inside (or <a>owned</a> by) an element with the required context role, with no other intermixed containing elements with non-presentational roles.</p>
+			<p>For example, an element with role <code>listitem</code> is only meaningful when contained inside (or owned by) an element with role <code>list</code>, as demonstrated by the following code snippet.</p>
+			<div class="example">
+				<pre class="highlight">
+          &lt;div role="list" aria-owns="owned_item">
+            &lt;div role="listitem">Direct child of the list.&lt;/div>
+            &lt;div role="presentation">
+              &lt;div role="listitem">Descendant contained by a presentational element.&lt;/div>
+            &lt;/div>
+          &lt;/div>
+          &lt;div role="listitem" id="owned_item">List item that is "owned" by its sibling "list".&lt;/div>
+        </pre>
+      </div>
+
+      <p>The following example shows <code>listitem</code> elements that do not meet the required context role expectations.</p>
+      <div class="example">
+        <pre class="highlight">
+          &lt;div role="list">
+            &lt;div>
+              &lt;div role="listitem">...&lt;/div>
+            &lt;/div>
+          &lt;/div>
+          &lt;div role="listitem">...&lt;/div>
+				</pre>
+			</div>
 			<p class="note">A role that has 'required context role' does not imply the reverse relationship. While an element with the given role needs to appear within an element of the listed role(s) in order to be meaningful, elements of the listed roles do not always need descendant elements of the given role in order to be meaningful. See <a href="#mustContain">required owned elements</a> for requirements about elements that require presence of a given descendant to be processed properly.</p>
 			<p class="note">An element with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> fulfills this requirement.</p>
 		</section>


### PR DESCRIPTION
This PR aims to close #1161 for ARIA 1.2.

It expands the definition of "owned element" to mention the concept of specific required context roles.  

Required Context Role was revised to indicate there are "...no other intermixed containing elements with non-presentational roles" that separate the role from its required context role.

Valid and invalid examples were added to this section to further demonstrate.

Other issues/PRs such as #1162 will help further clarify how owned elements may need to be setup. 

This update touches on the topic raised in issue #748, which is marked for 1.3.... though I would say this PR does not "solve" that issue... it at least might help clarify things a bit prior to additional work needing to be done for 1.3.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#dfn-owned-element, #scope
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 20, 2021, 10:59 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Faria%2Fe6baf7cf97595fe515947e69bf7dc806caeb1372%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 27999 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/aria%231213.)._
</details>
