### PR TITLE
Authors do not need to set aria-selected in single-selection containers…

### DIFF
--- a/index.html
+++ b/index.html
@@ -12943,6 +12943,7 @@ button.ariaPressed; // "undefined" (Note: button is no longer a toggle button.)<
 					<li>Single-selection containers where the currently focused item is not selected. The selection normally follows the focus, and is managed by the <a>user agent</a>.</li>
 					<li>Multiple-selection containers. Authors SHOULD ensure that any selectable descendant of a container in which the <pref>aria-multiselectable</pref> attribute is <code>true</code> specifies a value of either <code>true</code> or <code>false</code> for the <sref>aria-selected</sref> attribute.</li>
 				</ol>
+				<p>Authors SHOULD NOT set <sref>aria-selected</sref> in single-selection containers where selection follows focus.</p>
 				<p>Any explicit assignment of <sref>aria-selected</sref> takes precedence over the implicit selection based on focus. If no <abbr title="Document Object Model">DOM</abbr> element in the widget is explicitly marked as selected, assistive technologies MAY convey implicit selection which follows the keyboard focus of the <a href="#managingfocus">managed focus</a> widget. If any <abbr title="Document Object Model">DOM</abbr> element in the widget is explicitly marked as selected, the user agent MUST NOT convey implicit selection for the widget.</p>
 			</div>
 			<table class="state-features">

--- a/index.html
+++ b/index.html
@@ -12943,7 +12943,7 @@ button.ariaPressed; // "undefined" (Note: button is no longer a toggle button.)<
 					<li>Single-selection containers where the currently focused item is not selected. The selection normally follows the focus, and is managed by the <a>user agent</a>.</li>
 					<li>Multiple-selection containers. Authors SHOULD ensure that any selectable descendant of a container in which the <pref>aria-multiselectable</pref> attribute is <code>true</code> specifies a value of either <code>true</code> or <code>false</code> for the <sref>aria-selected</sref> attribute.</li>
 				</ol>
-				<p>Authors SHOULD NOT set <sref>aria-selected</sref> in single-selection containers where selection follows focus.</p>
+				<p>Authors do not need to set <sref>aria-selected</sref> in single-selection containers where selection follows focus, unless <code>aria-selected="false"</code> is being used on the focused item to indicate that the container does not currently have a selection.</p>
 				<p>Any explicit assignment of <sref>aria-selected</sref> takes precedence over the implicit selection based on focus. If no <abbr title="Document Object Model">DOM</abbr> element in the widget is explicitly marked as selected, assistive technologies MAY convey implicit selection which follows the keyboard focus of the <a href="#managingfocus">managed focus</a> widget. If any <abbr title="Document Object Model">DOM</abbr> element in the widget is explicitly marked as selected, the user agent MUST NOT convey implicit selection for the widget.</p>
 			</div>
 			<table class="state-features">


### PR DESCRIPTION
…where selection follows focus

This change attempts to address one small aspect of https://github.com/w3c/aria/issues/1052


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1327.html" title="Last updated on Sep 21, 2020, 11:08 PM UTC (e456923)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1327/02fee23...e456923.html" title="Last updated on Sep 21, 2020, 11:08 PM UTC (e456923)">Diff</a>