### PR TITLE
Use "containing/contained by" wording instead of arrow abbreviations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ To add a contributor (other than yourself, that's automatic), mark them one per 
 ```
 +@github_username
 ```
-
+ 
 If you added a contributor by mistake, you can remove them in a comment with:
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ To add a contributor (other than yourself, that's automatic), mark them one per 
 ```
 +@github_username
 ```
- 
+
 If you added a contributor by mistake, you can remove them in a comment with:
 
 ```

--- a/index.html
+++ b/index.html
@@ -3570,7 +3570,7 @@
 						<td class="role-mustcontain">
 							<ul>
 								<li><rref>row</rref></li>
-								<li><rref>rowgroup</rref> <abbr title="containing" class="symbol">→</abbr> <rref>row</rref></li>
+								<li><rref>rowgroup</rref> containing <rref>row</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -4636,7 +4636,7 @@
 						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
 						<td class="role-mustcontain">
 							<ul>
-								<li><rref>group</rref> <abbr title="containing" class="symbol">→</abbr> <rref>option</rref></li>
+								<li><rref>group</rref> containing <rref>option</rref></li>
 								<li><rref>option</rref></li>
 							</ul>
 						</td>
@@ -5392,9 +5392,9 @@
 						<td class="role-mustcontain">
 							<ul>
 								<!-- keep in sync with #menubar -->
-								<li><rref>group</rref> <abbr title="containing" class="symbol">→</abbr> <rref>menuitem</rref></li>
-								<li><rref>group</rref> <abbr title="containing" class="symbol">→</abbr> <rref>menuitemradio</rref></li>
-								<li><rref>group</rref> <abbr title="containing" class="symbol">→</abbr> <rref>menuitemcheckbox</rref></li>
+								<li><rref>group</rref> containing <rref>menuitem</rref></li>
+								<li><rref>group</rref> containing <rref>menuitemradio</rref></li>
+								<li><rref>group</rref> containing <rref>menuitemcheckbox</rref></li>
 								<li><rref>menuitem</rref></li>
 								<li><rref>menuitemcheckbox</rref></li>
 								<li><rref>menuitemradio</rref></li>
@@ -5486,9 +5486,9 @@
 						<td class="role-mustcontain">
 							<ul>
 								<!-- keep in sync with #menu -->
-								<li><rref>group</rref> <abbr title="containing" class="symbol">→</abbr> <rref>menuitem</rref></li>
-								<li><rref>group</rref> <abbr title="containing" class="symbol">→</abbr> <rref>menuitemradio</rref></li>
-								<li><rref>group</rref> <abbr title="containing" class="symbol">→</abbr> <rref>menuitemcheckbox</rref></li>
+								<li><rref>group</rref> containing <rref>menuitem</rref></li>
+								<li><rref>group</rref> containing <rref>menuitemradio</rref></li>
+								<li><rref>group</rref> containing <rref>menuitemcheckbox</rref></li>
 								<li><rref>menuitem</rref></li>
 								<li><rref>menuitemcheckbox</rref></li>
 								<li><rref>menuitemradio</rref></li>
@@ -5585,8 +5585,8 @@
 							<ul>
 								<li><rref>menu</rref></li>
 								<li><rref>menubar</rref></li>
-								<li><rref>group</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>menu</rref></li>
-								<li><rref>group</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>menubar</rref></li>
+								<li><rref>group</rref> contained by <rref>menu</rref></li>
+								<li><rref>group</rref> contained by <rref>menubar</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -5688,8 +5688,8 @@
 							<ul>
 								<li><rref>menu</rref></li>
 								<li><rref>menubar</rref></li>
-								<li><rref>group</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>menu</rref></li>
-								<li><rref>group</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>menubar</rref></li>
+								<li><rref>group</rref> contained by <rref>menu</rref></li>
+								<li><rref>group</rref> contained by <rref>menubar</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -5789,8 +5789,8 @@
 							<ul>
 								<li><rref>menu</rref></li>
 								<li><rref>menubar</rref></li>
-								<li><rref>group</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>menu</rref></li>
-								<li><rref>group</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>menubar</rref></li>
+								<li><rref>group</rref> contained by <rref>menu</rref></li>
+								<li><rref>group</rref> contained by <rref>menubar</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -6050,7 +6050,7 @@
 						<td class="role-scope">
 							<ul>
 								<li><rref>listbox</rref></li>
-								<li><rref>group</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>listbox</rref></li>
+								<li><rref>group</rref> contained by <rref>listbox</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -7024,9 +7024,9 @@
 								<li><rref>grid</rref></li>
 								<li><rref>table</rref></li>
 								<li><rref>treegrid</rref></li>
-								<li><rref>rowgroup</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>grid</rref></li>
-								<li><rref>rowgroup</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>table</rref></li>
-								<li><rref>rowgroup</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>treegrid</rref></li>
+								<li><rref>rowgroup</rref> contained by <rref>grid</rref></li>
+								<li><rref>rowgroup</rref> contained by <rref>table</rref></li>
+								<li><rref>rowgroup</rref> contained by <rref>treegrid</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -8861,7 +8861,7 @@
 						<td class="role-mustcontain">
 							<ul>
 								<li><rref>row</rref></li>
-								<li><rref>rowgroup</rref> <abbr title="containing" class="symbol">→</abbr> <rref>row</rref></li>
+								<li><rref>rowgroup</rref> containing <rref>row</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -9775,7 +9775,7 @@
 						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
 						<td class="role-mustcontain">
 							<ul>
-								<li><rref>group</rref> <abbr title="containing" class="symbol">→</abbr> <rref>treeitem</rref></li>
+								<li><rref>group</rref> containing <rref>treeitem</rref></li>
 								<li><rref>treeitem</rref></li>
 							</ul>
 						</td>
@@ -9879,7 +9879,7 @@
 						<td class="role-mustcontain">
 							<ul>
 								<li><rref>row</rref></li>
-								<li><rref>rowgroup</rref> <abbr title="containing" class="symbol">→</abbr> <rref>row</rref></li>
+								<li><rref>rowgroup</rref> containing <rref>row</rref></li>
 							</ul>
 						</td>
 					</tr>
@@ -9964,7 +9964,7 @@
 						<td class="role-scope">
 							<ul>
 								<li><rref>tree</rref></li>
-								<li><rref>group</rref> <abbr title="contained by" class="symbol">←</abbr> <rref>treeitem</rref></li>
+								<li><rref>group</rref> contained by <rref>treeitem</rref></li>
 							</ul>
 						</td>
 					</tr>


### PR DESCRIPTION
Addresses issue #1368 by removing the abbr problem completely and using words instead of arrows.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1375.html" title="Last updated on Mar 4, 2021, 11:59 PM UTC (17f9af8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1375/c803925...17f9af8.html" title="Last updated on Mar 4, 2021, 11:59 PM UTC (17f9af8)">Diff</a>