### PR TITLE
Fix: add aria-level as supported on treeitem

### DIFF
--- a/index.html
+++ b/index.html
@@ -10002,6 +10002,7 @@
 							<ul>
 								<li><sref>aria-expanded</sref></li>
 								<li><pref>aria-haspopup</pref></li>
+								<li><pref>aria-level</pref></li>
 							</ul>
 						</td>
 					</tr>


### PR DESCRIPTION
closes #1605

adds `aria-level` to the supported states and property cell of the characteristics table since its no longer being inherited due to the change to `listitem`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1676.html" title="Last updated on Jan 14, 2022, 1:44 PM UTC (a88cef4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1676/b2503c8...a88cef4.html" title="Last updated on Jan 14, 2022, 1:44 PM UTC (a88cef4)">Diff</a>