### PR TITLE
include 'owned by textbox' in aria-activedescendant instructions for UAs

### DIFF
--- a/index.html
+++ b/index.html
@@ -400,7 +400,7 @@
 		  <li>Otherwise, the user agent MAY attempt to set <abbr title="Document Object Model">DOM</abbr> focus to the child element itself.</li>
 		</ol>
 	      </li>
-	      <li>If the current element has an ID and an ancestor with the <code>aria-activedescendant</code> attribute present, the user agent MUST set the accessibility <abbr title="Application Programming Interface">API</abbr> focused state and fire an accessibility <abbr title="Application Programming Interface">API</abbr> focus <a>event</a> on the new active descendant.</li>
+	      <li>If the current element has an ID and either has an ancestor with the <code>aria-activedescendant</code> attribute present or is owned by an element that is controlled by a <rref>textbox</rref> with the <pref>aria-activedescendant</pref> attribute present, the user agent MUST set the accessibility <abbr title="Application Programming Interface">API</abbr> focused state and fire an accessibility <abbr title="Application Programming Interface">API</abbr> focus <a>event</a> on the new active descendant.</li>
 	    </ol>
 	  </section>
 	</section>

--- a/index.html
+++ b/index.html
@@ -394,7 +394,7 @@
 	      <li>Set the <abbr title="Document Object Model">DOM</abbr> focus:
 		<ol>
 		  <li>If the <a class="termref">element</a> can take <abbr title="Document Object Model">DOM</abbr> focus, the <a class="termref">user agent</a> MUST set the <abbr title="Document Object Model">DOM</abbr> focus to it.</li>
-		  <li>Otherwise, if the current element has an ID and an ancestor with the <pref>aria-activedescendant</pref> attribute present, and that ancestor is focusable, the user agent MUST set <abbr title="Document Object Model">DOM</abbr> focus to that ancestor.
+		  <li>Otherwise, if the current element has an ID and either has an ancestor with the <pref>aria-activedescendant</pref> attribute present or is owned by an element that is controlled by a <rref>textbox</rref> with the <pref>aria-activedescendant</pref> attribute present, and that ancestor is focusable, the user agent MUST set <abbr title="Document Object Model">DOM</abbr> focus to that ancestor.
 		    <p class="note">The inability to set <abbr title="Document Object Model">DOM</abbr> focus to the containing element indicates an author error.</p>
 		  </li>
 		  <li>Otherwise, the user agent MAY attempt to set <abbr title="Document Object Model">DOM</abbr> focus to the child element itself.</li>


### PR DESCRIPTION
Resolves #1121


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1252.html" title="Last updated on Apr 23, 2020, 5:04 PM UTC (682fb23)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1252/5f19d17...682fb23.html" title="Last updated on Apr 23, 2020, 5:04 PM UTC (682fb23)">Diff</a>