### PR TITLE
Resolves #834, remove ARIA element reflection IDL until element reflection settles in HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -13491,7 +13491,7 @@
 		<h2>Interface Mixin <dfn>AriaAttributes</dfn></h2>
 		<pre class="idl">
 			interface mixin AriaAttributes {
-				attribute Element? ariaActiveDescendantElement;
+				<!-- attribute Element? ariaActiveDescendantElement; -->
 				attribute DOMString? ariaAtomic;
 				attribute DOMString? ariaAutoComplete;
 				attribute DOMString? ariaBusy;
@@ -13500,28 +13500,28 @@
 				attribute DOMString? ariaColIndex;
 				attribute DOMString? ariaColIndexText;
 				attribute DOMString? ariaColSpan;
-				attribute FrozenArray&lt;Element&gt;? ariaControlsElements;
+				<!-- attribute FrozenArray&lt;Element&gt;? ariaControlsElements; -->
 				attribute DOMString? ariaCurrent;
-				attribute FrozenArray&lt;Element&gt;? ariaDescribedByElements;
+				<!-- attribute FrozenArray&lt;Element&gt;? ariaDescribedByElements; -->
 				attribute DOMString? ariaDescription;
-				attribute FrozenArray&lt;Element&gt;? ariaDetailsElements;
+				<!-- attribute FrozenArray&lt;Element&gt;? ariaDetailsElements; -->
 				attribute DOMString? ariaDisabled;
-				attribute Element? ariaErrorMessageElement;
+				<!-- attribute Element? ariaErrorMessageElement; -->
 				attribute DOMString? ariaExpanded;
-				attribute FrozenArray&lt;Element&gt;? ariaFlowToElements;
+				<!-- attribute FrozenArray&lt;Element&gt;? ariaFlowToElements; -->
 				attribute DOMString? ariaHasPopup;
 				attribute DOMString? ariaHidden;
 				attribute DOMString? ariaInvalid;
 				attribute DOMString? ariaKeyShortcuts;
 				attribute DOMString? ariaLabel;
-				attribute FrozenArray&lt;Element&gt;? ariaLabelledByElements;
+				<!-- attribute FrozenArray&lt;Element&gt;? ariaLabelledByElements; -->
 				attribute DOMString? ariaLevel;
 				attribute DOMString? ariaLive;
 				attribute DOMString? ariaModal;
 				attribute DOMString? ariaMultiLine;
 				attribute DOMString? ariaMultiSelectable;
 				attribute DOMString? ariaOrientation;
-				attribute FrozenArray&lt;Element&gt;? ariaOwnsElements;
+				<!-- attribute FrozenArray&lt;Element&gt;? ariaOwnsElements; -->
 				attribute DOMString? ariaPlaceholder;
 				attribute DOMString? ariaPosInSet;
 				attribute DOMString? ariaPressed;
@@ -13548,7 +13548,7 @@
 			<p>User agents MUST <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflecting-content-attributes-in-idl-attributes">reflect</a> the following content attributes to each of the corresponding IDL attributes.</p>
 			<table>
 				<tr><th>IDL Attribute</th><th>Reflected ARIA Content Attribute</th></tr>
-				<tr><td><dfn>ariaActiveDescendantElement</dfn></td><td><pref>aria-activedescendant</pref></td></tr>
+				<!-- <tr><td><dfn>ariaActiveDescendantElement</dfn></td><td><pref>aria-activedescendant</pref></td></tr> -->
 				<tr><td><dfn>ariaAtomic</dfn></td><td><pref>aria-atomic</pref></td></tr>
 				<tr><td><dfn>ariaAutoComplete</dfn></td><td><pref>aria-autocomplete</pref></td></tr>
 				<tr><td><dfn>ariaBusy</dfn></td><td><sref>aria-busy</sref></td></tr>
@@ -13557,28 +13557,28 @@
 				<tr><td><dfn>ariaColIndex</dfn></td><td><pref>aria-colindex</pref></td></tr>
 				<tr><td><dfn>ariaColIndexText</dfn></td><td><pref>aria-colindextext</pref></td></tr>
 				<tr><td><dfn>ariaColSpan</dfn></td><td><pref>aria-colspan</pref></td></tr>
-				<tr><td><dfn>ariaControlsElements</dfn></td><td><pref>aria-controls</pref></td></tr>
+				<!-- <tr><td><dfn>ariaControlsElements</dfn></td><td><pref>aria-controls</pref></td></tr> -->
 				<tr><td><dfn>ariaCurrent</dfn></td><td><sref>aria-current</sref></td></tr>
-				<tr><td><dfn>ariaDescribedByElements</dfn></td><td><pref>aria-describedby</pref></td></tr>
+				<!-- <tr><td><dfn>ariaDescribedByElements</dfn></td><td><pref>aria-describedby</pref></td></tr> -->
 				<tr><td><dfn>ariaDescription</dfn></td><td><pref>aria-description</pref></td></tr>
-				<tr><td><dfn>ariaDetailsElements</dfn></td><td><pref>aria-details</pref></td></tr>
+				<!-- <tr><td><dfn>ariaDetailsElements</dfn></td><td><pref>aria-details</pref></td></tr> -->
 				<tr><td><dfn>ariaDisabled</dfn></td><td><sref>aria-disabled</sref></td></tr>
-				<tr><td><dfn>ariaErrorMessageElement</dfn></td><td><pref>aria-errormessage</pref></td></tr>
+				<!-- <tr><td><dfn>ariaErrorMessageElement</dfn></td><td><pref>aria-errormessage</pref></td></tr> -->
 				<tr><td><dfn>ariaExpanded</dfn></td><td><sref>aria-expanded</sref></td></tr>
-				<tr><td><dfn>ariaFlowToElements</dfn></td><td><pref>aria-flowto</pref></td></tr>
+				<!-- <tr><td><dfn>ariaFlowToElements</dfn></td><td><pref>aria-flowto</pref></td></tr> -->
 				<tr><td><dfn>ariaHasPopup</dfn></td><td><pref>aria-haspopup</pref></td></tr>
 				<tr><td><dfn>ariaHidden</dfn></td><td><sref>aria-hidden</sref></td></tr>
 				<tr><td><dfn>ariaInvalid</dfn></td><td><sref>aria-invalid</sref></td></tr>
 				<tr><td><dfn>ariaKeyShortcuts</dfn></td><td><pref>aria-keyshortcuts</pref></td></tr>
 				<tr><td><dfn>ariaLabel</dfn></td><td><pref>aria-label</pref></td></tr>
-				<tr><td><dfn>ariaLabelledByElements</dfn></td><td><pref>aria-labelledby</pref></td></tr>
+				<!-- <tr><td><dfn>ariaLabelledByElements</dfn></td><td><pref>aria-labelledby</pref></td></tr> -->
 				<tr><td><dfn>ariaLevel</dfn></td><td><pref>aria-level</pref></td></tr>
 				<tr><td><dfn>ariaLive</dfn></td><td><pref>aria-live</pref></td></tr>
 				<tr><td><dfn>ariaModal</dfn></td><td><pref>aria-modal</pref></td></tr>
 				<tr><td><dfn>ariaMultiLine</dfn></td><td><pref>aria-multiline</pref></td></tr>
 				<tr><td><dfn>ariaMultiSelectable</dfn></td><td><pref>aria-multiselectable</pref></td></tr>
 				<tr><td><dfn>ariaOrientation</dfn></td><td><pref>aria-orientation</pref></td></tr>
-				<tr><td><dfn>ariaOwnsElements</dfn></td><td><pref>aria-owns</pref></td></tr>
+				<!-- <tr><td><dfn>ariaOwnsElements</dfn></td><td><pref>aria-owns</pref></td></tr> -->
 				<tr><td><dfn>ariaPlaceholder</dfn></td><td><pref>aria-placeholder</pref></td></tr>
 				<tr><td><dfn>ariaPosInSet</dfn></td><td><pref>aria-posinset</pref></td></tr>
 				<tr><td><dfn>ariaPressed</dfn></td><td><sref>aria-pressed</sref></td></tr>


### PR DESCRIPTION
remove ARIA element reflection IDL until element reflection settles in HTML 

Commented b/c this will likely go back in to ARIA 1.3.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1260.html" title="Last updated on May 7, 2020, 6:07 AM UTC (45157e4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1260/757b6b3...45157e4.html" title="Last updated on May 7, 2020, 6:07 AM UTC (45157e4)">Diff</a>