### PR TITLE
clarify wording

### DIFF
--- a/index.html
+++ b/index.html
@@ -13834,7 +13834,7 @@ button.ariaPressed; // "undefined" (Note: button is no longer a toggle button.)<
 		<ul>
 			<li>If an element is focusable, or otherwise interactive, user agents MUST ignore the <code>presentation</code> role and expose the element with its implicit role, in order to ensure that the element is <a>operable</a>.</li>
 			<li>If a <a href="#mustContain">required owned element</a> has an explicit non-presentational role, user agents MUST ignore an inherited presentational role and expose the element with its explicit role. If the action of exposing the explicit role causes the accessibility tree to be malformed, the expected results are undefined.</li>
-			<li>If an element has global WAI-ARIA states or properties, user agents MUST ignore the <code>presentation</code> role and expose the element with its implicit role. However, if an element has only non-global, role-specific WAI-ARIA states or properties, the element MUST NOT be exposed unless the presentational role is inherited and an explicit non-presentational role is applied.</li>
+			<li>If an element has global WAI-ARIA states or properties, user agents MUST ignore the <code>presentation</code> role and instead expose the element's implicit role. However, if an element has only non-global, role-specific WAI-ARIA states or properties, the element MUST NOT be exposed unless the presentational role is inherited and an explicit non-presentational role is applied.</li>
 		</ul>
 		<p>For example, <pref>aria-describedby</pref> is a global attribute and would always be applied; <pref>aria-level</pref> is not a global attribute and would therefore only apply if the element was not in a presentational state.</p>
 		<pre class="example highlight">


### PR DESCRIPTION
closes #1388

UA must ignore the presentation role and re-expose the implict role. NOT expose the element with its implicit role as was interpreted in 1388


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1495.html" title="Last updated on Jun 2, 2021, 2:28 PM UTC (33d3471)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1495/d494e74...33d3471.html" title="Last updated on Jun 2, 2021, 2:28 PM UTC (33d3471)">Diff</a>