### PR TITLE
Update related concepts for landmarks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1572,7 +1572,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"> </td>
+						<td class="role-related"><code>&lt;header&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2663,7 +2663,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"> </td>
+						<td class="role-related"><code>&lt;aside&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2823,7 +2823,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"> </td>
+						<td class="role-related"><code>&lt;footer&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>

--- a/index.html
+++ b/index.html
@@ -4910,7 +4910,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"> </td>
+						<td class="role-related"><code>&lt;main&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>


### PR DESCRIPTION
closes  #1677

The initial PR adds the related concept row to the `main` landmark, referencing HTML's `<main>` element. 

Follow-on updates to this PR will be contingent on the direction decided in the linked issue.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1678.html" title="Last updated on Jan 17, 2022, 1:40 PM UTC (28ca1e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1678/b2503c8...28ca1e2.html" title="Last updated on Jan 17, 2022, 1:40 PM UTC (28ca1e2)">Diff</a>