### PR TITLE
Update authoring requirement for aria-selected on options

### DIFF
--- a/index.html
+++ b/index.html
@@ -6030,11 +6030,12 @@
         </p>
         <p>
           Authors SHOULD indicate selection for <rref>option</rref> elements using one of the following:
-				</p>
-				<ul>
-					<li>An <sref>aria-selected</sref> value of <code>true</code> on the selected option within a single-select <rref>listbox</rref>, and optionally <sref>aria-selected</sref> values of <code>false</code> on unselected options.</li>
-					<li>either <sref>aria-selected</sref> or <sref>aria-checked</sref> on all options within a multi-select <rref>listbox</rref></li>
-				<p>
+	</p>
+	<ul>
+		<li>An <sref>aria-selected</sref> value of <code>true</code> on the selected option within a single-select <rref>listbox</rref>, and optionally <sref>aria-selected</sref> values of <code>false</code> on unselected options.</li>
+		<li>Either <sref>aria-selected</sref> or <sref>aria-checked</sref> on all options within a multi-select <rref>listbox</rref></li>
+	</ul>
+	<p>
           Authors SHOULD NOT specify both <sref>aria-selected</sref> and <sref>aria-checked</sref> on <rref>option</rref> elements contained by the same <rref>listbox</rref> except in the extremely rare circumstances where all the following conditions are met:
         </p>
         <ul>

--- a/index.html
+++ b/index.html
@@ -6033,9 +6033,9 @@
         </p>
         <ul>
           <li>An <sref>aria-selected</sref> value of <code>true</code> on the selected option within a single-select <rref>listbox</rref>, and optionally <sref>aria-selected</sref> values of <code>false</code> on unselected options.</li>
-          <li>Either <sref>aria-selected</sref> or <sref>aria-checked</sref> on all options within a multi-select <rref>listbox</rref></li>
+          <li>Either <sref>aria-selected</sref> or <sref>aria-checked</sref> on all options within a multi-select <rref>listbox</rref>, with a value of <code>true</code> on selected options, and a value of <code>false</code> on unselected options.</li>
         </ul>
-	<p>
+        <p>
           Authors SHOULD NOT specify both <sref>aria-selected</sref> and <sref>aria-checked</sref> on <rref>option</rref> elements contained by the same <rref>listbox</rref> except in the extremely rare circumstances where all the following conditions are met:
         </p>
         <ul>

--- a/index.html
+++ b/index.html
@@ -6030,11 +6030,11 @@
         </p>
         <p>
           Authors SHOULD indicate selection for <rref>option</rref> elements using one of the following:
-	</p>
-	<ul>
-		<li>An <sref>aria-selected</sref> value of <code>true</code> on the selected option within a single-select <rref>listbox</rref>, and optionally <sref>aria-selected</sref> values of <code>false</code> on unselected options.</li>
-		<li>Either <sref>aria-selected</sref> or <sref>aria-checked</sref> on all options within a multi-select <rref>listbox</rref></li>
-	</ul>
+        </p>
+        <ul>
+          <li>An <sref>aria-selected</sref> value of <code>true</code> on the selected option within a single-select <rref>listbox</rref>, and optionally <sref>aria-selected</sref> values of <code>false</code> on unselected options.</li>
+          <li>Either <sref>aria-selected</sref> or <sref>aria-checked</sref> on all options within a multi-select <rref>listbox</rref></li>
+        </ul>
 	<p>
           Authors SHOULD NOT specify both <sref>aria-selected</sref> and <sref>aria-checked</sref> on <rref>option</rref> elements contained by the same <rref>listbox</rref> except in the extremely rare circumstances where all the following conditions are met:
         </p>

--- a/index.html
+++ b/index.html
@@ -6029,8 +6029,12 @@
           Otherwise, if a user agent provides an implicit <sref>aria-selected</sref> value for an <rref>option</rref>, the value SHOULD be <code>false</code>.
         </p>
         <p>
-          Authors MAY indicate selection for <rref>option</rref> elements  using either <sref>aria-selected</sref> or <sref>aria-checked</sref>.
-          Some user interfaces indicate selection with <sref>aria-selected</sref> in single-select list boxes and with <sref>aria-checked</sref> in multi-select list boxes.
+          Authors SHOULD indicate selection for <rref>option</rref> elements using one of the following:
+				</p>
+				<ul>
+					<li>An <sref>aria-selected</sref> value of <code>true</code> on the selected option within a single-select <rref>listbox</rref>, and optionally <sref>aria-selected</sref> values of <code>false</code> on unselected options.</li>
+					<li>either <sref>aria-selected</sref> or <sref>aria-checked</sref> on all options within a multi-select <rref>listbox</rref></li>
+				<p>
           Authors SHOULD NOT specify both <sref>aria-selected</sref> and <sref>aria-checked</sref> on <rref>option</rref> elements contained by the same <rref>listbox</rref> except in the extremely rare circumstances where all the following conditions are met:
         </p>
         <ul>


### PR DESCRIPTION
A different solution for #1661, discussed on 4/7 and summarized in this comment: https://github.com/w3c/aria/issues/1661#issuecomment-1092024562

I wrangled the existing wording around single vs. multiselect a little because the new `SHOULD` text about `aria-selected` overlapped with the existing single vs. multi-select wording, so I consolidated a bit.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1719.html" title="Last updated on Apr 9, 2022, 6:50 PM UTC (146e602)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1719/5051beb...146e602.html" title="Last updated on Apr 9, 2022, 6:50 PM UTC (146e602)">Diff</a>