### PR TITLE
Remove aria-level from listitem

### DIFF
--- a/index.html
+++ b/index.html
@@ -4974,7 +4974,6 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
-								<li><pref>aria-level</pref></li>
 								<li><pref>aria-posinset</pref></li>
 								<li><pref>aria-setsize</pref></li>
 							</ul>


### PR DESCRIPTION
Creating a draft pull request to log work completed. I'm not sure if there is more that needs to be done, so I wanted to have this reviewed.

- Marked `aria-level` deprecated `true` on roleInfo.js for `listitem` role
- Updated documentation to note that this is deprecated in 1.3


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WilliamTennisNFCU/aria/pull/1484.html" title="Last updated on Jun 11, 2021, 12:07 AM UTC (740202d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1484/f4c6669...WilliamTennisNFCU:740202d.html" title="Last updated on Jun 11, 2021, 12:07 AM UTC (740202d)">Diff</a>