### PR TITLE
use default W3C license

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,6 @@
 		// if you wish the publication date to be other than today, set this
 		//publishDate:  "2014-12-11",
 		copyrightStart:  "2013",
-		license: "document",
 
 		// if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
 		// and its maturity status


### PR DESCRIPTION
New charter has changed license to Respec default


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1692.html" title="Last updated on Feb 9, 2022, 12:56 PM UTC (20cb617)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1692/157d711...20cb617.html" title="Last updated on Feb 9, 2022, 12:56 PM UTC (20cb617)">Diff</a>