### PR TITLE
Reword use 'on a page' instead of 'within any document or application'

### DIFF
--- a/index.html
+++ b/index.html
@@ -1469,7 +1469,7 @@
   				[=user agents=] SHOULD treat elements with role <code>banner</code> as navigational <a>landmarks</a>.
   				[=user agents=] MAY enable users to quickly navigate to elements with role <code>banner</code>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #main and #contentinfo-->
-				<p>Within any <rref>document</rref> or <rref>application</rref>, the author SHOULD mark no more than one <a>element</a> with the <code>banner</code> <a>role</a>.</p>
+				<p>The author SHOULD mark no more than one <a>element</a> on a page with the <code>banner</code> <a>role</a>.</p>
 				<p class="note">Because <code>document</code> and <code>application</code> elements can be nested in the <abbr title="Document Object Model">DOM</abbr>, they may have multiple <code>banner</code> elements as <abbr title="Document Object Model">DOM</abbr> descendants, assuming each of those is associated with different document nodes, either by a DOM nesting (e.g., <rref>document</rref> within <rref>document</rref>) or by use of the <pref>aria-owns</pref> <a>attribute</a>.</p>
 			</div>
 			<table class="role-features">
@@ -2766,7 +2766,7 @@
   				[=user agents=] SHOULD treat elements with role <code>contentinfo</code> as navigational <a>landmarks</a>.
   				[=user agents=] MAY enable users to quickly navigate to elements with role <code>contentinfo</code>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #banner and #main -->
-				<p>Within any <rref>document</rref> or <rref>application</rref>, the author SHOULD mark no more than one <a>element</a> with the <code>contentinfo</code> role.</p>
+				<p>The author SHOULD mark no more than one <a>element</a> on a page with the <code>contentinfo</code> role.</p>
 				<p class="note">Because <code>document</code> and <code>application</code> elements can be nested in the <abbr title="Document Object Model">DOM</abbr>, they may have multiple <code>contentinfo</code> elements as <abbr title="Document Object Model">DOM</abbr> descendants, assuming each of those is associated with different document nodes, either by a DOM nesting (e.g., <rref>document</rref> within <rref>document</rref>) or by use of the <pref>aria-owns</pref> attribute.</p>
 			</div>
 			<table class="role-features">
@@ -4853,7 +4853,7 @@
   				[=user agents=] SHOULD treat elements with role <code>main</code> as navigational <a>landmarks</a>.
   				[=user agents=] MAY enable users to quickly navigate to elements with role <code>main</code>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #banner and #contentinfo -->
-				<p>Within any <rref>document</rref> or <rref>application</rref>, the author SHOULD mark no more than one <a>element</a> with the <code>main</code> role.</p>
+				<p>The author SHOULD mark no more than one <a>element</a> on a page with the <code>main</code> role.</p>
 				<p class="note">Because <code>document</code> and <code>application</code> elements can be nested in the <abbr title="Document Object Model">DOM</abbr>, they may have multiple <code>main</code> elements as <abbr title="Document Object Model">DOM</abbr> descendants, assuming each of those is associated with different document nodes, either by a DOM nesting (e.g., <rref>document</rref> within <rref>document</rref>) or by use of the <pref>aria-owns</pref> attribute.</p>
 			</div>
 			<table class="role-features">
@@ -7511,7 +7511,7 @@
 		<div class="role" id="section">
 			<rdef>section</rdef>
 			<div class="role-description">
-				<p>A renderable structural containment unit in a document or application.</p>
+				<p>A renderable structural containment unit on a page.</p>
 				<p><code>section</code> is an <a href="#isAbstract">abstract role</a> used for the ontology. Authors MUST NOT use <code>section</code> role in content.</p>
 			</div>
 			<table class="role-features">


### PR DESCRIPTION
Fixing issue #1320 

This rewords any place that `within any documentation or application` is used and replaces it with `on a page`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 504 Gateway Timeout :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 10, 2022, 12:47 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fariellalgilmore%2Faria%2F82004b24bb4871fd46c65fcb25fbea71aa331de2%2Findex.html%3FisPreview%3Dtrue)

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/aria%231754.)._
</details>
