### PR TITLE
Do not restrict img naming to aria-label/labelledby

### DIFF
--- a/index.html
+++ b/index.html
@@ -4115,7 +4115,7 @@
 			<rdef>img</rdef>
 			<div class="role-description">
 				<p>A container for a collection of <a>elements</a> that form an image. See synonym <rref>image</rref>.</p>
-				<p>An <code>img</code> can contain captions and descriptive text, as well as multiple image files that when viewed together give the impression of a single image. An <code>img</code> represents a single graphic within a document, whether or not it is formed by a collection of drawing <a>objects</a>. In order for elements with a <a>role</a> of <code>img</code> to be <a>perceivable</a>, authors MUST provide a label using the <pref>aria-label</pref> or <pref>aria-labelledby</pref> attribute.</p>
+				<p>An <code>img</code> can contain captions and descriptive text, as well as multiple image files that when viewed together give the impression of a single image. An <code>img</code> represents a single graphic within a document, whether or not it is formed by a collection of drawing <a>objects</a>. In order for an element with a <a>role</a> of <code>img</code> to be <a>perceivable</a>, authors MUST provide the element with an <a>accessible name</a>. This can be done using the <pref>aria-label</pref> or <pref>aria-labelledby</pref> attribute.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>


### PR DESCRIPTION
rewording of how a _name_ (not necessarily a “label” - so changed that word) can be specified for a `role=img`, so as to not imply that a host language naming mechinism would not be allowed. However, I’m wary of explicitly stating a host language naming mechanism could be used here, as I don’t think it’s necessary to do so in this spec.

closes #1398


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1496.html" title="Last updated on Jun 2, 2021, 2:49 PM UTC (9e7051d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1496/d494e74...9e7051d.html" title="Last updated on Jun 2, 2021, 2:49 PM UTC (9e7051d)">Diff</a>