### PR TITLE
Remove bad license

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,6 @@
 		// if you wish the publication date to be other than today, set this
 		//publishDate:  "2014-12-11",
 		copyrightStart:  "2013",
-		license: "document",
 
 		// if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
 		// and its maturity status


### PR DESCRIPTION
"document" is not a valid license. ReSpec automatically defaults to "w3c-software-doc", which is what we want here.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1624.html" title="Last updated on Oct 5, 2021, 12:00 AM UTC (3a36195)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1624/0d06a71...3a36195.html" title="Last updated on Oct 5, 2021, 12:00 AM UTC (3a36195)">Diff</a>