### PR TITLE
Add name required info to name from content section

### DIFF
--- a/common/script/aria.js
+++ b/common/script/aria.js
@@ -353,7 +353,7 @@ require(["core/pubsubhub"], function( respecEvents ) {
                                 fromAuthor += "<li><a href=\"#" + pnID + "\" class=\"role-reference\"><code>" + content + "</code></a>" + req + "</li>";
                             } 
                             if (!isAbstract && node.textContent.indexOf("content") !== -1) {
-                                fromContent += "<li><a href=\"#" + pnID + "\" class=\"role-reference\"><code>" + content + "</code></a>" + "</li>";
+                                fromContent += "<li><a href=\"#" + pnID + "\" class=\"role-reference\"><code>" + content + "</code></a>" + req + "</li>";
                             }
                             if (node.textContent.indexOf("prohibited") !== -1) {
                                 fromProhibited += "<li><a href=\"#" + pnID + "\" class=\"role-reference\"><code>" + content + "</code></a>" + req + "</li>";


### PR DESCRIPTION
Resolves #1237 

Looks like there was just an oversight in the code to generate the Name from Content roles list. This PR updates it to include the "(name required)" string where applicable.