### PR TITLE
Closes #1217

### DIFF
--- a/index.html
+++ b/index.html
@@ -5224,7 +5224,7 @@
 					</tr>
 					<tr>
 						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
-						<td class="role-childpresentational">False</td>
+						<td class="role-childpresentational"> </td>
 					</tr>
 					<tr>
 						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
@@ -13202,7 +13202,6 @@
 	          <li><rref>button</rref></li>
 	          <li><rref>checkbox</rref></li>
 	          <li><rref>img</rref></li>
-	          <li><rref>math</rref></li>
 	          <li><rref>menuitemcheckbox</rref></li>
 	          <li><rref>menuitemradio</rref></li>
 	          <li><rref>option</rref></li>

--- a/index.html
+++ b/index.html
@@ -13202,6 +13202,7 @@
 	          <li><rref>button</rref></li>
 	          <li><rref>checkbox</rref></li>
 	          <li><rref>img</rref></li>
+	          <li><rref>math</rref></li>
 	          <li><rref>menuitemcheckbox</rref></li>
 	          <li><rref>menuitemradio</rref></li>
 	          <li><rref>option</rref></li>


### PR DESCRIPTION
- removes math from children presentational list
  [**Edit:** this change was put back because it is on deck in #1100]
- also removes childpresentational row from math characteristics table for consistency with other childpresentational false roles


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#math
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1218.html#math" title="Last updated on Mar 26, 2020, 3:12 PM UTC (38f5189)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1218/9c73b5b...38f5189.html" title="Last updated on Mar 26, 2020, 3:12 PM UTC (38f5189)">Diff</a>