### PR TITLE
Using suffix Element/s for IDL attributes referring to elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -13831,7 +13831,7 @@ button.ariaPressed; // null</pre>
 				<li>If all trusted dictionary sources list a single spelling of a compound word with no spaces or hyphens, only the first letter of the term is capitalized. For example, neither “place-holder” nor “place holder” are considered valid spellings of the term “placeholder,” so <pref>aria-placeholder</pref> becomes <code>ariaPlaceholder</code> with only the P capitalized.</li>
 				<li>There are currently no acronym-based ARIA attributes, but if future attributes include acronym usage, attempt to match existing DOM conventions (e.g. ID becomes Id).</li>
 			</ul>
-		</section>
+			<p class="note">The specification does not currently define IDL attributes for ARIA content attributes of types ID reference or ID reference list. Naming of these IDL attributes is being <a href="https://github.com/whatwg/html/issues/3515">discussed</a> and may not follow the rules above.</p>
 		<section class="informative" id="idl_attr_exceptions">
 			<h3>IDL Attribute Name Notes or Exceptions</h3>
 			<p>Any notes or exceptions for specific attribute names will be listed here.</p>

--- a/index.html
+++ b/index.html
@@ -13832,6 +13832,7 @@ button.ariaPressed; // null</pre>
 				<li>There are currently no acronym-based ARIA attributes, but if future attributes include acronym usage, attempt to match existing DOM conventions (e.g. ID becomes Id).</li>
 			</ul>
 			<p class="note">The specification does not currently define IDL attributes for ARIA content attributes of types ID reference or ID reference list. Naming of these IDL attributes is being <a href="https://github.com/whatwg/html/issues/3515">discussed</a> and may not follow the rules above.</p>
+		</section>
 		<section class="informative" id="idl_attr_exceptions">
 			<h3>IDL Attribute Name Notes or Exceptions</h3>
 			<p>Any notes or exceptions for specific attribute names will be listed here.</p>


### PR DESCRIPTION
Fixes #1732


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1738.html" title="Last updated on Sep 20, 2022, 1:21 AM UTC (fe65c69)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1738/fde8933...fe65c69.html" title="Last updated on Sep 20, 2022, 1:21 AM UTC (fe65c69)">Diff</a>