### PR TITLE
Remove multiple inheritance from menuitemcheckbox and menuitemradio

### DIFF
--- a/common/script/aria.js
+++ b/common/script/aria.js
@@ -339,10 +339,8 @@ require(["core/pubsubhub"], function( respecEvents ) {
                                 attrs.push( { is: type, name: name, required: req, disallowed: dis, deprecated: dep } );                                               
 
                                 // remember that the state or property is
-                                // referenced by this role (unless disallowed)
-                                if (!dis) {
-                                    propList[name].roles.push(title);
-                                }
+                                // referenced by this role
+                                propList[name].roles.push(title);
                             });
                         }
                     });
@@ -494,18 +492,10 @@ require(["core/pubsubhub"], function( respecEvents ) {
                         var output = "";
                         var section = document.querySelector("#" + item.name);
                         var placeholder = section.querySelector(".state-applicability, .property-applicability");
-                        var deprecatedAsGlobal = placeholder && ((placeholder.textContent || placeholder.innerText) === "Use as a global deprecated in ARIA 1.2");
-                        if ((placeholder && ((placeholder.textContent || placeholder.innerText) === "Placeholder") || deprecatedAsGlobal) && item.roles.length) {
+                        if (placeholder && ((placeholder.textContent || placeholder.innerText) === "Placeholder") && item.roles.length) {
                             // update the used in roles list
                             var sortedList = [];
                             sortedList = item.roles.sort();
-                            if (deprecatedAsGlobal) {
-                              // remove roletype from the sorted list
-                              const index = sortedList.indexOf('roletype');
-                              if (index > -1) {
-                                  sortedList.splice(index, 1);
-                              }
-                            }
                             for (var j = 0; j < sortedList.length; j++) {
                                 output += "<li><rref>" + sortedList[j] + "</rref></li>\n";
                             }
@@ -513,7 +503,7 @@ require(["core/pubsubhub"], function( respecEvents ) {
                                 output = "<ul>\n" + output + "</ul>\n";
                             }
                             placeholder.innerHTML = output;
-                            // update the inherits into roles list
+                            // also update any inherited roles
                             var myList = [];
                             $.each(item.roles, function(j, role) {
                                 var children = getAllSubRoles(role);
@@ -523,16 +513,54 @@ require(["core/pubsubhub"], function( respecEvents ) {
                                 children = $.grep(children, function(subrole) {
                                     return $.inArray(subrole, propList[item.name].roles) == -1;
                                 });
-                                // Filter out subroles where the attribute is disallowed.
+                                $.merge(myList, children);
+                            });
+                            placeholder = section.querySelector(".state-descendants, .property-descendants");
+                            if (placeholder && myList.length) {
+                                sortedList = myList.sort();
+                                output = "";
+                                var last = "";
+                                for (j = 0; j < sortedList.length; j++) {
+                                    var sItem = sortedList[j];
+                                    if (last != sItem) {
+                                        output += "<li><rref>" + sItem + "</rref></li>\n";
+                                        last = sItem;
+                                    }
+                                }
+                                if (output !== "") {
+                                    output = "<ul>\n" + output + "</ul>\n";
+                                }
+                                placeholder.innerHTML = output;
+                            }
+                        }
+                        else if (placeholder && (((placeholder.textContent || placeholder.innerText) ==="Use as a global deprecated in ARIA 1.2")) && item.roles.length)
+                        {
+                            // update the used in roles list
+                            var sortedList = [];
+                            sortedList = item.roles.sort();
+                            //remove roletype from the sorted list
+                            const index = sortedList.indexOf('roletype');
+                            if (index > -1) {
+                                sortedList.splice(index, 1);
+                            }
+
+
+                            for (var j = 0; j < sortedList.length; j++) {
+                                output += "<li><rref>" + sortedList[j] + "</rref></li>\n";
+                            }
+                            if (output !== "") {
+                                output = "<ul>\n" + output + "</ul>\n";
+                            }
+                            placeholder.innerHTML = output;
+                            // also update any inherited roles
+                            var myList = [];
+                            $.each(item.roles, function(j, role) {
+                                var children = getAllSubRoles(role);
+                                // Some subroles have required properties which are also required by the superclass.
+                                // Example: The checked state of radio, which is also required by superclass checkbox.
+                                // We only want to include these one time, so filter out the subroles.
                                 children = $.grep(children, function(subrole) {
-                                    var dis = false;
-                                    $.each(roleInfo[subrole].localprops, function(k, attr) {
-                                        if (attr.name === item.name) {
-                                            dis = attr.disallowed;
-                                            return true; // break out of $.each
-                                        }
-                                    });
-                                    return !dis;
+                                    return $.inArray(subrole, propList[item.name].roles) == -1;
                                 });
                                 $.merge(myList, children);
                             });

--- a/index.html
+++ b/index.html
@@ -5708,15 +5708,6 @@
 						<td class="role-inherited">Placeholder</td>
 					</tr>
 					<tr>
-						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
-						<td class="role-disallowed">
-							<ul>
-								<li><pref>aria-expanded</pref></li>
-								<li><pref>aria-haspopup</pref></li>
-							</ul>
-						</td>
-					</tr>
-					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
 						<td class="role-namefrom">
 							<ul>
@@ -5807,15 +5798,6 @@
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
 						<td class="role-inherited">Placeholder</td>
-					</tr>
-					<tr>
-						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
-						<td class="role-disallowed">
-							<ul>
-								<li><pref>aria-expanded</pref></li>
-								<li><pref>aria-haspopup</pref></li>
-							</ul>
-						</td>
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
@@ -6615,7 +6597,6 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
-								<li><pref>aria-expanded</pref></li>
 								<li><pref>aria-posinset</pref></li>
 								<li><pref>aria-setsize</pref></li>
 							</ul>

--- a/index.html
+++ b/index.html
@@ -5712,6 +5712,7 @@
 						<td class="role-disallowed">
 							<ul>
 								<li><pref>aria-expanded</pref></li>
+								<li><pref>aria-haspopup</pref></li>
 							</ul>
 						</td>
 					</tr>
@@ -5770,7 +5771,6 @@
 						<td class="role-parent">
 							<ul>
 								<li><rref>menuitemcheckbox</rref></li>
-								<li><rref>radio</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -5813,6 +5813,7 @@
 						<td class="role-disallowed">
 							<ul>
 								<li><pref>aria-expanded</pref></li>
+								<li><pref>aria-haspopup</pref></li>
 							</ul>
 						</td>
 					</tr>

--- a/index.html
+++ b/index.html
@@ -5705,6 +5705,14 @@
 						<td class="role-inherited">Placeholder</td>
 					</tr>
 					<tr>
+						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
+						<td class="role-disallowed">
+							<ul>
+								<li><pref>aria-expanded</pref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
 						<td class="role-namefrom">
 							<ul>
@@ -5796,6 +5804,14 @@
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
 						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-disallowed-head" scope="row">Prohibited States and Properties:</th>
+						<td class="role-disallowed">
+							<ul>
+								<li><pref>aria-expanded</pref></li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
@@ -6595,6 +6611,7 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
+								<li><pref>aria-expanded</pref></li>
 								<li><pref>aria-posinset</pref></li>
 								<li><pref>aria-setsize</pref></li>
 							</ul>

--- a/index.html
+++ b/index.html
@@ -5661,7 +5661,6 @@
 						<th class="role-parent-head" scope="row">Superclass Role:</th>
 						<td class="role-parent">
 							<ul>
-								<li><rref>checkbox</rref></li>
 								<li><rref>menuitem</rref></li>
 							</ul>
 						</td>
@@ -5694,7 +5693,11 @@
 					</tr>
 					<tr>
 						<th class="role-required-properties-head">Required States and Properties:</th>
-						<td class="role-required-properties"> </td>
+						<td class="role-required-properties">
+							<ul>
+								<li><sref>aria-checked</sref></li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>


### PR DESCRIPTION
**NOTE: June 13, 2020**
For some reason pr-preview did not run, so the Preview and Diff are old (tooltip says "Last updated on May 26, 2020"). Please just look at the code changes in Files changed - there are only 3 changes (2 deletions and an addition).

Closes #1277

- removes checkbox from menuitemcheckbox superclasses (so it only inherits from menuitem)
- removes radio from menuitemradio superclasses (so it only inherits from menuitemcheckbox)
- requires aria-checked on menuitemcheckbox (which menuitemradio inherits)

<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1278.html" title="Last updated on May 26, 2020, 12:27 PM UTC (3f845d5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1278/3c600ae...3f845d5.html" title="Last updated on May 26, 2020, 12:27 PM UTC (3f845d5)">Diff</a>