### PR TITLE
Clean up inconsistency in abstract role note

### DIFF
--- a/index.html
+++ b/index.html
@@ -2255,7 +2255,7 @@
 			<rdef>command</rdef>
 			<div class="role-description">
 				<p>A form of widget that performs an action but does not receive input data.</p>
-				<p class="note"><code>command</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
+				<p class="note"><code>command</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -2514,7 +2514,7 @@
 			<div class="role-description">
 				<p>A <a>widget</a> that may contain navigable descendants or <a>owned</a> children.</p>
 				<p>Authors SHOULD ensure that a composite widget exists as a single navigation stop within the larger navigation system of the web page. Once the composite widget has focus, authors SHOULD provide a separate navigation mechanism for users to navigate to <a>elements</a> that are descendants or owned children of the composite element.</p>
-				<p class="note"><code>composite</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
+				<p class="note"><code>composite</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -3972,6 +3972,7 @@
 			<rdef>input</rdef>
 			<div class="role-description">
 				<p>A generic type of <a>widget</a> that allows user input.</p>
+				<p class="note"><code>input</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4232,7 +4233,7 @@
 				 <p>Authors designate the purpose of the content by assigning a role that is a subclass of the landmark role and, when needed, by providing a brief, descriptive label.</p>
 <p>Elements with a role that is a subclass of the landmark role are known as landmark regions or navigational landmark regions.
 <a>Assistive technologies</a> SHOULD enable users to quickly navigate to landmark regions. Mainstream <a>user agents</a> MAY enable users to quickly navigate to landmark regions.</p>
-				<p class="note"><code>landmark</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
+				<p class="note"><code>landmark</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4586,7 +4587,7 @@
 			<rdef>listbox</rdef>
 			<div class="role-description">
 				<p>A <a>widget</a> that allows the user to select one or more items from a list of choices. See related <rref>combobox</rref> and <rref>list</rref>.</p>
-				<p>Items within the list are static and, unlike standard <abbr title="Hypertext Markup Language">HTML</abbr> <code>select</code> <a>elements</a>, may contain images. List boxes contain children whose <a>role</a> is <rref>option</rref> or elements whose <a>role</a> is <rref>group</rref> which in turn contains children whose <a>role</a> is <rref>option</rref>.</p>
+				<p>Items within the list are static and, unlike standard <abbr title="Hypertext Markup Language">HTML</abbr> <code>select</code> <a>elements</a>, may contain images. List boxes contain children whose <a>role</a> is <rref>option</rref> or elements whose <a>role</a> is <rref>group</rref> which in turn contain children whose <a>role</a> is <rref>option</rref>.</p>
 				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of <rref>option</rref> descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
 				<p>Elements with the role <code>listbox</code> have an implicit <pref>aria-orientation</pref> value of <code>vertical</code>.</p>
 			</div>
@@ -6760,7 +6761,7 @@
 			<rdef>range</rdef>
 			<div class="role-description">
 				<p>An element representing a range of values.</p>
-				<p class="note"><code>range</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
+				<p class="note"><code>range</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -6918,7 +6919,7 @@
 			<div class="role-description">
 				<p>The base <a>role</a> from which all other roles inherit.</p>
 				<p>Properties of this role describe the structural and functional purpose of <a>objects</a> that are assigned this role. A role is a concept that can be used to understand and operate instances.</p>
-				<p class="note"><code>roletype</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
+				<p class="note"><code>roletype</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -7561,7 +7562,7 @@
 			<rdef>section</rdef>
 			<div class="role-description">
 				<p>A renderable structural containment unit in a document or application.</p>
-				<p class="note"><code>section</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
+				<p class="note"><code>section</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -7631,7 +7632,7 @@
 			<rdef>sectionhead</rdef>
 			<div class="role-description">
 				<p>A structure that labels or summarizes the topic of its related section.</p>
-				<p class="note"><code>sectionhead</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
+				<p class="note"><code>sectionhead</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -7706,7 +7707,7 @@
 			<rdef>select</rdef>
 			<div class="role-description">
 				<p>A form widget that allows the user to make selections from a set of choices.</p>
-				<p class="note"><code>select</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
+				<p class="note"><code>select</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -8287,7 +8288,7 @@
 			<div class="role-description">
 				<p>A document structural <a>element</a>.</p>
 				<p><a>Roles</a> for document structure support the accessibility of dynamic web content by helping <a>assistive technologies</a> determine active content versus static document content. Structural roles by themselves do not all map to <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a>, but are used to create <a>widget</a> roles or assist content adaptation for assistive technologies.</p>
-				<p class="note"><code>structure</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
+				<p class="note"><code>structure</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -10059,7 +10060,7 @@
 			<div class="role-description">
 				<p>An interactive component of a graphical user interface (<abbr title="Graphical User Interface">GUI</abbr>).</p>
 				<p>Widgets are discrete user interface objects with which the user can interact. Widget <a>roles</a> map to standard features in <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a>. When the user navigates an element assigned any of the non-abstract subclass roles of <code>widget</code>, <a>assistive technologies</a> that typically intercept standard keyboard events SHOULD switch to an application browsing mode, and pass keyboard events through to the web application. The intent is to hint to certain <a>assistive technologies</a> to switch from normal browsing mode into a mode more appropriate for interacting with a web application; some <a>user agents</a> have a browse navigation mode where keys, such as up and down arrows, are used to browse the document, and this native behavior prevents the use of these keys by a web application.</p>
-				<p class="note"><code>widget</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
+				<p class="note"><code>widget</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -10135,7 +10136,7 @@
 				<p>A browser or application window.</p>
 				<p><a>Elements</a> with this <a>role</a> have a window-like behavior in a graphical user interface (<abbr title="Graphical User Interface">GUI</abbr>) context, regardless of whether they are implemented as a native window in the operating system, or merely as a section of the document styled to look like a window.</p>
 				<p class="note">In the description of this role, the term "application" does not refer to the <rref>application</rref> role, which specifies specific assistive technology behaviors.</p>
-				<p class="note"><code>window</code> is an abstract role used for the ontology. Authors should not use this role in content.</p>
+				<p class="note"><code>window</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>


### PR DESCRIPTION
Resolves #1015.

Clean up inconsistency in abstract role note:
- remove text about "should not" from note
- add link to #isAbstract to note
- add note to input role

(also fixes up one pluralization typo in listbox)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1420.html" title="Last updated on Mar 4, 2021, 4:43 PM UTC (ed23808)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1420/8c9d7b6...ed23808.html" title="Last updated on Mar 4, 2021, 4:43 PM UTC (ed23808)">Diff</a>