### PR TITLE
Add validator test for combobox role

### DIFF
--- a/validator-tests/README.md
+++ b/validator-tests/README.md
@@ -9,6 +9,8 @@ corresponding changes in validators.
 
 * [Abstract Roles Prohibited](abstract-roles-prohibited.html)
   * @axe-core/cli: [Results](absract-roles-prohibited.json)
+* [Combobox Role Associated Popup](combobox-role-associated-popup.html)
+  * @axe-core/cli: [Results](combobox-role-associated-popup-axe.json), [bug](https://github.com/dequelabs/axe-core-npm/issues/314)
 * [Dialog Must Have Name](dialog-must-have-name.html)
   * @axe-core/cli: [Results](dialog-must-have-name-axe.json)
 * [Img Role Must Have Name](img-role-must-have-name.html)

--- a/validator-tests/combobox-role-associate-popup-axe.json
+++ b/validator-tests/combobox-role-associate-popup-axe.json
@@ -1,0 +1,2995 @@
+[
+  {
+    "inapplicable": [
+      {
+        "description": "Ensures every ARIA meter node has an accessible name",
+        "help": "ARIA meter nodes must have an accessible name",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-meter-name?application=webdriverjs",
+        "id": "aria-meter-name",
+        "impact": null,
+        "nodes": [],
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag111"
+        ]
+      },
+      {
+        "description": "Ensures every ARIA progressbar node has an accessible name",
+        "help": "ARIA progressbar nodes must have an accessible name",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-progressbar-name?application=webdriverjs",
+        "id": "aria-progressbar-name",
+        "impact": null,
+        "nodes": [],
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag111"
+        ]
+      },
+      {
+        "description": "Ensure aria-roledescription is only used on elements with an implicit or explicit role",
+        "help": "Use aria-roledescription on elements with a semantic role",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-roledescription?application=webdriverjs",
+        "id": "aria-roledescription",
+        "impact": null,
+        "nodes": [],
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag412"
+        ]
+      },
+      {
+        "description": "Ensures \"role=text\" is used on elements with no focusable descendants",
+        "help": "\"role=text\" should have no focusable descendants",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-text?application=webdriverjs",
+        "id": "aria-text",
+        "impact": null,
+        "nodes": [],
+        "tags": [
+          "cat.aria",
+          "best-practice"
+        ]
+      },
+      {
+        "description": "Ensures every ARIA toggle field has an accessible name",
+        "help": "ARIA toggle fields have an accessible name",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-toggle-field-name?application=webdriverjs",
+        "id": "aria-toggle-field-name",
+        "impact": null,
+        "nodes": [],
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag412",
+          "ACT"
+        ]
+      },
+      {
+        "description": "Ensures every ARIA tooltip node has an accessible name",
+        "help": "ARIA tooltip nodes must have an accessible name",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-tooltip-name?application=webdriverjs",
+        "id": "aria-tooltip-name",
+        "impact": null,
+        "nodes": [],
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag412"
+        ]
+      },
+      {
+        "description": "Ensures every ARIA treeitem node has an accessible name",
+        "help": "ARIA treeitem nodes should have an accessible name",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-treeitem-name?application=webdriverjs",
+        "id": "aria-treeitem-name",
+        "impact": null,
+        "nodes": [],
+        "tags": [
+          "cat.aria",
+          "best-practice"
+        ]
+      },
+      {
+        "description": "Ensures table headers have discernible text",
+        "help": "Table header text must not be empty",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/empty-table-header?application=webdriverjs",
+        "id": "empty-table-header",
+        "impact": null,
+        "nodes": [],
+        "tags": [
+          "wcag131",
+          "cat.aria"
+        ]
+      },
+      {
+        "description": "Flags elements whose role is none or presentation and which cause the role conflict resolution to trigger.",
+        "help": "Elements of role none or presentation should be flagged",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/presentation-role-conflict?application=webdriverjs",
+        "id": "presentation-role-conflict",
+        "impact": null,
+        "nodes": [],
+        "tags": [
+          "cat.aria",
+          "best-practice"
+        ]
+      }
+    ],
+    "incomplete": [
+      {
+        "description": "Ensures elements with an ARIA role that require child roles contain them",
+        "help": "Certain ARIA roles must contain particular children",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-required-children?application=webdriverjs",
+        "id": "aria-required-children",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": [
+                  "option"
+                ],
+                "id": "aria-required-children",
+                "impact": "critical",
+                "message": "Expecting ARIA child role to be added: option",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Expecting ARIA child role to be added: option",
+            "html": "<div id=\"associated-element-4\" role=\"listbox\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "#associated-element-4"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": [
+                  "group",
+                  "treeitem"
+                ],
+                "id": "aria-required-children",
+                "impact": "critical",
+                "message": "Expecting ARIA children role to be added: group, treeitem",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Expecting ARIA children role to be added: group, treeitem",
+            "html": "<div role=\"tree\" id=\"associated-element-5\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "#associated-element-5"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": [
+                  "rowgroup",
+                  "row"
+                ],
+                "id": "aria-required-children",
+                "impact": "critical",
+                "message": "Expecting ARIA children role to be added: rowgroup, row",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Expecting ARIA children role to be added: rowgroup, row",
+            "html": "<div role=\"grid\" id=\"associated-element-6\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "#associated-element-6"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag131"
+        ]
+      }
+    ],
+    "passes": [
+      {
+        "description": "Ensures ARIA attributes are allowed for an element's role",
+        "help": "Elements must only use allowed ARIA attributes",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-allowed-attr?application=webdriverjs",
+        "id": "aria-allowed-attr",
+        "impact": "serious",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-attr",
+                "impact": "critical",
+                "message": "ARIA attributes are used correctly for the defined role",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-1\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "aria-unsupported-attr",
+                "impact": "critical",
+                "message": "ARIA attribute is supported",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-prohibited-attr",
+                "impact": "serious",
+                "message": "ARIA attribute is allowed",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-1\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-attr",
+                "impact": "critical",
+                "message": "ARIA attributes are used correctly for the defined role",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-2\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"listbox\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "aria-unsupported-attr",
+                "impact": "critical",
+                "message": "ARIA attribute is supported",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-prohibited-attr",
+                "impact": "serious",
+                "message": "ARIA attribute is allowed",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-2\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-attr",
+                "impact": "critical",
+                "message": "ARIA attributes are used correctly for the defined role",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"alert\" id=\"associated-element-2\" aria-label=\"bar\" class=\"fail\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "aria-unsupported-attr",
+                "impact": "critical",
+                "message": "ARIA attribute is supported",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-prohibited-attr",
+                "impact": "serious",
+                "message": "ARIA attribute is allowed",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "#associated-element-2"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-attr",
+                "impact": "critical",
+                "message": "ARIA attributes are used correctly for the defined role",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-3\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"menubar\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "aria-unsupported-attr",
+                "impact": "critical",
+                "message": "ARIA attribute is supported",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-prohibited-attr",
+                "impact": "serious",
+                "message": "ARIA attribute is allowed",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-3\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-attr",
+                "impact": "critical",
+                "message": "ARIA attributes are used correctly for the defined role",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"menubar\" id=\"associated-element-3\" aria-label=\"bar\" class=\"fail\">\n    <div role=\"menuitem\" aria-label=\"baz\"></div>\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "aria-unsupported-attr",
+                "impact": "critical",
+                "message": "ARIA attribute is supported",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-prohibited-attr",
+                "impact": "serious",
+                "message": "ARIA attribute is allowed",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "#associated-element-3"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-attr",
+                "impact": "critical",
+                "message": "ARIA attributes are used correctly for the defined role",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"menuitem\" aria-label=\"baz\"></div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "aria-unsupported-attr",
+                "impact": "critical",
+                "message": "ARIA attribute is supported",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-prohibited-attr",
+                "impact": "serious",
+                "message": "ARIA attribute is allowed",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[role=\"menuitem\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-attr",
+                "impact": "critical",
+                "message": "ARIA attributes are used correctly for the defined role",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-4\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "aria-unsupported-attr",
+                "impact": "critical",
+                "message": "ARIA attribute is supported",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-prohibited-attr",
+                "impact": "serious",
+                "message": "ARIA attribute is allowed",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-4\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-attr",
+                "impact": "critical",
+                "message": "ARIA attributes are used correctly for the defined role",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div id=\"associated-element-4\" role=\"listbox\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "aria-unsupported-attr",
+                "impact": "critical",
+                "message": "ARIA attribute is supported",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-prohibited-attr",
+                "impact": "serious",
+                "message": "ARIA attribute is allowed",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "#associated-element-4"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-attr",
+                "impact": "critical",
+                "message": "ARIA attributes are used correctly for the defined role",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-5\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"tree\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "aria-unsupported-attr",
+                "impact": "critical",
+                "message": "ARIA attribute is supported",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-prohibited-attr",
+                "impact": "serious",
+                "message": "ARIA attribute is allowed",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-5\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-attr",
+                "impact": "critical",
+                "message": "ARIA attributes are used correctly for the defined role",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"tree\" id=\"associated-element-5\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "aria-unsupported-attr",
+                "impact": "critical",
+                "message": "ARIA attribute is supported",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-prohibited-attr",
+                "impact": "serious",
+                "message": "ARIA attribute is allowed",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "#associated-element-5"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-attr",
+                "impact": "critical",
+                "message": "ARIA attributes are used correctly for the defined role",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-6\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"grid\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "aria-unsupported-attr",
+                "impact": "critical",
+                "message": "ARIA attribute is supported",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-prohibited-attr",
+                "impact": "serious",
+                "message": "ARIA attribute is allowed",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-6\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-attr",
+                "impact": "critical",
+                "message": "ARIA attributes are used correctly for the defined role",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"grid\" id=\"associated-element-6\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "aria-unsupported-attr",
+                "impact": "critical",
+                "message": "ARIA attribute is supported",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-prohibited-attr",
+                "impact": "serious",
+                "message": "ARIA attribute is allowed",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "#associated-element-6"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-attr",
+                "impact": "critical",
+                "message": "ARIA attributes are used correctly for the defined role",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-7\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"dialog\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "aria-unsupported-attr",
+                "impact": "critical",
+                "message": "ARIA attribute is supported",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-prohibited-attr",
+                "impact": "serious",
+                "message": "ARIA attribute is allowed",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-7\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-attr",
+                "impact": "critical",
+                "message": "ARIA attributes are used correctly for the defined role",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"dialog\" id=\"associated-element-7\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "aria-unsupported-attr",
+                "impact": "critical",
+                "message": "ARIA attribute is supported",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-prohibited-attr",
+                "impact": "serious",
+                "message": "ARIA attribute is allowed",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "#associated-element-7"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag412"
+        ]
+      },
+      {
+        "description": "Ensures role attribute has an appropriate value for the element",
+        "help": "ARIA role should be appropriate for the element",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-allowed-role?application=webdriverjs",
+        "id": "aria-allowed-role",
+        "impact": null,
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-role",
+                "impact": "minor",
+                "message": "ARIA role is allowed for given element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-1\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-1\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-role",
+                "impact": "minor",
+                "message": "ARIA role is allowed for given element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-2\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"listbox\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-2\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-role",
+                "impact": "minor",
+                "message": "ARIA role is allowed for given element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"alert\" id=\"associated-element-2\" aria-label=\"bar\" class=\"fail\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-2"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-role",
+                "impact": "minor",
+                "message": "ARIA role is allowed for given element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-3\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"menubar\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-3\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-role",
+                "impact": "minor",
+                "message": "ARIA role is allowed for given element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"menubar\" id=\"associated-element-3\" aria-label=\"bar\" class=\"fail\">\n    <div role=\"menuitem\" aria-label=\"baz\"></div>\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-3"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-role",
+                "impact": "minor",
+                "message": "ARIA role is allowed for given element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"menuitem\" aria-label=\"baz\"></div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[role=\"menuitem\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-role",
+                "impact": "minor",
+                "message": "ARIA role is allowed for given element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-4\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-4\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-role",
+                "impact": "minor",
+                "message": "ARIA role is allowed for given element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div id=\"associated-element-4\" role=\"listbox\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-4"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-role",
+                "impact": "minor",
+                "message": "ARIA role is allowed for given element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-5\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"tree\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-5\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-role",
+                "impact": "minor",
+                "message": "ARIA role is allowed for given element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"tree\" id=\"associated-element-5\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-5"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-role",
+                "impact": "minor",
+                "message": "ARIA role is allowed for given element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-6\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"grid\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-6\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-role",
+                "impact": "minor",
+                "message": "ARIA role is allowed for given element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"grid\" id=\"associated-element-6\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-6"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-role",
+                "impact": "minor",
+                "message": "ARIA role is allowed for given element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-7\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"dialog\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-7\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-allowed-role",
+                "impact": "minor",
+                "message": "ARIA role is allowed for given element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"dialog\" id=\"associated-element-7\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-7"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.aria",
+          "best-practice"
+        ]
+      },
+      {
+        "description": "Ensures every ARIA button, link and menuitem has an accessible name",
+        "help": "ARIA commands must have an accessible name",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-command-name?application=webdriverjs",
+        "id": "aria-command-name",
+        "impact": null,
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-label",
+                "impact": "serious",
+                "message": "aria-label attribute exists and is not empty",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"menuitem\" aria-label=\"baz\"></div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[role=\"menuitem\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag412"
+        ]
+      },
+      {
+        "description": "Ensures every ARIA dialog and alertdialog node has an accessible name",
+        "help": "ARIA dialog and alertdialog nodes should have an accessible name",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-dialog-name?application=webdriverjs",
+        "id": "aria-dialog-name",
+        "impact": null,
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-label",
+                "impact": "serious",
+                "message": "aria-label attribute exists and is not empty",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"dialog\" id=\"associated-element-7\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-7"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.aria",
+          "best-practice"
+        ]
+      },
+      {
+        "description": "Ensures aria-hidden='true' is not present on the document body.",
+        "help": "aria-hidden='true' must not be present on the document body",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-hidden-body?application=webdriverjs",
+        "id": "aria-hidden-body",
+        "impact": null,
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-hidden-body",
+                "impact": "critical",
+                "message": "No aria-hidden attribute is present on document body",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<body>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "body"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag412"
+        ]
+      },
+      {
+        "description": "Ensures every ARIA input field has an accessible name",
+        "help": "ARIA input fields must have an accessible name",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-input-field-name?application=webdriverjs",
+        "id": "aria-input-field-name",
+        "impact": null,
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-label",
+                "impact": "serious",
+                "message": "aria-label attribute exists and is not empty",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-1\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": "combobox",
+                "id": "no-implicit-explicit-label",
+                "impact": "moderate",
+                "message": "There is no mismatch between a <label> and accessible name",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-1\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-label",
+                "impact": "serious",
+                "message": "aria-label attribute exists and is not empty",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-2\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"listbox\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": "combobox",
+                "id": "no-implicit-explicit-label",
+                "impact": "moderate",
+                "message": "There is no mismatch between a <label> and accessible name",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-2\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-label",
+                "impact": "serious",
+                "message": "aria-label attribute exists and is not empty",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-3\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"menubar\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": "combobox",
+                "id": "no-implicit-explicit-label",
+                "impact": "moderate",
+                "message": "There is no mismatch between a <label> and accessible name",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-3\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-label",
+                "impact": "serious",
+                "message": "aria-label attribute exists and is not empty",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-4\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": "combobox",
+                "id": "no-implicit-explicit-label",
+                "impact": "moderate",
+                "message": "There is no mismatch between a <label> and accessible name",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-4\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-label",
+                "impact": "serious",
+                "message": "aria-label attribute exists and is not empty",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div id=\"associated-element-4\" role=\"listbox\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": "listbox",
+                "id": "no-implicit-explicit-label",
+                "impact": "moderate",
+                "message": "There is no mismatch between a <label> and accessible name",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "#associated-element-4"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-label",
+                "impact": "serious",
+                "message": "aria-label attribute exists and is not empty",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-5\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"tree\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": "combobox",
+                "id": "no-implicit-explicit-label",
+                "impact": "moderate",
+                "message": "There is no mismatch between a <label> and accessible name",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-5\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-label",
+                "impact": "serious",
+                "message": "aria-label attribute exists and is not empty",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-6\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"grid\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": "combobox",
+                "id": "no-implicit-explicit-label",
+                "impact": "moderate",
+                "message": "There is no mismatch between a <label> and accessible name",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-6\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-label",
+                "impact": "serious",
+                "message": "aria-label attribute exists and is not empty",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-7\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"dialog\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": "combobox",
+                "id": "no-implicit-explicit-label",
+                "impact": "moderate",
+                "message": "There is no mismatch between a <label> and accessible name",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-7\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag412",
+          "ACT"
+        ]
+      },
+      {
+        "description": "Ensures elements with ARIA roles have all required ARIA attributes",
+        "help": "Required ARIA attributes must be provided",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-required-attr?application=webdriverjs",
+        "id": "aria-required-attr",
+        "impact": null,
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-required-attr",
+                "impact": "critical",
+                "message": "All required ARIA attributes are present",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-1\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-1\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-required-attr",
+                "impact": "critical",
+                "message": "All required ARIA attributes are present",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-2\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"listbox\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-2\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-required-attr",
+                "impact": "critical",
+                "message": "All required ARIA attributes are present",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"alert\" id=\"associated-element-2\" aria-label=\"bar\" class=\"fail\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-2"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-required-attr",
+                "impact": "critical",
+                "message": "All required ARIA attributes are present",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-3\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"menubar\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-3\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-required-attr",
+                "impact": "critical",
+                "message": "All required ARIA attributes are present",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"menubar\" id=\"associated-element-3\" aria-label=\"bar\" class=\"fail\">\n    <div role=\"menuitem\" aria-label=\"baz\"></div>\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-3"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-required-attr",
+                "impact": "critical",
+                "message": "All required ARIA attributes are present",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"menuitem\" aria-label=\"baz\"></div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[role=\"menuitem\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-required-attr",
+                "impact": "critical",
+                "message": "All required ARIA attributes are present",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-4\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-4\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-required-attr",
+                "impact": "critical",
+                "message": "All required ARIA attributes are present",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div id=\"associated-element-4\" role=\"listbox\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-4"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-required-attr",
+                "impact": "critical",
+                "message": "All required ARIA attributes are present",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-5\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"tree\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-5\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-required-attr",
+                "impact": "critical",
+                "message": "All required ARIA attributes are present",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"tree\" id=\"associated-element-5\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-5"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-required-attr",
+                "impact": "critical",
+                "message": "All required ARIA attributes are present",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-6\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"grid\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-6\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-required-attr",
+                "impact": "critical",
+                "message": "All required ARIA attributes are present",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"grid\" id=\"associated-element-6\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-6"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-required-attr",
+                "impact": "critical",
+                "message": "All required ARIA attributes are present",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-7\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"dialog\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-7\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-required-attr",
+                "impact": "critical",
+                "message": "All required ARIA attributes are present",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"dialog\" id=\"associated-element-7\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-7"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag412"
+        ]
+      },
+      {
+        "description": "Ensures elements with an ARIA role that require child roles contain them",
+        "help": "Certain ARIA roles must contain particular children",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-required-children?application=webdriverjs",
+        "id": "aria-required-children",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-required-children",
+                "impact": "critical",
+                "message": "Required ARIA children are present",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"menubar\" id=\"associated-element-3\" aria-label=\"bar\" class=\"fail\">\n    <div role=\"menuitem\" aria-label=\"baz\"></div>\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-3"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag131"
+        ]
+      },
+      {
+        "description": "Ensures elements with an ARIA role that require parent roles are contained by them",
+        "help": "Certain ARIA roles must be contained by particular parents",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-required-parent?application=webdriverjs",
+        "id": "aria-required-parent",
+        "impact": null,
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-required-parent",
+                "impact": "critical",
+                "message": "Required ARIA parent role present",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"menuitem\" aria-label=\"baz\"></div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[role=\"menuitem\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag131"
+        ]
+      },
+      {
+        "description": "Ensures all elements with a role attribute use a valid value",
+        "help": "ARIA roles used must conform to valid values",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-roles?application=webdriverjs",
+        "id": "aria-roles",
+        "impact": null,
+        "nodes": [
+          {
+            "all": [],
+            "any": [],
+            "html": "<div aria-controls=\"associated-element-1\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "fallbackrole",
+                "impact": "serious",
+                "message": "Only one role value used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "invalidrole",
+                "impact": "critical",
+                "message": "ARIA role is valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "abstractrole",
+                "impact": "serious",
+                "message": "Abstract roles are not used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "unsupportedrole",
+                "impact": "critical",
+                "message": "ARIA role is supported",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-1\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [],
+            "html": "<div aria-controls=\"associated-element-2\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"listbox\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "fallbackrole",
+                "impact": "serious",
+                "message": "Only one role value used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "invalidrole",
+                "impact": "critical",
+                "message": "ARIA role is valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "abstractrole",
+                "impact": "serious",
+                "message": "Abstract roles are not used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "unsupportedrole",
+                "impact": "critical",
+                "message": "ARIA role is supported",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-2\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [],
+            "html": "<div role=\"alert\" id=\"associated-element-2\" aria-label=\"bar\" class=\"fail\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "fallbackrole",
+                "impact": "serious",
+                "message": "Only one role value used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "invalidrole",
+                "impact": "critical",
+                "message": "ARIA role is valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "abstractrole",
+                "impact": "serious",
+                "message": "Abstract roles are not used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "unsupportedrole",
+                "impact": "critical",
+                "message": "ARIA role is supported",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "#associated-element-2"
+            ]
+          },
+          {
+            "all": [],
+            "any": [],
+            "html": "<div aria-controls=\"associated-element-3\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"menubar\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "fallbackrole",
+                "impact": "serious",
+                "message": "Only one role value used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "invalidrole",
+                "impact": "critical",
+                "message": "ARIA role is valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "abstractrole",
+                "impact": "serious",
+                "message": "Abstract roles are not used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "unsupportedrole",
+                "impact": "critical",
+                "message": "ARIA role is supported",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-3\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [],
+            "html": "<div role=\"menubar\" id=\"associated-element-3\" aria-label=\"bar\" class=\"fail\">\n    <div role=\"menuitem\" aria-label=\"baz\"></div>\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "fallbackrole",
+                "impact": "serious",
+                "message": "Only one role value used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "invalidrole",
+                "impact": "critical",
+                "message": "ARIA role is valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "abstractrole",
+                "impact": "serious",
+                "message": "Abstract roles are not used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "unsupportedrole",
+                "impact": "critical",
+                "message": "ARIA role is supported",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "#associated-element-3"
+            ]
+          },
+          {
+            "all": [],
+            "any": [],
+            "html": "<div role=\"menuitem\" aria-label=\"baz\"></div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "fallbackrole",
+                "impact": "serious",
+                "message": "Only one role value used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "invalidrole",
+                "impact": "critical",
+                "message": "ARIA role is valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "abstractrole",
+                "impact": "serious",
+                "message": "Abstract roles are not used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "unsupportedrole",
+                "impact": "critical",
+                "message": "ARIA role is supported",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[role=\"menuitem\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [],
+            "html": "<div aria-controls=\"associated-element-4\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "fallbackrole",
+                "impact": "serious",
+                "message": "Only one role value used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "invalidrole",
+                "impact": "critical",
+                "message": "ARIA role is valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "abstractrole",
+                "impact": "serious",
+                "message": "Abstract roles are not used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "unsupportedrole",
+                "impact": "critical",
+                "message": "ARIA role is supported",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-4\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [],
+            "html": "<div id=\"associated-element-4\" role=\"listbox\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "fallbackrole",
+                "impact": "serious",
+                "message": "Only one role value used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "invalidrole",
+                "impact": "critical",
+                "message": "ARIA role is valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "abstractrole",
+                "impact": "serious",
+                "message": "Abstract roles are not used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "unsupportedrole",
+                "impact": "critical",
+                "message": "ARIA role is supported",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "#associated-element-4"
+            ]
+          },
+          {
+            "all": [],
+            "any": [],
+            "html": "<div aria-controls=\"associated-element-5\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"tree\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "fallbackrole",
+                "impact": "serious",
+                "message": "Only one role value used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "invalidrole",
+                "impact": "critical",
+                "message": "ARIA role is valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "abstractrole",
+                "impact": "serious",
+                "message": "Abstract roles are not used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "unsupportedrole",
+                "impact": "critical",
+                "message": "ARIA role is supported",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-5\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [],
+            "html": "<div role=\"tree\" id=\"associated-element-5\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "fallbackrole",
+                "impact": "serious",
+                "message": "Only one role value used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "invalidrole",
+                "impact": "critical",
+                "message": "ARIA role is valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "abstractrole",
+                "impact": "serious",
+                "message": "Abstract roles are not used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "unsupportedrole",
+                "impact": "critical",
+                "message": "ARIA role is supported",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "#associated-element-5"
+            ]
+          },
+          {
+            "all": [],
+            "any": [],
+            "html": "<div aria-controls=\"associated-element-6\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"grid\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "fallbackrole",
+                "impact": "serious",
+                "message": "Only one role value used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "invalidrole",
+                "impact": "critical",
+                "message": "ARIA role is valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "abstractrole",
+                "impact": "serious",
+                "message": "Abstract roles are not used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "unsupportedrole",
+                "impact": "critical",
+                "message": "ARIA role is supported",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-6\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [],
+            "html": "<div role=\"grid\" id=\"associated-element-6\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "fallbackrole",
+                "impact": "serious",
+                "message": "Only one role value used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "invalidrole",
+                "impact": "critical",
+                "message": "ARIA role is valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "abstractrole",
+                "impact": "serious",
+                "message": "Abstract roles are not used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "unsupportedrole",
+                "impact": "critical",
+                "message": "ARIA role is supported",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "#associated-element-6"
+            ]
+          },
+          {
+            "all": [],
+            "any": [],
+            "html": "<div aria-controls=\"associated-element-7\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"dialog\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "fallbackrole",
+                "impact": "serious",
+                "message": "Only one role value used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "invalidrole",
+                "impact": "critical",
+                "message": "ARIA role is valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "abstractrole",
+                "impact": "serious",
+                "message": "Abstract roles are not used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "unsupportedrole",
+                "impact": "critical",
+                "message": "ARIA role is supported",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "div[aria-controls=\"associated-element-7\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [],
+            "html": "<div role=\"dialog\" id=\"associated-element-7\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [
+              {
+                "data": null,
+                "id": "fallbackrole",
+                "impact": "serious",
+                "message": "Only one role value used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "invalidrole",
+                "impact": "critical",
+                "message": "ARIA role is valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "abstractrole",
+                "impact": "serious",
+                "message": "Abstract roles are not used",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "unsupportedrole",
+                "impact": "critical",
+                "message": "ARIA role is supported",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "#associated-element-7"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag412"
+        ]
+      },
+      {
+        "description": "Ensures all ARIA attributes have valid values",
+        "help": "ARIA attributes must conform to valid values",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-valid-attr-value?application=webdriverjs",
+        "id": "aria-valid-attr-value",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [
+              {
+                "data": null,
+                "id": "aria-valid-attr-value",
+                "impact": "critical",
+                "message": "ARIA attribute values are valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-errormessage",
+                "impact": "critical",
+                "message": "aria-errormessage exists and references elements visible to screen readers that use a supported aria-errormessage technique",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-level",
+                "impact": "serious",
+                "message": "aria-level values are valid",
+                "relatedNodes": []
+              }
+            ],
+            "any": [],
+            "html": "<div aria-controls=\"associated-element-1\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-1\"]"
+            ]
+          },
+          {
+            "all": [
+              {
+                "data": null,
+                "id": "aria-valid-attr-value",
+                "impact": "critical",
+                "message": "ARIA attribute values are valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-errormessage",
+                "impact": "critical",
+                "message": "aria-errormessage exists and references elements visible to screen readers that use a supported aria-errormessage technique",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-level",
+                "impact": "serious",
+                "message": "aria-level values are valid",
+                "relatedNodes": []
+              }
+            ],
+            "any": [],
+            "html": "<div id=\"associated-element-1\" aria-label=\"bar\" class=\"fail\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-1"
+            ]
+          },
+          {
+            "all": [
+              {
+                "data": null,
+                "id": "aria-valid-attr-value",
+                "impact": "critical",
+                "message": "ARIA attribute values are valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-errormessage",
+                "impact": "critical",
+                "message": "aria-errormessage exists and references elements visible to screen readers that use a supported aria-errormessage technique",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-level",
+                "impact": "serious",
+                "message": "aria-level values are valid",
+                "relatedNodes": []
+              }
+            ],
+            "any": [],
+            "html": "<div aria-controls=\"associated-element-2\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"listbox\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-2\"]"
+            ]
+          },
+          {
+            "all": [
+              {
+                "data": null,
+                "id": "aria-valid-attr-value",
+                "impact": "critical",
+                "message": "ARIA attribute values are valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-errormessage",
+                "impact": "critical",
+                "message": "aria-errormessage exists and references elements visible to screen readers that use a supported aria-errormessage technique",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-level",
+                "impact": "serious",
+                "message": "aria-level values are valid",
+                "relatedNodes": []
+              }
+            ],
+            "any": [],
+            "html": "<div role=\"alert\" id=\"associated-element-2\" aria-label=\"bar\" class=\"fail\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-2"
+            ]
+          },
+          {
+            "all": [
+              {
+                "data": null,
+                "id": "aria-valid-attr-value",
+                "impact": "critical",
+                "message": "ARIA attribute values are valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-errormessage",
+                "impact": "critical",
+                "message": "aria-errormessage exists and references elements visible to screen readers that use a supported aria-errormessage technique",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-level",
+                "impact": "serious",
+                "message": "aria-level values are valid",
+                "relatedNodes": []
+              }
+            ],
+            "any": [],
+            "html": "<div role=\"menubar\" id=\"associated-element-3\" aria-label=\"bar\" class=\"fail\">\n    <div role=\"menuitem\" aria-label=\"baz\"></div>\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-3"
+            ]
+          },
+          {
+            "all": [
+              {
+                "data": null,
+                "id": "aria-valid-attr-value",
+                "impact": "critical",
+                "message": "ARIA attribute values are valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-errormessage",
+                "impact": "critical",
+                "message": "aria-errormessage exists and references elements visible to screen readers that use a supported aria-errormessage technique",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-level",
+                "impact": "serious",
+                "message": "aria-level values are valid",
+                "relatedNodes": []
+              }
+            ],
+            "any": [],
+            "html": "<div role=\"menuitem\" aria-label=\"baz\"></div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[role=\"menuitem\"]"
+            ]
+          },
+          {
+            "all": [
+              {
+                "data": null,
+                "id": "aria-valid-attr-value",
+                "impact": "critical",
+                "message": "ARIA attribute values are valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-errormessage",
+                "impact": "critical",
+                "message": "aria-errormessage exists and references elements visible to screen readers that use a supported aria-errormessage technique",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-level",
+                "impact": "serious",
+                "message": "aria-level values are valid",
+                "relatedNodes": []
+              }
+            ],
+            "any": [],
+            "html": "<div aria-controls=\"associated-element-4\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-4\"]"
+            ]
+          },
+          {
+            "all": [
+              {
+                "data": null,
+                "id": "aria-valid-attr-value",
+                "impact": "critical",
+                "message": "ARIA attribute values are valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-errormessage",
+                "impact": "critical",
+                "message": "aria-errormessage exists and references elements visible to screen readers that use a supported aria-errormessage technique",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-level",
+                "impact": "serious",
+                "message": "aria-level values are valid",
+                "relatedNodes": []
+              }
+            ],
+            "any": [],
+            "html": "<div id=\"associated-element-4\" role=\"listbox\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-4"
+            ]
+          },
+          {
+            "all": [
+              {
+                "data": null,
+                "id": "aria-valid-attr-value",
+                "impact": "critical",
+                "message": "ARIA attribute values are valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-errormessage",
+                "impact": "critical",
+                "message": "aria-errormessage exists and references elements visible to screen readers that use a supported aria-errormessage technique",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-level",
+                "impact": "serious",
+                "message": "aria-level values are valid",
+                "relatedNodes": []
+              }
+            ],
+            "any": [],
+            "html": "<div aria-controls=\"associated-element-5\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"tree\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-5\"]"
+            ]
+          },
+          {
+            "all": [
+              {
+                "data": null,
+                "id": "aria-valid-attr-value",
+                "impact": "critical",
+                "message": "ARIA attribute values are valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-errormessage",
+                "impact": "critical",
+                "message": "aria-errormessage exists and references elements visible to screen readers that use a supported aria-errormessage technique",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-level",
+                "impact": "serious",
+                "message": "aria-level values are valid",
+                "relatedNodes": []
+              }
+            ],
+            "any": [],
+            "html": "<div role=\"tree\" id=\"associated-element-5\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-5"
+            ]
+          },
+          {
+            "all": [
+              {
+                "data": null,
+                "id": "aria-valid-attr-value",
+                "impact": "critical",
+                "message": "ARIA attribute values are valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-errormessage",
+                "impact": "critical",
+                "message": "aria-errormessage exists and references elements visible to screen readers that use a supported aria-errormessage technique",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-level",
+                "impact": "serious",
+                "message": "aria-level values are valid",
+                "relatedNodes": []
+              }
+            ],
+            "any": [],
+            "html": "<div aria-controls=\"associated-element-6\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"grid\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-6\"]"
+            ]
+          },
+          {
+            "all": [
+              {
+                "data": null,
+                "id": "aria-valid-attr-value",
+                "impact": "critical",
+                "message": "ARIA attribute values are valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-errormessage",
+                "impact": "critical",
+                "message": "aria-errormessage exists and references elements visible to screen readers that use a supported aria-errormessage technique",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-level",
+                "impact": "serious",
+                "message": "aria-level values are valid",
+                "relatedNodes": []
+              }
+            ],
+            "any": [],
+            "html": "<div role=\"grid\" id=\"associated-element-6\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-6"
+            ]
+          },
+          {
+            "all": [
+              {
+                "data": null,
+                "id": "aria-valid-attr-value",
+                "impact": "critical",
+                "message": "ARIA attribute values are valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-errormessage",
+                "impact": "critical",
+                "message": "aria-errormessage exists and references elements visible to screen readers that use a supported aria-errormessage technique",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-level",
+                "impact": "serious",
+                "message": "aria-level values are valid",
+                "relatedNodes": []
+              }
+            ],
+            "any": [],
+            "html": "<div aria-controls=\"associated-element-7\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"dialog\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-7\"]"
+            ]
+          },
+          {
+            "all": [
+              {
+                "data": null,
+                "id": "aria-valid-attr-value",
+                "impact": "critical",
+                "message": "ARIA attribute values are valid",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-errormessage",
+                "impact": "critical",
+                "message": "aria-errormessage exists and references elements visible to screen readers that use a supported aria-errormessage technique",
+                "relatedNodes": []
+              },
+              {
+                "data": null,
+                "id": "aria-level",
+                "impact": "serious",
+                "message": "aria-level values are valid",
+                "relatedNodes": []
+              }
+            ],
+            "any": [],
+            "html": "<div role=\"dialog\" id=\"associated-element-7\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-7"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag412"
+        ]
+      },
+      {
+        "description": "Ensures attributes that begin with aria- are valid ARIA attributes",
+        "help": "ARIA attributes must conform to valid names",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-valid-attr?application=webdriverjs",
+        "id": "aria-valid-attr",
+        "impact": null,
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-valid-attr",
+                "impact": "critical",
+                "message": "ARIA attribute name is valid",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-1\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-1\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-valid-attr",
+                "impact": "critical",
+                "message": "ARIA attribute name is valid",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div id=\"associated-element-1\" aria-label=\"bar\" class=\"fail\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-1"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-valid-attr",
+                "impact": "critical",
+                "message": "ARIA attribute name is valid",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-2\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"listbox\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-2\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-valid-attr",
+                "impact": "critical",
+                "message": "ARIA attribute name is valid",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"alert\" id=\"associated-element-2\" aria-label=\"bar\" class=\"fail\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-2"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-valid-attr",
+                "impact": "critical",
+                "message": "ARIA attribute name is valid",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-3\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"menubar\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-3\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-valid-attr",
+                "impact": "critical",
+                "message": "ARIA attribute name is valid",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"menubar\" id=\"associated-element-3\" aria-label=\"bar\" class=\"fail\">\n    <div role=\"menuitem\" aria-label=\"baz\"></div>\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-3"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-valid-attr",
+                "impact": "critical",
+                "message": "ARIA attribute name is valid",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"menuitem\" aria-label=\"baz\"></div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[role=\"menuitem\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-valid-attr",
+                "impact": "critical",
+                "message": "ARIA attribute name is valid",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-4\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-4\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-valid-attr",
+                "impact": "critical",
+                "message": "ARIA attribute name is valid",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div id=\"associated-element-4\" role=\"listbox\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-4"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-valid-attr",
+                "impact": "critical",
+                "message": "ARIA attribute name is valid",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-5\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"tree\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-5\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-valid-attr",
+                "impact": "critical",
+                "message": "ARIA attribute name is valid",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"tree\" id=\"associated-element-5\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-5"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-valid-attr",
+                "impact": "critical",
+                "message": "ARIA attribute name is valid",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-6\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"grid\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-6\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-valid-attr",
+                "impact": "critical",
+                "message": "ARIA attribute name is valid",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"grid\" id=\"associated-element-6\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-6"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-valid-attr",
+                "impact": "critical",
+                "message": "ARIA attribute name is valid",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div aria-controls=\"associated-element-7\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"dialog\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-7\"]"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "aria-valid-attr",
+                "impact": "critical",
+                "message": "ARIA attribute name is valid",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div role=\"dialog\" id=\"associated-element-7\" aria-label=\"bar\" class=\"pass\">\n  </div>",
+            "impact": null,
+            "none": [],
+            "target": [
+              "#associated-element-7"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag412"
+        ]
+      }
+    ],
+    "testEngine": {
+      "name": "axe-core",
+      "version": "4.3.2"
+    },
+    "testEnvironment": {
+      "orientationAngle": 0,
+      "orientationType": "landscape-primary",
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/91.0.4472.114 Safari/537.36",
+      "windowHeight": 600,
+      "windowWidth": 800
+    },
+    "testRunner": {
+      "name": "axe"
+    },
+    "timestamp": "2021-08-03T20:56:54.483Z",
+    "toolOptions": {
+      "reporter": "v1",
+      "runOnly": {
+        "type": "tag",
+        "values": [
+          "cat.aria"
+        ]
+      }
+    },
+    "url": "http://localhost:8000/combobox-role-associated-popup.html",
+    "violations": [
+      {
+        "description": "Ensures ARIA attributes are allowed for an element's role",
+        "help": "Elements must only use allowed ARIA attributes",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-allowed-attr?application=webdriverjs",
+        "id": "aria-allowed-attr",
+        "impact": "serious",
+        "nodes": [
+          {
+            "all": [],
+            "any": [],
+            "failureSummary": "Fix all of the following:\n  ARIA attribute cannot be used, add a role attribute or use a different element: aria-label",
+            "html": "<div id=\"associated-element-1\" aria-label=\"bar\" class=\"fail\">\n  </div>",
+            "impact": "serious",
+            "none": [
+              {
+                "data": [
+                  "aria-label"
+                ],
+                "id": "aria-prohibited-attr",
+                "impact": "serious",
+                "message": "ARIA attribute cannot be used, add a role attribute or use a different element: aria-label",
+                "relatedNodes": []
+              }
+            ],
+            "target": [
+              "#associated-element-1"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag412"
+        ]
+      },
+      {
+        "description": "Ensures all ARIA attributes have valid values",
+        "help": "ARIA attributes must conform to valid values",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/aria-valid-attr-value?application=webdriverjs",
+        "id": "aria-valid-attr-value",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [
+              {
+                "data": [
+                  "aria-haspopup=\"menubar\""
+                ],
+                "id": "aria-valid-attr-value",
+                "impact": "critical",
+                "message": "Invalid ARIA attribute value: aria-haspopup=\"menubar\"",
+                "relatedNodes": []
+              }
+            ],
+            "any": [],
+            "failureSummary": "Fix all of the following:\n  Invalid ARIA attribute value: aria-haspopup=\"menubar\"",
+            "html": "<div aria-controls=\"associated-element-3\" role=\"combobox\" aria-label=\"foo\" aria-expanded=\"true\" aria-haspopup=\"menubar\">\n  </div>",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "div[aria-controls=\"associated-element-3\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag412"
+        ]
+      }
+    ]
+  }
+]

--- a/validator-tests/combobox-role-associated-popup.html
+++ b/validator-tests/combobox-role-associated-popup.html
@@ -1,0 +1,109 @@
+<html lang="en-US">
+<head><title>Popup element associated with a combobox must have allowed roles.</title></head>
+  <body>
+    <!--
+    URL: https://www.w3.org/TR/wai-aria-1.2/#combobox
+    RULE: "Authors MUST ensure the popup element associated with a combobox has
+    * a role of listbox, tree, grid, or dialog."
+    -->
+  </body>
+
+  <!-- Should fail -->
+
+  <div aria-controls="associated-element-1"
+       role="combobox"
+       aria-label="foo"
+       aria-expanded="true">
+  </div>
+  <div
+       id="associated-element-1"
+       aria-label="bar"
+       class="fail">
+  </div>
+
+  <div aria-controls="associated-element-2"
+       role="combobox"
+       aria-label="foo"
+       aria-expanded="true"
+       aria-haspopup="listbox"
+       >
+  </div>
+  <div
+       role="alert"
+       id="associated-element-2"
+       aria-label="bar"
+       class="fail">
+  </div>
+
+  <div aria-controls="associated-element-3"
+       role="combobox"
+       aria-label="foo"
+       aria-expanded="true"
+       aria-haspopup="menubar"
+       >
+  </div>
+  <div
+       role="menubar"
+       id="associated-element-3"
+       aria-label="bar"
+       class="fail">
+    <div role="menuitem" aria-label="baz"></div>
+  </div>
+
+  <!-- Should pass -->
+
+  <div aria-controls="associated-element-4"
+       role="combobox"
+       aria-label="foo"
+       aria-expanded="true">
+  </div>
+  <div
+       id="associated-element-4"
+       role="listbox"
+       aria-label="bar"
+       class="pass">
+  </div>
+
+  <div aria-controls="associated-element-5"
+       role="combobox"
+       aria-label="foo"
+       aria-expanded="true"
+       aria-haspopup="tree"
+       >
+  </div>
+  <div
+       role="tree"
+       id="associated-element-5"
+       aria-label="bar"
+       class="pass">
+  </div>
+
+  <div aria-controls="associated-element-6"
+       role="combobox"
+       aria-label="foo"
+       aria-expanded="true"
+       aria-haspopup="grid"
+       >
+  </div>
+  <div
+       role="grid"
+       id="associated-element-6"
+       aria-label="bar"
+       class="pass">
+  </div>
+
+  <div aria-controls="associated-element-7"
+       role="combobox"
+       aria-label="foo"
+       aria-expanded="true"
+       aria-haspopup="dialog"
+       >
+  </div>
+  <div
+       role="dialog"
+       id="associated-element-7"
+       aria-label="bar"
+       class="pass">
+  </div>
+
+</html>

--- a/validator-tests/combobox-role-associated-popup.html
+++ b/validator-tests/combobox-role-associated-popup.html
@@ -1,109 +1,109 @@
 <html lang="en-US">
 <head><title>Popup element associated with a combobox must have allowed roles.</title></head>
-  <body>
-    <!--
-    URL: https://www.w3.org/TR/wai-aria-1.2/#combobox
-    RULE: "Authors MUST ensure the popup element associated with a combobox has
-    * a role of listbox, tree, grid, or dialog."
-    -->
-  </body>
+<body>
+  <!--
+  URL: https://www.w3.org/TR/wai-aria-1.2/#combobox
+  RULE: "Authors MUST ensure the popup element associated with a combobox has
+  * a role of listbox, tree, grid, or dialog."
+  -->
 
-  <!-- Should fail -->
+<!-- Should fail -->
 
-  <div aria-controls="associated-element-1"
-       role="combobox"
-       aria-label="foo"
-       aria-expanded="true">
-  </div>
-  <div
-       id="associated-element-1"
-       aria-label="bar"
-       class="fail">
-  </div>
+<div aria-controls="associated-element-1"
+     role="combobox"
+     aria-label="foo"
+     aria-expanded="true">
+</div>
+<div
+     id="associated-element-1"
+     aria-label="bar"
+     class="fail">
+</div>
 
-  <div aria-controls="associated-element-2"
-       role="combobox"
-       aria-label="foo"
-       aria-expanded="true"
-       aria-haspopup="listbox"
-       >
-  </div>
-  <div
-       role="alert"
-       id="associated-element-2"
-       aria-label="bar"
-       class="fail">
-  </div>
+<div aria-controls="associated-element-2"
+     role="combobox"
+     aria-label="foo"
+     aria-expanded="true"
+     aria-haspopup="listbox"
+     >
+</div>
+<div
+     role="alert"
+     id="associated-element-2"
+     aria-label="bar"
+     class="fail">
+</div>
 
-  <div aria-controls="associated-element-3"
-       role="combobox"
-       aria-label="foo"
-       aria-expanded="true"
-       aria-haspopup="menubar"
-       >
-  </div>
-  <div
-       role="menubar"
-       id="associated-element-3"
-       aria-label="bar"
-       class="fail">
-    <div role="menuitem" aria-label="baz"></div>
-  </div>
+<div aria-controls="associated-element-3"
+     role="combobox"
+     aria-label="foo"
+     aria-expanded="true"
+     aria-haspopup="menubar"
+     >
+</div>
+<div
+     role="menubar"
+     id="associated-element-3"
+     aria-label="bar"
+     class="fail">
+  <div role="menuitem" aria-label="baz"></div>
+</div>
 
-  <!-- Should pass -->
+<!-- Should pass -->
 
-  <div aria-controls="associated-element-4"
-       role="combobox"
-       aria-label="foo"
-       aria-expanded="true">
-  </div>
-  <div
-       id="associated-element-4"
-       role="listbox"
-       aria-label="bar"
-       class="pass">
-  </div>
+<div aria-controls="associated-element-4"
+     role="combobox"
+     aria-label="foo"
+     aria-expanded="true">
+</div>
+<div
+     id="associated-element-4"
+     role="listbox"
+     aria-label="bar"
+     class="pass">
+</div>
 
-  <div aria-controls="associated-element-5"
-       role="combobox"
-       aria-label="foo"
-       aria-expanded="true"
-       aria-haspopup="tree"
-       >
-  </div>
-  <div
-       role="tree"
-       id="associated-element-5"
-       aria-label="bar"
-       class="pass">
-  </div>
+<div aria-controls="associated-element-5"
+     role="combobox"
+     aria-label="foo"
+     aria-expanded="true"
+     aria-haspopup="tree"
+     >
+</div>
+<div
+     role="tree"
+     id="associated-element-5"
+     aria-label="bar"
+     class="pass">
+</div>
 
-  <div aria-controls="associated-element-6"
-       role="combobox"
-       aria-label="foo"
-       aria-expanded="true"
-       aria-haspopup="grid"
-       >
-  </div>
-  <div
-       role="grid"
-       id="associated-element-6"
-       aria-label="bar"
-       class="pass">
-  </div>
+<div aria-controls="associated-element-6"
+     role="combobox"
+     aria-label="foo"
+     aria-expanded="true"
+     aria-haspopup="grid"
+     >
+</div>
+<div
+     role="grid"
+     id="associated-element-6"
+     aria-label="bar"
+     class="pass">
+</div>
 
-  <div aria-controls="associated-element-7"
-       role="combobox"
-       aria-label="foo"
-       aria-expanded="true"
-       aria-haspopup="dialog"
-       >
-  </div>
-  <div
-       role="dialog"
-       id="associated-element-7"
-       aria-label="bar"
-       class="pass">
-  </div>
+<div aria-controls="associated-element-7"
+     role="combobox"
+     aria-label="foo"
+     aria-expanded="true"
+     aria-haspopup="dialog"
+     >
+</div>
+<div
+     role="dialog"
+     id="associated-element-7"
+     aria-label="bar"
+     class="pass">
+</div>
 
+</body>
 </html>


### PR DESCRIPTION
Add test for [combobox](https://www.w3.org/TR/wai-aria-1.2/#combobox): `Authors MUST ensure the popup element associated with a combobox has a role of listbox, tree, grid, or dialog.`

Closes #1563