### PR TITLE
Editorial: remove unnecessary role from example

### DIFF
--- a/index.html
+++ b/index.html
@@ -527,7 +527,7 @@
 [aria-checked=&quot;true&quot;]::before { background-image: url(checked.gif); }</pre>
 		<p>If CSS is not used to toggle the visual representation of the check mark, the author could include additional markup and scripts to manage an image that represents whether or not the <rref>menuitemcheckbox</rref> is checked.</p>
 		<pre class="example highlight">&lt;li role=&quot;menuitemcheckbox&quot; aria-checked=&quot;true&quot;&gt;
-  &lt;img src=&quot;checked.gif&quot; role=&quot;presentation&quot; alt=&quot;&quot;&gt;
+  &lt;img src=&quot;checked.gif&quot; alt=&quot;&quot;&gt;
   <span class="comment">&lt;!-- note: additional scripts required to toggle image source --&gt;</span>
   Sort by Last Modified
 &lt;/li&gt;</pre>


### PR DESCRIPTION
In section 4.2 there is a markup example which contains an `<img>` with both an `alt=“”` and `role=presentation`. The role is unnecessary here so this PR removes it.  I do not want authors to think they need the role when they’ve already set the image to have no alternative text.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1497.html" title="Last updated on Jun 2, 2021, 3:02 PM UTC (f70420e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1497/d494e74...f70420e.html" title="Last updated on Jun 2, 2021, 3:02 PM UTC (f70420e)">Diff</a>