### PR TITLE
Issue1161 inconsistent use of aria owns

### DIFF
--- a/index.html
+++ b/index.html
@@ -5336,7 +5336,7 @@
 				<p>A type of <a>widget</a> that offers a list of choices to the user.</p>
 				<p>A menu is often a list of common actions or functions that the user can invoke. The <code>menu</code> <a>role</a> is appropriate when a list of menu items is presented in a manner similar to a menu on a desktop application.</p>
 				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
-				<p>Elements with the role <code>menu</code>SHOULD only own  elements with the roles of <rref>menuitem</rref>, <rref>menuitemcheckbox</rref>, <rref>menuitemradio</rref>, <rref>group</rref> or <rref>separator</rref>.</p>
+				<p>Elements with the role <code>menu</code> SHOULD only own elements with the roles of <rref>menuitem</rref>, <rref>menuitemcheckbox</rref>, <rref>menuitemradio</rref>, <rref>group</rref> or <rref>separator</rref>.</p>
 				<p>Elements with the role <code>menu</code> have an implicit <pref>aria-orientation</pref> value of <code>vertical</code>.</p>
 			</div>
 			<table class="role-features">

--- a/index.html
+++ b/index.html
@@ -5335,7 +5335,7 @@
 			<div class="role-description">
 				<p>A type of <a>widget</a> that offers a list of choices to the user.</p>
 				<p>A menu is often a list of common actions or functions that the user can invoke. The <code>menu</code> <a>role</a> is appropriate when a list of menu items is presented in a manner similar to a menu on a desktop application.</p>
-				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
+				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.  Authors SHOULD only include elements with roles from the list of required owned elements as descendants of the menu.</p>
 				<p>Elements with the role <code>menu</code> have an implicit <pref>aria-orientation</pref> value of <code>vertical</code>.</p>
 			</div>
 			<table class="role-features">
@@ -5527,7 +5527,7 @@
 			<div class="role-description">
 				<p>An option in a set of choices contained by a <rref>menu</rref> or <rref>menubar</rref>.</p>
 				<p>Authors MAY disable a menu item with the <sref>aria-disabled</sref> attribute. If the menu item has its <pref>aria-haspopup</pref> attribute set to <code>true</code>, it indicates that the menu item may be used to launch a sub-level menu, and authors SHOULD display a new sub-level menu when the menu item is activated.</p>
-				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu items are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>, or by a role <rref>group</rref> which itself is <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
+				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu items are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -5634,7 +5634,7 @@
 			<div class="role-description">
 				<p>A <rref>menuitem</rref> with a checkable state whose possible <span>values</span> are <code>true</code>, <code>false</code>, or <code>mixed</code>.</p>
 				<p>The <sref>aria-checked</sref> <a>attribute</a> of a <code>menuitemcheckbox</code> indicates whether the menu item is checked (<code>true</code>), unchecked (<code>false</code>), or represents a sub-level menu of other menu items that have a mixture of checked and unchecked values (<code>mixed</code>).</p>
-				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu item checkboxes are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>, or by a role <rref>group</rref> which itself is <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
+				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu item checkboxes are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -5335,7 +5335,8 @@
 			<div class="role-description">
 				<p>A type of <a>widget</a> that offers a list of choices to the user.</p>
 				<p>A menu is often a list of common actions or functions that the user can invoke. The <code>menu</code> <a>role</a> is appropriate when a list of menu items is presented in a manner similar to a menu on a desktop application.</p>
-				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.  Authors SHOULD only include elements with roles from the list of required owned elements as descendants of the menu.</p>
+				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
+				<p>Elements with the role <code>menu</code>SHOULD only own  elements with the roles of <rref>menuitem</rref>, <rref>menuitemcheckbox</rref>, <rref>menuitemradio</rref>, <rref>group</rref> or <rref>separator</rref>.</p>
 				<p>Elements with the role <code>menu</code> have an implicit <pref>aria-orientation</pref> value of <code>vertical</code>.</p>
 			</div>
 			<table class="role-features">


### PR DESCRIPTION
Issue #1161

This pull request makes the following changes:
1. Removes the statement "or by a role group which itself is owned by an element with role menu or menubar." from `menuitem` and `menuitemcheckbox` role definitions.
1. Adds a SHOULD to the `menu` role to only include `menuitem`, `menutiencheckbox`, menuitemradio`, `group` or `separator` roles as owned elements.

[Menu changes](https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1235.html#menu)
[Menuitem changes](https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1235.html#menuitem)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1235.html" title="Last updated on Apr 15, 2020, 6:13 PM UTC (27247e7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1235/f7cf32e...27247e7.html" title="Last updated on Apr 15, 2020, 6:13 PM UTC (27247e7)">Diff</a>