### PR TITLE
chore: remove redundant location code

### DIFF
--- a/common/script/resolveReferences.js
+++ b/common/script/resolveReferences.js
@@ -283,12 +283,3 @@ function fixIncludes(utils, content) {
     return (base.innerHTML);
 }
 
-// Fix the scroll-to-fragID problem:
-require(["core/pubsubhub"], function (respecEvents) {
-    "use strict";
-    respecEvents.sub("end-all", function () {
-        if(window.location.hash) {
-            window.location = window.location.hash;
-        }
-    });
-});


### PR DESCRIPTION
ReSpec already does this