### PR TITLE
Revisions to accessible name required

### DIFF
--- a/index.html
+++ b/index.html
@@ -3254,7 +3254,7 @@
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-						<td class="role-namerequired">False</td>
+						<td class="role-namerequired"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
@@ -3429,7 +3429,7 @@
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-						<td class="role-namerequired">False</td>
+						<td class="role-namerequired"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
@@ -3510,7 +3510,7 @@
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-						<td class="role-namerequired">False</td>
+						<td class="role-namerequired"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
@@ -4491,7 +4491,7 @@
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-						<td class="role-namerequired">False</td>
+						<td class="role-namerequired"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
@@ -7573,7 +7573,7 @@
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-						<td class="role-namerequired">False</td>
+						<td class="role-namerequired"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>

--- a/index.html
+++ b/index.html
@@ -9009,7 +9009,7 @@
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-						<td class="role-namerequired"> </td>
+						<td class="role-namerequired"> True </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
@@ -9928,7 +9928,7 @@
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-						<td class="role-namerequired">True</td>
+						<td class="role-namerequired"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>


### PR DESCRIPTION
closes #1466

* Removes instances of "accessible name required: false" - only when accName is required will this row have a "True" value.
* Requires `tab` have an accessible name.
* Removes requirement that a `tooltip` needs an accessible name.

Note: #1465 is related to this issue and accepting that PR will mark `form` as being marked as requiring an accessible name in sections such as 5.2.8.4 Roles Supporting Name from Author


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1477.html" title="Last updated on May 18, 2021, 11:42 PM UTC (1e0c5ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1477/f6998c7...1e0c5ee.html" title="Last updated on May 18, 2021, 11:42 PM UTC (1e0c5ee)">Diff</a>