### PR TITLE
resolves #1265, aria-relevant missing "(default)" notation in values table

### DIFF
--- a/index.html
+++ b/index.html
@@ -12503,7 +12503,7 @@
 						<td class="value-description">Element nodes are added to the accessibility tree within the live region.</td>
 					</tr>
 					<tr>
-						<th class="value-name" scope="row"><strong class="default">additions text</strong></th>
+						<th class="value-name" scope="row"><strong class="default">additions text (default)</strong></th>
 						<td class="value-description">Equivalent to the combination of values, "additions text".</td>
 					</tr>
 					<tr>


### PR DESCRIPTION
Minor editorial oversight. The default value was already contained in the intended `strong.default` element. Only the content text was missing.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1266.html" title="Last updated on May 7, 2020, 8:54 PM UTC (89f0c40)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1266/757b6b3...89f0c40.html" title="Last updated on May 7, 2020, 8:54 PM UTC (89f0c40)">Diff</a>