### PR TITLE
abstract roles remove 'name from'

### DIFF
--- a/index.html
+++ b/index.html
@@ -2499,7 +2499,7 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -2757,7 +2757,7 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -4222,7 +4222,7 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -4387,7 +4387,7 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -6790,7 +6790,7 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -6943,11 +6943,7 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">
-							<ul>
-								<li><abbr title="not applicable">n/a</abbr></li>
-							</ul>
-						</td>
+						<td class="role-namefrom"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -7583,7 +7579,7 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom"><abbr title="not applicable">n/a</abbr></td>
+						<td class="role-namefrom"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -7653,12 +7649,7 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">
-							<ul>
-								<li>contents</li>
-								<li>author</li>
-							</ul>
-						</td>
+						<td class="role-namefrom"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -7733,7 +7724,7 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -8304,11 +8295,7 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">
-							<ul>
-								<li><abbr title="not applicable">n/a</abbr></li>
-							</ul>
-						</td>
+						<td class="role-namefrom"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -10081,11 +10068,7 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">
-							<ul>
-								<li><abbr title="not applicable">n/a</abbr></li>
-							</ul>
-						</td>
+						<td class="role-namefrom"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -10157,7 +10140,7 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom"> </td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>


### PR DESCRIPTION
closes #1436, removes name from entries from the abstract role characteristic tables.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1667.html" title="Last updated on Dec 21, 2021, 1:31 PM UTC (0afa70e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1667/9653692...0afa70e.html" title="Last updated on Dec 21, 2021, 1:31 PM UTC (0afa70e)">Diff</a>