### PR TITLE
Editorial: Fix typo in markup example

### DIFF
--- a/index.html
+++ b/index.html
@@ -623,7 +623,7 @@
 		<section id="baseConcept">
 			<h3>Base Concept</h3>
 			<p>Informative data about <a>objects</a> that are considered prototypes for the <a>role</a>. Base concept is similar to type, but without inheritance of limitations and properties. Base concepts are designed as a substitute for inheritance for external concepts. A base concept is like a <a href="#relatedConcept">related concept</a> except that the base concept is almost identical to the role definition.</p>
-			<p>For example, the <rref>checkbox</rref> defined in this document has similar functionality and anticipated behavior to a <code>&lt;input[type="checkbox"]&gt;</code> defined in [[HTML]]. Therefore, a <rref>checkbox</rref> has an [[HTML]] <code>checkbox</code> as a <code>baseConcept</code>. However, if the original [[HTML]] checkbox baseConcept definition is modified, the definition of a <rref>checkbox</rref> in this document will not be affected, because there is no actual inheritance of the respective type.</p>
+			<p>For example, the <rref>checkbox</rref> defined in this document has similar functionality and anticipated behavior to a <code>&lt;input type="checkbox"&gt;</code> defined in [[HTML]]. Therefore, a <rref>checkbox</rref> has an [[HTML]] <code>checkbox</code> as a <code>baseConcept</code>. However, if the original [[HTML]] checkbox baseConcept definition is modified, the definition of a <rref>checkbox</rref> in this document will not be affected, because there is no actual inheritance of the respective type.</p>
 		</section>
 	</section>
 	<section id="Properties">


### PR DESCRIPTION
In the 5.1.4 Base Concept section the following was written: `<input[type="checkbox"]>` which appears to be a mix between writing the HTML tag and the CSS selector for a native checkbox.  

This PR removes the brackets in favor of displaying this as an HTML tag, since the example is immediately followed with the text "defined in [HTML]"


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1615.html" title="Last updated on Sep 14, 2021, 3:49 PM UTC (d016c5a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1615/95f3b73...d016c5a.html" title="Last updated on Sep 14, 2021, 3:49 PM UTC (d016c5a)">Diff</a>