### PR TITLE
Add section element to fix heading levels

### DIFF
--- a/index.html
+++ b/index.html
@@ -13824,7 +13824,7 @@ el.getAttribute("aria-label"); // Returns "Publish"</pre>
 <section class="appendix" id="changelog">
 	<h2>Change Log</h2>
 	<section>
-		<h2>Substantive changes targetted for the 1.3 release</h2>
+		<h2>Substantive changes targeted for the 1.3 release</h2>
 		<ul>
 			<li>11-Mar-2020: Add <pref>aria-braillelabel</pref></li>
 			<li>13-Feb-2020: Role <rref>suggestion</rref> added</li>
@@ -13835,6 +13835,8 @@ el.getAttribute("aria-label"); // Returns "Publish"</pre>
 			<li>14-Oct-2019: Add <pref>aria-brailleroledescription</pref></li>
 
 		</ul>
+	</section>
+	<section>
 		<h2>Substantive changes since the last public working draft</h2>
 		<ul>
 			<!-- EdNote: After each WD publish, move contents of this list into the next one below. -->


### PR DESCRIPTION
The ARIA 1.3 [Change Log section (Appendix B)](https://w3c.github.io/aria/#changelog) has 3 subsections, but the 2nd subsection is missing its `<section>` wrapper, and as a result, some of the ReSpec magic is not happening correctly, namely:
- section B.2, "Substantive changes since the last public working draft", is missing from the Table of Contents
- the permalink (paragraph symbol §) for section B.2 has the wrong id
- the h2 in the source is not getting converted into an h3 (which results in multiple levels of h2)

This PR simply adds `</section><section>` to delineate section B.2 from B.1.
Also, fixes [spelling of targeted](https://english.stackexchange.com/questions/205815/is-targetted-a-standard-british-english-spelling) in the heading for section B.1.

(No associated issue).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#changelog
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1356.html#changelog" title="Last updated on Dec 2, 2020, 9:46 PM UTC (27d3865)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1356/fee19ba...27d3865.html" title="Last updated on Dec 2, 2020, 9:46 PM UTC (27d3865)">Diff</a>