### PR TITLE
turn off optional checks for ed drafts

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,4 +14,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: w3c/spec-prod@v2
         with:
+          TOOLCHAIN: respec
+          GH_PAGES_BUILD_OVERRIDE: |
+            lint: false
+          BUILD_FAIL_ON: nothing
           GH_PAGES_BRANCH: gh-pages
+          VALIDATE_WEBIDL: false
+          VALIDATE_MARKUP: false


### PR DESCRIPTION
allow editors' drafts to build with non-critical errors present