### PR TITLE
added validation test for Authors MUST NOT apply aria-expanded, aria-…

### DIFF
--- a/validator-tests/row-must-not-in-table-grid.html
+++ b/validator-tests/row-must-not-in-table-grid.html
@@ -1,0 +1,44 @@
+<html lang="en-US">
+<head><title>Row  MUST NOT apply aria-expanded, aria-posinset, aria-setsize, and aria-level to a row that descends from a table or grid</title></head>
+<body>
+
+<!--
+URL: https://www.w3.org/TR/wai-aria-1.2/#row
+RULE: "Authors MUST NOT apply aria-expanded, aria-posinset, aria-setsize, and aria-level to a row that descends from a table or grid."
+-->
+
+  <div role="table">
+    <div role="row" class="fail" aria-expanded="false"></div>
+    <div role="row" class="fail" aria-posinset="1"></div>
+    <div role="row" class="fail" aria-setsize="10"></div>
+    <div role="row" class="fail" aria-level="1"></div>
+  </div>
+
+  <div role="table">
+    <div role="rowgroup">
+      <div role="row" class="fail" aria-expanded="true"></div>
+      <div role="row" class="fail" aria-posinset="2"></div>
+      <div role="row" class="fail" aria-setsize="8"></div>
+      <div role="row" class="fail" aria-level="3"></div>
+    </div>
+  </div>
+
+  <div role="grid">
+    <div role="row" class="fail" aria-expanded="false"></div>
+    <div role="row" class="fail" aria-posinset="1"></div>
+    <div role="row" class="fail" aria-setsize="10"></div>
+    <div role="row" class="fail" aria-level="1"></div>
+  </div>
+
+  <div role="grid">
+    <div role="rowgroup">
+      <div role="row" class="fail" aria-expanded="true"></div>
+      <div role="row" class="fail" aria-posinset="2"></div>
+      <div role="row" class="fail" aria-setsize="8"></div>
+      <div role="row" class="fail" aria-level="3"></div>
+    </div>
+  </div>
+
+</body>
+</html>
+

--- a/validator-tests/row-must-not-in-table-grid.html
+++ b/validator-tests/row-must-not-in-table-grid.html
@@ -10,58 +10,57 @@ RULE: "Authors MUST NOT apply aria-expanded, aria-posinset, aria-setsize, and ar
 <!-- Rows that should fail -->
 
   <div role="table">
-    <div role="row" class="fail" aria-expanded="false"></div>
-    <div role="row" class="fail" aria-posinset="1"></div>
-    <div role="row" class="fail" aria-setsize="10"></div>
-    <div role="row" class="fail" aria-level="1"></div>
+    <div id="row11" role="row" class="fail" aria-expanded="false"></div>
+    <div id="row12" role="row" class="fail" aria-posinset="1"></div>
+    <div id="row13" role="row" class="fail" aria-setsize="10"></div>
+    <div id="row14" role="row" class="fail" aria-level="1"></div>
   </div>
 
   <div role="table">
     <div role="rowgroup">
-      <div role="row" class="fail" aria-expanded="true"></div>
-      <div role="row" class="fail" aria-posinset="2"></div>
-      <div role="row" class="fail" aria-setsize="8"></div>
-      <div role="row" class="fail" aria-level="3"></div>
+      <div id="row21" role="row" class="fail" aria-expanded="true"></div>
+      <div id="row22" role="row" class="fail" aria-posinset="2"></div>
+      <div id="row23" role="row" class="fail" aria-setsize="8"></div>
+      <div id="row24" role="row" class="fail" aria-level="3"></div>
     </div>
   </div>
 
   <div role="grid">
-    <div role="row" class="fail" aria-expanded="false"></div>
-    <div role="row" class="fail" aria-posinset="1"></div>
-    <div role="row" class="fail" aria-setsize="10"></div>
-    <div role="row" class="fail" aria-level="1"></div>
+    <div id="row31" role="row" class="fail" aria-expanded="false"></div>
+    <div id="row32" role="row" class="fail" aria-posinset="1"></div>
+    <div id="row33" role="row" class="fail" aria-setsize="10"></div>
+    <div id="row34" role="row" class="fail" aria-level="1"></div>
   </div>
 
   <div role="grid">
     <div role="rowgroup">
-      <div role="row" class="fail" aria-expanded="true"></div>
-      <div role="row" class="fail" aria-posinset="2"></div>
-      <div role="row" class="fail" aria-setsize="8"></div>
-      <div role="row" class="fail" aria-level="3"></div>
+      <div id="row41" role="row" class="fail" aria-expanded="true"></div>
+      <div id="row42" role="row" class="fail" aria-posinset="2"></div>
+      <div id="row43" role="row" class="fail" aria-setsize="8"></div>
+      <div id="row44" role="row" class="fail" aria-level="3"></div>
     </div>
   </div>
 
 <!-- Rows that should pass -->
 
   <div role="treegrid">
-    <div role="row" class="pass" aria-expanded="true"></div>
-    <div role="row" class="pass" aria-expanded="false"></div>
-    <div role="row" class="pass" aria-posinset="4"></div>
-    <div role="row" class="pass" aria-setsize="5"></div>
-    <div role="row" class="pass" aria-level="2"></div>
+    <div id="row51" role="row" class="pass" aria-expanded="true"></div>
+    <div id="row52" role="row" class="pass" aria-expanded="false"></div>
+    <div id="row53" role="row" class="pass" aria-posinset="4"></div>
+    <div id="row54" role="row" class="pass" aria-setsize="5"></div>
+    <div id="row55" role="row" class="pass" aria-level="2"></div>
   </div>
 
 
   <div role="treegrid">
     <div role="rowgroup">
-      <div role="row" class="pass" aria-expanded="true"></div>
-      <div role="row" class="pass" aria-expanded="false"></div>
-      <div role="row" class="pass" aria-posinset="2"></div>
-      <div role="row" class="pass" aria-setsize="8"></div>
-      <div role="row" class="pass" aria-level="3"></div>
+      <div id="row61" role="row" class="pass" aria-expanded="true"></div>
+      <div id="row62" role="row" class="pass" aria-expanded="false"></div>
+      <div id="row63" role="row" class="pass" aria-posinset="2"></div>
+      <div id="row64" role="row" class="pass" aria-setsize="8"></div>
+      <div id="row65" role="row" class="pass" aria-level="3"></div>
     </div>
   </div>
-
 
 </body>
 </html>

--- a/validator-tests/row-must-not-in-table-grid.html
+++ b/validator-tests/row-must-not-in-table-grid.html
@@ -7,6 +7,8 @@ URL: https://www.w3.org/TR/wai-aria-1.2/#row
 RULE: "Authors MUST NOT apply aria-expanded, aria-posinset, aria-setsize, and aria-level to a row that descends from a table or grid."
 -->
 
+<!-- Rows that should fail -->
+
   <div role="table">
     <div role="row" class="fail" aria-expanded="false"></div>
     <div role="row" class="fail" aria-posinset="1"></div>
@@ -38,6 +40,28 @@ RULE: "Authors MUST NOT apply aria-expanded, aria-posinset, aria-setsize, and ar
       <div role="row" class="fail" aria-level="3"></div>
     </div>
   </div>
+
+<!-- Rows that should pass -->
+
+  <div role="treegrid">
+    <div role="row" class="pass" aria-expanded="true"></div>
+    <div role="row" class="pass" aria-expanded="false"></div>
+    <div role="row" class="pass" aria-posinset="4"></div>
+    <div role="row" class="pass" aria-setsize="5"></div>
+    <div role="row" class="pass" aria-level="2"></div>
+  </div>
+
+
+  <div role="treegrid">
+    <div role="rowgroup">
+      <div role="row" class="pass" aria-expanded="true"></div>
+      <div role="row" class="pass" aria-expanded="false"></div>
+      <div role="row" class="pass" aria-posinset="2"></div>
+      <div role="row" class="pass" aria-setsize="8"></div>
+      <div role="row" class="pass" aria-level="3"></div>
+    </div>
+  </div>
+
 
 </body>
 </html>


### PR DESCRIPTION
Validation test for authors MUST NOT apply `aria-expanded`, `aria-posinset`, `aria-setsize`, and `aria-level` to a `row` that descends from a `table` or `grid`.