### PR TITLE
include mention of figure/caption

### DIFF
--- a/index.html
+++ b/index.html
@@ -11297,7 +11297,7 @@ button.ariaPressed; // null</pre>
 				<ul>
 					<li>Comment: <code>aria-details</code> refers to an element with role <rref>comment</rref>.</li>
 					<li>Definition: <code>aria-details</code> is applied to an element with role <rref>term</rref> and refers to an element with role <rref>definition</rref>.</li>
-					<li>Figure: <code>aria-details</code> is applied to an element with role <rref>figure</rref> and refers to an element with role <rref>caption</rref>, or an element within a <code>caption</code>.</li>
+					<li>Caption: <code>aria-details</code> is applied to an element with role <rref>figure</rref> and refers to an element with role <rref>caption</rref>, or an element within a <code>caption</code>.</li>
 					<li>Footnote: <code>aria-details</code> refers to an element with role <code>doc-footnote</code>. This role is defined in [[DPUB-ARIA-1.0]].</li>
 					<li>Endnote: <code>aria-details</code> refers to an element with role <code>doc-endnote</code>. This role is defined in [[DPUB-ARIA-1.0]].</li>
 					<li>Description or general annotation: <code>aria-details</code> refers to an element with any other role.</li>

--- a/index.html
+++ b/index.html
@@ -11297,7 +11297,7 @@ button.ariaPressed; // null</pre>
 				<ul>
 					<li>Comment: <code>aria-details</code> refers to an element with role <rref>comment</rref>.</li>
 					<li>Definition: <code>aria-details</code> is applied to an element with role <rref>term</rref> and refers to an element with role <rref>definition</rref>.</li>
-					<li>Figure: <code>aria-details</code> is applied to an element with role <rref>figure</rref> and refers to an element with role <rref>caption</rref>, or an element witin a <code>caption</code>.</li>
+					<li>Figure: <code>aria-details</code> is applied to an element with role <rref>figure</rref> and refers to an element with role <rref>caption</rref>, or an element within a <code>caption</code>.</li>
 					<li>Footnote: <code>aria-details</code> refers to an element with role <code>doc-footnote</code>. This role is defined in [[DPUB-ARIA-1.0]].</li>
 					<li>Endnote: <code>aria-details</code> refers to an element with role <code>doc-endnote</code>. This role is defined in [[DPUB-ARIA-1.0]].</li>
 					<li>Description or general annotation: <code>aria-details</code> refers to an element with any other role.</li>

--- a/index.html
+++ b/index.html
@@ -11297,6 +11297,7 @@ button.ariaPressed; // null</pre>
 				<ul>
 					<li>Comment: <code>aria-details</code> refers to an element with role <rref>comment</rref>.</li>
 					<li>Definition: <code>aria-details</code> is applied to an element with role <rref>term</rref> and refers to an element with role <rref>definition</rref>.</li>
+					<li>Figure: <code>aria-details</code> is applied to an element with role <rref>figure</rref> and refers to an element with role <rref>caption</rref>, or an element witin a <code>caption</code>.</li>
 					<li>Footnote: <code>aria-details</code> refers to an element with role <code>doc-footnote</code>. This role is defined in [[DPUB-ARIA-1.0]].</li>
 					<li>Endnote: <code>aria-details</code> refers to an element with role <code>doc-endnote</code>. This role is defined in [[DPUB-ARIA-1.0]].</li>
 					<li>Description or general annotation: <code>aria-details</code> refers to an element with any other role.</li>


### PR DESCRIPTION
this pr updates `aria-details` to mention `figure` and `figcaption`.

This update is related to HTML AAM's update to the `figure` and `figcaption` elements - https://github.com/w3c/html-aam/pull/359.
It is a follow on to my other PR, #1703 which updates the `caption` role and includes information about `aria-details`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1704.html" title="Last updated on Apr 1, 2022, 8:44 PM UTC (35aa5e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1704/af94c5f...35aa5e8.html" title="Last updated on Apr 1, 2022, 8:44 PM UTC (35aa5e8)">Diff</a>