### PR TITLE
Tighten up Required Context Role: group

### DIFF
--- a/index.html
+++ b/index.html
@@ -9937,7 +9937,7 @@
 						<td class="role-scope">
 							<ul>
 								<li><rref>tree</rref></li>
-								<li><rref>tree</rref> <abbr title="containing" class="symbol">→</abbr> <rref>group</rref></li>
+								<li><rref>treeitem</rref> <abbr title="containing" class="symbol">→</abbr> <rref>group</rref></li>
 							</ul>
 						</td>
 					</tr>

--- a/index.html
+++ b/index.html
@@ -7006,9 +7006,11 @@
 						<td class="role-scope">
 							<ul>
 								<li><rref>grid</rref></li>
-								<li><rref>rowgroup</rref></li>
 								<li><rref>table</rref></li>
 								<li><rref>treegrid</rref></li>
+								<li><rref>grid</rref> <abbr title="containing" class="symbol">→</abbr> <rref>rowgroup</rref></li>
+								<li><rref>table</rref> <abbr title="containing" class="symbol">→</abbr> <rref>rowgroup</rref></li>
+								<li><rref>treegrid</rref> <abbr title="containing" class="symbol">→</abbr> <rref>rowgroup</rref></li>
 							</ul>
 						</td>
 					</tr>

--- a/index.html
+++ b/index.html
@@ -5577,8 +5577,8 @@
 							<ul>
 								<li><rref>menu</rref></li>
 								<li><rref>menubar</rref></li>
-								<li><rref>menu</rref> <abbr title="containing" class="symbol">→</abbr> <rref>group</rref></li>
-								<li><rref>menubar</rref> <abbr title="containing" class="symbol">→</abbr> <rref>group</rref></li>
+								<li><rref>group</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>menu</rref></li>
+								<li><rref>group</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>menubar</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -5680,8 +5680,8 @@
 							<ul>
 								<li><rref>menu</rref></li>
 								<li><rref>menubar</rref></li>
-								<li><rref>menu</rref> <abbr title="containing" class="symbol">→</abbr> <rref>group</rref></li>
-								<li><rref>menubar</rref> <abbr title="containing" class="symbol">→</abbr> <rref>group</rref></li>
+								<li><rref>group</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>menu</rref></li>
+								<li><rref>group</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>menubar</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -5781,8 +5781,8 @@
 							<ul>
 								<li><rref>menu</rref></li>
 								<li><rref>menubar</rref></li>
-								<li><rref>menu</rref> <abbr title="containing" class="symbol">→</abbr> <rref>group</rref></li>
-								<li><rref>menubar</rref> <abbr title="containing" class="symbol">→</abbr> <rref>group</rref></li>
+								<li><rref>group</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>menu</rref></li>
+								<li><rref>group</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>menubar</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -6034,7 +6034,7 @@
 						<td class="role-scope">
 							<ul>
 								<li><rref>listbox</rref></li>
-								<li><rref>listbox</rref> <abbr title="containing" class="symbol">→</abbr> <rref>group</rref></li>
+								<li><rref>group</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>listbox</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -7008,9 +7008,9 @@
 								<li><rref>grid</rref></li>
 								<li><rref>table</rref></li>
 								<li><rref>treegrid</rref></li>
-								<li><rref>grid</rref> <abbr title="containing" class="symbol">→</abbr> <rref>rowgroup</rref></li>
-								<li><rref>table</rref> <abbr title="containing" class="symbol">→</abbr> <rref>rowgroup</rref></li>
-								<li><rref>treegrid</rref> <abbr title="containing" class="symbol">→</abbr> <rref>rowgroup</rref></li>
+								<li><rref>rowgroup</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>grid</rref></li>
+								<li><rref>rowgroup</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>table</rref></li>
+								<li><rref>rowgroup</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>treegrid</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -9939,7 +9939,7 @@
 						<td class="role-scope">
 							<ul>
 								<li><rref>tree</rref></li>
-								<li><rref>treeitem</rref> <abbr title="containing" class="symbol">→</abbr> <rref>group</rref></li>
+								<li><rref>group</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>treeitem</rref></li>
 							</ul>
 						</td>
 					</tr>

--- a/index.html
+++ b/index.html
@@ -5575,9 +5575,10 @@
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
 						<td class="role-scope">
 							<ul>
-								<li><rref>group</rref></li>
 								<li><rref>menu</rref></li>
 								<li><rref>menubar</rref></li>
+								<li><rref>menu</rref> <abbr title="containing" class="symbol">→</abbr> <rref>group</rref></li>
+								<li><rref>menubar</rref> <abbr title="containing" class="symbol">→</abbr> <rref>group</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -5677,9 +5678,10 @@
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
 						<td class="role-scope">
 							<ul>
-								<li><rref>group</rref></li>
 								<li><rref>menu</rref></li>
 								<li><rref>menubar</rref></li>
+								<li><rref>menu</rref> <abbr title="containing" class="symbol">→</abbr> <rref>group</rref></li>
+								<li><rref>menubar</rref> <abbr title="containing" class="symbol">→</abbr> <rref>group</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -5777,9 +5779,10 @@
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
 						<td class="role-scope">
 							<ul>
-								<li><rref>group</rref></li>
 								<li><rref>menu</rref></li>
 								<li><rref>menubar</rref></li>
+								<li><rref>menu</rref> <abbr title="containing" class="symbol">→</abbr> <rref>group</rref></li>
+								<li><rref>menubar</rref> <abbr title="containing" class="symbol">→</abbr> <rref>group</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -6030,8 +6033,8 @@
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
 						<td class="role-scope">
 							<ul>
-								<li><rref>group</rref></li>
 								<li><rref>listbox</rref></li>
+								<li><rref>listbox</rref> <abbr title="containing" class="symbol">→</abbr> <rref>group</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -9933,8 +9936,8 @@
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
 						<td class="role-scope">
 							<ul>
-								<li><rref>group</rref></li>
 								<li><rref>tree</rref></li>
+								<li><rref>tree</rref> <abbr title="containing" class="symbol">→</abbr> <rref>group</rref></li>
 							</ul>
 						</td>
 					</tr>


### PR DESCRIPTION
The group role can only be a required context role if the group is contained in the primary context role.

So:
- `option` can only be in a group if the group is in a `listbox`
- `treeitem` can only be in a group if the group is in a `tree`
- `menuitem[checkbox|radio]` can only be in a group if the group is in a `menu` or `menubar`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#option, #treeitem, #menuitem
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1359.html" title="Last updated on Dec 10, 2020, 11:47 PM UTC (6d9bc59)">Preview</a> (<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1359.html#option" title="#option">#option</a>) (<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1359.html#treeitem" title="#treeitem">#treeitem</a>) (<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1359.html#menuitem" title="#menuitem">#menuitem</a>) | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1359/fee19ba...6d9bc59.html" title="Last updated on Dec 10, 2020, 11:47 PM UTC (6d9bc59)">Diff</a>