### PR TITLE
Remove aria-selected as required from option

### DIFF
--- a/index.html
+++ b/index.html
@@ -6021,15 +6021,6 @@
 						</td>
 					</tr>
 					<tr>
-						<th class="role-scope-head" scope="row">Required Context Role:</th>
-						<td class="role-scope">
-							<ul>
-								<li><rref>group</rref></li>
-								<li><rref>listbox</rref></li>
-							</ul>
-						</td>
-					</tr>
-					<tr>
 						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
 						<td class="role-mustcontain"> </td>
 					</tr>


### PR DESCRIPTION
option has a default value of false, therefore aria-selected should not be required. Similar changes related to default values were already done. This one seems to have been overlooked. I checked the docs for others, couldn't find any.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WilcoFiers/aria/pull/1233.html" title="Last updated on Apr 7, 2020, 10:22 AM UTC (a79504a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1233/f7cf32e...WilcoFiers:a79504a.html" title="Last updated on Apr 7, 2020, 10:22 AM UTC (a79504a)">Diff</a>