### PR TITLE
associationlist and related roles have tediously long names

### DIFF
--- a/index.html
+++ b/index.html
@@ -818,9 +818,6 @@
 			<ul>
 				<li><rref>application</rref></li>
 				<li><rref>article</rref></li>
-				<li><rref>associationlist</rref></li>
-				<li><rref>associationlistitemkey</rref></li>
-				<li><rref>associationlistitemvalue</rref></li>
 				<li><rref>blockquote</rref></li>
 				<li><rref>caption</rref></li>
 				<li><rref>cell</rref></li>
@@ -841,6 +838,8 @@
 				<li><rref>insertion</rref></li>
 				<li><rref>list</rref></li>
 				<li><rref>listitem</rref></li>
+				<li><rref>listitemkey</rref></li>
+				<li><rref>listitemvalue</rref></li>
 				<li><rref>mark</rref></li>
 				<li><rref>math</rref></li>
 				<li><rref>meter</rref></li>
@@ -1261,7 +1260,7 @@
 				</tbody>
 			</table>
 		</div>
-    <div class="role" id="associationlist">
+    <!-- <div class="role" id="associationlist"> 
       <rdef>associationlist</rdef>
       <div class="role-description">
         <p>A <rref>section</rref> containing <rref>associationlistitemkey</rref> and <rref>associationlistitemvalue</rref> elements.</p>
@@ -1354,184 +1353,7 @@
           </tr>
         </tbody>
       </table>
-    </div>
-    <div class="role" id="associationlistitemkey">
-      <rdef>associationlistitemkey</rdef>
-      <div class="role-description">
-        <p>A single key item in an association list.</p>
-
-        <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>associationlistitemkey</code>:</p>
-        <ul>
-          <li>MUST be contained in an element whose <a>role</a> is <rref>associationlist</rref>.</li>
-          <li>SHOULD be followed by one or more sibling <a>elements</a> whose <a>role</a> is <rref>associationlistitemvalue</rref>.</li>
-          <li>MAY be followed by one or more sibling elements whose role is also <rref>associationlistitemkey</rref>.</li>
-        </ul>
-
-      </div>
-      <table class="role-features">
-        <caption>Characteristics:</caption>
-        <thead>
-          <tr>
-            <th scope="col">Characteristic</th>
-            <th scope="col">Value</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th class="role-abstract-head" scope="row">Is Abstract:</th>
-            <td class="role-abstract"> </td>
-          </tr>
-          <tr>
-            <th class="role-parent-head" scope="row">Superclass Role:</th>
-            <td class="role-parent"><rref>section</rref></td>
-          </tr>
-          <tr>
-            <th class="role-children-head" scope="row">Subclass Roles:</th>
-            <td class="role-children">Placeholder</td>
-          </tr>
-          <tr>
-            <th class="role-base-head" scope="row">Base Concept:</th>
-            <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dt-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dt</code></a></td>
-          </tr>
-          <tr>
-            <th class="role-related-head" scope="row">Related Concepts:</th>
-            <td class="role-related"> </td>
-          </tr>
-          <tr>
-            <th class="role-scope-head" scope="row">Required Context Role:</th>
-            <td class="role-scope"><rref>associationlist</rref></td>
-          </tr>
-          <tr>
-            <th class="role-required-properties-head">Required States and Properties:</th>
-            <td class="role-required-properties"> </td>
-          </tr>
-          <tr>
-            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
-            <td class="role-properties">
-              <ul>
-                <li><pref>aria-level</pref></li>
-                <li><pref>aria-posinset</pref></li>
-                <li><pref>aria-setsize</pref></li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
-            <td class="role-inherited">Placeholder</td>
-          </tr>
-          <tr>
-            <th class="role-namefrom-head" scope="row">Name From:</th>
-            <td class="role-namefrom">author</td>
-          </tr>
-          <tr>
-            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-            <td class="role-namerequired"> </td>
-          </tr>
-          <tr>
-            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
-            <td class="role-namerequired-inherited"> </td>
-          </tr>
-          <tr>
-            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
-            <td class="role-childpresentational"> </td>
-          </tr>
-          <tr>
-            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
-            <td class="role-presentational-inherited"> </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    <div class="role" id="associationlistitemvalue">
-      <rdef>associationlistitemvalue</rdef>
-      <div class="role-description">
-        <p>A single value item in an association list.</p>
-
-        <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>associationlistitemvalue</code>:</p>
-        <ul>
-          <li>MUST be contained in an element whose <a>role</a> is <rref>associationlist</rref>.</li>
-          <li>SHOULD have a preceding sibling <a>element</a> whose <a>role</a> is <rref>associationlistitemkey</rref>.</li>
-          <li>MAY be followed by one or more sibling elements whose role is also <rref>associationlistitemvalue</rref>.</li>
-        </ul>
-
-      </div>
-      <table class="role-features">
-        <caption>Characteristics:</caption>
-        <thead>
-          <tr>
-            <th scope="col">Characteristic</th>
-            <th scope="col">Value</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th class="role-abstract-head" scope="row">Is Abstract:</th>
-            <td class="role-abstract"> </td>
-          </tr>
-          <tr>
-            <th class="role-parent-head" scope="row">Superclass Role:</th>
-            <td class="role-parent"><rref>section</rref></td>
-          </tr>
-          <tr>
-            <th class="role-children-head" scope="row">Subclass Roles:</th>
-            <td class="role-children">Placeholder</td>
-          </tr>
-          <tr>
-            <th class="role-base-head" scope="row">Base Concept:</th>
-            <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dd-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dd</code></a></td>
-          </tr>
-          <tr>
-            <th class="role-related-head" scope="row">Related Concepts:</th>
-            <td class="role-related"> </td>
-          </tr>
-          <tr>
-            <th class="role-scope-head" scope="row">Required Context Role:</th>
-            <td class="role-scope"><rref>associationlist</rref></td>
-          </tr>
-          <tr>
-            <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
-            <td class="role-mustcontain"> </td>
-          </tr>
-          <tr>
-            <th class="role-required-properties-head">Required States and Properties:</th>
-            <td class="role-required-properties"> </td>
-          </tr>
-          <tr>
-            <th class="role-properties-head" scope="row">Supported States and Properties:</th>
-            <td class="role-properties">
-              <ul>
-                <li><pref>aria-posinset</pref></li>
-                <li><pref>aria-setsize</pref></li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
-            <td class="role-inherited">Placeholder</td>
-          </tr>
-          <tr>
-            <th class="role-namefrom-head" scope="row">Name From:</th>
-            <td class="role-namefrom">author</td>
-          </tr>
-          <tr>
-            <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-            <td class="role-namerequired"> </td>
-          </tr>
-          <tr>
-            <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
-            <td class="role-namerequired-inherited"> </td>
-          </tr>
-          <tr>
-            <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
-            <td class="role-childpresentational"> </td>
-          </tr>
-          <tr>
-            <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
-            <td class="role-presentational-inherited"> </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    </div> -->
 		<div class="role" id="banner">
 			<rdef>banner</rdef>
 			<div class="role-description">
@@ -4558,8 +4380,8 @@
 		<div class="role" id="list">
 			<rdef>list</rdef>
 			<div class="role-description">
-				<p>A <rref>section</rref> containing <rref>listitem</rref> elements. See related <rref>listbox</rref>.</p>
-				<p>Lists contain children whose <a>role</a> is <rref>listitem</rref>.</p>
+				<p>A <rref>section</rref> containing <rref>listitem</rref> elements or <rref>listitemkey</rref> and <rref>listitemvalue</rref> elements. See related <rref>listbox</rref>.</p>
+				<p>Lists contain either children whose <a>role</a> is <rref>listitem</rref> to represent a list of items, or children whose <a>role</a> is <rref>listitemkey</rref> and <rref>listitemvalue</rref> to represent a list of key items each having one or more values.</p>		
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4588,6 +4410,7 @@
 							<ul>
 								<li><code>&lt;ol&gt;</code> in [[HTML]]</li>
 								<li><code>&lt;ul&gt;</code> in [[HTML]]</li>
+								<li><code>&lt;dl&gt;</code> in [[HTML]]</li>
 							</ul>
 						</td>
 					</tr>
@@ -4601,7 +4424,13 @@
 					</tr>
 					<tr>
 						<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
-						<td class="role-mustcontain"><rref>listitem</rref></td>
+						<td class="role-mustcontain">
+							<ul>
+								<li><rref>listitem</rref></li>
+								<li><rref>listitemkey</rref></li>
+								<li><rref>listitemvalue</rref></li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-required-properties-head">Required States and Properties:</th>
@@ -4833,6 +4662,183 @@
 				</tbody>
 			</table>
 		</div>
+		<div class="role" id="listitemkey">
+			<rdef>listitemkey</rdef>
+			<div class="role-description">
+			  <p>A single key item in a list.</p>
+	  
+			  <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>listitemkey</code>:</p>
+			  <ul>
+				<li>MUST be contained in an element whose <a>role</a> is <rref>list</rref>.</li>
+				<li>SHOULD be followed by one or more sibling <a>elements</a> whose <a>role</a> is <rref>listitemvalue</rref>.</li>
+				<li>MAY be followed by one or more sibling elements whose role is also <rref>listitemkey</rref>.</li>
+			  </ul>
+	  
+			</div>
+			<table class="role-features">
+			  <caption>Characteristics:</caption>
+			  <thead>
+				<tr>
+				  <th scope="col">Characteristic</th>
+				  <th scope="col">Value</th>
+				</tr>
+			  </thead>
+			  <tbody>
+				<tr>
+				  <th class="role-abstract-head" scope="row">Is Abstract:</th>
+				  <td class="role-abstract"> </td>
+				</tr>
+				<tr>
+				  <th class="role-parent-head" scope="row">Superclass Role:</th>
+				  <td class="role-parent"><rref>section</rref></td>
+				</tr>
+				<tr>
+				  <th class="role-children-head" scope="row">Subclass Roles:</th>
+				  <td class="role-children">Placeholder</td>
+				</tr>
+				<tr>
+				  <th class="role-base-head" scope="row">Base Concept:</th>
+				  <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dt-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dt</code></a></td>
+				</tr>
+				<tr>
+				  <th class="role-related-head" scope="row">Related Concepts:</th>
+				  <td class="role-related"> </td>
+				</tr>
+				<tr>
+				  <th class="role-scope-head" scope="row">Required Context Role:</th>
+				  <td class="role-scope"><rref>list</rref></td>
+				</tr>
+				<tr>
+				  <th class="role-required-properties-head">Required States and Properties:</th>
+				  <td class="role-required-properties"> </td>
+				</tr>
+				<tr>
+				  <th class="role-properties-head" scope="row">Supported States and Properties:</th>
+				  <td class="role-properties">
+					<ul>
+					  <li><pref>aria-level</pref></li>
+					  <li><pref>aria-posinset</pref></li>
+					  <li><pref>aria-setsize</pref></li>
+					</ul>
+				  </td>
+				</tr>
+				<tr>
+				  <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+				  <td class="role-inherited">Placeholder</td>
+				</tr>
+				<tr>
+				  <th class="role-namefrom-head" scope="row">Name From:</th>
+				  <td class="role-namefrom">author</td>
+				</tr>
+				<tr>
+				  <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+				  <td class="role-namerequired"> </td>
+				</tr>
+				<tr>
+				  <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+				  <td class="role-namerequired-inherited"> </td>
+				</tr>
+				<tr>
+				  <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+				  <td class="role-childpresentational"> </td>
+				</tr>
+				<tr>
+				  <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+				  <td class="role-presentational-inherited"> </td>
+				</tr>
+			  </tbody>
+			</table>
+		  </div>
+		  <div class="role" id="listitemvalue">
+			<rdef>listitemvalue</rdef>
+			<div class="role-description">
+			  <p>A single value item in a list.</p>
+	  
+			  <p>Author requirements for <a>elements</a> whose <a>role</a> is <code>listitemvalue</code>:</p>
+			  <ul>
+				<li>MUST be contained in an element whose <a>role</a> is <rref>list</rref>.</li>
+				<li>SHOULD have a preceding sibling <a>element</a> whose <a>role</a> is <rref>listitemkey</rref>.</li>
+				<li>MAY be followed by one or more sibling elements whose role is also <rref>listitemvalue</rref>.</li>
+			  </ul>
+	  
+			</div>
+			<table class="role-features">
+			  <caption>Characteristics:</caption>
+			  <thead>
+				<tr>
+				  <th scope="col">Characteristic</th>
+				  <th scope="col">Value</th>
+				</tr>
+			  </thead>
+			  <tbody>
+				<tr>
+				  <th class="role-abstract-head" scope="row">Is Abstract:</th>
+				  <td class="role-abstract"> </td>
+				</tr>
+				<tr>
+				  <th class="role-parent-head" scope="row">Superclass Role:</th>
+				  <td class="role-parent"><rref>section</rref></td>
+				</tr>
+				<tr>
+				  <th class="role-children-head" scope="row">Subclass Roles:</th>
+				  <td class="role-children">Placeholder</td>
+				</tr>
+				<tr>
+				  <th class="role-base-head" scope="row">Base Concept:</th>
+				  <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dd-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dd</code></a></td>
+				</tr>
+				<tr>
+				  <th class="role-related-head" scope="row">Related Concepts:</th>
+				  <td class="role-related"> </td>
+				</tr>
+				<tr>
+				  <th class="role-scope-head" scope="row">Required Context Role:</th>
+				  <td class="role-scope"><rref>list</rref></td>
+				</tr>
+				<tr>
+				  <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+				  <td class="role-mustcontain"> </td>
+				</tr>
+				<tr>
+				  <th class="role-required-properties-head">Required States and Properties:</th>
+				  <td class="role-required-properties"> </td>
+				</tr>
+				<tr>
+				  <th class="role-properties-head" scope="row">Supported States and Properties:</th>
+				  <td class="role-properties">
+					<ul>
+					  <li><pref>aria-posinset</pref></li>
+					  <li><pref>aria-setsize</pref></li>
+					</ul>
+				  </td>
+				</tr>
+				<tr>
+				  <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+				  <td class="role-inherited">Placeholder</td>
+				</tr>
+				<tr>
+				  <th class="role-namefrom-head" scope="row">Name From:</th>
+				  <td class="role-namefrom">author</td>
+				</tr>
+				<tr>
+				  <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+				  <td class="role-namerequired"> </td>
+				</tr>
+				<tr>
+				  <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+				  <td class="role-namerequired-inherited"> </td>
+				</tr>
+				<tr>
+				  <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+				  <td class="role-childpresentational"> </td>
+				</tr>
+				<tr>
+				  <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+				  <td class="role-presentational-inherited"> </td>
+				</tr>
+			  </tbody>
+			</table>
+		  </div>		
 		<div class="role" id="log">
 			<rdef>log</rdef>
 			<div class="role-description">

--- a/index.html
+++ b/index.html
@@ -4698,7 +4698,7 @@
 				</tr>
 				<tr>
 				  <th class="role-base-head" scope="row">Base Concept:</th>
-				  <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dt-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dt</code></a></td>
+				  <td class="role-base"><li><code>&lt;dt&gt;</code> in [[HTML]]</li></td>
 				</tr>
 				<tr>
 				  <th class="role-related-head" scope="row">Related Concepts:</th>
@@ -4785,7 +4785,7 @@
 				</tr>
 				<tr>
 				  <th class="role-base-head" scope="row">Base Concept:</th>
-				  <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dd-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dd</code></a></td>
+				  <td class="role-base"><li><code>&lt;dd&gt;</code> in [[HTML]]</li></td>
 				</tr>
 				<tr>
 				  <th class="role-related-head" scope="row">Related Concepts:</th>


### PR DESCRIPTION
Fixes #1662


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 504 Gateway Time-out :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 11, 2022, 5:04 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Faria%2Fa7467cf6737b7ca99f5bbae8a19931a0a89511c2%2Findex.html%3FisPreview%3Dtrue)

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/aria%231740.)._
</details>
