### PR TITLE
Escape examples for `role="time"`

### DIFF
--- a/index.html
+++ b/index.html
@@ -9376,19 +9376,21 @@
 				<p>An element that represents a specific point in time.</p>
 				<p class="note">At the present time, there are no <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> properties corresponding to the <code>datetime</code> attribute supported on <code>&lt;time&gt;</code> in [[HTML]]. The addition of this property will be considered for ARIA version 1.3.</p>
 				<p>Authors SHOULD limit text contents to a valid date- or time-related string, or apply this future <code>datetime</code>-equivalent property to the element which has role <code>time</code>.</p>
-				<p>Examples of valid date- or time-related strings as text contents of an element with the <code>time</code> role:</p>
-				<ul>
-					<li>A valid month string: <code>&lt;span role="time"&gt;2019-11&lt;/span&gt;</code></li>
-					<li>A valid date string: <code>&lt;span role="time"&gt;2019-11-18&lt;/span&gt;</code></li>
-					<li>A valid yearless date string: <code>&lt;span role="time"&gt;11-18&lt;/span&gt;</code></li>
-					<li>A valid time string: <code>&lt;span role="time"&gt;09:54:39&lt;/span&gt;</code></li>
-					<li>A valid floating date and time string: <code>&lt;span role="time"&gt;2019-11-18T14:54&lt;/span&gt;</code></li>
-					<li>A valid time-zone offset string: <code>&lt;span role="time"&gt;-08:00&lt;/span&gt;</code></li>
-					<li>A valid global date and time string: <code>&lt;span role="time"&gt;2019-11-18T14:54Z&lt;/span&gt;</code></li>
-					<li>A valid week string: <code>&lt;span role="time"&gt;2019-W47&lt;/span&gt;</code></li>
-					<li>Four or more ASCII digits, at least one of which is not U+0030 DIGIT ZERO (0): <code>&lt;span role="time"&gt;0001&lt;/span&gt;</code></li>
-					<li>A valid duration string: <code>&lt;span role="time"&gt;4h 18m 3s&lt;/span&gt;</code></li>
-				</ul>
+				<aside class="example">
+					<p>Examples of valid date- or time-related strings as text contents of an element with the <code>time</code> role:</p>
+					<ul>
+						<li>A valid month string: <code>&lt;span role="time"&gt;2019-11&lt;/span&gt;</code></li>
+						<li>A valid date string: <code>&lt;span role="time"&gt;2019-11-18&lt;/span&gt;</code></li>
+						<li>A valid yearless date string: <code>&lt;span role="time"&gt;11-18&lt;/span&gt;</code></li>
+						<li>A valid time string: <code>&lt;span role="time"&gt;09:54:39&lt;/span&gt;</code></li>
+						<li>A valid floating date and time string: <code>&lt;span role="time"&gt;2019-11-18T14:54&lt;/span&gt;</code></li>
+						<li>A valid time-zone offset string: <code>&lt;span role="time"&gt;-08:00&lt;/span&gt;</code></li>
+						<li>A valid global date and time string: <code>&lt;span role="time"&gt;2019-11-18T14:54Z&lt;/span&gt;</code></li>
+						<li>A valid week string: <code>&lt;span role="time"&gt;2019-W47&lt;/span&gt;</code></li>
+						<li>Four or more ASCII digits, at least one of which is not U+0030 DIGIT ZERO (0): <code>&lt;span role="time"&gt;0001&lt;/span&gt;</code></li>
+						<li>A valid duration string: <code>&lt;span role="time"&gt;4h 18m 3s&lt;/span&gt;</code></li>
+					</ul>
+				</aside>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -9378,16 +9378,16 @@
 				<p>Authors SHOULD limit text contents to a valid date- or time-related string, or apply this future <code>datetime</code>-equivalent property to the element which has role <code>time</code>.</p>
 				<p>Examples of valid date- or time-related strings as text contents of an element with the <code>time</code> role:</p>
 				<ul>
-					<li>A valid month string: <code><span role="time">2019-11</span></code></li>
-					<li>A valid date string: <code><span role="time">2019-11-18</span></code></li>
-					<li>A valid yearless date string: <code><span role="time">11-18</span></code></li>
-					<li>A valid time string: <code><span role="time">09:54:39</span></code></li>
-					<li>A valid floating date and time string: <code><span role="time">2019-11-18T14:54</span></code></li>
-					<li>A valid time-zone offset string: <code><span role="time">-08:00</span></code></li>
-					<li>A valid global date and time string: <code><span role="time">2019-11-18T14:54Z</span></code></li>
-					<li>A valid week string: <code><span role="time">2019-W47</span></code></li>
-					<li>Four or more ASCII digits, at least one of which is not U+0030 DIGIT ZERO (0): <code><span role="time">0001</span></code></li>
-					<li>A valid duration string: <code><span role="time">4h 18m 3s</span></code></li>
+					<li>A valid month string: <code>&lt;span role="time"&gt;2019-11&lt;/span&gt;</code></li>
+					<li>A valid date string: <code>&lt;span role="time"&gt;2019-11-18&lt;/span&gt;</code></li>
+					<li>A valid yearless date string: <code>&lt;span role="time"&gt;11-18&lt;/span&gt;</code></li>
+					<li>A valid time string: <code>&lt;span role="time"&gt;09:54:39&lt;/span&gt;</code></li>
+					<li>A valid floating date and time string: <code>&lt;span role="time"&gt;2019-11-18T14:54&lt;/span&gt;</code></li>
+					<li>A valid time-zone offset string: <code>&lt;span role="time"&gt;-08:00&lt;/span&gt;</code></li>
+					<li>A valid global date and time string: <code>&lt;span role="time"&gt;2019-11-18T14:54Z&lt;/span&gt;</code></li>
+					<li>A valid week string: <code>&lt;span role="time"&gt;2019-W47&lt;/span&gt;</code></li>
+					<li>Four or more ASCII digits, at least one of which is not U+0030 DIGIT ZERO (0): <code>&lt;span role="time"&gt;0001&lt;/span&gt;</code></li>
+					<li>A valid duration string: <code>&lt;span role="time"&gt;4h 18m 3s&lt;/span&gt;</code></li>
 				</ul>
 			</div>
 			<table class="role-features">

--- a/index.html
+++ b/index.html
@@ -9378,16 +9378,16 @@
 				<p>Authors SHOULD limit text contents to a valid date- or time-related string, or apply this future <code>datetime</code>-equivalent property to the element which has role <code>time</code>.</p>
 				<p>Examples of valid date- or time-related strings as text contents of an element with the <code>time</code> role:</p>
 				<ul>
-					<li>A valid month string: <code><span role="time">2019-11</span></code></li>
-					<li>A valid date string: <code><span role="time">2019-11-18</span></code></li>
-					<li>A valid yearless date string: <code><span role="time">11-18</span></code></li>
-					<li>A valid time string: <code><span role="time">09:54:39</span></code></li>
-					<li>A valid floating date and time string: <code><span role="time">2019-11-18T14:54</span></code></li>
-					<li>A valid time-zone offset string: <code><span role="time">-08:00</span></code></li>
-					<li>A valid global date and time string: <code><span role="time">2019-11-18T14:54Z</span></code></li>
-					<li>A valid week string: <code><span role="time">2019-W47</span></code></li>
-					<li>Four or more ASCII digits, at least one of which is not U+0030 DIGIT ZERO (0): <code><span role="time">0001</span></code></li>
-					<li>A valid duration string: <code><span role="time">4h 18m 3s</span></code></li>
+					<li>A valid month string: <code><time>2019-11</time></code></li>
+					<li>A valid date string: <code><time>2019-11-18</time></code></li>
+					<li>A valid yearless date string: <code><time>11-18</time></code></li>
+					<li>A valid time string: <code><time>09:54:39</time></code></li>
+					<li>A valid floating date and time string: <code><time>2019-11-18T14:54</time></code></li>
+					<li>A valid time-zone offset string: <code><time>-08:00</time></code></li>
+					<li>A valid global date and time string: <code><time>2019-11-18T14:54Z</time></code></li>
+					<li>A valid week string: <code><time>2019-W47</time></code></li>
+					<li>Four or more ASCII digits, at least one of which is not U+0030 DIGIT ZERO (0): <code><time>0001</time></code></li>
+					<li>A valid duration string: <code><time>4h 18m 3s</time></code></li>
 				</ul>
 			</div>
 			<table class="role-features">

--- a/index.html
+++ b/index.html
@@ -9378,16 +9378,16 @@
 				<p>Authors SHOULD limit text contents to a valid date- or time-related string, or apply this future <code>datetime</code>-equivalent property to the element which has role <code>time</code>.</p>
 				<p>Examples of valid date- or time-related strings as text contents of an element with the <code>time</code> role:</p>
 				<ul>
-					<li>A valid month string: <code><time>2019-11</time></code></li>
-					<li>A valid date string: <code><time>2019-11-18</time></code></li>
-					<li>A valid yearless date string: <code><time>11-18</time></code></li>
-					<li>A valid time string: <code><time>09:54:39</time></code></li>
-					<li>A valid floating date and time string: <code><time>2019-11-18T14:54</time></code></li>
-					<li>A valid time-zone offset string: <code><time>-08:00</time></code></li>
-					<li>A valid global date and time string: <code><time>2019-11-18T14:54Z</time></code></li>
-					<li>A valid week string: <code><time>2019-W47</time></code></li>
-					<li>Four or more ASCII digits, at least one of which is not U+0030 DIGIT ZERO (0): <code><time>0001</time></code></li>
-					<li>A valid duration string: <code><time>4h 18m 3s</time></code></li>
+					<li>A valid month string: <code><span role="time">2019-11</span></code></li>
+					<li>A valid date string: <code><span role="time">2019-11-18</span></code></li>
+					<li>A valid yearless date string: <code><span role="time">11-18</span></code></li>
+					<li>A valid time string: <code><span role="time">09:54:39</span></code></li>
+					<li>A valid floating date and time string: <code><span role="time">2019-11-18T14:54</span></code></li>
+					<li>A valid time-zone offset string: <code><span role="time">-08:00</span></code></li>
+					<li>A valid global date and time string: <code><span role="time">2019-11-18T14:54Z</span></code></li>
+					<li>A valid week string: <code><span role="time">2019-W47</span></code></li>
+					<li>Four or more ASCII digits, at least one of which is not U+0030 DIGIT ZERO (0): <code><span role="time">0001</span></code></li>
+					<li>A valid duration string: <code><span role="time">4h 18m 3s</span></code></li>
 				</ul>
 			</div>
 			<table class="role-features">


### PR DESCRIPTION
Fixes another issue from #1623 

Not sure whether using `role="time"` in the definition of `role="time"` makes sense, but please tell me if it actually does.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/aria/pull/1638.html" title="Last updated on Nov 5, 2021, 9:14 PM UTC (fa4235d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1638/43b08b9...saschanaz:fa4235d.html" title="Last updated on Nov 5, 2021, 9:14 PM UTC (fa4235d)">Diff</a>