### PR TITLE
Update aria sort value descriptions to include "row" fixes #1614

### DIFF
--- a/index.html
+++ b/index.html
@@ -13134,15 +13134,15 @@ button.ariaPressed; // "undefined" (Note: button is no longer a toggle button.)<
 				<tbody>
 					<tr>
 						<th class="value-name" scope="row">ascending</th>
-						<td class="value-description">Items are sorted in ascending order by this column or row.</td>
+						<td class="value-description">Items are sorted in ascending order.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">descending</th>
-						<td class="value-description">Items are sorted in descending order by this column or row.</td>
+						<td class="value-description">Items are sorted in descending order.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row"><strong class="default">none (default)</strong></th>
-						<td class="value-description">There is no defined sort applied to the column or row.</td>
+						<td class="value-description">There is no defined sort applied.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">other</th>

--- a/index.html
+++ b/index.html
@@ -13134,15 +13134,15 @@ button.ariaPressed; // "undefined" (Note: button is no longer a toggle button.)<
 				<tbody>
 					<tr>
 						<th class="value-name" scope="row">ascending</th>
-						<td class="value-description">Items are sorted in ascending order by this column.</td>
+						<td class="value-description">Items are sorted in ascending order by this column or row.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">descending</th>
-						<td class="value-description">Items are sorted in descending order by this column.</td>
+						<td class="value-description">Items are sorted in descending order by this column or row.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row"><strong class="default">none (default)</strong></th>
-						<td class="value-description">There is no defined sort applied to the column.</td>
+						<td class="value-description">There is no defined sort applied to the column or row.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">other</th>


### PR DESCRIPTION
Address #1614 by adding "or row" to descriptions of aria-sort values so that they now say "column or row"


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1616.html" title="Last updated on Sep 23, 2021, 5:25 PM UTC (ff9f56e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1616/7c5efbe...ff9f56e.html" title="Last updated on Sep 23, 2021, 5:25 PM UTC (ff9f56e)">Diff</a>