### PR TITLE
"values" does not need to be uppercase in note

### DIFF
--- a/index.html
+++ b/index.html
@@ -13597,7 +13597,7 @@ button.ariaPressed; // "undefined" (Note: button is no longer a toggle button.)<
 				</tr>
 			</tbody>
 		</table>
-		<p class="note">Implicit Values for non-required states and properties appear in the characteristics table for each role. These are not considered fallback values so are not included here.</p>
+		<p class="note">Implicit values for non-required states and properties appear in the characteristics table for each role. These are not considered fallback values so are not included here.</p>
 	</section>
 </section>
 <section id="idl-interface" class="normative">


### PR DESCRIPTION
Testing local origin/main with this 1-character change.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1399.html" title="Last updated on Feb 9, 2021, 12:06 AM UTC (5c9b56b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1399/e46dc86...5c9b56b.html" title="Last updated on Feb 9, 2021, 12:06 AM UTC (5c9b56b)">Diff</a>