### PR TITLE
reorder meter in role listings

### DIFF
--- a/common/script/roleInfo.js
+++ b/common/script/roleInfo.js
@@ -4241,22 +4241,6 @@ var roleInfo = {
     ],
     "localprops": []
   },
-  "meter": {
-    "name": "meter",
-    "fragID": "meter",
-    "parentRoles": [
-      "range"
-    ],
-    "localprops": [
-      {
-        "is": "property",
-        "name": "aria-valuenow",
-        "required": true,
-        "disallowed": false,
-        "deprecated": false
-      }
-    ]
-  },
   "menu": {
     "name": "menu",
     "fragID": "menu",
@@ -4921,6 +4905,22 @@ var roleInfo = {
       {
         "is": "state",
         "name": "aria-checked",
+        "required": true,
+        "disallowed": false,
+        "deprecated": false
+      }
+    ]
+  },
+  "meter": {
+    "name": "meter",
+    "fragID": "meter",
+    "parentRoles": [
+      "range"
+    ],
+    "localprops": [
+      {
+        "is": "property",
+        "name": "aria-valuenow",
         "required": true,
         "disallowed": false,
         "deprecated": false

--- a/index.html
+++ b/index.html
@@ -5449,103 +5449,6 @@
 				</tbody>
 			</table>
 		</div>
-		<div class="role" id="meter">
-			<rdef>meter</rdef>
-			<div class="role-description">
-				<p>An <a>element</a> that represents a scalar measurement within a known range, or a fractional value. See related <rref>progressbar</rref>.</p>
-				<p>Authors MAY set <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> to indicate the minimum and maximum values for the <code>meter</code>. Otherwise, their implicit values follow the same rules as <code>&lt;input[type="range"]&gt;</code> in [[HTML]]:</p>
-				<ul>
-					<li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero).</li>
-					<li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100.</li>
-				</ul>
-				<p>The value of <pref>aria-valuenow</pref> MUST NOT fall below or exceed the computed values of <code>aria-valuemin</code> and <code>aria-valuemax</code>, respectively.</p>
-				<p>Authors SHOULD NOT use the <code>meter</code> role to indicate progress; the <rref>progressbar</rref> role exists to address that need.</p>
-				<p class="note">Presently, there are no <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> properties corresponding to the <code>low</code>, <code>optimum</code>, and <code>high</code> attributes supported on the <code>&lt;meter&gt;</code> element in [[HTML]]. The addition of these properties will be considered for ARIA version 1.3.</p>
-			</div>
-			<table class="role-features">
-				<caption>Characteristics:</caption>
-				<thead>
-					<tr>
-						<th scope="col">Characteristic</th>
-						<th scope="col">Value</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<th class="role-abstract-head" scope="row">Is Abstract:</th>
-						<td class="role-abstract"> </td>
-					</tr>
-					<tr>
-						<th class="role-parent-head" scope="row">Superclass Role:</th>
-						<td class="role-parent"><rref>range</rref></td>
-					</tr>
-					<tr>
-						<th class="role-children-head" scope="row">Subclass Roles:</th>
-						<td class="role-children">Placeholder</td>
-					</tr>
-					<tr>
-						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"> </td>
-					</tr>
-					<tr>
-						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;meter&gt;</code> in [[HTML]]</td>
-					</tr>
-					<tr>
-						<th class="role-scope-head" scope="row">Required Context Role:</th>
-						<td class="role-scope"> </td>
-					</tr>
-					<tr>
-						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
-						<td class="role-mustcontain"> </td>
-					</tr>
-					<tr>
-						<th class="role-required-properties-head">Required States and Properties:</th>
-						<td class="role-required-properties"><pref>aria-valuenow</pref></td>
-					</tr>
-					<tr>
-						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"> </td>
-					</tr>
-					<tr>
-						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
-						<td class="role-inherited">Placeholder</td>
-					</tr>
-					<tr>
-						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">
-							<ul>
-								<li>encapsulation</li>
-								<li>author</li>
-							</ul>
-						</td>
-					</tr>
-					<tr>
-						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-						<td class="role-namerequired">True</td>
-					</tr>
-					<tr>
-						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
-						<td class="role-namerequired-inherited"> </td>
-					</tr>
-					<tr>
-						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
-						<td class="role-childpresentational">True</td>
-					</tr>
-					<tr>
-						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
-						<td class="role-presentational-inherited"> </td>
-					</tr>
-					<tr>
-						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
-						<td class="implicit-values">
-							Default for <pref>aria-valuemin</pref> is <code class="default">0</code>. <br/>
-							Default for <pref>aria-valuemax</pref> is <code class="default">100</code>.
-						</td>
-					</tr>
-				</tbody>
-			</table>
-		</div>
 		<div class="role" id="menu">
 			<rdef>menu</rdef>
 			<div class="role-description">
@@ -6045,6 +5948,103 @@
 					<tr>
 						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
 						<td class="role-presentational-inherited"> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div class="role" id="meter">
+			<rdef>meter</rdef>
+			<div class="role-description">
+				<p>An <a>element</a> that represents a scalar measurement within a known range, or a fractional value. See related <rref>progressbar</rref>.</p>
+				<p>Authors MAY set <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> to indicate the minimum and maximum values for the <code>meter</code>. Otherwise, their implicit values follow the same rules as <code>&lt;input[type="range"]&gt;</code> in [[HTML]]:</p>
+				<ul>
+					<li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero).</li>
+					<li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100.</li>
+				</ul>
+				<p>The value of <pref>aria-valuenow</pref> MUST NOT fall below or exceed the computed values of <code>aria-valuemin</code> and <code>aria-valuemax</code>, respectively.</p>
+				<p>Authors SHOULD NOT use the <code>meter</code> role to indicate progress; the <rref>progressbar</rref> role exists to address that need.</p>
+				<p class="note">Presently, there are no <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> properties corresponding to the <code>low</code>, <code>optimum</code>, and <code>high</code> attributes supported on the <code>&lt;meter&gt;</code> element in [[HTML]]. The addition of these properties will be considered for ARIA version 1.3.</p>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent"><rref>range</rref></td>
+					</tr>
+					<tr>
+						<th class="role-children-head" scope="row">Subclass Roles:</th>
+						<td class="role-children">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"> </td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"><code>&lt;meter&gt;</code> in [[HTML]]</td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Context Role:</th>
+						<td class="role-scope"> </td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"><pref>aria-valuenow</pref></td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">
+							<ul>
+								<li>encapsulation</li>
+								<li>author</li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired">True</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational">True</td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
+						<td class="implicit-values">
+							Default for <pref>aria-valuemin</pref> is <code class="default">0</code>. <br/>
+							Default for <pref>aria-valuemax</pref> is <code class="default">100</code>.
+						</td>
 					</tr>
 				</tbody>
 			</table>


### PR DESCRIPTION
Fixes #1441 

- Update the order of roles in aria.js so that meter falls before navigation
- Move the meter role entry in index.html


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1446.html" title="Last updated on Apr 1, 2021, 7:26 PM UTC (5d3c112)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1446/16dfd46...5d3c112.html" title="Last updated on Apr 1, 2021, 7:26 PM UTC (5d3c112)">Diff</a>