### PR TITLE
Fix accNameURLs -- should be TR/accname-1.2, not TR/accname-aam-1.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,10 +116,10 @@
         },
         accNameURLs: {
           "ED": "https://w3c.github.io/accname/",
-          "WD" : "https://www.w3.org/TR/accname-aam-1.2/",
-          "FPWD": "https://www.w3.org/TR/accname-aam-1.2/",
-          "CR" : "https://www.w3.org/TR/accname-aam-1.2/",
-          "REC": "https://www.w3.org/TR/accname-aam-1.2/"
+          "WD" : "https://www.w3.org/TR/accname-1.2/",
+          "FPWD": "https://www.w3.org/TR/accname-1.2/",
+          "CR" : "https://www.w3.org/TR/accname-1.2/",
+          "REC": "https://www.w3.org/TR/accname-1.2/"
         },
         coreMappingURLs: {
           "ED": "https://w3c.github.io/core-aam/",


### PR DESCRIPTION
This fixes some broken links, like the one in this section (click "Accessible Name and Description Computation"):
https://www.w3.org/TR/2021/CR-wai-aria-1.2-20210302/#textalternativecomputation


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/twilco/aria/pull/1514.html" title="Last updated on Jul 18, 2021, 4:26 PM UTC (9da1bd9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1514/51f2093...twilco:9da1bd9.html" title="Last updated on Jul 18, 2021, 4:26 PM UTC (9da1bd9)">Diff</a>