### PR TITLE
Require user agents to expose a value for combobox elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -2134,10 +2134,13 @@
           When a descendant of the popup element is active, authors MAY set <pref>aria-activedescendant</pref> on the <code>combobox</code> to a value that refers to the active element within the popup while focus remains on the <code>combobox</code> element.
         </p>
         <p>
-          User agents MUST compute a value for elements with role <code>combobox</code> and expose the value to <a>assistive technologies</a>.
-          If the <code>combobox</code> element is also a host language element that provides a value, such as an HTML <code>input</code> element, the value of the combobox is the value of that element.
-          Otherwise, the value of the <code>combobox</code> is computed from descendant elements of the <code>combobox</code> using the same algorithm that is used to compute the name of a <rref>button</rref> from its descendant content.
+          User agents MUST expose the value of elements with role <code>combobox</code> to <a>assistive technologies</a>.
+          The value of a <code>combobox</code> is represented by one of the following:
         </p>
+        <ul>
+          <li>If the <code>combobox</code> element is a host language element that provides a value, such as an HTML <code>input</code> element, the value of the combobox is the value of that element.</li>
+          <li> Otherwise, the value of the <code>combobox</code> is represented by its descendant elements and can be determined using the same method used to compute the name of a <rref>button</rref> from its descendant content.</li>
+        </ul>
 				<pre class="example highlight">
           &lt;label for="tag_combo">Tag&lt;/label>
 		      &lt;input type="text" id="tag_combo"

--- a/index.html
+++ b/index.html
@@ -2114,7 +2114,7 @@
         </p>
 				<p>
           Typically, the initial state of a <code>combobox</code> is collapsed.
-          In the collapsed state, only the <code>combobox</code> element and an optional popup control <rref>button</rref> are visible.
+          In the collapsed state, only the <code>combobox</code> element and a separate, optional popup control <rref>button</rref> are visible.
           A <code>combobox</code> is said to be expanded when both the <code>combobox</code> element showing its current value and its associated popup element are visible.
           Authors MUST set <sref>aria-expanded</sref> to <code>true</code> on an element with role <code>combobox</code> when it is expanded and <code>false</code> when it is collapsed.
         </p>
@@ -2127,16 +2127,16 @@
           If the <code>combobox</code> popup element has a role other than <rref>listbox</rref>, authors MUST specify a value for <pref>aria-haspopup</pref> that corresponds to the role of its popup.
         </p>
 				<p>
-          If the user interface includes an additional icon that allows the visibility of the popup to be controlled via pointer and touch events, authors SHOULD ensure that element has role <rref>button</rref> and that it is focusable but not included in the page <kbd>Tab</kbd> sequence.
+          If the user interface includes an additional icon that allows the visibility of the popup to be controlled via pointer and touch events, authors SHOULD ensure that element has role <rref>button</rref>, that it is focusable but not included in the page <kbd>Tab</kbd> sequence, and that it is not a descendant of the element with role <code>combobox</code>.
           In addition, to be keyboard accessible, authors SHOULD provide keyboard mechanisms for moving focus between the <code>combobox</code> element and elements contained in the popup.
           For example, one common convention is that <kbd>Down Arrow</kbd> moves focus from the input to the first focusable descendant of the popup element.
           If the popup element supports <pref>aria-activedescendant</pref>, in lieu of moving focus, such keyboard mechanisms can control the value of <pref>aria-activedescendant</pref> on the <code>combobox</code> element.
           When a descendant of the popup element is active, authors MAY set <pref>aria-activedescendant</pref> on the <code>combobox</code> to a value that refers to the active element within the popup while focus remains on the <code>combobox</code> element.
         </p>
         <p>
-          User agents MUST compute a value for the <code>combobox</code>.
-          If the <code>combobox</code> element is also a host language element that provides a value, such as an HTML <code>input</code> element, user agents MUST set the value of the combobox to that value.
-          Otherwise, user agents must compute the value of the <code>combobox</code> from the descendant content of the <code>combobox</code> element.
+          User agents MUST compute a value for elements with role <code>combobox</code> and expose it to <a>assistive technologies</a>.
+          If the <code>combobox</code> element is also a host language element that provides a value, such as an HTML <code>input</code> element, the value of the combobox is the value of that element.
+          Otherwise, the value of the <code>combobox</code> is computed from descendant elements of the <code>combobox</code> using the same algorithm that is used to compute the name of a <rref>button</rref> from its descendant content.
         </p>
 				<pre class="example highlight">
           &lt;label for="tag_combo">Tag&lt;/label>

--- a/index.html
+++ b/index.html
@@ -2133,6 +2133,11 @@
           If the popup element supports <pref>aria-activedescendant</pref>, in lieu of moving focus, such keyboard mechanisms can control the value of <pref>aria-activedescendant</pref> on the <code>combobox</code> element.
           When a descendant of the popup element is active, authors MAY set <pref>aria-activedescendant</pref> on the <code>combobox</code> to a value that refers to the active element within the popup while focus remains on the <code>combobox</code> element.
         </p>
+        <p>
+          User agents MUST compute a value for the <code>combobox</code>.
+          If the <code>combobox</code> element is also a host language element that provides a value, such as an HTML <code>input</code> element, user agents MUST set the value of the combobox to that value.
+          Otherwise, user agents must compute the value of the <code>combobox</code> from the descendant content of the <code>combobox</code> element.
+        </p>
 				<pre class="example highlight">
           &lt;label for="tag_combo">Tag&lt;/label>
 		      &lt;input type="text" id="tag_combo"

--- a/index.html
+++ b/index.html
@@ -2139,7 +2139,7 @@
         </p>
         <ul>
           <li>If the <code>combobox</code> element is a host language element that provides a value, such as an HTML <code>input</code> element, the value of the combobox is the value of that element.</li>
-          <li> Otherwise, the value of the <code>combobox</code> is represented by its descendant elements and can be determined using the same method used to compute the name of a <rref>button</rref> from its descendant content.</li>
+          <li>Otherwise, the value of the <code>combobox</code> is represented by its descendant elements and can be determined using the same method used to compute the name of a <rref>button</rref> from its descendant content.</li>
         </ul>
 				<pre class="example highlight">
           &lt;label for="tag_combo">Tag&lt;/label>

--- a/index.html
+++ b/index.html
@@ -2134,7 +2134,7 @@
           When a descendant of the popup element is active, authors MAY set <pref>aria-activedescendant</pref> on the <code>combobox</code> to a value that refers to the active element within the popup while focus remains on the <code>combobox</code> element.
         </p>
         <p>
-          User agents MUST compute a value for elements with role <code>combobox</code> and expose it to <a>assistive technologies</a>.
+          User agents MUST compute a value for elements with role <code>combobox</code> and expose the value to <a>assistive technologies</a>.
           If the <code>combobox</code> element is also a host language element that provides a value, such as an HTML <code>input</code> element, the value of the combobox is the value of that element.
           Otherwise, the value of the <code>combobox</code> is computed from descendant elements of the <code>combobox</code> using the same algorithm that is used to compute the name of a <rref>button</rref> from its descendant content.
         </p>


### PR DESCRIPTION
This resolves the simplest use case identified by issue #711 by requiring user agents to expose a value for elements with the combobox role. This will enable combobox to be used to create a custom select.

This PR requires user agents to expose a value to assistive technologies. If the combobox element is anHTML element that has a value, user agents must expose that value. Otherwise, they expose a string that represents descendant content using methods described in accname.

The idea of using valuetext doesn't make sense in the simplest use case because it would just force authors to copy innertext into an attribute. In more complex cases, an aria-valuedby attribute could be use to specified the element or elements that provide the value. However, we can save that for ARIA 1.3; it is not essential for making a custom select.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#combobox
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 15, 2020, 2:00 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Faria%2Fa1fc4d77fdbc25f9ab2d8af60ee406f3607e59d8%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 30000 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/aria%231225.)._
</details>
