### PR TITLE
Assistive tech SHOULD provide landmark navigation... user agents MAY

### DIFF
--- a/index.html
+++ b/index.html
@@ -4871,7 +4871,7 @@
 			<rdef>main</rdef>
 			<div class="role-description">
 				<p>A <rref>landmark</rref> containing the main content of a document.</p>
-				<p>This marks the content that is directly related to or expands upon the central topic of the document. The <code>main</code> <a>role</a> is a non-obtrusive alternative for "skip to main content" links, where the navigation option to go to the main content (or other <a>landmarks</a>) is provided by the <a>user agent</a> through a keyboard shortcut (or <abbr title="User Interface">UI</abbr> feature such as a side panel or dialog) or by <a>assistive technologies</a>.</p>
+				<p>This marks the content that is directly related to or expands upon the central topic of the document. The <code>main</code> <a>role</a> is a non-obtrusive alternative for "skip to main content" links, where the navigation option to go to the main content (or other <a>landmarks</a>) is provided by <a>assistive technologies</a>, or by a <a>user agent</a> or browser extension, through a keyboard shortcut or <abbr title="User Interface">UI</abbr> feature such as a side panel or dialog.</p>
 				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>main</code>.
   				<a>User agents</a> SHOULD treat elements with role <code>main</code> as navigational <a>landmarks</a>.
   				<a>User agents</a> MAY enable users to quickly navigate to elements with role <code>main</code>.</p>

--- a/index.html
+++ b/index.html
@@ -1345,7 +1345,7 @@
 			<div class="role-description">
 				<p>A <rref>landmark</rref> that contains mostly site-oriented content, rather than page-specific content.</p>
 				<p>Site-oriented content typically includes things such as the logo or identity of the site sponsor, and a site-specific search tool. A banner usually appears at the top of the page and typically spans the full width.</p>
-				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>banner</code>. Mainstream <a>user agents</a> SHOULD enable users to quickly navigate to <a>elements</a> that have an implicit role of <code>banner</code>.</p>
+				<p><a>User agents</a> and <a>assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>banner</code>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #main and #contentinfo-->
 				<p>Within any <rref>document</rref> or <rref>application</rref>, the author SHOULD mark no more than one <a>element</a> with the <code>banner</code> <a>role</a>.</p>
 				<p class="note">Because <code>document</code> and <code>application</code> elements can be nested in the <abbr title="Document Object Model">DOM</abbr>, they may have multiple <code>banner</code> elements as <abbr title="Document Object Model">DOM</abbr> descendants, assuming each of those is associated with different document nodes, either by a DOM nesting (e.g., <rref>document</rref> within <rref>document</rref>) or by use of the <pref>aria-owns</pref> <a>attribute</a>.</p>
@@ -2437,7 +2437,7 @@
 			<div class="role-description">
 				<p>A <rref>landmark</rref> that is designed to be complementary to the main content at a similar level in the DOM hierarchy, but remaining meaningful when separated from the main content.</p>
 				<p>There are various types of content that would appropriately have this <a>role</a>. For example, in the case of a portal, this may include but not be limited to show times, current weather, related articles, or stocks to watch. The complementary role indicates that contained content is relevant to the main content. If the complementary content is completely separable from the main content, it may be appropriate to use a more general role.</p>
-				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>complementary</code>. Mainstream <a>user agents</a> SHOULD enable users to quickly navigate to <a>elements</a> that have an implicit role of <code>complementary</code>.</p>
+				<p><a>User agents</a> and <a>assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>complementary</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -2592,7 +2592,7 @@
 			<div class="role-description">
 				<p>A <rref>landmark</rref> that contains information about the parent document.</p>
 				<p>Examples of information included in this region of the page are copyrights and links to privacy statements.</p>
-				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>contentinfo</code>. Mainstream <a>user agents</a> SHOULD enable users to quickly navigate to <a>elements</a> that have an implicit role of <code>contentinfo</code>.</p>
+				<p><a>User agents</a> and <a>assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>contentinfo</code>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #banner and #main -->
 				<p>Within any <rref>document</rref> or <rref>application</rref>, the author SHOULD mark no more than one <a>element</a> with the <code>contentinfo</code> role.</p>
 				<p class="note">Because <code>document</code> and <code>application</code> elements can be nested in the <abbr title="Document Object Model">DOM</abbr>, they may have multiple <code>contentinfo</code> elements as <abbr title="Document Object Model">DOM</abbr> descendants, assuming each of those is associated with different document nodes, either by a DOM nesting (e.g., <rref>document</rref> within <rref>document</rref>) or by use of the <pref>aria-owns</pref> attribute.</p>
@@ -3328,7 +3328,7 @@
 				<p>A form may contain a mix of host language form controls, scripted controls, and hyperlinks. Authors are reminded to use native host language semantics to create form controls whenever possible. If the purpose of a form is to submit search criteria, authors SHOULD use the <rref>search</rref> role instead of the generic <code>form</code> role.</p>
 				<p>Authors MUST give each element with role <code>form</code> a brief label that describes the purpose of the form. Authors SHOULD reference a visible label with <pref>aria-labelledby</pref> if a visible label is present. Authors SHOULD include the label inside of a heading whenever possible. The heading MAY be an instance of the standard host language heading element or an instance of an element with role <rref>heading</rref>.</p>
 				<p>If an author uses a script to submit a form based on a user action that would otherwise not trigger an <code>onsubmit</code> event (for example, a form submission triggered by the user changing a form element's value), the author SHOULD provide the user with advance notification of the behavior.</p>
-				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>form</code>. Mainstream <a>user agents</a> SHOULD enable users to quickly navigate to <a>elements</a> that have an implicit role of <code>form</code>.</p>
+				<p><a>User agents</a> and <a>assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>form</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4223,7 +4223,7 @@
 				<p>A perceivable <rref>section</rref> containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.</p>
 				 <p>Authors designate the purpose of the content by assigning a role that is a subclass of the landmark role and, when needed, by providing a brief, descriptive label.</p>
 <p>Elements with a role that is a subclass of the landmark role are known as <a>landmark</a> regions or navigational landmark regions.
-<a>Assistive technologies</a> SHOULD enable users to quickly navigate to landmark regions. Mainstream <a>user agents</a> SHOULD enable users to quickly navigate to <a>elements</a> whose implicit role is a landmark region.</p>
+<a>User agents</a> and <a>assistive technologies</a> SHOULD enable users to quickly navigate to landmark regions.</p>
 				<p class="note"><code>landmark</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
 			</div>
 			<table class="role-features">
@@ -4863,7 +4863,7 @@
 			<div class="role-description">
 				<p>A <rref>landmark</rref> containing the main content of a document.</p>
 				<p>This marks the content that is directly related to or expands upon the central topic of the document. The <code>main</code> <a>role</a> is a non-obtrusive alternative for "skip to main content" links, where the navigation option to go to the main content (or other <a>landmarks</a>) is provided by the <a>user agent</a> through a keyboard shortcut (or <abbr title="User Interface">UI</abbr> feature such as a side panel or dialog) or by <a>assistive technologies</a>.</p>
-				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>main</code>. Mainstream <a>user agents</a> SHOULD enable users to quickly navigate to <a>elements</a> that have an implicit role of <code>main</code>.</p>
+				<p><a>User agents</a> and <a>assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>main</code>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #banner and #contentinfo -->
 				<p>Within any <rref>document</rref> or <rref>application</rref>, the author SHOULD mark no more than one <a>element</a> with the <code>main</code> role.</p>
 				<p class="note">Because <code>document</code> and <code>application</code> elements can be nested in the <abbr title="Document Object Model">DOM</abbr>, they may have multiple <code>main</code> elements as <abbr title="Document Object Model">DOM</abbr> descendants, assuming each of those is associated with different document nodes, either by a DOM nesting (e.g., <rref>document</rref> within <rref>document</rref>) or by use of the <pref>aria-owns</pref> attribute.</p>
@@ -5827,7 +5827,7 @@
 			<rdef>navigation</rdef>
 			<div class="role-description">
 				<p>A <rref>landmark</rref> containing a collection of navigational <a>elements</a> (usually links) for navigating the document or related documents.</p>
-				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>navigation</code>. Mainstream <a>user agents</a> SHOULD enable users to quickly navigate to <a>elements</a> that have an implicit role of <code>navigation</code>.</p>
+				<p><a>User agents</a> and <a>assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>navigation</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -6805,7 +6805,7 @@
 				<p>A <rref>landmark</rref> containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.</p>
 				<p>Authors SHOULD limit use of the region role to sections containing content with a purpose that is not accurately described by one of the other <a href="#landmark_roles">landmark roles</a>, such as <rref>main</rref>, <rref>complementary</rref>, or <rref>navigation</rref>.</p>
 				<p>Authors MUST give each element with role region a brief label that describes the purpose of the content in the region. Authors SHOULD reference a visible label with <pref>aria-labelledby</pref> if a visible label is present. Authors SHOULD include the label inside of a heading whenever possible. The heading MAY be an instance of the standard host language heading element or an instance of an element with role <rref>heading</rref>.</p>
-				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>region</code>. Mainstream <a>user agents</a> SHOULD enable users to quickly navigate to <a>elements</a> that have an implicit role of <code>region</code>.</p>
+				<p><a>User agents</a> and <a>assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>region</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -7373,7 +7373,7 @@
 			<div class="role-description">
 				<p>A <rref>landmark</rref> region that contains a collection of items and objects that, as a whole, combine to create a search facility. See related <rref>form</rref> and <rref>searchbox</rref>.</p>
 				<p>A search region may be a mix of host language form controls, scripted controls, and hyperlinks.</p>
-				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>search</code>. Mainstream <a>user agents</a> SHOULD enable users to quickly navigate to <a>elements</a> that have an implicit role of <code>search</code>.</p>
+				<p><a>User agents</a> and <a>assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>search</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -1345,7 +1345,7 @@
 			<div class="role-description">
 				<p>A <rref>landmark</rref> that contains mostly site-oriented content, rather than page-specific content.</p>
 				<p>Site-oriented content typically includes things such as the logo or identity of the site sponsor, and a site-specific search tool. A banner usually appears at the top of the page and typically spans the full width.</p>
-				<p>User agents SHOULD treat elements with the role of <code>banner</code> as navigational <a>landmarks</a>.</p>
+				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>banner</code>. Mainstream <a>user agents</a> SHOULD enable users to quickly navigate to <a>elements</a> that have an implicit role of <code>banner</code>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #main and #contentinfo-->
 				<p>Within any <rref>document</rref> or <rref>application</rref>, the author SHOULD mark no more than one <a>element</a> with the <code>banner</code> <a>role</a>.</p>
 				<p class="note">Because <code>document</code> and <code>application</code> elements can be nested in the <abbr title="Document Object Model">DOM</abbr>, they may have multiple <code>banner</code> elements as <abbr title="Document Object Model">DOM</abbr> descendants, assuming each of those is associated with different document nodes, either by a DOM nesting (e.g., <rref>document</rref> within <rref>document</rref>) or by use of the <pref>aria-owns</pref> <a>attribute</a>.</p>
@@ -2437,7 +2437,7 @@
 			<div class="role-description">
 				<p>A <rref>landmark</rref> that is designed to be complementary to the main content at a similar level in the DOM hierarchy, but remaining meaningful when separated from the main content.</p>
 				<p>There are various types of content that would appropriately have this <a>role</a>. For example, in the case of a portal, this may include but not be limited to show times, current weather, related articles, or stocks to watch. The complementary role indicates that contained content is relevant to the main content. If the complementary content is completely separable from the main content, it may be appropriate to use a more general role.</p>
-				<p>User agents SHOULD treat elements with the role of <code>complementary</code> as navigational <a>landmarks</a>.</p>
+				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>complementary</code>. Mainstream <a>user agents</a> SHOULD enable users to quickly navigate to <a>elements</a> that have an implicit role of <code>complementary</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -2592,7 +2592,7 @@
 			<div class="role-description">
 				<p>A <rref>landmark</rref> that contains information about the parent document.</p>
 				<p>Examples of information included in this region of the page are copyrights and links to privacy statements.</p>
-				<p>User agents SHOULD treat elements with the role of <code>contentinfo</code> as navigational <a>landmarks</a>.</p>
+				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>contentinfo</code>. Mainstream <a>user agents</a> SHOULD enable users to quickly navigate to <a>elements</a> that have an implicit role of <code>contentinfo</code>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #banner and #main -->
 				<p>Within any <rref>document</rref> or <rref>application</rref>, the author SHOULD mark no more than one <a>element</a> with the <code>contentinfo</code> role.</p>
 				<p class="note">Because <code>document</code> and <code>application</code> elements can be nested in the <abbr title="Document Object Model">DOM</abbr>, they may have multiple <code>contentinfo</code> elements as <abbr title="Document Object Model">DOM</abbr> descendants, assuming each of those is associated with different document nodes, either by a DOM nesting (e.g., <rref>document</rref> within <rref>document</rref>) or by use of the <pref>aria-owns</pref> attribute.</p>
@@ -3328,7 +3328,7 @@
 				<p>A form may contain a mix of host language form controls, scripted controls, and hyperlinks. Authors are reminded to use native host language semantics to create form controls whenever possible. If the purpose of a form is to submit search criteria, authors SHOULD use the <rref>search</rref> role instead of the generic <code>form</code> role.</p>
 				<p>Authors MUST give each element with role <code>form</code> a brief label that describes the purpose of the form. Authors SHOULD reference a visible label with <pref>aria-labelledby</pref> if a visible label is present. Authors SHOULD include the label inside of a heading whenever possible. The heading MAY be an instance of the standard host language heading element or an instance of an element with role <rref>heading</rref>.</p>
 				<p>If an author uses a script to submit a form based on a user action that would otherwise not trigger an <code>onsubmit</code> event (for example, a form submission triggered by the user changing a form element's value), the author SHOULD provide the user with advance notification of the behavior.</p>
-				<p>User agents SHOULD treat elements with the role of <code>form</code> as navigational <a>landmarks</a>.</p>
+				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>form</code>. Mainstream <a>user agents</a> SHOULD enable users to quickly navigate to <a>elements</a> that have an implicit role of <code>form</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4222,8 +4222,8 @@
 			<div class="role-description">
 				<p>A perceivable <rref>section</rref> containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.</p>
 				 <p>Authors designate the purpose of the content by assigning a role that is a subclass of the landmark role and, when needed, by providing a brief, descriptive label.</p>
-<p>Elements with a role that is a subclass of the landmark role are known as landmark regions or navigational landmark regions.
-<a>Assistive technologies</a> SHOULD enable users to quickly navigate to landmark regions. Mainstream <a>user agents</a> MAY enable users to quickly navigate to landmark regions.</p>
+<p>Elements with a role that is a subclass of the landmark role are known as <a>landmark</a> regions or navigational landmark regions.
+<a>Assistive technologies</a> SHOULD enable users to quickly navigate to landmark regions. Mainstream <a>user agents</a> SHOULD enable users to quickly navigate to <a>elements</a> whose implicit role is a landmark region.</p>
 				<p class="note"><code>landmark</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
 			</div>
 			<table class="role-features">
@@ -4862,8 +4862,8 @@
 			<rdef>main</rdef>
 			<div class="role-description">
 				<p>A <rref>landmark</rref> containing the main content of a document.</p>
-				<p>This marks the content that is directly related to or expands upon the central topic of the document. The <code>main</code> <a>role</a> is a non-obtrusive alternative for "skip to main content" links, where the navigation option to go to the main content (or other <a>landmarks</a>) is provided by the <a>user agent</a> through a dialog or by <a>assistive technologies</a>.</p>
-				<p>User agents SHOULD treat elements with the role of <code>main</code> as navigational landmarks.</p>
+				<p>This marks the content that is directly related to or expands upon the central topic of the document. The <code>main</code> <a>role</a> is a non-obtrusive alternative for "skip to main content" links, where the navigation option to go to the main content (or other <a>landmarks</a>) is provided by the <a>user agent</a> through a keyboard shortcut (or <abbr title="User Interface">UI</abbr> feature such as a side panel or dialog) or by <a>assistive technologies</a>.</p>
+				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>main</code>. Mainstream <a>user agents</a> SHOULD enable users to quickly navigate to <a>elements</a> that have an implicit role of <code>main</code>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #banner and #contentinfo -->
 				<p>Within any <rref>document</rref> or <rref>application</rref>, the author SHOULD mark no more than one <a>element</a> with the <code>main</code> role.</p>
 				<p class="note">Because <code>document</code> and <code>application</code> elements can be nested in the <abbr title="Document Object Model">DOM</abbr>, they may have multiple <code>main</code> elements as <abbr title="Document Object Model">DOM</abbr> descendants, assuming each of those is associated with different document nodes, either by a DOM nesting (e.g., <rref>document</rref> within <rref>document</rref>) or by use of the <pref>aria-owns</pref> attribute.</p>
@@ -5827,7 +5827,7 @@
 			<rdef>navigation</rdef>
 			<div class="role-description">
 				<p>A <rref>landmark</rref> containing a collection of navigational <a>elements</a> (usually links) for navigating the document or related documents.</p>
-				<p>User agents SHOULD treat elements with the role of <code>navigation</code> as navigational <a>landmarks</a>.</p>
+				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>navigation</code>. Mainstream <a>user agents</a> SHOULD enable users to quickly navigate to <a>elements</a> that have an implicit role of <code>navigation</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -6803,9 +6803,9 @@
 			<rdef>region</rdef>
 			<div class="role-description">
 				<p>A <rref>landmark</rref> containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.</p>
-				<p>Authors SHOULD limit use of the region role to sections containing content with a purpose that is not accurately described by one of the other <rref>landmark</rref> roles, such as <rref>main</rref>, <rref>complementary</rref>, or <rref>navigation</rref>.</p>
+				<p>Authors SHOULD limit use of the region role to sections containing content with a purpose that is not accurately described by one of the other <a>landmark roles</a>, such as <rref>main</rref>, <rref>complementary</rref>, or <rref>navigation</rref>.</p>
 				<p>Authors MUST give each element with role region a brief label that describes the purpose of the content in the region. Authors SHOULD reference a visible label with <pref>aria-labelledby</pref> if a visible label is present. Authors SHOULD include the label inside of a heading whenever possible. The heading MAY be an instance of the standard host language heading element or an instance of an element with role <rref>heading</rref>.</p>
-				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role region. Mainstream <a>user agents</a> MAY enable users to quickly navigate to elements with role region.</p>
+				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>region</code>. Mainstream <a>user agents</a> SHOULD enable users to quickly navigate to <a>elements</a> that have an implicit role of <code>region</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -7373,7 +7373,7 @@
 			<div class="role-description">
 				<p>A <rref>landmark</rref> region that contains a collection of items and objects that, as a whole, combine to create a search facility. See related <rref>form</rref> and <rref>searchbox</rref>.</p>
 				<p>A search region may be a mix of host language form controls, scripted controls, and hyperlinks.</p>
-				<p>User agents SHOULD treat elements with the role of <code>search</code> as navigational <a>landmarks</a>.</p>
+				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>search</code>. Mainstream <a>user agents</a> SHOULD enable users to quickly navigate to <a>elements</a> that have an implicit role of <code>search</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -1345,7 +1345,9 @@
 			<div class="role-description">
 				<p>A <rref>landmark</rref> that contains mostly site-oriented content, rather than page-specific content.</p>
 				<p>Site-oriented content typically includes things such as the logo or identity of the site sponsor, and a site-specific search tool. A banner usually appears at the top of the page and typically spans the full width.</p>
-				<p><a>User agents</a> and <a>assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>banner</code>.</p>
+				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>banner</code>.
+  				<a>User agents</a> SHOULD treat elements with role <code>banner</code> as navigational <a>landmarks</a>.
+  				<a>User agents</a> MAY enable users to quickly navigate to elements with role <code>banner</code>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #main and #contentinfo-->
 				<p>Within any <rref>document</rref> or <rref>application</rref>, the author SHOULD mark no more than one <a>element</a> with the <code>banner</code> <a>role</a>.</p>
 				<p class="note">Because <code>document</code> and <code>application</code> elements can be nested in the <abbr title="Document Object Model">DOM</abbr>, they may have multiple <code>banner</code> elements as <abbr title="Document Object Model">DOM</abbr> descendants, assuming each of those is associated with different document nodes, either by a DOM nesting (e.g., <rref>document</rref> within <rref>document</rref>) or by use of the <pref>aria-owns</pref> <a>attribute</a>.</p>
@@ -2437,7 +2439,9 @@
 			<div class="role-description">
 				<p>A <rref>landmark</rref> that is designed to be complementary to the main content at a similar level in the DOM hierarchy, but remaining meaningful when separated from the main content.</p>
 				<p>There are various types of content that would appropriately have this <a>role</a>. For example, in the case of a portal, this may include but not be limited to show times, current weather, related articles, or stocks to watch. The complementary role indicates that contained content is relevant to the main content. If the complementary content is completely separable from the main content, it may be appropriate to use a more general role.</p>
-				<p><a>User agents</a> and <a>assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>complementary</code>.</p>
+				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>complementary</code>.
+  				<a>User agents</a> SHOULD treat elements with role <code>complementary</code> as navigational <a>landmarks</a>.
+  				<a>User agents</a> MAY enable users to quickly navigate to elements with role <code>complementary</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -2592,7 +2596,9 @@
 			<div class="role-description">
 				<p>A <rref>landmark</rref> that contains information about the parent document.</p>
 				<p>Examples of information included in this region of the page are copyrights and links to privacy statements.</p>
-				<p><a>User agents</a> and <a>assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>contentinfo</code>.</p>
+				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>contentinfo</code>.
+  				<a>User agents</a> SHOULD treat elements with role <code>contentinfo</code> as navigational <a>landmarks</a>.
+  				<a>User agents</a> MAY enable users to quickly navigate to elements with role <code>contentinfo</code>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #banner and #main -->
 				<p>Within any <rref>document</rref> or <rref>application</rref>, the author SHOULD mark no more than one <a>element</a> with the <code>contentinfo</code> role.</p>
 				<p class="note">Because <code>document</code> and <code>application</code> elements can be nested in the <abbr title="Document Object Model">DOM</abbr>, they may have multiple <code>contentinfo</code> elements as <abbr title="Document Object Model">DOM</abbr> descendants, assuming each of those is associated with different document nodes, either by a DOM nesting (e.g., <rref>document</rref> within <rref>document</rref>) or by use of the <pref>aria-owns</pref> attribute.</p>
@@ -3328,7 +3334,9 @@
 				<p>A form may contain a mix of host language form controls, scripted controls, and hyperlinks. Authors are reminded to use native host language semantics to create form controls whenever possible. If the purpose of a form is to submit search criteria, authors SHOULD use the <rref>search</rref> role instead of the generic <code>form</code> role.</p>
 				<p>Authors MUST give each element with role <code>form</code> a brief label that describes the purpose of the form. Authors SHOULD reference a visible label with <pref>aria-labelledby</pref> if a visible label is present. Authors SHOULD include the label inside of a heading whenever possible. The heading MAY be an instance of the standard host language heading element or an instance of an element with role <rref>heading</rref>.</p>
 				<p>If an author uses a script to submit a form based on a user action that would otherwise not trigger an <code>onsubmit</code> event (for example, a form submission triggered by the user changing a form element's value), the author SHOULD provide the user with advance notification of the behavior.</p>
-				<p><a>User agents</a> and <a>assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>form</code>.</p>
+				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>form</code>.
+  				<a>User agents</a> SHOULD treat elements with role <code>form</code> as navigational <a>landmarks</a>.
+  				<a>User agents</a> MAY enable users to quickly navigate to elements with role <code>form</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4221,9 +4229,10 @@
 			<rdef>landmark</rdef>
 			<div class="role-description">
 				<p>A perceivable <rref>section</rref> containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.</p>
-				 <p>Authors designate the purpose of the content by assigning a role that is a subclass of the landmark role and, when needed, by providing a brief, descriptive label.</p>
+				<p>Authors designate the purpose of the content by assigning a role that is a subclass of the landmark role and, when needed, by providing a brief, descriptive label.</p>
 <p>Elements with a role that is a subclass of the landmark role are known as <a>landmark</a> regions or navigational landmark regions.
-<a>User agents</a> and <a>assistive technologies</a> SHOULD enable users to quickly navigate to landmark regions.</p>
+				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to landmark regions.
+  				<a>User agents</a> MAY enable users to quickly navigate to landmark regions.</p>
 				<p class="note"><code>landmark</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
 			</div>
 			<table class="role-features">
@@ -4863,7 +4872,9 @@
 			<div class="role-description">
 				<p>A <rref>landmark</rref> containing the main content of a document.</p>
 				<p>This marks the content that is directly related to or expands upon the central topic of the document. The <code>main</code> <a>role</a> is a non-obtrusive alternative for "skip to main content" links, where the navigation option to go to the main content (or other <a>landmarks</a>) is provided by the <a>user agent</a> through a keyboard shortcut (or <abbr title="User Interface">UI</abbr> feature such as a side panel or dialog) or by <a>assistive technologies</a>.</p>
-				<p><a>User agents</a> and <a>assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>main</code>.</p>
+				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>main</code>.
+  				<a>User agents</a> SHOULD treat elements with role <code>main</code> as navigational <a>landmarks</a>.
+  				<a>User agents</a> MAY enable users to quickly navigate to elements with role <code>main</code>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #banner and #contentinfo -->
 				<p>Within any <rref>document</rref> or <rref>application</rref>, the author SHOULD mark no more than one <a>element</a> with the <code>main</code> role.</p>
 				<p class="note">Because <code>document</code> and <code>application</code> elements can be nested in the <abbr title="Document Object Model">DOM</abbr>, they may have multiple <code>main</code> elements as <abbr title="Document Object Model">DOM</abbr> descendants, assuming each of those is associated with different document nodes, either by a DOM nesting (e.g., <rref>document</rref> within <rref>document</rref>) or by use of the <pref>aria-owns</pref> attribute.</p>
@@ -5827,7 +5838,9 @@
 			<rdef>navigation</rdef>
 			<div class="role-description">
 				<p>A <rref>landmark</rref> containing a collection of navigational <a>elements</a> (usually links) for navigating the document or related documents.</p>
-				<p><a>User agents</a> and <a>assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>navigation</code>.</p>
+				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>navigation</code>.
+  				<a>User agents</a> SHOULD treat elements with role <code>navigation</code> as navigational <a>landmarks</a>.
+  				<a>User agents</a> MAY enable users to quickly navigate to elements with role <code>navigation</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -6805,7 +6818,9 @@
 				<p>A <rref>landmark</rref> containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.</p>
 				<p>Authors SHOULD limit use of the region role to sections containing content with a purpose that is not accurately described by one of the other <a href="#landmark_roles">landmark roles</a>, such as <rref>main</rref>, <rref>complementary</rref>, or <rref>navigation</rref>.</p>
 				<p>Authors MUST give each element with role region a brief label that describes the purpose of the content in the region. Authors SHOULD reference a visible label with <pref>aria-labelledby</pref> if a visible label is present. Authors SHOULD include the label inside of a heading whenever possible. The heading MAY be an instance of the standard host language heading element or an instance of an element with role <rref>heading</rref>.</p>
-				<p><a>User agents</a> and <a>assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>region</code>.</p>
+				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>region</code>.
+  				<a>User agents</a> SHOULD treat elements with role <code>region</code> as navigational <a>landmarks</a>.
+  				<a>User agents</a> MAY enable users to quickly navigate to elements with role <code>region</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -7373,7 +7388,9 @@
 			<div class="role-description">
 				<p>A <rref>landmark</rref> region that contains a collection of items and objects that, as a whole, combine to create a search facility. See related <rref>form</rref> and <rref>searchbox</rref>.</p>
 				<p>A search region may be a mix of host language form controls, scripted controls, and hyperlinks.</p>
-				<p><a>User agents</a> and <a>assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>search</code>.</p>
+				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>search</code>.
+  				<a>User agents</a> SHOULD treat elements with role <code>search</code> as navigational <a>landmarks</a>.
+  				<a>User agents</a> MAY enable users to quickly navigate to elements with role <code>search</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -6803,7 +6803,7 @@
 			<rdef>region</rdef>
 			<div class="role-description">
 				<p>A <rref>landmark</rref> containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.</p>
-				<p>Authors SHOULD limit use of the region role to sections containing content with a purpose that is not accurately described by one of the other <a>landmark roles</a>, such as <rref>main</rref>, <rref>complementary</rref>, or <rref>navigation</rref>.</p>
+				<p>Authors SHOULD limit use of the region role to sections containing content with a purpose that is not accurately described by one of the other <a href="#landmark_roles">landmark roles</a>, such as <rref>main</rref>, <rref>complementary</rref>, or <rref>navigation</rref>.</p>
 				<p>Authors MUST give each element with role region a brief label that describes the purpose of the content in the region. Authors SHOULD reference a visible label with <pref>aria-labelledby</pref> if a visible label is present. Authors SHOULD include the label inside of a heading whenever possible. The heading MAY be an instance of the standard host language heading element or an instance of an element with role <rref>heading</rref>.</p>
 				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>region</code>. Mainstream <a>user agents</a> SHOULD enable users to quickly navigate to <a>elements</a> that have an implicit role of <code>region</code>.</p>
 			</div>


### PR DESCRIPTION
Resolves #350.

Issue #350 noted some discrepancies in the normative language across all of the various landmark roles.
This PR ensures that the wording is uniform, including making sure there is a normative statement for both AT and UA.

~I was given permission by the ARIA WG to go part-way (SHOULD instead of MUST) towards my [earlier comment](https://github.com/w3c/aria/issues/350#issue-150943681):~
~> if I could, I'd spec it so that user agents MUST enable users to quickly navigate to landmark roles...~

~So this PR basically uses statements similar to the following for each of the landmark roles:~
~> Assistive technologies SHOULD enable users to quickly navigate to landmarks.~
~> User agents SHOULD enable users to quickly navigate to elements whose implicit role is a landmark.~


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1315.html" title="Last updated on Mar 19, 2021, 5:03 PM UTC (fb093f5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1315/a6bc636...fb093f5.html" title="Last updated on Mar 19, 2021, 5:03 PM UTC (fb093f5)">Diff</a>