### PR TITLE
add note to aria-roledescription

### DIFF
--- a/index.html
+++ b/index.html
@@ -12736,11 +12736,12 @@ button.ariaPressed; // null</pre>
 				<p><a>Defines</a> a human-readable, author-localized description for the <a>role</a> of an <a>element</a>.</p>
 				<p>Some <a>assistive technologies</a>, such as screen readers, present the role of an element as part of the user experience. Such assistive technologies typically localize the name of the role, and they may customize it as well. Users of these assistive technologies depend on the presentation of the role name, such as "region," "button," or "slider," for an understanding of the purpose of the element and, if it is a widget, how to interact with it.</p>
 				<p>The <code>aria-roledescription</code> property gives authors the ability to override how assistive technologies localize and express the name of a role. Thus inappropriately using <code>aria-roledescription</code> may inhibit users' ability to understand or interact with an element. Authors SHOULD limit use of <code>aria-roledescription</code> to clarifying the purpose of non-interactive container roles like <rref>group</rref> or <rref>region</rref>, or to providing a <em>more specific</em> description of a <rref>widget</rref>.</p>
-				<p> When using <code>aria-roledescription</code>, authors SHOULD also ensure that:</p>
+				<p>When using <code>aria-roledescription</code>, authors SHOULD also ensure that:</p>
 				<ol>
 					<li>The element to which <code>aria-roledescription</code> is applied has a valid <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role or has an implicit WAI-ARIA role semantic.</li>
 					<li>The value of <code>aria-roledescription</code> is not empty or does not contain only whitespace characters.</li>
 				</ol>
+				<p class="note">Depending on the assistive technology, user verbosity settings, or other factors, certain elements and their implicit or explicit ARIA role descriptions might not be conveyed. Authors need to be aware that if specifying <code>aria-roledescription</code> on these elements, then their custom role descriptions may not be conveyed by these assistive technologies, as well.</p>
 				<p>User agents MUST NOT expose the <code>aria-roledescription</code> property if any of the following conditions exist:</p>
 				<ol>
 					<li>The element to which <code>aria-roledescription</code> is applied has an explicit or implicit WAI-ARIA role where <code>aria-roledescription</code> is <a href="#prohibitedattributes">prohibited</a>.</li>

--- a/index.html
+++ b/index.html
@@ -12741,7 +12741,7 @@ button.ariaPressed; // null</pre>
 					<li>The element to which <code>aria-roledescription</code> is applied has a valid <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role or has an implicit WAI-ARIA role semantic.</li>
 					<li>The value of <code>aria-roledescription</code> is not empty or does not contain only whitespace characters.</li>
 				</ol>
-				<p class="note">Depending on the assistive technology, user verbosity settings, or other factors, certain elements and their implicit or explicit ARIA role descriptions might not be conveyed. Authors need to be aware that if specifying <code>aria-roledescription</code> on these elements, then their custom role descriptions may not be conveyed by these assistive technologies, as well.</p>
+				<p class="note">Depending on the assistive technology, user verbosity settings, or other factors, certain elements' role descriptions might not be conveyed. If specifying <code>aria-roledescription</code> on such elements, then the custom role descriptions may also not be conveyed by these assistive technologies.</p>
 				<p>User agents MUST NOT expose the <code>aria-roledescription</code> property if any of the following conditions exist:</p>
 				<ol>
 					<li>The element to which <code>aria-roledescription</code> is applied has an explicit or implicit WAI-ARIA role where <code>aria-roledescription</code> is <a href="#prohibitedattributes">prohibited</a>.</li>


### PR DESCRIPTION
closes #1651

adds a note indicating that `aria-roledescription` may not be conveyed depending on the element/AT defaults or user settings.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1666.html" title="Last updated on Dec 23, 2021, 3:04 AM UTC (edeea7d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1666/9653692...edeea7d.html" title="Last updated on Dec 23, 2021, 3:04 AM UTC (edeea7d)">Diff</a>