### PR TITLE
Add role=image as synonym for role=img

### DIFF
--- a/index.html
+++ b/index.html
@@ -3885,7 +3885,7 @@
 			<rdef>image</rdef>
 			<div class="role-description">
 				<p>A container for a collection of <a>elements</a> that form an image. See synonym <rref>img</rref>.</p>
-				<div class="note" id="role-none-note-none">
+				<div class="note" id="role-image-note-image">
 					<h5>Note regarding the ARIA 1.3 <code>image</code> role.</h5>
 					<p>In ARIA 1.3, the working group introduced <code>image</code> as a synonym to the <rref>img</rref> role. This was done to mitigate author confusion and errors due to the role being an outlier compared to all other roles, which are complete words or concatenations of complete words.</p>
 					<p>Until implementations include sufficient support for <code>role="image"</code>, web authors are advised to use the <code>img</code> role alone.</p>

--- a/index.html
+++ b/index.html
@@ -3888,7 +3888,7 @@
 				<div class="note" id="role-image-note-image">
 					<h5>Note regarding the ARIA 1.3 <code>image</code> role.</h5>
 					<p>In ARIA 1.3, the working group introduced <code>image</code> as a synonym to the <rref>img</rref> role. This was done to mitigate author confusion and errors due to the role being an outlier compared to all other roles, which are complete words or concatenations of complete words.</p>
-					<p>Until implementations include sufficient support for <code>role="image"</code>, web authors are advised to use the <code>img</code> role alone.</p>
+					<p>Until implementations include sufficient support for <code>role="image"</code>, web authors are advised to use both roles as a fallback <code>role="image img"</code> or to use the <code>img</code> role alone.</p>
 				</div>
 			</div>
 		</div>

--- a/index.html
+++ b/index.html
@@ -3895,7 +3895,7 @@
 		<div class="role" id="img">
 			<rdef>img</rdef>
 			<div class="role-description">
-				<p>A container for a collection of <a>elements</a> that form an image.</p>
+				<p>A container for a collection of <a>elements</a> that form an image. See synonym <rref>image</rref>.</p>
 				<p>An <code>img</code> can contain captions and descriptive text, as well as multiple image files that when viewed together give the impression of a single image. An <code>img</code> represents a single graphic within a document, whether or not it is formed by a collection of drawing <a>objects</a>. In order for elements with a <a>role</a> of <code>img</code> to be <a>perceivable</a>, authors MUST provide a label using the <pref>aria-label</pref> or <pref>aria-labelledby</pref> attribute.</p>
 			</div>
 			<table class="role-features">

--- a/index.html
+++ b/index.html
@@ -3881,6 +3881,17 @@
 				</tbody>
 			</table>
 		</div>
+		<div class="role" id="image">
+			<rdef>image</rdef>
+			<div class="role-description">
+				<p>A container for a collection of <a>elements</a> that form an image. See synonym <rref>img</rref>.</p>
+				<div class="note" id="role-none-note-none">
+					<h5>Note regarding the ARIA 1.3 <code>image</code> role.</h5>
+					<p>In ARIA 1.3, the working group introduced <code>image</code> as a synonym to the <rref>img</rref> role. This was done to mitigate author confusion and errors due to the role being an outlier compared to all other roles, which are complete words or concatenations of complete words.</p>
+					<p>Until implementations include sufficient support for <code>role="image"</code>, web authors are advised to use the <code>img</code> role alone.</p>
+				</div>
+			</div>
+		</div>
 		<div class="role" id="img">
 			<rdef>img</rdef>
 			<div class="role-description">

--- a/index.html
+++ b/index.html
@@ -3887,8 +3887,10 @@
 				<p>A container for a collection of <a>elements</a> that form an image. See synonym <rref>img</rref>.</p>
 				<div class="note" id="role-image-note-image">
 					<h5>Note regarding the ARIA 1.3 <code>image</code> role.</h5>
-					<p>In ARIA 1.3, the working group introduced <code>image</code> as a synonym to the <rref>img</rref> role. This was done to mitigate author confusion and errors due to the role being an outlier compared to all other roles, which are complete words or concatenations of complete words.</p>
-					<p>Until implementations include sufficient support for <code>role="image"</code>, web authors are advised to use both roles as a fallback <code>role="image img"</code> or to use the <code>img</code> role alone.</p>
+					<p>The <code>image</code> was added to ARIA in version 1.3 as a
+					synonym of the ARIA 1.0 <rref>img</rref> role. The <code>image</code>
+					role improves syntactic consistency with the names of other roles,
+					which are complete words or concatenations of complete words.</p>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Using `none` as a reference point, created a first draft of the `image` entry into the spec.  

This initial commit only adds the note about why `image` is being added to the new `image` entry.  Once we are happy with this note, we can add it to the `img` section as well... if we think that's necessary (they do show up right next to each other in the spec, after all).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#image, #img
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1370.html" title="Last updated on Apr 12, 2021, 6:56 PM UTC (40403e4)">Preview</a> (<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1370.html#image" title="#image">#image</a>) (<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1370.html#img" title="#img">#img</a>) | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1370/257b0e1...40403e4.html" title="Last updated on Apr 12, 2021, 6:56 PM UTC (40403e4)">Diff</a>