### PR TITLE
Remove instance of 'mainstream' in figure role

### DIFF
--- a/index.html
+++ b/index.html
@@ -3454,7 +3454,7 @@
 			<div class="role-description">
 				<p>A perceivable <rref>section</rref> of content that typically contains a <a>graphical document</a>, images, code snippets, or example text. The parts of a <code>figure</code> MAY be user-navigable.</p>
 				<p>Authors SHOULD provide a reference to the <code>figure</code> from the main text, but the <code>figure</code> need not be displayed at the same location as the referencing element. Authors MAY reference text serving as a caption using <pref>aria-describedby</pref>. Authors MAY provide a label using <pref>aria-label</pref> or MAY reference text serving as a label using <pref>aria-labelledby</pref>.</p>
-				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to figures. Mainstream <a>user agents</a> MAY enable users to quickly navigate to figures.</p>
+				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to figures. <a>User agents</a> MAY enable users to quickly navigate to figures.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>


### PR DESCRIPTION
closes #1321, makes `figure` consistent with other role definitions which do not refer to user agents as 'mainstream user agents'


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1700.html" title="Last updated on Mar 7, 2022, 8:13 AM UTC (b253b78)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1700/c577b84...b253b78.html" title="Last updated on Mar 7, 2022, 8:13 AM UTC (b253b78)">Diff</a>