### PR TITLE
Editorial: pluralize descendants, clarify not selected

### DIFF
--- a/index.html
+++ b/index.html
@@ -12158,7 +12158,7 @@ button.ariaPressed; // "undefined" (Note: button is no longer a toggle button.)<
 			<pdef>aria-multiselectable</pdef>
 			<div class="property-description">
 				<p>Indicates that the user may select more than one item from the current selectable descendants.</p>
-				<p>Authors SHOULD ensure that selected descendants have the <sref>aria-selected</sref> <a>attribute</a> set to <code>true</code>, and selectable descendant have the <sref>aria-selected</sref> attribute set to <code>false</code>. Authors SHOULD NOT use the <sref>aria-selected</sref> attribute on descendants that are not selectable.</p>
+				<p>Authors SHOULD ensure that selected descendants have the <sref>aria-selected</sref> <a>attribute</a> set to <code>true</code>, and selectable descendants that are not selected have the <sref>aria-selected</sref> attribute set to <code>false</code>. Authors SHOULD NOT use the <sref>aria-selected</sref> attribute on descendants that are not selectable.</p>
 				<p class="note">Lists and trees are examples of roles that might allow users to select more than one item at a time.</p>
 			</div>
 			<table class="property-features">


### PR DESCRIPTION
Noticed a pluralization typo (descendant -> descendants) in https://w3c.github.io/aria/#aria-multiselectable, which led to me thinking that a bit more clarification was needed in order to make it abundantly clear that `aria-selected` should be set to `true` for selected descendants, `false` for unselected descendants, and not used at all for non-selectable descendants. This adds the bit about `false` being for unselected (but selectable) descendants.

(5-word change, if anyone is looking for an easy review...)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1326.html" title="Last updated on Sep 21, 2020, 7:40 PM UTC (d066b93)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1326/02fee23...d066b93.html" title="Last updated on Sep 21, 2020, 7:40 PM UTC (d066b93)">Diff</a>