### PR TITLE
Editorial: remove text that links nowhere

### DIFF
--- a/common/terms.html
+++ b/common/terms.html
@@ -150,7 +150,7 @@
     </dd>
     <dt><dfn data-lt="property|properties">Property</dfn></dt>
     <dd>
-      <p><a class="termref" data-lt="attribute">Attributes</a> that are essential to the nature of a given <a>object</a>, or that represent a data value associated with the object. A change of a property may significantly impact the meaning or presentation of an object. Certain properties (for example, <pref>aria-multiline</pref>) are less likely to change than <a class="termref" href="#dfn-state">states</a>, but note that the frequency of change difference is not a rule. A few properties, such as <pref>aria-activedescendant</pref>, <pref>aria-valuenow</pref>, and <pref>aria-valuetext</pref> are expected to change often. See <a class="specref" href="#statevsprop">clarification of states versus properties</a>.</p>
+      <p><a class="termref" data-lt="attribute">Attributes</a> that are essential to the nature of a given <a>object</a>, or that represent a data value associated with the object. A change of a property may significantly impact the meaning or presentation of an object. Certain properties (for example, <pref>aria-multiline</pref>) are less likely to change than <a class="termref" href="#dfn-state">states</a>, but note that the frequency of change difference is not a rule. A few properties, such as <pref>aria-activedescendant</pref>, <pref>aria-valuenow</pref>, and <pref>aria-valuetext</pref> are expected to change often.</p>
     </dd>
     <dt><dfn data-lt="relationship|relationships">Relationship</dfn></dt>
     <dd>
@@ -170,7 +170,7 @@
     </dd>
     <dt><dfn data-lt="state|states">State</dfn></dt>
     <dd>
-      <p>A state is a dynamic <a class="termref" href="#dfn-property">property</a> expressing characteristics of an <a>object</a> that may change in response to user action or automated processes. States do not affect the essential nature of the object, but represent data associated with the object or user interaction possibilities. See <a class="specref" href="#statevsprop">clarification of states versus properties</a>.</p>
+      <p>A state is a dynamic <a class="termref" href="#dfn-property">property</a> expressing characteristics of an <a>object</a> that may change in response to user action or automated processes. States do not affect the essential nature of the object, but represent data associated with the object or user interaction possibilities.</p>
     </dd>
     <dt><dfn>Sub-document</dfn></dt>
     <dd>


### PR DESCRIPTION
Currently,  the `<a class="specref" href="#statevsprop">clarification of states versus properties</a>` doesn't link to anything in terms.html, so the link checker (and ReSpec) is complaining. 