### PR TITLE
Add validation for children of groups in listbox context

### DIFF
--- a/validator-tests/README.md
+++ b/validator-tests/README.md
@@ -12,6 +12,8 @@ corresponding changes in validators.
 * [Dialog Must Have Name](dialog-must-have-name.html)
   * @axe-core/cli: [Results](dialog-must-have-name-axe.json)
 * [Img Role Must Have Name](img-role-must-have-name.html)
+* [Listbox Group Children Must Be Option](listbox-group-children-must-be-option.html)
+  * @axe-core/cli: [Results](listbox-group-children-must-be-option-axe.json), [bug](https://github.com/dequelabs/axe-core-npm/issues/313)
 * [Menuitemcheckbox Owned By Menu](menuitemcheckbox-owned-by-menu.html)
 * [Menuitem Owned By Menu](menuitem-owned-by-menu.html)
 * [Menuitemradio Owned By Menu](menuitemradio-owned-by-menu.html)
@@ -24,7 +26,6 @@ corresponding changes in validators.
 * [Scrollbar Role Aria Controls](scrollbar-role-aria-controls.html)
 * [Scrollbar Role Aria Valuenow](scrollbar-role-aria-valuenow.html)
 * [Slide Role Aria Valuenow](slider-role-aria-valuenow.html)
-
 
 ## Writing Tests
 

--- a/validator-tests/listbox-group-children-must-be-option-axe.json
+++ b/validator-tests/listbox-group-children-must-be-option-axe.json
@@ -1,0 +1,216 @@
+[
+  {
+    "inapplicable": [],
+    "incomplete": [],
+    "passes": [],
+    "testEngine": {
+      "name": "axe-core",
+      "version": "4.3.2"
+    },
+    "testEnvironment": {
+      "orientationAngle": 0,
+      "orientationType": "landscape-primary",
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/91.0.4472.114 Safari/537.36",
+      "windowHeight": 600,
+      "windowWidth": 800
+    },
+    "testRunner": {
+      "name": "axe"
+    },
+    "timestamp": "2021-08-03T16:39:34.187Z",
+    "toolOptions": {
+      "reporter": "v1",
+      "runOnly": {
+        "type": "rule",
+        "values": [
+          "aria-required-children"
+        ]
+      }
+    },
+    "url": "http://localhost:8000/listbox-group-children-must-be-option.html",
+    "violations": [
+      {
+        "description": "Ensures elements with an ARIA role that require child roles contain them",
+        "help": "Certain ARIA roles must contain particular children",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-required-children?application=webdriverjs",
+        "id": "aria-required-children",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": [
+                  "option"
+                ],
+                "id": "aria-required-children",
+                "impact": "critical",
+                "message": "Required ARIA child role not present: option",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Required ARIA child role not present: option",
+            "html": "<div role=\"listbox\" aria-label=\"foo\">\n    <div role=\"group\" id=\"listbox-group-1\">\n      <div></div>\n    </div>\n  </div>",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "div[role=\"listbox\"][aria-label=\"foo\"]:nth-child(1)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": [
+                  "option"
+                ],
+                "id": "aria-required-children",
+                "impact": "critical",
+                "message": "Required ARIA child role not present: option",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Required ARIA child role not present: option",
+            "html": "<div role=\"listbox\" aria-label=\"foo\">\n    <div role=\"group\" id=\"listbox-group-2\">\n      <div></div>\n      <div role=\"option\" aria-label=\"bar\"></div>\n    </div>\n  </div>",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "div[role=\"listbox\"][aria-label=\"foo\"]:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": [
+                  "option"
+                ],
+                "id": "aria-required-children",
+                "impact": "critical",
+                "message": "Required ARIA child role not present: option",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Required ARIA child role not present: option",
+            "html": "<div role=\"listbox\" aria-label=\"foo\">\n    <div role=\"group\" id=\"listbox-group-3\">\n      <h1></h1>\n    </div>\n  </div>",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "div[role=\"listbox\"][aria-label=\"foo\"]:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": [
+                  "option"
+                ],
+                "id": "aria-required-children",
+                "impact": "critical",
+                "message": "Required ARIA child role not present: option",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Required ARIA child role not present: option",
+            "html": "<div role=\"listbox\" aria-label=\"foo\">\n    <div role=\"group\" id=\"listbox-group-4\">\n      <ul>\n        <li role=\"option\" aria-label=\"bar\"></li>\n      </ul>\n    </div>\n  </div>",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "div[role=\"listbox\"][aria-label=\"foo\"]:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": [
+                  "option"
+                ],
+                "id": "aria-required-children",
+                "impact": "critical",
+                "message": "Required ARIA child role not present: option",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Required ARIA child role not present: option",
+            "html": "<div role=\"listbox\" aria-label=\"foo\">\n    <ul role=\"group\" id=\"listbox-group-5\">\n      <li></li>\n    </ul>\n  </div>",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "div[role=\"listbox\"][aria-label=\"foo\"]:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": [
+                  "option"
+                ],
+                "id": "aria-required-children",
+                "impact": "critical",
+                "message": "Required ARIA child role not present: option",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Required ARIA child role not present: option",
+            "html": "<div role=\"listbox\" aria-label=\"foo\">\n    <div role=\"group\" id=\"listbox-group-6\">\n      <div role=\"option\" aria-label=\"bar\"></div>\n    </div>\n  </div>",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "div[role=\"listbox\"][aria-label=\"foo\"]:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": [
+                  "option"
+                ],
+                "id": "aria-required-children",
+                "impact": "critical",
+                "message": "Required ARIA child role not present: option",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Required ARIA child role not present: option",
+            "html": "<div role=\"listbox\" aria-label=\"foo\">\n    <ul role=\"group\" id=\"listbox-group-7\">\n      <li role=\"option\" aria-label=\"bar\"></li>\n    </ul>\n  </div>",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "div[role=\"listbox\"][aria-label=\"foo\"]:nth-child(7)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": [
+                  "option"
+                ],
+                "id": "aria-required-children",
+                "impact": "critical",
+                "message": "Required ARIA child role not present: option",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Required ARIA child role not present: option",
+            "html": "<ul role=\"listbox\" aria-label=\"foo\">\n    <li>\n      <ul role=\"group\" id=\"listbox-group-8\">\n        <li role=\"option\" aria-label=\"bar\"></li>\n      </ul>\n    </li>\n  </ul>",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "body > ul"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag131"
+        ]
+      }
+    ]
+  }
+]

--- a/validator-tests/listbox-group-children-must-be-option.html
+++ b/validator-tests/listbox-group-children-must-be-option.html
@@ -1,0 +1,68 @@
+<html lang="en-US">
+<head><title>In the context of a listbox, the children of a group element must be option elements.</title></head>
+  <body>
+    <!--
+    URL: https://www.w3.org/TR/wai-aria-1.2/#group
+    RULE: "when a group is used in the context of a listbox, authors MUST limit
+    * its children to option elements."
+    -->
+  </body>
+
+  <!-- Children elements of group that should fail -->
+
+  <div role="listbox" aria-label="foo">
+    <div role="group" id="listbox-group-1">
+      <div></div>
+    </div>
+  </div>
+
+  <div role="listbox" aria-label="foo">
+    <div role="group" id="listbox-group-2">
+      <div></div>
+      <div role="option" aria-label="bar"></div>
+    </div>
+  </div>
+
+  <div role="listbox" aria-label="foo">
+    <div role="group" id="listbox-group-3">
+      <h1></h1>
+    </div>
+  </div>
+
+  <div role="listbox" aria-label="foo">
+    <div role="group" id="listbox-group-4">
+      <ul>
+        <li role="option" aria-label="bar"></li>
+      </ul>
+    </div>
+  </div>
+
+  <div role="listbox" aria-label="foo">
+    <ul role="group" id="listbox-group-5">
+      <li></li>
+    </ul>
+  </div>
+
+  <!-- Children elements of group that should pass -->
+
+  <div role="listbox" aria-label="foo">
+    <div role="group" id="listbox-group-6">
+      <div role="option" aria-label="bar"></div>
+    </div>
+  </div>
+
+  <div role="listbox" aria-label="foo">
+    <ul role="group" id="listbox-group-7">
+      <li role="option" aria-label="bar"></li>
+    </ul>
+  </div>
+
+  <ul role="listbox" aria-label="foo">
+    <li>
+      <ul role="group" id="listbox-group-8">
+        <li role="option" aria-label="bar"></li>
+      </ul>
+    </li>
+  </ul>
+
+</html>

--- a/validator-tests/listbox-group-children-must-be-option.html
+++ b/validator-tests/listbox-group-children-must-be-option.html
@@ -1,68 +1,67 @@
 <html lang="en-US">
 <head><title>In the context of a listbox, the children of a group element must be option elements.</title></head>
-  <body>
-    <!--
-    URL: https://www.w3.org/TR/wai-aria-1.2/#group
-    RULE: "when a group is used in the context of a listbox, authors MUST limit
-    * its children to option elements."
-    -->
-  </body>
+<body>
+  <!--
+  URL: https://www.w3.org/TR/wai-aria-1.2/#group
+  RULE: "when a group is used in the context of a listbox, authors MUST limit
+  * its children to option elements."
+  -->
 
-  <!-- Children elements of group that should fail -->
+<!-- Children elements of group that should fail -->
 
-  <div role="listbox" aria-label="foo">
-    <div role="group" id="listbox-group-1" class="fail">
-      <div></div>
-    </div>
+<div role="listbox" aria-label="foo">
+  <div role="group" id="listbox-group-1" class="fail">
+    <div></div>
   </div>
+</div>
 
-  <div role="listbox" aria-label="foo">
-    <div role="group" id="listbox-group-2" class="fail">
-      <div></div>
-      <div role="option" aria-label="bar"></div>
-    </div>
+<div role="listbox" aria-label="foo">
+  <div role="group" id="listbox-group-2" class="fail">
+    <div></div>
+    <div role="option" aria-label="bar"></div>
   </div>
+</div>
 
-  <div role="listbox" aria-label="foo">
-    <div role="group" id="listbox-group-3" class="fail">
-      <h1></h1>
-    </div>
+<div role="listbox" aria-label="foo">
+  <div role="group" id="listbox-group-3" class="fail">
+    <h1></h1>
   </div>
+</div>
 
-  <div role="listbox" aria-label="foo">
-    <div role="group" id="listbox-group-4" class="fail">
-      <ul>
-        <li role="option" aria-label="bar"></li>
-      </ul>
-    </div>
-  </div>
-
-  <div role="listbox" aria-label="foo">
-    <ul role="group" id="listbox-group-5" class="fail">
-      <li></li>
-    </ul>
-  </div>
-
-  <!-- Children elements of group that should pass -->
-
-  <div role="listbox" aria-label="foo">
-    <div role="group" id="listbox-group-6" class="pass">
-      <div role="option" aria-label="bar"></div>
-    </div>
-  </div>
-
-  <div role="listbox" aria-label="foo">
-    <ul role="group" id="listbox-group-7" class="pass">
+<div role="listbox" aria-label="foo">
+  <div role="group" id="listbox-group-4" class="fail">
+    <ul>
       <li role="option" aria-label="bar"></li>
     </ul>
   </div>
+</div>
 
-  <ul role="listbox" aria-label="foo">
-    <li>
-      <ul role="group" id="listbox-group-8" class="pass">
-        <li role="option" aria-label="bar"></li>
-      </ul>
-    </li>
+<div role="listbox" aria-label="foo">
+  <ul role="group" id="listbox-group-5" class="fail">
+    <li></li>
   </ul>
+</div>
 
+<!-- Children elements of group that should pass -->
+
+<div role="listbox" aria-label="foo">
+  <div role="group" id="listbox-group-6" class="pass">
+    <div role="option" aria-label="bar"></div>
+  </div>
+</div>
+
+<div role="listbox" aria-label="foo">
+  <ul role="group" id="listbox-group-7" class="pass">
+    <li role="option" aria-label="bar"></li>
+  </ul>
+</div>
+
+<ul role="listbox" aria-label="foo">
+  <li>
+    <ul role="group" id="listbox-group-8" class="pass">
+      <li role="option" aria-label="bar"></li>
+    </ul>
+  </li>
+</ul>
+</body>
 </html>

--- a/validator-tests/listbox-group-children-must-be-option.html
+++ b/validator-tests/listbox-group-children-must-be-option.html
@@ -11,26 +11,26 @@
   <!-- Children elements of group that should fail -->
 
   <div role="listbox" aria-label="foo">
-    <div role="group" id="listbox-group-1">
+    <div role="group" id="listbox-group-1" class="fail">
       <div></div>
     </div>
   </div>
 
   <div role="listbox" aria-label="foo">
-    <div role="group" id="listbox-group-2">
+    <div role="group" id="listbox-group-2" class="fail">
       <div></div>
       <div role="option" aria-label="bar"></div>
     </div>
   </div>
 
   <div role="listbox" aria-label="foo">
-    <div role="group" id="listbox-group-3">
+    <div role="group" id="listbox-group-3" class="fail">
       <h1></h1>
     </div>
   </div>
 
   <div role="listbox" aria-label="foo">
-    <div role="group" id="listbox-group-4">
+    <div role="group" id="listbox-group-4" class="fail">
       <ul>
         <li role="option" aria-label="bar"></li>
       </ul>
@@ -38,7 +38,7 @@
   </div>
 
   <div role="listbox" aria-label="foo">
-    <ul role="group" id="listbox-group-5">
+    <ul role="group" id="listbox-group-5" class="fail">
       <li></li>
     </ul>
   </div>
@@ -46,20 +46,20 @@
   <!-- Children elements of group that should pass -->
 
   <div role="listbox" aria-label="foo">
-    <div role="group" id="listbox-group-6">
+    <div role="group" id="listbox-group-6" class="pass">
       <div role="option" aria-label="bar"></div>
     </div>
   </div>
 
   <div role="listbox" aria-label="foo">
-    <ul role="group" id="listbox-group-7">
+    <ul role="group" id="listbox-group-7" class="pass">
       <li role="option" aria-label="bar"></li>
     </ul>
   </div>
 
   <ul role="listbox" aria-label="foo">
     <li>
-      <ul role="group" id="listbox-group-8">
+      <ul role="group" id="listbox-group-8" class="pass">
         <li role="option" aria-label="bar"></li>
       </ul>
     </li>


### PR DESCRIPTION
Add author test case for [group role](https://www.w3.org/TR/wai-aria-1.2/#group): `However, when a group is used in the context of a listbox, authors MUST limit its children to option elements.`

See Issue  #1566