### PR TITLE
removed references to <range>

### DIFF
--- a/index.html
+++ b/index.html
@@ -13211,7 +13211,7 @@ button.ariaPressed; // null</pre>
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><code>&lt;input&gt;</code> element <code>max</code> attribute in [[HTML]]</td>
+						<td class="property-related"><code>&lt;input type="range"&gt;</code> element <code>max</code> attribute in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>

--- a/index.html
+++ b/index.html
@@ -13285,7 +13285,7 @@ button.ariaPressed; // null</pre>
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><code>&lt;input&gt;</code> element <code>value</code> attribute in [[HTML]]</td>
+						<td class="property-related"><code>&lt;input type="range"&gt;</code> element <code>value</code> attribute in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>

--- a/index.html
+++ b/index.html
@@ -13211,7 +13211,7 @@ button.ariaPressed; // null</pre>
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><code>&lt;range&gt;</code> element <code>max</code> attribute in [[HTML]]</td>
+						<td class="property-related"><code>&lt;input&gt;</code> element <code>max</code> attribute in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -13246,7 +13246,7 @@ button.ariaPressed; // null</pre>
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><code>&lt;range&gt;</code> element <code>min</code> attribute in [[HTML]]</td>
+						<td class="property-related"><code>&lt;input&gt;</code> element <code>min</code> attribute in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -13285,7 +13285,7 @@ button.ariaPressed; // null</pre>
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><code>&lt;range&gt;</code> element <code>value</code> attribute in [[HTML]]</td>
+						<td class="property-related"><code>&lt;input&gt;</code> element <code>value</code> attribute in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>

--- a/index.html
+++ b/index.html
@@ -13246,7 +13246,7 @@ button.ariaPressed; // null</pre>
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><code>&lt;input&gt;</code> element <code>min</code> attribute in [[HTML]]</td>
+						<td class="property-related"><code>&lt;input type="range"&gt;</code> element <code>min</code> attribute in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>


### PR DESCRIPTION
`<range>` is not currently in HTML.
min, max, and value are attributes in input, meter, and progress.
changed the related concept for aria-valuemin, aria-valuemax, and aria-valuenow to input (from range)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/estelle/aria/pull/1652.html" title="Last updated on Dec 4, 2021, 7:53 AM UTC (9e9b0a2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1652/fcea743...estelle:9e9b0a2.html" title="Last updated on Dec 4, 2021, 7:53 AM UTC (9e9b0a2)">Diff</a>