### PR TITLE
chore: remove redudant config options

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,28 +9,20 @@
 <script src="common/script/resolveReferences.js" class="remove"></script>
 <script class="remove">
 	var respecConfig = {
-		// embed RDFa data in the output
-		trace:  true,
-		useExperimentalStyles: true,
-		doRDFa: '1.1',
-		includePermalinks: true,
-		permalinkEdge:     true,
-		permalinkHide:     false,
+		github: "w3c/aria",
+		doJsonLd: true,
 		// specification status (e.g., WD, LC, NOTE, etc.). If in doubt use ED.
 		specStatus:           "ED",
 		//crEnd:                "2012-04-30",
 		//perEnd:               "2013-07-23",
 		//publishDate:          "2013-08-22",
-		diffTool:             "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
 
 		// the specifications short name, as in https://www.w3.org/TR/short-name/
 		shortName:            "wai-aria-1.2",
 
-
 		// if you wish the publication date to be other than today, set this
 		//publishDate:  "2014-12-11",
 		copyrightStart:  "2013",
-		license: "document",
 
 		// if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
 		// and its maturity status


### PR DESCRIPTION
Some options that are not used/supported anymore by ReSpec. 

Note, we don't do `doRDFa` anymore, we `doJsonLd` now tho :)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 21, 2020, 1:34 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fmarcoscaceres%2Faria%2F256a91a8c040606866df44f5672d74bfbfd7dd38%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
[36mSpecification: https://rawcdn.githack.com/marcoscaceres/aria/256a91a8c040606866df44f5672d74bfbfd7dd38/index.html?isPreview=true&publishDate=2020-04-21[39m
[36mReSpec version: 25.6.0[39m
[36mFile a bug: https://github.com/w3c/respec/[39m
[36mError: Error: Evaluation failed: Timeout: document.respecIsReady didn't resolve in 0ms.[39m
[36m    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/ExecutionContext.js:122:13)[39m
[36m    at runMicrotasks (<anonymous>)[39m
[36m    at processTicksAndRejections (internal/process/task_queues.js:97:5)[39m
[36m    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/ExecutionContext.js:48:12)[39m
[36m    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:128:12)[39m
[36m    at async fetchAndWrite (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:95:18)[39m
[36m    at async Object.generate [as respec] (/u/spec-generator/generators/respec.js:14:20)[39m
[36m    at async generate (/u/spec-generator/server.js:91:29)[39m
[36m  -- ASYNC --[39m
[36m    at ExecutionContext.<anonymous> (/u/spec-generator/node_modules/puppeteer/lib/helper.js:111:15)[39m
[36m    at DOMWorld.evaluate (/u/spec-generator/node_modules/puppeteer/lib/DOMWorld.js:112:20)[39m
[36m    at runMicrotasks (<anonymous>)[39m
[36m    at processTicksAndRejections (internal/process/task_queues.js:97:5)[39m
[36m  -- ASYNC --[39m
[36m    at Frame.<anonymous> (/u/spec-generator/node_modules/puppeteer/lib/helper.js:111:15)[39m
[36m    at Page.evaluate (/u/spec-generator/node_modules/puppeteer/lib/Page.js:860:43)[39m
[36m    at Page.<anonymous> (/u/spec-generator/node_modules/puppeteer/lib/helper.js:112:23)[39m
[36m    at generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:128:23)[39m
[36m    at runMicrotasks (<anonymous>)[39m
[36m    at processTicksAndRejections (internal/process/task_queues.js:97:5)[39m
[36m    at async fetchAndWrite (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:95:18)[39m
[36m    at async Object.generate [as respec] (/u/spec-generator/generators/respec.js:14:20)[39m
[36m    at async generate (/u/spec-generator/server.js:91:29)[39m
[36m[39m
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/aria%231246.)._
</details>
