### PR TITLE
Editorial: give role attr an xref type

### DIFF
--- a/index.html
+++ b/index.html
@@ -10218,7 +10218,7 @@
 				<dd>Unconstrained value type.</dd>
 				<dt id="valuetype_token">token</dt>
 				<dd>One of a limited set of allowed enumerated values. The default value is defined in each attribute's Values table, as specified in the <a href="#enumerated-attribute-values">Enumerated Attribute Values</a> section.</dd>
-				<dt id="valuetype_token_list">token list</dt>
+				<dt id="valuetype_token_list"><dfn>token list</dfn></dt>
 				<dd>A list of one or more tokens.</dd>
 			</dl>
 			<p>These are generic types for states and properties, but do not define specific representation. See <a href="#state_property_processing">State and Property Attribute Processing</a> for details on how these values are expressed and handled in host languages.</p>
@@ -13358,10 +13358,9 @@ button.ariaPressed; // "undefined" (Note: button is no longer a toggle button.)<
 	<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles, states, and properties are implemented as <a>attributes</a> of <a>elements</a>. Roles are applied by placing their names among the tokens appearing in the value of a host-language-provided <code>role</code> attribute. States and properties each get their own attribute, with values as defined for each particular state or property in this specification. The name of the attribute is the aria-prefixed name of the state or property.</p>
 	<section id="host_general_role">
 		<h2>Role Attribute</h2>
-		<p>An implementing host language will provide an <a>attribute</a> with the following characteristics:</p>
+		<p>An implementing host language will provide a <code><dfn id="attr-role" data-dfn-type="element-attr">role</dfn></code> <a>attribute</a> with the following characteristics:</p>
 		<ul>
-			<li>The attribute name MUST be <code>role</code>;</li>
-			<li>The attribute value MUST allow a token list as the value;</li>
+			<li>The attribute value MUST allow a [=token list=] as the value;</li>
 			<li>The appearance of the name literal of any concrete <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>role</a> as one of these tokens MUST NOT in and of itself make the attribute value illegal in the host-language syntax; and</li>
 			<li>The first name literal of a non-abstract <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role in the list of tokens in the role attribute defines the role according to which the user agent MUST process the element. User Agent processing for roles is defined in the <cite><a href="" class="core-mapping">Core Accessibility API Mappings</a></cite> [[CORE-AAM-1.2]].</li>
 		</ul>


### PR DESCRIPTION
Closes #1517

The HTML spec is squatting the definition of "role". The aria spec should own it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1516.html" title="Last updated on Jul 19, 2021, 6:26 AM UTC (d5b6f7e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1516/b41a010...d5b6f7e.html" title="Last updated on Jul 19, 2021, 6:26 AM UTC (d5b6f7e)">Diff</a>