### PR TITLE
fix owned element references

### DIFF
--- a/index.html
+++ b/index.html
@@ -507,7 +507,7 @@
 	      <li>Implement the host language method for keyboard navigation so that widgets that support <code>aria-activedescendant</code> may be included in the tab order.</li>
 	      <li>For platforms that expose <a>desktop focus</a> or <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> focus separately from <abbr title="Document Object Model">DOM</abbr> focus, do not expose the focused state in the accessibility <abbr title="application programming interface">API</abbr> for any element when it has <abbr title="Document Object Model">DOM</abbr> focus and also has <pref>aria-activedescendant</pref> which points to a valid <a href="#valuetype_idref">ID reference</a>.</li>
 	      <li>When the <pref>aria-activedescendant</pref> attribute changes on an element that currently has <abbr title="Document Object Model">DOM</abbr> focus, remove the focused state from the previously focused object and fire an accessibility <abbr title="application programming interface">API</abbr> <a>desktop focus event</a> on the new element referenced by <code>aria-activedescendant</code>. If <pref>aria-activedescendant</pref> is cleared or does not point to an element in the current document, fire a desktop focus event for the <a>object</a> that had the attribute change.</li>
-	      <li>Apply the following accessibility <abbr title="Application Programming Interface">API</abbr> states to any element with an ID attribute that can be referenced by an element with both an <pref>aria-activedescendant</pref> attribute and has <abbr title="Document Object Model">DOM</abbr> focus. There are two ways an element can be referenced by <pref>aria-activedescendant</pref>. One way is when it is <a>owned</a> by an element with <pref>aria-activedescendant</pref> and the other is when it is <a>owned</a> by an element that is controlled by an element with role of <rref>combobox</rref>, <rref>textbox</rref> or <rref>searchbox</rref> with an <pref>aria-activedescendant</pref> attribute:
+	      <li>Apply the following accessibility <abbr title="Application Programming Interface">API</abbr> states to any element with an ID attribute that can be referenced by an element with both an <pref>aria-activedescendant</pref> attribute and has <abbr title="Document Object Model">DOM</abbr> focus. There are two ways an element can be referenced by <pref>aria-activedescendant</pref>. One way is when it is [=ARIA/owned=] by an element with <pref>aria-activedescendant</pref> and the other is when it is [=ARIA/owned=] by an element that is controlled by an element with role of <rref>combobox</rref>, <rref>textbox</rref> or <rref>searchbox</rref> with an <pref>aria-activedescendant</pref> attribute:
 		<ol>
 		  <li>Focusable, if the element also has a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref">role</a>. The element needs to be focusable because it could be referenced by the <pref>aria-activedescendant</pref> attribute. Native elements that have no <a class="termref">role</a> attribute do not need to be checked; their native semantics determine the focusable state.</li>
 		  <li>Focused, whenever the element is the target of the <pref>aria-activedescendant</pref> attribute and the element with the <pref>aria-activedescendant</pref> attribute has <abbr title="Document Object Model">DOM</abbr> focus.</li>
@@ -521,13 +521,13 @@
 		<ol>
 		  <li>If the <a class="termref">element</a> can take <abbr title="Document Object Model">DOM</abbr> focus, the <a class="termref">user agent</a> MUST set the <abbr title="Document Object Model">DOM</abbr> focus to it.</li>
 		  <li>Otherwise, if the element being focused has an ID and the ID is referenced by the <pref>aria-activedescendant</pref> attribute of an element that is focusable, the user agent MUST set <abbr title="Document Object Model">DOM</abbr> focus to the element that has the <pref>aria-activedescendant</pref> attribute.
-		  	<p class="note">An element with an ID can be referenced when it is <a>owned</a> by a container element that has the <pref>aria-activedescendant</pref> attribute or by a container element that is controlled by an element that has the <pref>aria-activedescendant</pref> attribute  (e.g. see <rref>combobox</rref>).  Otherwise the <pref>aria-activedescendant</pref> attribute reference indicates an author error.</p>
+		  	<p class="note">An element with an ID can be referenced when it is [=ARIA/owned=] by a container element that has the <pref>aria-activedescendant</pref> attribute or by a container element that is controlled by an element that has the <pref>aria-activedescendant</pref> attribute  (e.g. see <rref>combobox</rref>).  Otherwise the <pref>aria-activedescendant</pref> attribute reference indicates an author error.</p>
 		    <p class="note">The inability to set <abbr title="Document Object Model">DOM</abbr> focus to the containing element indicates an author error.</p>
 		  </li>
 		  <li>Otherwise, the user agent MAY attempt to set <abbr title="Document Object Model">DOM</abbr> focus to the child element itself.</li>
 		</ol>
 	      </li>
-	      <li>If the element being focused has an ID and is <a>owned</a> by either a container element with both an <code>aria-activedescendant</code> attribute and has <abbr title="Document Object Model">DOM</abbr> focus, or by a container element that is controlled by an element with both an <pref>aria-activedescendant</pref> attribute and has <abbr title="Document Object Model">DOM</abbr> focus, the user agent MUST set the accessibility <abbr title="Application Programming Interface">API</abbr> focused state and fire an accessibility <abbr title="Application Programming Interface">API</abbr> focus <a>event</a> on the element identified  by the value of <code>aria-activedescendant</code>.</li>
+	      <li>If the element being focused has an ID and is [=ARIA/owned=] by either a container element with both an <code>aria-activedescendant</code> attribute and has <abbr title="Document Object Model">DOM</abbr> focus, or by a container element that is controlled by an element with both an <pref>aria-activedescendant</pref> attribute and has <abbr title="Document Object Model">DOM</abbr> focus, the user agent MUST set the accessibility <abbr title="Application Programming Interface">API</abbr> focused state and fire an accessibility <abbr title="Application Programming Interface">API</abbr> focus <a>event</a> on the element identified  by the value of <code>aria-activedescendant</code>.</li>
 	    </ol>
 	  </section>
 	</section>
@@ -597,16 +597,16 @@
 			</section>
 		<section id="mustContain">
 			<h3>Required Owned Elements</h3>
-			<p>Any <a>element</a> that will be <a>owned</a> by the element with this <a>role</a>. For example, an element with the role <rref>list</rref> will own at least one element with the role <rref>listitem</rref>.</p>
-			<p>When multiple roles are specified as <em>required owned elements</em> for a role, at least one instance of one required <a>owned</a> element is expected. This specification does <em>not</em> require an instance of each of the listed owned roles. For example, a <code>menu</code> should have at least one instance of a <code>menuitem</code>, <code>menuitemcheckbox</code>, <em>or</em> <code>menuitemradio</code>. The <code>menu</code> role does not require one instance of each. </p>
-			<p>There may be times that required <a>owned</a> elements are missing, for example, while editing or while loading a data set. When a widget is missing <em>required owned elements</em> due to script execution or loading, authors MUST mark a containing element with <sref>aria-busy</sref> equal to <code>true</code>. For example, until a page is fully initialized and complete, an author could mark the document element as busy.</p>
+			<p>Any <a>element</a> that will be [=ARIA/owned=] by the element with this <a>role</a>. For example, an element with the role <rref>list</rref> will own at least one element with the role <rref>listitem</rref>.</p>
+			<p>When multiple roles are specified as <em>required owned elements</em> for a role, at least one instance of one required [=ARIA/owned=] element is expected. This specification does <em>not</em> require an instance of each of the listed owned roles. For example, a <code>menu</code> should have at least one instance of a <code>menuitem</code>, <code>menuitemcheckbox</code>, <em>or</em> <code>menuitemradio</code>. The <code>menu</code> role does not require one instance of each. </p>
+			<p>There may be times that required [=ARIA/owned=] elements are missing, for example, while editing or while loading a data set. When a widget is missing <em>required owned elements</em> due to script execution or loading, authors MUST mark a containing element with <sref>aria-busy</sref> equal to <code>true</code>. For example, until a page is fully initialized and complete, an author could mark the document element as busy.</p>
 			<p class="note">A role that has 'required owned elements' does not imply the reverse relationship. While processing of a role may be incomplete without elements of given roles present as descendants, elements with roles in this list do not always have to be found within elements of the given role. See <a href="#scope">required context role</a> for requirements about the context where elements of a given role will be contained.</p>
-			<p class="note">An element with a <a href="#subclassroles">subclass role</a> of the 'required owned element' does not fulfill this requirement. For example, the <rref>listbox</rref> role requires ownership of an element using the <rref>option</rref> or <rref>group</rref> role. Although the <rref>group</rref> role is the superclass of <rref>row</rref>, adding an <a>owned</a> element with a role of <rref>row</rref> will not fulfill the requirement that <rref>listbox</rref> owns an <rref>option</rref> or a <rref>group</rref>.</p>
+			<p class="note">An element with a <a href="#subclassroles">subclass role</a> of the 'required owned element' does not fulfill this requirement. For example, the <rref>listbox</rref> role requires ownership of an element using the <rref>option</rref> or <rref>group</rref> role. Although the <rref>group</rref> role is the superclass of <rref>row</rref>, adding an [=ARIA/owned=] element with a role of <rref>row</rref> will not fulfill the requirement that <rref>listbox</rref> owns an <rref>option</rref> or a <rref>group</rref>.</p>
 			<p class="note">An element with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> fulfills this requirement.</p>
 		</section>
 		<section id="scope">
 			<h3>Required Context Role</h3>
-			<p>The required context role defines the owning container where this <a>role</a> is allowed. If a role has a required context, authors MUST ensure that an element with the role is contained inside (or <a>owned</a> by) an element with the required context role. For example, an element with role <code>listitem</code> is only meaningful when contained inside (or <a>owned</a> by) an element with role <code>list</code>.</p>
+			<p>The required context role defines the owning container where this <a>role</a> is allowed. If a role has a required context, authors MUST ensure that an element with the role is contained inside (or [=ARIA/owned=] by) an element with the required context role. For example, an element with role <code>listitem</code> is only meaningful when contained inside (or [=ARIA/owned=] by) an element with role <code>list</code>.</p>
 			<p class="note">A role that has 'required context role' does not imply the reverse relationship. While an element with the given role needs to appear within an element of the listed role(s) in order to be meaningful, elements of the listed roles do not always need descendant elements of the given role in order to be meaningful. See <a href="#mustContain">required owned elements</a> for requirements about elements that require presence of a given descendant to be processed properly.</p>
 			<p class="note">An element with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> fulfills this requirement.</p>
 		</section>
@@ -1020,7 +1020,7 @@
 				<ol>
 					<li>Associate the content with a focusable element using <pref>aria-labelledby</pref> or <pref>aria-describedby</pref>.</li>
 					<li>Place the content in a focusable element that has role <rref>document</rref> or <rref>article</rref>.</li>
-					<li>Manage focus of <a>owned</a> elements as described in <a href="#managingfocus">Managing Focus</a>, updating the value of <pref>aria-activedescendant</pref> to reference the <a>element</a> containing the focused content.</li>
+					<li>Manage focus of [=ARIA/owned=] elements as described in <a href="#managingfocus">Managing Focus</a>, updating the value of <pref>aria-activedescendant</pref> to reference the <a>element</a> containing the focused content.</li>
 				</ol>
 				</div>
 			<table class="role-features">
@@ -2172,7 +2172,7 @@
 				<p>A cell containing header information for a column.</p>
 				<p><code>columnheader</code> can be used as a column header in a table or grid. It could also be used in a pie chart to show a similar <a>relationship</a> in the data.</p>
 				<p>The <code>columnheader</code> establishes a relationship between it and all cells in the corresponding column. It is the structural equivalent to an <abbr title="Hypertext Markup Language">HTML</abbr> <code>th</code> <a>element</a> with a column scope.</p>
-				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>columnheader</code> are contained in, or <a>owned</a> by, an element with the role <rref>row</rref>.</p>
+				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>columnheader</code> are contained in, or [=ARIA/owned=] by, an element with the role <rref>row</rref>.</p>
 				<p>Applying the <sref>aria-selected</sref> state on a columnheader MUST not cause the user agent to automatically propagate the <sref>aria-selected</sref> state to all the cells in the corresponding column. An author MAY choose to propagate selection in this manner depending on the specific application.</p>
 				<p>While the <code>columnheader</code> role can be used in both interactive grids and non-interactive tables, the use of <pref>aria-readonly</pref> and <pref>aria-required</pref> is only applicable to interactive elements. Therefore, authors SHOULD NOT use <pref>aria-required</pref> or <pref>aria-readonly</pref> in a <code>columnheader</code> that descends from a <rref>table</rref>, and user agents SHOULD NOT expose either property to <a>assistive technologies</a> unless the <code>columnheader</code> descends from a <rref>grid</rref>.</p>
 				<p class="note">Because cells are organized into rows, there is not a single container element for the column. The column is the set of <rref>gridcell</rref> elements in a particular position within their respective <rref>row</rref> containers.</p>
@@ -2684,7 +2684,7 @@
 		<div class="role" id="composite">
 			<rdef>composite</rdef>
 			<div class="role-description">
-				<p>A <a>widget</a> that may contain navigable descendants or <a>owned</a> children.</p>
+				<p>A <a>widget</a> that may contain navigable descendants or [=ARIA/owned=] children.</p>
 				<p>Authors SHOULD ensure that a composite widget exists as a single navigation stop within the larger navigation system of the web page. Once the composite widget has focus, authors SHOULD provide a separate navigation mechanism for users to navigate to [=elements=] that are descendants or owned children of the composite element.</p>
 				<p><code>composite</code> is an <a href="#isAbstract">abstract role</a> used for the ontology. Authors MUST NOT use <code>composite</code> role in content.</p>
 			</div>
@@ -3681,7 +3681,7 @@
 			<div class="role-description">
 				<p>A composite <rref>widget</rref> containing a collection of one or more rows with one or more cells where some or all cells in the grid are focusable by using methods of two-dimensional navigation, such as directional arrow keys.</p>
 				<p>The <code>grid</code> role does not imply a specific visual, e.g., tabular, presentation. It describes <a>relationships</a> among [=elements=]. It may be used for purposes as simple as grouping a collection of checkboxes or navigation links or as complex as creating a full-featured spreadsheet application.</p>
-				<p>The cell elements of a <code>grid</code> have role <rref>gridcell</rref>. Authors MAY designate a cell as a row or column header by using either the <rref>rowheader</rref> or <rref>columnheader</rref> <a>role</a> in lieu of the <rref>gridcell</rref> role. Authors MUST ensure elements with role <rref>gridcell</rref>, <rref>columnheader</rref>, or <rref>rowheader</rref> are <a>owned</a> by elements with role <rref>row</rref>, which are in turn owned by an element with role <rref>rowgroup</rref>, or <code>grid</code>.</p>
+				<p>The cell elements of a <code>grid</code> have role <rref>gridcell</rref>. Authors MAY designate a cell as a row or column header by using either the <rref>rowheader</rref> or <rref>columnheader</rref> <a>role</a> in lieu of the <rref>gridcell</rref> role. Authors MUST ensure elements with role <rref>gridcell</rref>, <rref>columnheader</rref>, or <rref>rowheader</rref> are [=ARIA/owned=] by elements with role <rref>row</rref>, which are in turn owned by an element with role <rref>rowgroup</rref>, or <code>grid</code>.</p>
 				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants of a <code>grid</code> as described in <a href="#managingfocus">Managing Focus</a>. When a user is navigating the <code>grid</code> content with a keyboard, authors SHOULD set focus as follows:</p>
 				<ul>
 					<li>If a <rref>gridcell</rref> contains a single interactive <rref>widget</rref> that will not consume arrow key presses when it receives focus, such as a <rref>checkbox</rref>, <rref>button</rref>, or <rref>link</rref>, authors MAY set focus on the interactive element contained in that cell. This allows the contained widget to be directly operable.</li>
@@ -3696,7 +3696,7 @@
 				<p>For example, if a cell in a spreadsheet contains a <rref>combobox</rref> or editable text, the <kbd>Enter</kbd> key might be used to activate a cell interaction or editing mode when that cell has focus so the directional arrow keys can be used to operate the contained <rref>combobox</rref> or <rref>textbox</rref>. Depending on the implementation, pressing <kbd>Enter</kbd> again, <kbd>Tab</kbd>, <kbd>Escape</kbd>, or another key may switch the application back to the grid navigation mode.</p>
 				<p>Authors MAY use a <rref>gridcell</rref> to display the result of a formula, which could be editable by the user. In a spreadsheet application, for example, a <rref>gridcell</rref> may show a value calculated from a formula until the user activates the <rref>gridcell</rref> for editing when a <rref>textbox</rref> appears in the <rref>gridcell</rref> containing the formula in an editable state.</p>
 				<!-- make sure the following para remains synced with its counterpart in #treegrid -->
-				 <p>If <pref>aria-readonly</pref> is set on an element with role <code>grid</code>, [=user agents=] MUST propagate the value to all <rref>gridcell</rref> elements <a>owned</a> by the <code>grid</code> and expose the value in the accessibility API. An author MAY override the propagated value of <pref>aria-readonly</pref> for an individual <rref>gridcell</rref> element.</p>
+				 <p>If <pref>aria-readonly</pref> is set on an element with role <code>grid</code>, [=user agents=] MUST propagate the value to all <rref>gridcell</rref> elements [=ARIA/owned=] by the <code>grid</code> and expose the value in the accessibility API. An author MAY override the propagated value of <pref>aria-readonly</pref> for an individual <rref>gridcell</rref> element.</p>
 				 <p>In a <code>grid</code> that provides cell content editing functions, if the content of a focusable <rref>gridcell</rref> element is not editable, authors MAY set <pref>aria-readonly</pref> to <code>true</code> on the <code>gridcell</code> element. However, the value of <pref>aria-readonly</pref>, whether specified for a <code>grid</code> or individual cells, only indicates whether the content contained in cells is editable. It does not represent availability of functions for navigating or manipulating the <code>grid</code> itself.</p>
 				 <p>An unspecified value for <pref>aria-readonly</pref> does not imply that a <code>grid</code> or a <rref>gridcell</rref> contains editable content. For example, if a <code>grid</code> presents a collection of elements that are not editable, such as a collection of <rref>link</rref> elements representing dates in a datepicker, it is not necessary for the author to specify a value for <pref>aria-readonly</pref>.</p>
 				<p>Authors MAY indicate that a focusable <rref>gridcell</rref> is selectable as the object of an action with the <sref>aria-selected</sref> attribute. If the <code>grid</code> allows multiple <rref>gridcell</rref>s to be selected, the author SHOULD set <pref>aria-multiselectable</pref> to <code>true</code> on the element with role <code>grid</code>.</p>
@@ -3797,7 +3797,7 @@
 				<p>A <code>gridcell</code> may be focusable, editable, and selectable. A <code>gridcell</code> may have <a>relationships</a> such as <pref>aria-controls</pref> to address the application of functional relationships.</p>
 				<p>If an author intends a <code>gridcell</code> to have a row header, column header, or both, and if the relevant headers cannot be determined from the <abbr title="Document Object Model">DOM</abbr> structure, authors SHOULD explicitly indicate which header cells are relevant to the <code>gridcell</code> by applying <pref>aria-describedby</pref> on the <code>gridcell</code> and referencing [=elements=] with <a>role</a> <rref>rowheader</rref> or <rref>columnheader</rref>.</p>
 				<p>In a <rref>treegrid</rref>, authors MAY define a <code>gridcell</code> as expandable by using the <sref>aria-expanded</sref> attribute. If the <sref>aria-expanded</sref> attribute is provided, it applies only to the individual cell. It is not a proxy for the container <rref>row</rref>, which also can be expanded. The main use case for providing this attribute on a <code>gridcell</code> is pivot table behavior.</p>
-				<p>Authors MUST ensure [=elements=] with <a>role</a> gridcell are contained in, or <a>owned</a> by, an element with the <a>role</a> <rref>row</rref>.</p>
+				<p>Authors MUST ensure [=elements=] with <a>role</a> gridcell are contained in, or [=ARIA/owned=] by, an element with the <a>role</a> <rref>row</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4677,7 +4677,7 @@
 			<rdef>listitem</rdef>
 			<div class="role-description">
 				<p>A single item in a list or directory.</p>
-				<p>Authors MUST ensure [=elements=] whose <a>role</a> is <code>listitem</code> are contained in, or <a>owned</a> by, an <a>element</a> whose <a>role</a> is <rref>list</rref>.</p>
+				<p>Authors MUST ensure [=elements=] whose <a>role</a> is <code>listitem</code> are contained in, or [=ARIA/owned=] by, an <a>element</a> whose <a>role</a> is <rref>list</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -5421,9 +5421,9 @@
 			<rdef>menuitem</rdef>
 			<div class="role-description">
 				<p>An option in a set of choices contained by a <rref>menu</rref> or <rref>menubar</rref>.</p>
-				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>menuitem</code> are contained in, or <a>owned</a> by, an element with role <rref>menu</rref> or an element with role <rref>group</rref> that is contained in, or owned by, an element with role <rref>menu</rref>.</p>
+				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>menuitem</code> are contained in, or [=ARIA/owned=] by, an element with role <rref>menu</rref> or an element with role <rref>group</rref> that is contained in, or owned by, an element with role <rref>menu</rref>.</p>
 				<p>Authors MAY disable a menu item with the <sref>aria-disabled</sref> attribute. If the menu item has its <pref>aria-haspopup</pref> attribute set to <code>true</code>, it indicates that the menu item may be used to launch a sub-level menu, and authors SHOULD display a new sub-level menu when the menu item is activated.</p>
-				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu items are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
+				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu items are [=ARIA/owned=] by an element with role <rref>menu</rref> or <rref>menubar</rref>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -5530,9 +5530,9 @@
 			<rdef>menuitemcheckbox</rdef>
 			<div class="role-description">
 				<p>A <rref>menuitem</rref> with a checkable state whose possible <span>values</span> are <code>true</code>, <code>false</code>, or <code>mixed</code>.</p>
-				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>menuitemcheckbox</code> are contained in, or <a>owned</a> by, an element with role <rref>menu</rref> or an element with role <rref>group</rref> that is contained in, or owned by, an element with role <rref>menu</rref>.</p>
+				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>menuitemcheckbox</code> are contained in, or [=ARIA/owned=] by, an element with role <rref>menu</rref> or an element with role <rref>group</rref> that is contained in, or owned by, an element with role <rref>menu</rref>.</p>
 				<p>The <sref>aria-checked</sref> <a>attribute</a> of a <code>menuitemcheckbox</code> indicates whether the menu item is checked (<code>true</code>), unchecked (<code>false</code>), or represents a sub-level menu of other menu items that have a mixture of checked and unchecked values (<code>mixed</code>).</p>
-				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu item checkboxes are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
+				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu item checkboxes are [=ARIA/owned=] by an element with role <rref>menu</rref> or <rref>menubar</rref>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -5630,10 +5630,10 @@
 			<rdef>menuitemradio</rdef>
 			<div class="role-description">
 				<p>A checkable <rref>menuitem</rref> in a set of elements with the same role, only one of which can be checked at a time.</p>
-				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>menuitemradio</code> are contained in, or <a>owned</a> by, an element with role <rref>menu</rref> or an element with role <rref>group</rref> that is contained in, or owned by, an element with role <rref>menu</rref>.</p>
+				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>menuitemradio</code> are contained in, or [=ARIA/owned=] by, an element with role <rref>menu</rref> or an element with role <rref>group</rref> that is contained in, or owned by, an element with role <rref>menu</rref>.</p>
 				<p>Authors SHOULD enforce that only one <code>menuitemradio</code> in a group can be checked at the same time. When one item in the group is checked, the previously checked item becomes unchecked (its <sref>aria-checked</sref> <a>attribute</a> becomes <code>false</code>).</p>
 				<!-- keep previous sentence synced with radiogroup, etc. -->
-				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu item radios are <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>, or by a role <rref>group</rref> which itself is <a>owned</a> by an element with role <rref>menu</rref> or <rref>menubar</rref>.</p>
+				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu item radios are [=ARIA/owned=] by an element with role <rref>menu</rref> or <rref>menubar</rref>, or by a role <rref>group</rref> which itself is [=ARIA/owned=] by an element with role <rref>menu</rref> or <rref>menubar</rref>.</p>
         <p>If a <rref>menu</rref> or <rref>menubar</rref> contains more than one group of <code>menuitemradio</code> elements, or if the menu contains one group and other, unrelated menu items, authors SHOULD contain each set of related <code>menuitemradio</code> elements in an element using the <rref>group</rref> role. Authors MAY also delimit the group from other menu items with an element using the <rref>separator</rref> role, or an element with an equivalent role from the native markup language.
 			</div>
 			<table class="role-features">
@@ -5991,7 +5991,7 @@
 			<rdef>option</rdef>
 			<div class="role-description">
 				<p>An item in a <rref>listbox</rref>.</p>
-				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>option</code> are contained in, or <a>owned</a> by, an element with <a>role</a> <rref>listbox</rref> or an element with <a>role</a> <rref>group</rref> that is contained in, or <a>owned</a> by, an element with <a>role</a> <code>listbox</code>. Options not associated with a <rref>listbox</rref> might not be correctly mapped to an <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a>.</p>
+				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>option</code> are contained in, or [=ARIA/owned=] by, an element with <a>role</a> <rref>listbox</rref> or an element with <a>role</a> <rref>group</rref> that is contained in, or [=ARIA/owned=] by, an element with <a>role</a> <code>listbox</code>. Options not associated with a <rref>listbox</rref> might not be correctly mapped to an <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a>.</p>
         <p>In certain conditions, a user agent MAY provide an implicit value for <sref>aria-selected</sref> for each <rref>option</rref> in a <rref>listbox</rref>, and if it does, the user agent MUST ensure the following conditions are met before providing an implicit value:</p>
         <ul>
           <li>The value of <pref>aria-multiselectable</pref> on the <rref>listbox</rref> is <code>false</code> or <code>undefined</code>.</li>
@@ -6949,7 +6949,7 @@
 				<p>Rows contain <rref>cell</rref> or <rref>gridcell</rref> [=elements=], and thus serve to organize a <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>.</p>
 				<p>While the row role can be used in a <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>, the semantics of <sref>aria-expanded</sref>, <pref>aria-posinset</pref>, <pref>aria-setsize</pref>, and <pref>aria-level</pref> are only applicable to the hierarchical structure of an interactive tree grid. Therefore, authors MUST NOT apply <sref>aria-expanded</sref>, <pref>aria-posinset</pref>, <pref>aria-setsize</pref>, and <pref>aria-level</pref> to a <rref>row</rref> that descends from a <rref>table</rref> or <rref>grid</rref>, and user agents SHOULD NOT expose any of these four properties to assistive technologies unless the <rref>row</rref> descends from a <rref>treegrid</rref>.
 				</p>
-				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>row</code> are contained in, or <a>owned</a> by, an element with the role <rref>table</rref>, <rref>grid</rref>, <rref>rowgroup</rref>, or <rref>treegrid</rref>.</p>
+				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>row</code> are contained in, or [=ARIA/owned=] by, an element with the role <rref>table</rref>, <rref>grid</rref>, <rref>rowgroup</rref>, or <rref>treegrid</rref>.</p>
 				<p class="note" title="Usage of aria-disabled">While <sref>aria-disabled</sref> is currently supported on <rref>row</rref>, in a future version the working group plans to prohibit its  on elements with role <rref>row</rref> except when the element is in the context of a <rref>grid</rref> or <rref>treegrid</rref>.</p>
 			</div>
 			<table class="role-features">
@@ -7065,8 +7065,8 @@
 			<rdef>rowgroup</rdef>
 			<div class="role-description">
 				<p>A structure containing one or more row elements in a tabular container.</p>
-				<p>The <code>rowgroup</code> role establishes a <a>relationship</a> between <a>owned</a> <rref>row</rref> elements. It is a structural equivalent to the <code>thead</code>, <code>tfoot</code>, and <code>tbody</code> elements in an <abbr title="Hypertext Markup Language">HTML</abbr> <code>table</code> <a>element</a>.</p>
-				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>rowgroup</code> are contained in, or <a>owned</a> by, an element with the role <rref>grid</rref>, <rref>table</rref>, or <rref>treegrid</rref>.</p>
+				<p>The <code>rowgroup</code> role establishes a <a>relationship</a> between [=ARIA/owned=] <rref>row</rref> elements. It is a structural equivalent to the <code>thead</code>, <code>tfoot</code>, and <code>tbody</code> elements in an <abbr title="Hypertext Markup Language">HTML</abbr> <code>table</code> <a>element</a>.</p>
+				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>rowgroup</code> are contained in, or [=ARIA/owned=] by, an element with the role <rref>grid</rref>, <rref>table</rref>, or <rref>treegrid</rref>.</p>
 				<p class="note">The <code>rowgroup</code> role exists, in part, to support role symmetry in HTML, and allows for the propagation of presentation inheritance on HTML <code>table</code> elements with an explicit <code>presentation</code> role applied.</p>
 				<p class="note">This role does not differentiate between types of row groups (e.g., <code>thead</code> vs. <code>tbody</code>), but an issue has been raised for <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 2.0.</p>
 			</div>
@@ -7153,7 +7153,7 @@
 			<div class="role-description">
 				<p>A cell containing header information for a row.</p>
 				<p>The <rref>rowheader</rref> role can be used to identify a cell as a header for a row in a <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>. The rowheader establishes a <a>relationship</a> between it and all cells in the corresponding row. It is a structural equivalent to setting <code>scope="row"</code> on an <abbr title="Hypertext Markup Language">HTML</abbr> <code>th</code> <a>element</a>.</p>
-				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>rowheader</code> are contained in, or <a>owned</a> by, an element with the role <rref>row</rref>.</p>
+				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>rowheader</code> are contained in, or [=ARIA/owned=] by, an element with the role <rref>row</rref>.</p>
 				<p>Applying the <sref>aria-selected</sref> state on a rowheader MUST NOT cause the user agent to automatically propagate the <sref>aria-selected</sref> state to all the cells in the corresponding row. An author MAY choose to propagate selection in this manner depending on the specific application.</p>
 				<p>While the <code>rowheader</code> role can be used in both interactive grids and non-interactive tables, the use of <sref>aria-expanded</sref>, <pref>aria-readonly</pref>, and <pref>aria-required</pref> is only applicable to interactive elements. Therefore, authors SHOULD NOT use <sref>aria-expanded</sref>, <pref>aria-readonly</pref>, or <pref>aria-required</pref> in a <code>rowheader</code> that descends from a <rref>table</rref>, and user agents SHOULD NOT expose these properties to <a>assistive technologies</a> unless the <code>rowheader</code> descends from a <rref>grid</rref> or <rref>treegrid</rref>.</p>
 				<p class="note" title="Usage of aria-disabled">While <sref>aria-disabled</sref> is currently supported on <rref>rowheader</rref>, in a future version the working group plans to prohibit its use on elements with role <rref>rowheader</rref> except when the element is in the context of a <rref>grid</rref> or <rref>treegrid</rref>.</p>
@@ -8664,7 +8664,7 @@
 			<div class="role-description">
 				<p>A grouping label providing a mechanism for selecting the tab content that is to be rendered to the user.</p>
 				<p>If a  <rref>tabpanel</rref> or item in a <rref>tabpanel</rref> has focus, the associated <code>tab</code> is the currently active tab in the <rref>tablist</rref>, as defined in <a href="#managingfocus">Managing Focus</a>. <rref>tablist</rref> elements, which contain a set of associated <rref>tab</rref> elements, are typically placed near a series of <rref>tabpanel</rref> elements, usually preceding it. See the <cite><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> for details on implementing a tab set design pattern.</p>
-				<p>Authors MUST ensure [=elements=] with <a>role</a> <rref>tab</rref> are contained in, or <a>owned</a> by, an element with the role <rref>tablist</rref>.</p>
+				<p>Authors MUST ensure [=elements=] with <a>role</a> <rref>tab</rref> are contained in, or [=ARIA/owned=] by, an element with the role <rref>tablist</rref>.</p>
 				<p>Authors SHOULD ensure the <rref>tabpanel</rref> associated with the currently active tab is <a>perceivable</a> to the user.</p>
 				<!-- keep following para synced with its counterpart in #tablist -->
 				<p>For a single-selectable <rref>tablist</rref>, authors SHOULD hide other <code>tabpanel</code> [=elements=] from the user until the user selects the tab associated with that tabpanel. For a multi-selectable <rref>tablist</rref>, authors SHOULD ensure that the <rref>tab</rref> for each visible <rref>tabpanel</rref> has the <sref>aria-expanded</sref> <a>attribute</a> set to <code>true</code>, and that the <code>tabs</code> associated with the remaining hidden <code>tabpanel</code> elements have their <sref>aria-expanded</sref> attributes set to <code>false</code>.</p>
@@ -9883,7 +9883,7 @@
 			<div class="role-description">
 				<p>An item in a <rref>tree</rref>.</p>
         				<p>A <rref>treeitem</rref> <a>element</a> may contain a sub-level group of elements that can be expanded or collapsed. An expandable collection of <code>treeitem</code> elements are enclosed in an element with the <rref>group</rref> <a>role</a>.</p>
-				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>treeitem</code> are contained in, or <a>owned</a> by, an element with role <rref>tree</rref> or an element with role <rref>group</rref> that is contained in, or owned by, an element with role <rref>treeitem</rref>.</p>
+				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>treeitem</code> are contained in, or [=ARIA/owned=] by, an element with role <rref>tree</rref> or an element with role <rref>group</rref> that is contained in, or owned by, an element with role <rref>treeitem</rref>.</p>
         <p>In certain conditions, a user agent MAY provide an implicit value for <sref>aria-selected</sref> for each <rref>treeitem</rref> in a <rref>tree</rref>, and if it does, the user agent MUST ensure the following conditions are met before providing an implicit value:</p>
         <ul>
           <li>The value of <pref>aria-multiselectable</pref> on the <rref>tree</rref> is <code>false</code> or <code>undefined</code>.</li>
@@ -10398,10 +10398,10 @@ button.ariaPressed; // null</pre>
 			<pdef>aria-activedescendant</pdef>
 			<div class="property-description">
 				<p><a>Identifies</a> the currently active element when DOM focus is on a <rref>composite</rref> widget, <rref>combobox</rref>, <rref>textbox</rref>, <rref>group</rref>, or <rref>application</rref>.</p>
-				<p>The <code>aria-activedescendant</code> property provides an alternative method of managing focus for interactive elements that may contain multiple focusable descendants, such as menus, grids, and toolbars. Instead of moving DOM focus among <a>owned</a> elements, authors MAY set DOM focus on a container <a>element</a> that supports <code>aria-activedescendant</code> and then use <code>aria-activedescendant</code> to refer to the element that is active.</p>
+				<p>The <code>aria-activedescendant</code> property provides an alternative method of managing focus for interactive elements that may contain multiple focusable descendants, such as menus, grids, and toolbars. Instead of moving DOM focus among [=ARIA/owned=] elements, authors MAY set DOM focus on a container <a>element</a> that supports <code>aria-activedescendant</code> and then use <code>aria-activedescendant</code> to refer to the element that is active.</p>
 				<p> Authors MUST ensure that one of the following two sets of conditions is met when setting the value of <code>aria-activedescendant</code> on an element with DOM focus:</p>
 				<ol>
-					<li>The value of <code>aria-activedescendant</code> refers to an <a>owned</a> element. An owned element is either a descendant of the element with DOM focus or a logical descendant as indicated by the <pref>aria-owns</pref> attribute.</li>
+					<li>The value of <code>aria-activedescendant</code> refers to an [=ARIA/owned=] element. An owned element is either a descendant of the element with DOM focus or a logical descendant as indicated by the <pref>aria-owns</pref> attribute.</li>
 					<li>
             The element with DOM focus is a <rref>combobox</rref>, <rref>textbox</rref> or <rref>searchbox</rref> with <pref>aria-controls</pref> referring to an element that supports <code>aria-activedescendant</code>, and the value of <code>aria-activedescendant</code> refers to an owned element of the controlled element.
             For example, in a <rref>combobox</rref>, focus may remain on the <rref>combobox</rref> while the value of <code>aria-activedescendant</code> on the <rref>combobox</rref> element refers to a descendant of a popup <rref>listbox</rref> that is controlled by the <rref>combobox</rref>.
@@ -10874,7 +10874,7 @@ button.ariaPressed; // null</pre>
 				<p><a>Defines</a> an [=element|element's=] column index or position with respect to the total number of columns within a <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>. See related <pref>aria-colindextext</pref>, <pref>aria-colcount</pref>, and <pref>aria-colspan</pref>.</p>
 				<p>If all of the columns are present in the <abbr title="Document Object Model">DOM</abbr>, it is not necessary to set this <a>attribute</a> as the <a>user agent</a> can automatically calculate the column index of each cell or <rref>gridcell</rref>. However, if only a portion of the columns is present in the <abbr title="Document Object Model">DOM</abbr> at a given moment, this attribute is needed to provide an explicit indication of the column of each cell or gridcell with respect to the full table.</p>
 				<p>Authors MUST set the <span>value</span> for <pref>aria-colindex</pref> to an integer greater than or equal to 1, greater than the <pref>aria-colindex</pref> value of any previous elements within the same row, and less than or equal to the number of columns in the full table. For a cell or gridcell which spans multiple columns, authors MUST set the value of <pref>aria-colindex</pref> to the start of the span.</p>
-				<p>If the set of columns which is present in the <abbr title="Document Object Model">DOM</abbr> is contiguous, and if there are no cells which span more than one row or column in that set, then authors MAY place <pref>aria-colindex</pref> on each row, setting the value to the index of the first column of the set. Otherwise, authors SHOULD place <pref>aria-colindex</pref> on all of the children or <a>owned</a> elements of each row.</p>
+				<p>If the set of columns which is present in the <abbr title="Document Object Model">DOM</abbr> is contiguous, and if there are no cells which span more than one row or column in that set, then authors MAY place <pref>aria-colindex</pref> on each row, setting the value to the index of the first column of the set. Otherwise, authors SHOULD place <pref>aria-colindex</pref> on all of the children or [=ARIA/owned=] elements of each row.</p>
 				<p>The following example shows a grid with 16 columns, of which columns 2 through 5 are displayed to the user. Because the set of columns is contiguous, <pref>aria-colindex</pref> can be placed on each row.</p>
 				<pre class="example highlight">
 &lt;div role="grid" aria-colcount="16"&gt;
@@ -11514,7 +11514,7 @@ button.ariaPressed; // null</pre>
 			<div class="state-description">
 				<p><a>Indicates</a> whether a grouping element owned or controlled by this element is expanded or collapsed.</p>
 				<p>The <sref>aria-expanded</sref> attribute is applied to a focusable, interactive element that toggles visibility of content in another element. For example, it is applied to a parent <rref>treeitem</rref> to indicate whether its child branch of the tree is shown. Similarly, it can be applied to a <rref>button</rref> that controls visibility of a section of page content.</p>
-				<p>If a grouping container that can be expanded or collapsed is not <a>owned</a> by the element that has the <sref>aria-expanded</sref> attribute, the author SHOULD identify the controlling relationship by referencing the container from the element that has <sref>aria-expanded</sref> with the <pref>aria-controls</pref> property.</p>
+				<p>If a grouping container that can be expanded or collapsed is not [=ARIA/owned=] by the element that has the <sref>aria-expanded</sref> attribute, the author SHOULD identify the controlling relationship by referencing the container from the element that has <sref>aria-expanded</sref> with the <pref>aria-controls</pref> property.</p>
 			</div>
 			<table class="state-features">
 				<caption>Characteristics:</caption>
@@ -12824,7 +12824,7 @@ button.ariaPressed; // null</pre>
 				<p><a>Defines</a> an [=element|element's=] row index or position with respect to the total number of rows within a <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>. See related <pref>aria-rowindextext</pref>, <pref>aria-rowcount</pref>, and <pref>aria-rowspan</pref>.</p>
 				<p>If all of the rows are present in the <abbr title="Document Object Model">DOM</abbr>, it is not necessary to set this <a>attribute</a> as the <a>user agent</a> can automatically calculate the index of each row. However, if only a portion of the rows is present in the <abbr title="Document Object Model">DOM</abbr> at a given moment, this attribute is needed to provide an explicit indication of each row's position with respect to the full table.</p>
 				<p>Authors MUST set the <span>value</span> for <pref>aria-rowindex</pref> to an integer greater than or equal to 1, greater than the <pref>aria-rowindex</pref> value of any previous rows, and less than or equal to the number of rows in the full table. For a cell or gridcell which spans multiple rows, authors MUST set the value of <pref>aria-rowindex</pref> to the start of the span.</p>
-				<p>Authors SHOULD place <pref>aria-rowindex</pref> on each row. Authors MAY also place <pref>aria-rowindex</pref> on all of the children or <a>owned elements</a> of each row.</p>
+				<p>Authors SHOULD place <pref>aria-rowindex</pref> on each row. Authors MAY also place <pref>aria-rowindex</pref> on all of the children or [=ARIA/owned elements=] of each row.</p>
 				<p>The following example shows a grid with 2000 rows, of which the first row and rows 100 through 102 are displayed to the user.</p>
 				<pre class="example highlight">
 &lt;div role="grid" aria-rowcount="2000"&gt;
@@ -12924,7 +12924,7 @@ button.ariaPressed; // null</pre>
 				<p><a>Defines</a> a human readable text alternative of <pref>aria-rowindex</pref>. See related <pref>aria-colindextext</pref>.</p>
                                 <p>Authors SHOULD only use <code>aria-rowindextext</code> when the provided or calculated value of <pref>aria-rowindex</pref> is not meaningful or does not reflect the displayed index, as can be seen in the game Battleship.</p>
                                 <p>Authors SHOULD NOT use <code>aria-rowindextext</code> as a replacement for <pref>aria-rowindex</pref> because some assistive technologies rely upon the numeric row index for the purpose of keeping track of the user's position or providing alternative table navigation.</p>
-				<p>Authors SHOULD place <code>aria-rowindextext</code> on each row. Authors MAY also place <code>aria-rowindextext</code> on all of the children or <a>owned elements</a> of each row.</p>
+				<p>Authors SHOULD place <code>aria-rowindextext</code> on each row. Authors MAY also place <code>aria-rowindextext</code> on all of the children or [=ARIA/owned elements=] of each row.</p>
 			</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>
@@ -13470,7 +13470,7 @@ button.ariaPressed; // null</pre>
 					<li>Correct usage with regard to <abbr title="Document Object Model">DOM</abbr> tree structure, such as an <a>element</a> being owned by more than one other element.</li>
 					<li>Elements with <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a>roles</a> correctly implement the  behavior of the specified role. For example, user agents do not verify that an element with a role of <rref>checkbox</rref> actually behaves like a checkbox.</li>
 					<li>Elements that do not correctly observe required child / parent role relationships or that appear elsewhere than in their required parent.</li>
-					<li>Determining whether <pref>aria-activedescendant</pref> actually points to an <a>owned</a> element of the container widget.</li>
+					<li>Determining whether <pref>aria-activedescendant</pref> actually points to an [=ARIA/owned=] element of the container widget.</li>
 					<li>Determining implicit values of <pref>aria-setsize</pref> and <pref>aria-posinset</pref> when they are specified on some but not all the elements of the set.</li>
 				</ol>
 			<p>If the author specifies a non-numeric value for a decimal or integer value type, the user agent SHOULD do the following:</p>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 504 Gateway Timeout :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 29, 2022, 5:39 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Faria%2Ff6819dbc19f470efca403fcf4bdf167e42fd5174%2Findex.html%3FisPreview%3Dtrue)

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/aria%231751.)._
</details>
