### PR TITLE
removal of redundant content

### DIFF
--- a/index.html
+++ b/index.html
@@ -499,13 +499,7 @@
 			<li>supported <a>states</a> and <a>properties</a> for each role (e.g., a <rref>checkbox</rref> supports being checked via <sref>aria-checked</sref>).</li>
 		</ul>
 		<p>Attaching a role gives <a>assistive technologies</a> information about how to handle each element. When <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> roles override host language semantics, there are no changes in the <abbr title="Document Object Model">DOM</abbr>, only in the <a class="termref">accessibility tree</a>.</p>
-		<p>User agents MUST use the first token in the sequence of tokens in the <code>role</code> <a>attribute</a> value that matches the name of any non-abstract <abbr title="Accessible Internet Application">WAI-ARIA</abbr> <a>role</a>. The following steps will correctly identify the applicable <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role:</p>
-		<ol>
-			<li>Use the rules of the host language to detect that an element has a role attribute and to identify the attribute value string for it.</li>
-			<li>Separate the attribute value string for that attribute into a sequence of whitespace-free substrings by separating on whitespace.</li>
-			<li>Compare the substrings to all the names of the non-abstract <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> roles. Case-sensitivity of the comparison inherits from the case-sensitivity of the host language.</li>
-			<li>Use the first such substring in textual order that matches the name of a non-abstract <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role.</li>
-		</ol>
+		<p>User agents MUST use the first token in the sequence of tokens in the <code>role</code> <a>attribute</a> value that matches the name of any non-abstract <abbr title="Accessible Internet Application">WAI-ARIA</abbr> <a>role</a>. Refer to the section on <a href="#host_general_role">`role` attribute implementation in Host Languages</a> for further details.</p>
 	</section>
 	<section id="introstates">
 		<h2><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> States and Properties</h2>


### PR DESCRIPTION
closes #1236

remove second sentence / steps to correctly identify WAI-ARIA roles from intro to roles section.

add new sentence linking to 8.1 Role Attribute steps for `role` implementation in the host language


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1457.html" title="Last updated on Apr 15, 2021, 7:10 PM UTC (cbe9c63)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1457/16dfd46...cbe9c63.html" title="Last updated on Apr 15, 2021, 7:10 PM UTC (cbe9c63)">Diff</a>