### PR TITLE
Use rref instead of ref, which is probably a typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -588,7 +588,7 @@
 		<ol>
 		  <li>If the <a class="termref">element</a> can take <abbr title="Document Object Model">DOM</abbr> focus, the <a class="termref">user agent</a> MUST set the <abbr title="Document Object Model">DOM</abbr> focus to it.</li>
 		  <li>Otherwise, if the element being focused has an ID and the ID is referenced by the <pref>aria-activedescendant</pref> attribute of an element that is focusable, the user agent MUST set <abbr title="Document Object Model">DOM</abbr> focus to the element that has the <pref>aria-activedescendant</pref> attribute.
-		  	<p class="note">An element with an ID can be referenced when it is <a>owned</a> by a container element that has the <pref>aria-activedescendant</pref> attribute or by a container element that is controlled by an element that has the <pref>aria-activedescendant</pref> attribute  (e.g. see <ref>combobox</ref>).  Otherwise the <pref>aria-activedescendant</pref> attribute reference indicates an author error.</p>
+		  	<p class="note">An element with an ID can be referenced when it is <a>owned</a> by a container element that has the <pref>aria-activedescendant</pref> attribute or by a container element that is controlled by an element that has the <pref>aria-activedescendant</pref> attribute  (e.g. see <rref>combobox</rref>).  Otherwise the <pref>aria-activedescendant</pref> attribute reference indicates an author error.</p>
 		    <p class="note">The inability to set <abbr title="Document Object Model">DOM</abbr> focus to the containing element indicates an author error.</p>
 		  </li>
 		  <li>Otherwise, the user agent MAY attempt to set <abbr title="Document Object Model">DOM</abbr> focus to the child element itself.</li>


### PR DESCRIPTION
Resolves one of the issues found in #1623.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/aria/pull/1631.html" title="Last updated on Nov 4, 2021, 6:18 PM UTC (439b495)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1631/0d06a71...saschanaz:439b495.html" title="Last updated on Nov 4, 2021, 6:18 PM UTC (439b495)">Diff</a>