### PR TITLE
added a label to the combobox listbox example

### DIFF
--- a/index.html
+++ b/index.html
@@ -2332,12 +2332,12 @@
 					<li>Otherwise, the value of the <code>combobox</code> is represented by its descendant elements and can be determined using the same method used to compute the name of a <rref>button</rref> from its descendant content.</li>
 				</ul>
 				<pre class="example highlight">
-          &lt;label for="tag_combo">Tag&lt;/label>
+          &lt;label id="tag_label" for="tag_combo">Tag&lt;/label>
 		      &lt;input type="text" id="tag_combo"
             role="combobox" aria-autocomplete="list"
             aria-haspopup="listbox" aria-expanded="true"
             aria-controls="popup_listbox" aria-activedescendant="selected_option"&gt;
-				  &lt;ul role="listbox" id="popup_listbox"&gt;
+				  &lt;ul role="listbox" id="popup_listbox" aria-labelledby="tag_label"&gt;
 			      &lt;li role="option"&gt;Zebra&lt;/li&gt;
 			      &lt;li role="option" id="selected_option"&gt;Zoom&lt;/li&gt;
 				  &lt;/ul&gt;


### PR DESCRIPTION
Added a label reference to the listbox in the combobox example, including adding an `id` attribute to the `label` element for reference by `aria-labelledby`.

This pull request replaces [pull 1227](https://github.com/w3c/aria/pull/1727).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1728.html" title="Last updated on Apr 21, 2022, 6:58 PM UTC (a8195c5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1728/87d775b...a8195c5.html" title="Last updated on Apr 21, 2022, 6:58 PM UTC (a8195c5)">Diff</a>