### PR TITLE
Move abstract roles out of main spec

### DIFF
--- a/common/css/common.css
+++ b/common/css/common.css
@@ -250,5 +250,9 @@ abbr.symbol {
 /* prevent <dt> from butting up against previous <dd> in .termlist (terms.html) */
 .termlist dt {margin-top: 1em;}
 
+.toggle-abstract.hidden {
+	display:none;
+}
+
 
 

--- a/common/script/aria.js
+++ b/common/script/aria.js
@@ -197,8 +197,8 @@ require(["core/pubsubhub"], function( respecEvents ) {
                     dRef.id = "desc-" + title;
                     dRef.setAttribute("role", "definition");
                     container.replaceChild(sp, item);
-                    roleIndex += "<dt" + ( isAbstract ? " class=\"toggle-abstract\"" : "" ) + "><a href=\"#" + pnID + "\" class=\"role-reference\"><code>" + content + "</code>" + ( isAbstract ? " (abstract role) " : "" ) + "</a></dt>\n";
-                    roleIndex += "<dd" + ( isAbstract ? " class=\"toggle-abstract\"" : "" ) + ">" + desc + "</dd>\n";
+                    roleIndex += "<dt" + ( isAbstract ? " class=\"toggle-abstract hidden\"" : "" ) + "><a href=\"#" + pnID + "\" class=\"role-reference\"><code>" + content + "</code>" + ( isAbstract ? " (abstract role) " : "" ) + "</a></dt>\n";
+                    roleIndex += "<dd" + ( isAbstract ? " class=\"toggle-abstract hidden\"" : "" ) + ">" + desc + "</dd>\n";
                     // grab info about this role
                     // do we have a parent class?  if so, put us in that parents list
                     var node = container.querySelectorAll(".role-parent rref");

--- a/common/script/aria.js
+++ b/common/script/aria.js
@@ -197,8 +197,8 @@ require(["core/pubsubhub"], function( respecEvents ) {
                     dRef.id = "desc-" + title;
                     dRef.setAttribute("role", "definition");
                     container.replaceChild(sp, item);
-                    roleIndex += "<dt><a href=\"#" + pnID + "\" class=\"role-reference\"><code>" + content + "</code>" + ( isAbstract ? " (abstract role) " : "" ) + "</a></dt>\n";
-                    roleIndex += "<dd>" + desc + "</dd>\n";
+                    roleIndex += "<dt" + ( isAbstract ? " class=\"toggle-abstract\"" : "" ) + "><a href=\"#" + pnID + "\" class=\"role-reference\"><code>" + content + "</code>" + ( isAbstract ? " (abstract role) " : "" ) + "</a></dt>\n";
+                    roleIndex += "<dd" + ( isAbstract ? " class=\"toggle-abstract\"" : "" ) + ">" + desc + "</dd>\n";
                     // grab info about this role
                     // do we have a parent class?  if so, put us in that parents list
                     var node = container.querySelectorAll(".role-parent rref");
@@ -576,9 +576,35 @@ require(["core/pubsubhub"], function( respecEvents ) {
                     }
                 });
 
+                // remove abstract roles
+
+                $.each(document.querySelectorAll(".role-abstract"), function(i, item) {
+                    var content = $(item).text();
+                    if (content === "True") {
+                        item.closest(".role").classList.add("toggle-abstract");
+                        item.closest(".role").classList.add("hidden");
+                    }
+                });
+                $.each(document.querySelectorAll("#abstract_roles"), function(i, item) {
+                    item.querySelector("ul").classList.add("toggle-abstract");
+                    item.querySelector("p").classList.add("toggle-abstract");
+                    item.querySelector("ul").classList.add("hidden");
+                    item.querySelector("p").classList.add("hidden");                    
+                });    
+                
+                // remove superclass and subclass role sections
+                $.each(document.querySelectorAll(".role-parent, .role-children"), function(i, item) {
+                    item.closest("tr").classList.add("toggle-abstract");
+                    item.closest("tr").classList.add("hidden");
+                });
+
+
+
+
                 updateReferences(document);
 
             }
     });
 
 });
+

--- a/common/terms.html
+++ b/common/terms.html
@@ -63,6 +63,12 @@
     <dd>
       <p>A set of instance <a class="termref" href="#dfn-object">objects</a> that share similar characteristics.</p>
     </dd>
+    <dt><dfn>Composite</dfn></dt>
+    <dd>
+      <p>A <a>widget</a> that may contain navigable descendants or <a>owned</a> children.</p>
+      <p>Authors SHOULD ensure that a composite widget exists as a single navigation stop within the larger navigation system of the web page. Once the composite widget has focus, authors SHOULD provide a separate navigation mechanism for users to navigate to <a>elements</a> that are descendants or owned children of the composite element.</p>
+      <p><code>composite</code> is an <a>abstract role</a> used for the ontology.</p>
+    </dd>    
     <dt><dfn data-lt="deprecated|deprecate|deprecation">Deprecated</dfn></dt>
     <dd>
       <p>A deprecated <a class="termref" href="#dfn-role">role</a>, <a class="termref" href="#dfn-state">state</a>, or <a class="termref" href="#dfn-property">property</a> is one which has been outdated by newer constructs or changed circumstances, and which may be removed in future versions of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> specification. <a class="termref" data-lt="user agent">User agents</a> are encouraged to continue to support items identified as deprecated for backward compatibility. For more information, see <a href="#deprecated" class="specref">Deprecated Requirements</a> in the Conformance section.</p>
@@ -96,6 +102,11 @@
     <dt><dfn data-lt="informative|non-normative">Informative</dfn></dt>
     <dd>
       <p>Content provided for information purposes and not required for conformance. Content required for conformance is referred to as <a>normative</a>.</p>
+    </dd>
+    <dt><dfn>Input</dfn></dt>
+    <dd>
+      <p>A generic type of <a>widget</a> that allows user input.</p>
+      <p class="note"><code>input</code> is an <a>abstract role</a> used for the ontology.</p>
     </dd>
     <dt><dfn>Keyboard Accessible</dfn></dt>
     <dd>
@@ -158,6 +169,11 @@
     <dd>
       <p><a class="termref" data-lt="attribute">Attributes</a> that are essential to the nature of a given <a>object</a>, or that represent a data value associated with the object. A change of a property may significantly impact the meaning or presentation of an object. Certain properties (for example, <pref>aria-multiline</pref>) are less likely to change than <a class="termref" href="#dfn-state">states</a>, but note that the frequency of change difference is not a rule. A few properties, such as <pref>aria-activedescendant</pref>, <pref>aria-valuenow</pref>, and <pref>aria-valuetext</pref> are expected to change often. See <a class="specref" href="#statevsprop">clarification of states versus properties</a>.</p>
     </dd>
+    <dt><dfn>Range</dfn></dt>
+    <dd>
+      <p>An element representing a range of values.</p>
+      <p class="note"><code>range</code> is an <a>abstract role</a> used for the ontology.</p>
+  </dd>    
     <dt><dfn data-lt="relationship|relationships">Relationship</dfn></dt>
     <dd>
       <p>A connection between two distinct things. Relationships may be of various types to indicate which <a>object</a> labels another, controls another, etc.</p>
@@ -170,6 +186,16 @@
     <dd>
       <p> The primary element containing non-metadata content. In many languages, this is  the document element but in <abbr title="Hypertext Markup Language">HTML</abbr>, it is the <code>&lt;body&gt;</code>.</p>
     </dd>
+    <dt><dfn>Section</dfn></dt>
+    <dd>
+      <p>A renderable structural containment unit in a document or application.</p>
+      <p class="note"><code>section</code> is an <a>abstract role</a> used for the ontology.</p>
+    </dd>
+    <dt><dfn>Select</dfn></dt>
+    <dd>
+      <p>A form widget that allows the user to make selections from a set of choices.</p>
+      <p class="note"><code>select</code> is an <a>abstract role</a> used for the ontology.</p>
+    </dd>
     <dt><dfn data-lt="semantics|semantic|semantically">Semantics</dfn></dt>
     <dd>
       <p>The meaning of something as understood by a human, defined in a way that computers can process a representation of an <a>object</a>, such as <a class="termref" data-lt="element">elements</a> and <a class="termref" data-lt="attribute">attributes</a>, and reliably represent the object in a way that various humans will achieve a mutually consistent understanding of the object.</p>
@@ -177,6 +203,12 @@
     <dt><dfn data-lt="state|states">State</dfn></dt>
     <dd>
       <p>A state is a dynamic <a class="termref" href="#dfn-property">property</a> expressing characteristics of an <a>object</a> that may change in response to user action or automated processes. States do not affect the essential nature of the object, but represent data associated with the object or user interaction possibilities. See <a class="specref" href="#statevsprop">clarification of states versus properties</a>.</p>
+    </dd>
+    <dt><dfn>Structure</dfn></dt>
+    <dd>
+      <p>A document structural <a>element</a>.</p>
+      <p><a>Roles</a> for document structure support the accessibility of dynamic web content by helping <a>assistive technologies</a> determine active content versus static document content. Structural roles by themselves do not all map to <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a>, but are used to create <a>widget</a> roles or assist content adaptation for assistive technologies.</p>
+      <p class="note"><code>structure</code> is an <a>abstract role</a> used for the ontology.</p>
     </dd>
     <dt><dfn>Sub-document</dfn></dt>
     <dd>

--- a/common/terms.html
+++ b/common/terms.html
@@ -1,5 +1,11 @@
 <p>While some terms are defined in place, the following definitions are used throughout this document. </p>
 <dl class="termlist">
+  <ul>
+    <dt><dfn data-lt="abstract role">Abstract Roles</dfn></dt>
+      <dd><p>Abstract Roles are used to support the WAI-ARIA Roles Model for the purpose of defining general role concepts.</p>
+      <p>Abstract roles are used for the ontology. Authors MUST NOT use abstract roles in content.</p>
+      <p>As of ARIA 1.3 they are no longer shown in the specification.</p>
+    </dd>
     <dt><dfn data-lt="accessibility api|accessibility apis">Accessibility <abbr title="Application Programming Interface">API</abbr></dfn></dt>
     <dd>
       <p>Operating systems and other platforms provide a set of interfaces that expose information about <a class="termref" data-lt="object">objects</a> and <a class="termref" data-lt="event">events</a> to <a>assistive technologies</a>. Assistive technologies use these interfaces to get information about and interact with those <a class="termref" data-lt="widget">widgets</a>. Examples of accessibility APIs are <a href="https://docs.microsoft.com/en-us/windows/win32/winauto/microsoft-active-accessibility">Microsoft Active Accessibility</a> [[MSAA]], <a href="https://docs.microsoft.com/en-us/windows/win32/winauto/entry-uiauto-win32">Microsoft User Interface Automation</a> [[UI-AUTOMATION]], <abbr title="Microsoft Active Accessibility">MSAA</abbr> with <cite><a href="https://docs.microsoft.com/en-us/windows/win32/winauto/iaccessibleex"><abbr title="User Interface Automation">UIA</abbr> Express</a></cite> [[UIA-EXPRESS]], the

--- a/index.html
+++ b/index.html
@@ -142,6 +142,30 @@
 	};
 </script>
 <script src="common/biblio.js" class="remove"></script>
+<script>
+	function toggleAbstract() {
+		if (document.getElementById("toggle-abstract-btn").textContent == "Show Abstract Roles")
+		{
+			document.getElementById("toggle-abstract-btn").textContent = "Hide Abstract Roles";
+			const sections = document.querySelectorAll('.toggle-abstract');
+			sections.forEach(
+				function(section){
+					section.classList.remove("hidden");
+				});
+	
+		}
+		else
+		{
+			document.getElementById("toggle-abstract-btn").textContent = "Show Abstract Roles";
+			const sections = document.querySelectorAll('.toggle-abstract');
+			sections.forEach(
+				function(section){
+					section.classList.add("hidden");
+				});
+	
+		}
+	}
+</script>
 </head>
 <body>
 <section id="abstract">
@@ -393,11 +417,11 @@
 	<section id="relationshipsconcepts">
 		<h2>Relationships Between Concepts</h2>
 		<p>The Roles Model uses the following relationships to relate <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles to each other and to concepts from other specifications, such as HTML.</p>
-		<section id="superclassrole">
+		<section id="superclassrole" class="toggle-abstract hidden notoc">
 			<h3>Superclass Role</h3>
 			<p>The <a>role</a> that the current subclassed role extends in the Roles Model. This extension causes all the properties and constraints of the superclass role to propagate to the subclass role. Other than well known stable specifications, inheritance may be restricted to items defined inside this specification, so that external items cannot be changed and affect inherited <a>classes</a>.</p>
 		</section>
-		<section id="subclassroles">
+		<section id="subclassroles" class="toggle-abstract hidden notoc">
 			<h3>Subclass Roles</h3>
 			<p>Informative list of <a>roles</a> for which this role is the superclass. This is provided to facilitate reading of the specification but adds no new information.</p>
 		</section>
@@ -416,7 +440,7 @@
 		<h2>Characteristics of Roles</h2>
 		<p>Roles are defined and described by their characteristics. Characteristics define the structural function of a role, such as what a role is, concepts behind it, and what instances the role can or must contain. In the case of <a>widgets</a> this also includes how it interacts with the <a>user agent</a> based on mapping to <abbr title="Hypertext Markup Language">HTML</abbr> forms. States and properties from <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> that are supported by the role are also indicated.</p>
 		<p>Roles define the following characteristics. </p>
-		<section id="isAbstract">
+		<section id="isAbstract" class="toggle-abstract hidden notoc">
 			<h3>Abstract Roles</h3>
 			<dl class="runin">
 					<dt>Values</dt>
@@ -533,17 +557,18 @@
 	<section id="roles_categorization">
 		<h2>Categorization of Roles</h2>
 		<p>To support the current user scenario, this specification categorizes <a>roles</a> that define user interface <a>widgets</a> (sliders, tree controls, etc.) and those that define page structure (sections, navigation, etc.). Note that some assistive technologies provide special modes of interaction for regions marked with role <code>application</code> or <code>document</code>.</p>
-		<p>A visual description of the relationships among roles is available in the <a href="https://www.w3.org/WAI/ARIA/1.2/class-diagram/">ARIA 1.2 Class Diagram</a>.</p>
+		<p>A visual description of the relationships among roles is available in the <a href="https://www.w3.org/WAI/ARIA/1.3/class-diagram/">ARIA 1.3 Class Diagram</a>.</p>
+		<p class="ednote"><a>Abstract Roles</a> are no longer shown in the specification by default. <button aria-pressed="false" onclick="toggleAbstract()" id="toggle-abstract-btn">Show Abstract Roles</button> </p>
 		<p>Roles are categorized as follows:</p>
 		<ol>
-			<li><a href="#abstract_roles">Abstract Roles</a></li>
+			<li class="toggle-abstract hidden"><a href="#abstract_roles">Abstract Roles</a></li>
 			<li><a href="#widget_roles">Widget Roles</a></li>
 			<li><a href="#document_structure_roles">Document Structure Roles</a></li>
 			<li><a href="#landmark_roles">Landmark Roles</a></li>
 			<li><a href="#live_region_roles">Live Region Roles</a></li>
 			<li><a href="#window_roles">Window Roles</a></li>
 		</ol>
-		<section id="abstract_roles">
+		<section id="abstract_roles" class="toggle-abstract hidden notoc">
 			<h3>Abstract Roles</h3>
 			<p>The following <a>roles</a> are used to support the WAI-ARIA Roles Model for the purpose of defining general role concepts.</p>
 			<p>Abstract roles are used for the ontology. Authors MUST NOT use abstract roles in content.</p>
@@ -701,7 +726,7 @@
 	<section id="role_definitions">
 		<h2>Definition of Roles</h2>
 		<p>Below is an alphabetical list of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>roles</a> to be used by authors.</p>
-		<p>Abstract roles are used for the ontology. Authors MUST NOT use abstract roles in content.</p>
+		<p class="toggle-abstract hidden">Abstract roles are used for the ontology. Authors MUST NOT use abstract roles in content.</p>
 		<p id="index_role">Placeholder for compact list of roles</p>
 		<div class="role" id="alert">
 			<rdef>alert</rdef>
@@ -2242,7 +2267,7 @@
 			<rdef>command</rdef>
 			<div class="role-description">
 				<p>A form of widget that performs an action but does not receive input data.</p>
-				<p class="note"><code>command</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
+				<p class="note"><code>command</code> is an <a>abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -2501,7 +2526,7 @@
 			<div class="role-description">
 				<p>A <a>widget</a> that may contain navigable descendants or <a>owned</a> children.</p>
 				<p>Authors SHOULD ensure that a composite widget exists as a single navigation stop within the larger navigation system of the web page. Once the composite widget has focus, authors SHOULD provide a separate navigation mechanism for users to navigate to <a>elements</a> that are descendants or owned children of the composite element.</p>
-				<p class="note"><code>composite</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
+				<p class="note"><code>composite</code> is an <a>abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -3959,7 +3984,7 @@
 			<rdef>input</rdef>
 			<div class="role-description">
 				<p>A generic type of <a>widget</a> that allows user input.</p>
-				<p class="note"><code>input</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
+				<p class="note"><code>input</code> is an <a>abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -6734,7 +6759,7 @@
 			<rdef>range</rdef>
 			<div class="role-description">
 				<p>An element representing a range of values.</p>
-				<p class="note"><code>range</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
+				<p class="note"><code>range</code> is an <a>abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -6892,7 +6917,7 @@
 			<div class="role-description">
 				<p>The base <a>role</a> from which all other roles inherit.</p>
 				<p>Properties of this role describe the structural and functional purpose of <a>objects</a> that are assigned this role. A role is a concept that can be used to understand and operate instances.</p>
-				<p class="note"><code>roletype</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
+				<p class="note"><code>roletype</code> is an <a>abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -7535,7 +7560,7 @@
 			<rdef>section</rdef>
 			<div class="role-description">
 				<p>A renderable structural containment unit in a document or application.</p>
-				<p class="note"><code>section</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
+				<p class="note"><code>section</code> is an <a>abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -7605,7 +7630,7 @@
 			<rdef>sectionhead</rdef>
 			<div class="role-description">
 				<p>A structure that labels or summarizes the topic of its related section.</p>
-				<p class="note"><code>sectionhead</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
+				<p class="note"><code>sectionhead</code> is an <a>abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -7680,7 +7705,7 @@
 			<rdef>select</rdef>
 			<div class="role-description">
 				<p>A form widget that allows the user to make selections from a set of choices.</p>
-				<p class="note"><code>select</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
+				<p class="note"><code>select</code> is an <a>abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -8261,7 +8286,7 @@
 			<div class="role-description">
 				<p>A document structural <a>element</a>.</p>
 				<p><a>Roles</a> for document structure support the accessibility of dynamic web content by helping <a>assistive technologies</a> determine active content versus static document content. Structural roles by themselves do not all map to <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a>, but are used to create <a>widget</a> roles or assist content adaptation for assistive technologies.</p>
-				<p class="note"><code>structure</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
+				<p class="note"><code>structure</code> is an <a>abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -10033,7 +10058,7 @@
 			<div class="role-description">
 				<p>An interactive component of a graphical user interface (<abbr title="Graphical User Interface">GUI</abbr>).</p>
 				<p>Widgets are discrete user interface objects with which the user can interact. Widget <a>roles</a> map to standard features in <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a>. When the user navigates an element assigned any of the non-abstract subclass roles of <code>widget</code>, <a>assistive technologies</a> that typically intercept standard keyboard events SHOULD switch to an application browsing mode, and pass keyboard events through to the web application. The intent is to hint to certain <a>assistive technologies</a> to switch from normal browsing mode into a mode more appropriate for interacting with a web application; some <a>user agents</a> have a browse navigation mode where keys, such as up and down arrows, are used to browse the document, and this native behavior prevents the use of these keys by a web application.</p>
-				<p class="note"><code>widget</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
+				<p class="note"><code>widget</code> is an <a>abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -10109,7 +10134,7 @@
 				<p>A browser or application window.</p>
 				<p><a>Elements</a> with this <a>role</a> have a window-like behavior in a graphical user interface (<abbr title="Graphical User Interface">GUI</abbr>) context, regardless of whether they are implemented as a native window in the operating system, or merely as a section of the document styled to look like a window.</p>
 				<p class="note">In the description of this role, the term "application" does not refer to the <rref>application</rref> role, which specifies specific assistive technology behaviors.</p>
-				<p class="note"><code>window</code> is an <a href="#isAbstract">abstract role</a> used for the ontology.</p>
+				<p class="note"><code>window</code> is an <a>abstract role</a> used for the ontology.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -13447,8 +13472,8 @@ button.ariaPressed; // "undefined" (Note: button is no longer a toggle button.)<
 	<section id="document-handling_author-errors_roles">
 		<h3>Roles</h3>
 		<p>User agents are expected to perform validation of <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a>roles</a>.</p>
-		<p>As stated in the <a href="#role_definitions">Definition of Roles</a> section, it is considered an authoring error to use <a href="#abstract_roles">abstract roles</a> in content. User agents MUST NOT map abstract roles via the standard role mechanism of the accessibility <abbr title="application programming interface">API</abbr>.</p>
-		<p>If the <code>role</code> attribute contains no tokens matching the name of a non-abstract <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role, the user agent MUST treat the element as if no <a>role</a> had been provided. For example, <code>&lt;table&nbsp;role=&quot;foo&quot;&gt;</code> should be exposed in the same way as <code>&lt;table&gt;</code> and <code>&lt;input&nbsp;type=&quot;text&quot;&nbsp;role=&quot;structure&quot;&gt;</code> in the same way as <code>&lt;input&nbsp;type=&quot;text&quot;&gt;</code>.</p>
+		<p>As stated in the <a href="#role_definitions">Definition of Roles</a> section, it is considered an authoring error to use <a>abstract roles</a> in content. User agents MUST NOT map abstract roles via the standard role mechanism of the accessibility <abbr title="application programming interface">API</abbr>.</p>
+		<p>If the <code>role</code> attribute contains no tokens matching the name of a non-abstract <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role, the user agent MUST treat the element as if no <a>role</a> had been provided. For example, <code>&lt;table&#160;role=&quot;foo&quot;&gt;</code> should be exposed in the same way as <code>&lt;table&gt;</code> and <code>&lt;input&#160;type=&quot;text&quot;&#160;role=&quot;structure&quot;&gt;</code> in the same way as <code>&lt;input&#160;type=&quot;text&quot;&gt;</code>.</p>
 	</section>
 	<section id="document-handling_author-errors_states-properties">
 		<h3>States and Properties</h3>
@@ -13981,6 +14006,7 @@ el.getAttribute("aria-label"); // Returns "Publish"</pre>
 		<div data-include="common/acknowledgements/aria-wg-active.html" data-include-replace="true"></div>
 		<div data-include="common/acknowledgements/aria-contributors.html" data-include-replace="true"></div>
 		<div data-include="common/acknowledgements/funders.html" data-include-replace="true"></div>
+		<ul id="gh-contributors"></ul>
 	</section>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -371,7 +371,7 @@
 	    </ul>
 	    <p>User agents that support <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> expand the usage of host language mechanisms such as <code>tabindex</code>, <code>focus</code>, and <code>blur</code> to allow them on all <a>elements</a>. Where the host language supports it, authors MAY add any element such as a <code>div</code>, <code>span</code>, or <code>img</code> to the default tab order by setting <code>tabindex=&quot;0&quot;</code>. In addition, any item with <code>tabindex</code> equal to a negative integer is focusable via script or a mouse click, but is not part of the default tab order. This is supported in both [[HTML]] and [[SVG2]].</p>
 	    <p>
-        Authors MAY use <pref>aria-activedescendant</pref> to inform <a>assistive technologies</a> which descendant of a <rref>widget</rref> element is treated as having keyboard focus in the user interface if the role of the widget element supports <code>aria-activedescendant</code>.
+        Authors MAY use <pref>aria-activedescendant</pref> to inform <a>assistive technologies</a> which descendant of a <a>widget</a> element is treated as having keyboard focus in the user interface if the role of the widget element supports <code>aria-activedescendant</code>.
         This is often a more convenient way of providing keyboard navigation within widgets, such as a <rref>listbox</rref>, where the widget occupies only one stop in the page <kbd>Tab</kbd> sequence and other keys, typically arrow keys, are used to focus elements inside the widget.
       </p>
 	    <p>Typically, the author will use host language <a>semantics</a> to put the widget in the <kbd>Tab</kbd> sequence (e.g., <code>tabindex="0"</code> in <abbr title="Hypertext Markup Language">HTML</abbr>) and <code>aria-activedescendant</code> to point to the ID of the currently active descendant. The author, not the user agent, is responsible for styling the currently active descendant to show it has keyboard focus. The author cannot use <code>:<span class="css-selector">focus</span></code> to style the currently active descendant since the actual focus is on the container.</p>
@@ -904,10 +904,10 @@
 		<div class="role" id="application">
 			<rdef>application</rdef>
 			<div class="role-description">
-				<p>A <rref>structure</rref> containing one or more focusable elements requiring user input, such as keyboard or gesture events, that do not follow a standard interaction pattern supported by a <rref>widget</rref> role.</p>
-				<p>Some <a>user agents</a> and <a>assistive technologies</a> have a browse mode where standard input events, such as up and down arrow key events, are intercepted and used to control a reading cursor. This browse mode behavior prevents elements that do not have a <rref>widget</rref> role from receiving and using such keyboard and gesture events to provide interactive functionality.</p>
-				<p>When there is a need to create an element with an interaction model that is not supported by any of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <rref>widget</rref> roles, authors MAY give that element role <code>application</code>. And, when a user navigates into an element with role <code>application</code>, <a>assistive technologies</a> that intercept standard input events SHOULD switch to a mode that passes most or all standard input events through to the web application.</p>
-				<p>For example, a presentation slide editor uses arrow keys to change the positions of textbox and image elements on the slide. There are not any WAI-ARIA <rref>widget</rref> roles that correspond to such an interaction model so an author could give the slide container role <code>application</code>, an <pref>aria-roledescription</pref> of &quot;Slide Editor&quot;, and use <pref>aria-describedby</pref> to provide instructions.</p>
+				<p>A <a>structure</a> containing one or more focusable elements requiring user input, such as keyboard or gesture events, that do not follow a standard interaction pattern supported by a <a>widget</a> role.</p>
+				<p>Some <a>user agents</a> and <a>assistive technologies</a> have a browse mode where standard input events, such as up and down arrow key events, are intercepted and used to control a reading cursor. This browse mode behavior prevents elements that do not have a <a>widget</a> role from receiving and using such keyboard and gesture events to provide interactive functionality.</p>
+				<p>When there is a need to create an element with an interaction model that is not supported by any of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>widget</a> roles, authors MAY give that element role <code>application</code>. And, when a user navigates into an element with role <code>application</code>, <a>assistive technologies</a> that intercept standard input events SHOULD switch to a mode that passes most or all standard input events through to the web application.</p>
+				<p>For example, a presentation slide editor uses arrow keys to change the positions of textbox and image elements on the slide. There are not any WAI-ARIA <a>widget</a> roles that correspond to such an interaction model so an author could give the slide container role <code>application</code>, an <pref>aria-roledescription</pref> of &quot;Slide Editor&quot;, and use <pref>aria-describedby</pref> to provide instructions.</p>
 				<p> Because only the focusable elements contained in an <code>application</code> element are accessible to users of some assistive technologies, authors MUST use one of the following techniques to ensure all non-decorative static text or image content inside an application is accessible:</p>
 				<ol>
 					<li>Associate the content with a focusable element using <pref>aria-labelledby</pref> or <pref>aria-describedby</pref>.</li>
@@ -1084,7 +1084,7 @@
     <div class="role" id="associationlist">
       <rdef>associationlist</rdef>
       <div class="role-description">
-        <p>A <rref>section</rref> containing <rref>associationlistitemkey</rref> and <rref>associationlistitemvalue</rref> elements.</p>
+        <p>A <a>section</a> containing <rref>associationlistitemkey</rref> and <rref>associationlistitemvalue</rref> elements.</p>
 
         <p>Association lists contain children whose <a>role</a> is <rref>associationlistitemkey</rref> and <rref>associationlistitemvalue</rref> to represent a list of key items each having one or more values.</p>
 
@@ -1355,7 +1355,7 @@
 		<div class="role" id="banner">
 			<rdef>banner</rdef>
 			<div class="role-description">
-				<p>A <rref>landmark</rref> that contains mostly site-oriented content, rather than page-specific content.</p>
+				<p>A <a>landmark</a> that contains mostly site-oriented content, rather than page-specific content.</p>
 				<p>Site-oriented content typically includes things such as the logo or identity of the site sponsor, and a site-specific search tool. A banner usually appears at the top of the page and typically spans the full width.</p>
 				<p>User agents SHOULD treat elements with the role of <code>banner</code> as navigational <a>landmarks</a>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #main and #contentinfo-->
@@ -2106,7 +2106,7 @@
 		<div class="role" id="combobox">
 			<rdef>combobox</rdef>
 			<div class="role-description">
-				<p>An <rref>input</rref> that controls another element, such as a <rref>listbox</rref> or <rref>grid</rref>, that can dynamically pop up to help the user set the value of the <rref>input</rref>.</p>
+				<p>An <a>input</a> that controls another element, such as a <rref>listbox</rref> or <rref>grid</rref>, that can dynamically pop up to help the user set the value of the <a>input</a>.</p>
 				<p class="ednote" title="Major Changes to combobox role in ARIA 1.2">
 					The Guidance for <rref>combobox</rref> has changed significantly in ARIA 1.2 due to problems with implementation of the previous patterns.
 					Authors and developers of User Agents, Assistive Technologies, and Conformance Checkers are advised to review this section carefully to understand the changes.
@@ -2445,7 +2445,7 @@
 		<div class="role" id="complementary">
 			<rdef>complementary</rdef>
 			<div class="role-description">
-				<p>A <rref>landmark</rref> that is designed to be complementary to the main content at a similar level in the DOM hierarchy, but remaining meaningful when separated from the main content.</p>
+				<p>A <a>landmark</a> that is designed to be complementary to the main content at a similar level in the DOM hierarchy, but remaining meaningful when separated from the main content.</p>
 				<p>There are various types of content that would appropriately have this <a>role</a>. For example, in the case of a portal, this may include but not be limited to show times, current weather, related articles, or stocks to watch. The complementary role indicates that contained content is relevant to the main content. If the complementary content is completely separable from the main content, it may be appropriate to use a more general role.</p>
 				<p>User agents SHOULD treat elements with the role of <code>complementary</code> as navigational <a>landmarks</a>.</p>
 			</div>
@@ -2600,7 +2600,7 @@
 		<div class="role" id="contentinfo">
 			<rdef>contentinfo</rdef>
 			<div class="role-description">
-				<p>A <rref>landmark</rref> that contains information about the parent document.</p>
+				<p>A <a>landmark</a> that contains information about the parent document.</p>
 				<p>Examples of information included in this region of the page are copyrights and links to privacy statements.</p>
 				<p>User agents SHOULD treat elements with the role of <code>contentinfo</code> as navigational <a>landmarks</a>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #banner and #main -->
@@ -3011,7 +3011,7 @@
 			<div class="role-description">
 				<p>An <a>element</a> containing content that <a>assistive technology</a> users may want to browse in a reading mode.</p>
 				<p>When <a>user agent</a> focus moves to an element assigned the role of <code>document</code>, <a>assistive technologies</a> having a reading mode for browsing static content MAY switch to that reading mode and intercept standard input events, such as Up or Down arrow keyboard events, to control the reading cursor.</p>
-				<p>Because <a>assistive technologies</a> that have a reading mode default to that mode for all elements except for those with either a <rref>widget</rref> or <rref>application</rref> role, the only circumstance where the <code>document</code> role is useful for changing assistive technology behavior is when the element with role <code>document</code> is a focusable child element of a <rref>widget</rref> or <rref>application</rref>. For example, given an <rref>application</rref> element which contains some static rich text, the author can apply role <code>document</code> to the element containing the text and give it a <code>tabindex</code> of <code>0</code>. When a screen reader user presses the Tab key and places focus on the <code>document</code> element, the user will be able to read the text with the screen reader's reading cursor.</p>
+				<p>Because <a>assistive technologies</a> that have a reading mode default to that mode for all elements except for those with either a <a>widget</a> or <rref>application</rref> role, the only circumstance where the <code>document</code> role is useful for changing assistive technology behavior is when the element with role <code>document</code> is a focusable child element of a <a>widget</a> or <rref>application</rref>. For example, given an <rref>application</rref> element which contains some static rich text, the author can apply role <code>document</code> to the element containing the text and give it a <code>tabindex</code> of <code>0</code>. When a screen reader user presses the Tab key and places focus on the <code>document</code> element, the user will be able to read the text with the screen reader's reading cursor.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -3263,7 +3263,7 @@
 		<div class="role" id="figure">
 			<rdef>figure</rdef>
 			<div class="role-description">
-				<p>A perceivable <rref>section</rref> of content that typically contains a <a>graphical document</a>, images, code snippets, or example text. The parts of a <code>figure</code> MAY be user-navigable.</p>
+				<p>A perceivable <a>section</a> of content that typically contains a <a>graphical document</a>, images, code snippets, or example text. The parts of a <code>figure</code> MAY be user-navigable.</p>
 				<p>Authors SHOULD provide a reference to the <code>figure</code> from the main text, but the <code>figure</code> need not be displayed at the same location as the referencing element. Authors MAY reference text serving as a caption using <pref>aria-describedby</pref>. Authors MAY provide a label using <pref>aria-label</pref> or MAY reference text serving as a label using <pref>aria-labelledby</pref>.</p>
 				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to figures. Mainstream <a>user agents</a> MAY enable users to quickly navigate to figures.</p>
 			</div>
@@ -3344,7 +3344,7 @@
 		<div class="role" id="form">
 			<rdef>form</rdef>
 			<div class="role-description">
-				<p>A <rref>landmark</rref> region that contains a collection of items and objects that, as a whole, combine to create a form. See related <rref>search</rref>.</p>
+				<p>A <a>landmark</a> region that contains a collection of items and objects that, as a whole, combine to create a form. See related <rref>search</rref>.</p>
 				<p>A form may contain a mix of host language form controls, scripted controls, and hyperlinks. Authors are reminded to use native host language semantics to create form controls whenever possible. If the purpose of a form is to submit search criteria, authors SHOULD use the <rref>search</rref> role instead of the generic <code>form</code> role.</p>
 				<p>Authors MUST give each element with role <code>form</code> a brief label that describes the purpose of the form. Authors SHOULD reference a visible label with <pref>aria-labelledby</pref> if a visible label is present. Authors SHOULD include the label inside of a heading whenever possible. The heading MAY be an instance of the standard host language heading element or an instance of an element with role <rref>heading</rref>.</p>
 				<p>If an author uses a script to submit a form based on a user action that would otherwise not trigger an <code>onsubmit</code> event (for example, a form submission triggered by the user changing a form element's value), the author SHOULD provide the user with advance notification of the behavior.</p>
@@ -3515,12 +3515,12 @@
 		<div class="role" id="grid">
 			<rdef>grid</rdef>
 			<div class="role-description">
-				<p>A composite <rref>widget</rref> containing a collection of one or more rows with one or more cells where some or all cells in the grid are focusable by using methods of two-dimensional navigation, such as directional arrow keys.</p>
+				<p>A composite <a>widget</a> containing a collection of one or more rows with one or more cells where some or all cells in the grid are focusable by using methods of two-dimensional navigation, such as directional arrow keys.</p>
 				<p>The <code>grid</code> role does not imply a specific visual, e.g., tabular, presentation. It describes <a>relationships</a> among <a>elements</a>. It may be used for purposes as simple as grouping a collection of checkboxes or navigation links or as complex as creating a full-featured spreadsheet application.</p>
 				<p>The cell elements of a <code>grid</code> have role <rref>gridcell</rref>. Authors MAY designate a cell as a row or column header by using either the <rref>rowheader</rref> or <rref>columnheader</rref> <a>role</a> in lieu of the <rref>gridcell</rref> role. Authors MUST ensure elements with role <rref>gridcell</rref>, <rref>columnheader</rref>, or <rref>rowheader</rref> are <a>owned</a> by elements with role <rref>row</rref>, which are in turn owned by an element with role <rref>rowgroup</rref>, or <code>grid</code>.</p>
 				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants of a <code>grid</code> as described in <a href="#managingfocus">Managing Focus</a>. When a user is navigating the <code>grid</code> content with a keyboard, authors SHOULD set focus as follows:</p>
 				<ul>
-					<li>If a <rref>gridcell</rref> contains a single interactive <rref>widget</rref> that will not consume arrow key presses when it receives focus, such as a <rref>checkbox</rref>, <rref>button</rref>, or <rref>link</rref>, authors MAY set focus on the interactive element contained in that cell. This allows the contained widget to be directly operable.</li>
+					<li>If a <rref>gridcell</rref> contains a single interactive <a>widget</a> that will not consume arrow key presses when it receives focus, such as a <rref>checkbox</rref>, <rref>button</rref>, or <rref>link</rref>, authors MAY set focus on the interactive element contained in that cell. This allows the contained widget to be directly operable.</li>
 					<li>Otherwise, authors SHOULD ensure the element that receives focus is a <rref>gridcell</rref>, <rref>rowheader</rref>, or <rref>columnheader</rref> element.</li>
 				</ul>
 				<p>Authors SHOULD provide a mechanism for changing to an interaction or edit mode that allows users to navigate and interact with content contained inside a focusable cell if that focusable cell contains any of the following:</p>
@@ -4241,7 +4241,7 @@
 		<div class="role" id="landmark">
 			<rdef>landmark</rdef>
 			<div class="role-description">
-				<p>A perceivable <rref>section</rref> containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.</p>
+				<p>A perceivable <a>section</a> containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.</p>
 				 <p>Authors designate the purpose of the content by assigning a role that is a subclass of the landmark role and, when needed, by providing a brief, descriptive label.</p>
 <p>Elements with a role that is a subclass of the landmark role are known as landmark regions or navigational landmark regions.
 <a>Assistive technologies</a> SHOULD enable users to quickly navigate to landmark regions. Mainstream <a>user agents</a> MAY enable users to quickly navigate to landmark regions.</p>
@@ -4515,7 +4515,7 @@
 		<div class="role" id="list">
 			<rdef>list</rdef>
 			<div class="role-description">
-				<p>A <rref>section</rref> containing <rref>listitem</rref> elements. See related <rref>listbox</rref>.</p>
+				<p>A <a>section</a> containing <rref>listitem</rref> elements. See related <rref>listbox</rref>.</p>
 				<p>Lists contain children whose <a>role</a> is <rref>listitem</rref>.</p>
 			</div>
 			<table class="role-features">
@@ -4882,7 +4882,7 @@
 		<div class="role" id="main">
 			<rdef>main</rdef>
 			<div class="role-description">
-				<p>A <rref>landmark</rref> containing the main content of a document.</p>
+				<p>A <a>landmark</a> containing the main content of a document.</p>
 				<p>This marks the content that is directly related to or expands upon the central topic of the document. The <code>main</code> <a>role</a> is a non-obtrusive alternative for "skip to main content" links, where the navigation option to go to the main content (or other <a>landmarks</a>) is provided by the <a>user agent</a> through a dialog or by <a>assistive technologies</a>.</p>
 				<p>User agents SHOULD treat elements with the role of <code>main</code> as navigational landmarks.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #banner and #contentinfo -->
@@ -5861,7 +5861,7 @@
 		<div class="role" id="navigation">
 			<rdef>navigation</rdef>
 			<div class="role-description">
-				<p>A <rref>landmark</rref> containing a collection of navigational <a>elements</a> (usually links) for navigating the document or related documents.</p>
+				<p>A <a>landmark</a> containing a collection of navigational <a>elements</a> (usually links) for navigating the document or related documents.</p>
 				<p>User agents SHOULD treat elements with the role of <code>navigation</code> as navigational <a>landmarks</a>.</p>
 			</div>
 			<table class="role-features">
@@ -6668,7 +6668,7 @@
 			<rdef>radiogroup</rdef>
 			<div class="role-description">
 				<p>A group of <rref>radio</rref> buttons.</p>
-				<p>A <code>radiogroup</code> is a type of <rref>select</rref> list that can only have a single entry checked at any one time. Authors SHOULD enforce that only one radio button in a group can be checked at the same time. When one item in the group is checked, the previously checked item becomes unchecked (its <sref>aria-checked</sref> <a>attribute</a> becomes <code>false</code>).</p>
+				<p>A <code>radiogroup</code> is a type of <a>select</a> list that can only have a single entry checked at any one time. Authors SHOULD enforce that only one radio button in a group can be checked at the same time. When one item in the group is checked, the previously checked item becomes unchecked (its <sref>aria-checked</sref> <a>attribute</a> becomes <code>false</code>).</p>
 				<!-- keep previous sentence synced with menuitemradio, etc. -->
 			</div>
 			<table class="role-features">
@@ -6835,8 +6835,8 @@
 		<div class="role" id="region">
 			<rdef>region</rdef>
 			<div class="role-description">
-				<p>A <rref>landmark</rref> containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.</p>
-				<p>Authors SHOULD limit use of the region role to sections containing content with a purpose that is not accurately described by one of the other <rref>landmark</rref> roles, such as <rref>main</rref>, <rref>complementary</rref>, or <rref>navigation</rref>.</p>
+				<p>A <a>landmark</a> containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.</p>
+				<p>Authors SHOULD limit use of the region role to sections containing content with a purpose that is not accurately described by one of the other <a>landmark</a> roles, such as <rref>main</rref>, <rref>complementary</rref>, or <rref>navigation</rref>.</p>
 				<p>Authors MUST give each element with role region a brief label that describes the purpose of the content in the region. Authors SHOULD reference a visible label with <pref>aria-labelledby</pref> if a visible label is present. Authors SHOULD include the label inside of a heading whenever possible. The heading MAY be an instance of the standard host language heading element or an instance of an element with role <rref>heading</rref>.</p>
 				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role region. Mainstream <a>user agents</a> MAY enable users to quickly navigate to elements with role region.</p>
 			</div>
@@ -7406,7 +7406,7 @@
 		<div class="role" id="search">
 			<rdef>search</rdef>
 			<div class="role-description">
-				<p>A <rref>landmark</rref> region that contains a collection of items and objects that, as a whole, combine to create a search facility. See related <rref>form</rref> and <rref>searchbox</rref>.</p>
+				<p>A <a>landmark</a> region that contains a collection of items and objects that, as a whole, combine to create a search facility. See related <rref>form</rref> and <rref>searchbox</rref>.</p>
 				<p>A search region may be a mix of host language form controls, scripted controls, and hyperlinks.</p>
 				<p>User agents SHOULD treat elements with the role of <code>search</code> as navigational <a>landmarks</a>.</p>
 			</div>
@@ -7780,8 +7780,8 @@
 			<rdef>separator</rdef>
 			<div class="role-description">
 				<p>A divider that separates and distinguishes sections of content or groups of menuitems.</p>
-				<p>There are two types of separators: a static <rref>structure</rref> that provides only a visible boundary and a focusable, interactive <rref>widget</rref> that is also moveable. If a <code>separator</code> is not focusable, it is revealed to <a>assistive technologies</a> as a static structural element. For example, a static <code>separator</code> can be used to help visually divide two groups of menu items in a menu or to provide a horizontal rule between two sections of a page.</p>
-				<p>Authors MAY make a <code>separator</code> focusable to create a <rref>widget</rref> that both provides a visible boundary between two sections of content and enables the user to change the relative size of the sections by changing the position of the <code>separator</code>. A variable <code>separator</code> widget can be moved continuously within a range, whereas a fixed <code>separator</code> widget supports only two discrete positions. Typically, a fixed <code>separator</code> widget is used to toggle one of the sections between expanded and collapsed states.</p>
+				<p>There are two types of separators: a static <a>structure</a> that provides only a visible boundary and a focusable, interactive <a>widget</a> that is also moveable. If a <code>separator</code> is not focusable, it is revealed to <a>assistive technologies</a> as a static structural element. For example, a static <code>separator</code> can be used to help visually divide two groups of menu items in a menu or to provide a horizontal rule between two sections of a page.</p>
+				<p>Authors MAY make a <code>separator</code> focusable to create a <a>widget</a> that both provides a visible boundary between two sections of content and enables the user to change the relative size of the sections by changing the position of the <code>separator</code>. A variable <code>separator</code> widget can be moved continuously within a range, whereas a fixed <code>separator</code> widget supports only two discrete positions. Typically, a fixed <code>separator</code> widget is used to toggle one of the sections between expanded and collapsed states.</p>
 				<p>If the <code>separator</code> is focusable, authors MUST set the value of <pref>aria-valuenow</pref> to a <a href="#valuetype_number">number</a> reflecting the current position of the <code>separator</code> and update that value when it changes. Authors SHOULD also provide the value of <pref>aria-valuemin</pref> if it is not <code>0</code> and the value of <pref>aria-valuemax</pref> if it is not <code>100</code>. If missing or not a number, the implicit values of these attributes are as follows:</p>
 				<ul>
 				    <li>The implicit value of <code>aria-valuemin</code> is <code>0</code>.</li>
@@ -7996,7 +7996,7 @@
 		<div class="role" id="spinbutton">
 			<rdef>spinbutton</rdef>
 			<div class="role-description">
-				<p>A form of <rref>range</rref> that expects the user to select from among discrete choices.</p>
+				<p>A form of <a>range</a> that expects the user to select from among discrete choices.</p>
 				<p>A <code>spinbutton</code> typically allows users to change its displayed value by activating increment and decrement buttons that step through a set of allowed values. Some implementations display the value in an text field that allows editing and typing but typically limits input in ways that help prevent invalid values.</p>
 				<p>Although a <code>spinbutton</code> is similar in appearance to many presentations of <code>select</code>, it is advisable to use <code>spinbutton</code> when working with known ranges (especially in the case of large ranges) as opposed to distinct options. For example, a <code>spinbutton</code> representing a range from 1 to 1,000,000 would provide much better performance than a <code>select</code> <a>widget</a> representing the same values.</p>
 				<p>Authors MAY create a <code>spinbutton</code> with children or owned elements, but MUST limit those elements to a <rref>textbox</rref> and/or two <rref title="button">buttons</rref>. Alternatively, authors MAY apply the <rref>spinbutton</rref> role to a text input and create sibling buttons to support the increment and decrement functions.</p>
@@ -8836,7 +8836,7 @@
 		<div class="role" id="table">
 			<rdef>table</rdef>
 			<div class="role-description">
-				<p>A <rref>section</rref> containing data arranged in rows and columns. See related <rref>grid</rref>.</p>
+				<p>A <a>section</a> containing data arranged in rows and columns. See related <rref>grid</rref>.</p>
 				<p>The <code>table</code> role is intended for tabular containers which are not interactive. If the tabular container maintains a selection state, provides its own two-dimensional navigation, or allows the user to rearrange or otherwise manipulate its contents or the display thereof, authors SHOULD use <rref>grid</rref> or <rref>treegrid</rref> instead.</p>
 				<p>Authors SHOULD prefer the use of the host language's semantics for table whenever possible, such as the <code>&lt;table&gt;</code> element in [[HTML]].</p>
 			</div>
@@ -9751,7 +9751,7 @@
 		<div class="role" id="tree">
 			<rdef>tree</rdef>
 			<div class="role-description">
-				<p>A <rref>widget</rref> that allows the user to select one or more items from a hierarchically organized collection.</p>
+				<p>A <a>widget</a> that allows the user to select one or more items from a hierarchically organized collection.</p>
 				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
 				<p>Elements with the role <code>tree</code> have an implicit <pref>aria-orientation</pref> value of <code>vertical</code>.</p>
 			</div>
@@ -10416,7 +10416,7 @@ button.ariaPressed; // "undefined" (Note: button is no longer a toggle button.)<
 		<div class="property" id="aria-activedescendant">
 			<pdef>aria-activedescendant</pdef>
 			<div class="property-description">
-				<p>Identifies the currently active element when DOM focus is on a <rref>composite</rref> widget, <rref>combobox</rref>, <rref>textbox</rref>, <rref>group</rref>, or <rref>application</rref>.</p>
+				<p>Identifies the currently active element when DOM focus is on a <a>composite</a> widget, <rref>combobox</rref>, <rref>textbox</rref>, <rref>group</rref>, or <rref>application</rref>.</p>
 				<p>The <code>aria-activedescendant</code> property provides an alternative method of managing focus for interactive elements that may contain multiple focusable descendants, such as menus, grids, and toolbars. Instead of moving DOM focus among <a>owned</a> elements, authors MAY set DOM focus on a container <a>element</a> that supports <code>aria-activedescendant</code> and then use <code>aria-activedescendant</code> to refer to the element that is active.</p>
 				<p> Authors MUST ensure that one of the following two sets of conditions is met when setting the value of <code>aria-activedescendant</code> on an element with DOM focus:</p>
 				<ol>
@@ -10646,7 +10646,7 @@ button.ariaPressed; // "undefined" (Note: button is no longer a toggle button.)<
 			<div class="property-description">
 				<p>Defines a human-readable, author-localized abbreviated description for the <a>role</a> of an <a>element</a>, which is intended to be converted into Braille. See related <pref>aria-roledescription</pref>.</p>
 				<p>Some <a>assistive technologies</a>, such as screen readers, present the role of an element as part of the user experience. Such assistive technologies typically localize the name of the role, and they may customize it as well. Users of these assistive technologies depend on the presentation of the role name, such as "region," "button," or "slider," for an understanding of the purpose of the element and, if it is a widget, how to interact with it.</p>
-				<p>The <code>aria-brailleroledescription</code> property gives authors the ability to override how <a>assistive technologies</a> localize and express the name of a role in Braille. Thus inappropriately using <code>aria-brailleroledescription</code> may inhibit users' ability to understand or interact with an element on braille interfaces. Authors SHOULD limit use of <code>aria-brailleroledescription</code> to clarifying the purpose of non-interactive container roles like <rref>group</rref> or <rref>region</rref>, or to providing a <em>more specific</em> description of a <rref>widget</rref> in a braille context.</p>
+				<p>The <code>aria-brailleroledescription</code> property gives authors the ability to override how <a>assistive technologies</a> localize and express the name of a role in Braille. Thus inappropriately using <code>aria-brailleroledescription</code> may inhibit users' ability to understand or interact with an element on braille interfaces. Authors SHOULD limit use of <code>aria-brailleroledescription</code> to clarifying the purpose of non-interactive container roles like <rref>group</rref> or <rref>region</rref>, or to providing a <em>more specific</em> description of a <a>widget</a> in a braille context.</p>
 				<p>Authors MUST NOT use <code>aria-brailleroledescription</code> without providing <code>aria-roledescription</code>. In general, <code>aria-brailleroledescription</code> should only be used in rare cases when a <code>aria-roledescription</code> is excessively verbose when rendered in Braille.</p>
 				<p> When using <code>aria-brailleroledescription</code>, authors SHOULD also ensure that:</p>
 				<ol>
@@ -10712,7 +10712,7 @@ button.ariaPressed; // "undefined" (Note: button is no longer a toggle button.)<
 				<p>The default value of <code>aria-busy</code> is <code>false</code> for all elements. When <code>aria-busy</code> is <code>true</code> for an element, assistive technologies MAY ignore changes to content owned by that element and then process all changes made during the busy period as a single, atomic update when <code>aria-busy</code> becomes <code>false</code>.</p>
 				<p>If it is necessary to make multiple additions, modifications, or removals within a container element that is already either partially or fully rendered, authors MAY set <code>aria-busy</code> to <code>true</code> on the container element before the first change, and then set it to <code>false</code> when the last change is complete. For example, if multiple changes to a <a>live region</a> should be spoken as a single unit of speech, authors MAY set <code>aria-busy</code> to <code>true</code> while the changes are being made and then set it to <code>false</code> when the changes are complete and ready to be spoken.</p>
 				<p>If an element with role <rref>feed</rref> is marked busy, assistive technologies MAY defer rendering changes that occur inside the <code>feed</code> with the exception of user-initiated changes that occur inside the <rref>article</rref> that the user is reading during the busy period.</p>
-				<p>If changes to a rendered <rref>widget</rref> would create a state where the <rref>widget</rref> is missing <a href="#mustContain">required owned elements</a> during script execution, authors MUST set <code>aria-busy</code> to <code>true</code> on the <rref>widget</rref> during the update process. For example, if a rendered tree grid required a set of simultaneous updates to multiple discontiguous branches, an alternative to replacing the complete tree element with a single update would be to mark the tree busy while each of the branches are modified.</p>
+				<p>If changes to a rendered <a>widget</a> would create a state where the <a>widget</a> is missing <a href="#mustContain">required owned elements</a> during script execution, authors MUST set <code>aria-busy</code> to <code>true</code> on the <a>widget</a> during the update process. For example, if a rendered tree grid required a set of simultaneous updates to multiple discontiguous branches, an alternative to replacing the complete tree element with a single update would be to mark the tree busy while each of the branches are modified.</p>
 			</div>
 			<table class="state-features">
 				<caption>Characteristics:</caption>
@@ -12717,7 +12717,7 @@ button.ariaPressed; // "undefined" (Note: button is no longer a toggle button.)<
 			<div class="property-description">
 				<p>Defines a human-readable, author-localized description for the <a>role</a> of an <a>element</a>.</p>
 				<p>Some <a>assistive technologies</a>, such as screen readers, present the role of an element as part of the user experience. Such assistive technologies typically localize the name of the role, and they may customize it as well. Users of these assistive technologies depend on the presentation of the role name, such as "region," "button," or "slider," for an understanding of the purpose of the element and, if it is a widget, how to interact with it.</p>
-				<p>The <code>aria-roledescription</code> property gives authors the ability to override how assistive technologies localize and express the name of a role. Thus inappropriately using <code>aria-roledescription</code> may inhibit users' ability to understand or interact with an element. Authors SHOULD limit use of <code>aria-roledescription</code> to clarifying the purpose of non-interactive container roles like <rref>group</rref> or <rref>region</rref>, or to providing a <em>more specific</em> description of a <rref>widget</rref>.</p>
+				<p>The <code>aria-roledescription</code> property gives authors the ability to override how assistive technologies localize and express the name of a role. Thus inappropriately using <code>aria-roledescription</code> may inhibit users' ability to understand or interact with an element. Authors SHOULD limit use of <code>aria-roledescription</code> to clarifying the purpose of non-interactive container roles like <rref>group</rref> or <rref>region</rref>, or to providing a <em>more specific</em> description of a <a>widget</a>.</p>
 				<p> When using <code>aria-roledescription</code>, authors SHOULD also ensure that:</p>
 				<ol>
 					<li>The element to which <code>aria-roledescription</code> is applied has a valid <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role or has an implicit WAI-ARIA role semantic.</li>
@@ -13010,7 +13010,7 @@ button.ariaPressed; // "undefined" (Note: button is no longer a toggle button.)<
 			<sdef>aria-selected</sdef>
 			<div class="state-description">
 				<p>Indicates the current "selected" <a>state</a> of various <a>widgets</a>. See related <sref>aria-checked</sref> and <sref>aria-pressed</sref>.</p>
-				<p>This <a>attribute</a> is used to indicate which elements within single-selection and multiple-selection <rref>composite</rref> widgets are selected.</p>
+				<p>This <a>attribute</a> is used to indicate which elements within single-selection and multiple-selection <a>composite</a> widgets are selected.</p>
         <p>The <rref>option</rref>, <rref>tab</rref>, and <rref>treeitem</rref> roles permit user agents to provide an implicit value for <sref>aria-selected</sref> when specified conditions are met. User agents MUST NOT provide an implicit value for aria-selected in any other circumstance.</p>
 			</div>
 			<table class="state-features">


### PR DESCRIPTION
Fixes #725
This would need to be split and mostly moved to aria-common. Here as a Proof of concept at the moment

[Preview Link](https://raw.githack.com/w3c/aria/removeAbstract/index.html)
<!--
no preview
-->