### PR TITLE
don't defer biblio script loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <title>Accessible Rich Internet Applications (WAI-ARIA) 1.2</title>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
 <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer="defer"></script>
-	<script src="common/biblio.js" class="remove" defer="defer"></script>
+<script src="common/biblio.js" class="remove"></script>
 <link href="common/css/common.css" rel="stylesheet" type="text/css"/>
 <script class="remove" src="common/script/aria.js"></script>
 <script src="common/script/resolveReferences.js" class="remove"></script>

--- a/index.html
+++ b/index.html
@@ -3,8 +3,7 @@
 <head>
 <title>Accessible Rich Internet Applications (WAI-ARIA) 1.2</title>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
-<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer="defer"></script>
-<script src="common/biblio.js" class="remove"></script>
+<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
 <link href="common/css/common.css" rel="stylesheet" type="text/css"/>
 <script class="remove" src="common/script/aria.js"></script>
 <script src="common/script/resolveReferences.js" class="remove"></script>
@@ -161,6 +160,7 @@
 
 	};
 </script>
+<script src="common/biblio.js" class="remove"></script>
 </head>
 <body>
 <section id="abstract">


### PR DESCRIPTION
- this may help pr-preview work more often?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1226.html" title="Last updated on Apr 2, 2020, 11:44 PM UTC (38703d5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1226/5d274d4...38703d5.html" title="Last updated on Apr 2, 2020, 11:44 PM UTC (38703d5)">Diff</a>