### PR TITLE
chore: prevent crash when respecConfig.definitionMap is missing

### DIFF
--- a/common/script/resolveReferences.js
+++ b/common/script/resolveReferences.js
@@ -253,7 +253,8 @@ require(["core/pubsubhub"], function(respecEvents) {
                     delete termNames[r] ;
                 }
             });
-    // delete any terms that were not referenced.
+            // delete any terms that were not referenced.
+            if (!respecConfig.definitionMap) return;
             Object.keys(termNames).forEach(function(term) {
                 var $p = $("#"+term);
                 if ($p) {


### PR DESCRIPTION
This prevents the respecConfig.definitionMap crash.

However, we need to trim common/terms.html to the ones that are used in this spec. And then export those terms so other specs can use them. 
 