### PR TITLE
make menuitemradio subclass menuitem, require aria-checked

### DIFF
--- a/index.html
+++ b/index.html
@@ -5671,7 +5671,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><rref>menuitem</rref></td>
+						<td class="role-related"><rref>menuitemradio</rref></td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -5757,7 +5757,7 @@
 						<th class="role-parent-head" scope="row">Superclass Role:</th>
 						<td class="role-parent">
 							<ul>
-								<li><rref>menuitemcheckbox</rref></li>
+								<li><rref>menuitem</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -5771,7 +5771,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><rref>menuitem</rref></td>
+						<td class="role-related"><rref>menuitemcheckbox</rref></td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -5786,6 +5786,14 @@
 					<tr>
 						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
 						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties">
+							<ul>
+								<li><sref>aria-checked</sref></li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th scope="row">Supported States and Properties:</th>


### PR DESCRIPTION
Closes #1347.

This PR:
- changes the superclass of menuitemradio to be menuitem (instead of menuitemcheckbox)
- makes aria-checked a required attribute of menuitemradio (was previously inherited from menuitemcheckbox)

Also, because menuitem superclass is now obviously a Related concept:
- changed menuitem to menuitemcheckbox under the Related concepts for menuitemradio
- changed menuitem to menuitemradio under the Related concepts for menuitemcheckbox

@WilcoFiers - would be great if you have a chance to review this. :)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#menuitemradio
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1354.html#menuitemradio" title="Last updated on Nov 20, 2020, 4:14 PM UTC (eba0a09)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1354/fee19ba...eba0a09.html" title="Last updated on Nov 20, 2020, 4:14 PM UTC (eba0a09)">Diff</a>