### PR TITLE
Resolves #978, add back ARIA element reflection IDL

### DIFF
--- a/index.html
+++ b/index.html
@@ -13612,7 +13612,7 @@ button.ariaPressed; // null</pre>
 		<pre class="idl">
 			interface mixin ARIAMixin {
 				attribute DOMString? role;
-				<!-- attribute Element? ariaActiveDescendantElement; -->
+				attribute Element? ariaActiveDescendantElement;
 				attribute DOMString? ariaAtomic;
 				attribute DOMString? ariaAutoComplete;
 				attribute DOMString? ariaBusy;
@@ -13621,28 +13621,28 @@ button.ariaPressed; // null</pre>
 				attribute DOMString? ariaColIndex;
 				attribute DOMString? ariaColIndexText;
 				attribute DOMString? ariaColSpan;
-				<!-- attribute FrozenArray&lt;Element&gt;? ariaControlsElements; -->
+				attribute FrozenArray&lt;Element&gt;? ariaControlsElements;
 				attribute DOMString? ariaCurrent;
-				<!-- attribute FrozenArray&lt;Element&gt;? ariaDescribedByElements; -->
+				attribute FrozenArray&lt;Element&gt;? ariaDescribedByElements;
 				attribute DOMString? ariaDescription;
-				<!-- attribute FrozenArray&lt;Element&gt;? ariaDetailsElements; -->
+				attribute FrozenArray&lt;Element&gt;? ariaDetailsElements;
 				attribute DOMString? ariaDisabled;
-				<!-- attribute Element? ariaErrorMessageElement; -->
+				attribute Element? ariaErrorMessageElement;
 				attribute DOMString? ariaExpanded;
-				<!-- attribute FrozenArray&lt;Element&gt;? ariaFlowToElements; -->
+				attribute FrozenArray&lt;Element&gt;? ariaFlowToElements;
 				attribute DOMString? ariaHasPopup;
 				attribute DOMString? ariaHidden;
 				attribute DOMString? ariaInvalid;
 				attribute DOMString? ariaKeyShortcuts;
 				attribute DOMString? ariaLabel;
-				<!-- attribute FrozenArray&lt;Element&gt;? ariaLabelledByElements; -->
+				attribute FrozenArray&lt;Element&gt;? ariaLabelledByElements;
 				attribute DOMString? ariaLevel;
 				attribute DOMString? ariaLive;
 				attribute DOMString? ariaModal;
 				attribute DOMString? ariaMultiLine;
 				attribute DOMString? ariaMultiSelectable;
 				attribute DOMString? ariaOrientation;
-				<!-- attribute FrozenArray&lt;Element&gt;? ariaOwnsElements; -->
+				attribute FrozenArray&lt;Element&gt;? ariaOwnsElements;
 				attribute DOMString? ariaPlaceholder;
 				attribute DOMString? ariaPosInSet;
 				attribute DOMString? ariaPressed;
@@ -13697,7 +13697,7 @@ button.ariaPressed; // null</pre>
 		<table>
 			<tr><th>IDL Attribute</th><th>Reflected ARIA Content Attribute</th></tr>
 			<tr><td>role</td><td><a href="#introroles">role</a></td></tr>
-			<!-- <tr><td><dfn>ariaActiveDescendantElement</dfn></td><td><pref>aria-activedescendant</pref></td></tr> -->
+			<tr><td><dfn>ariaActiveDescendantElement</dfn></td><td><pref>aria-activedescendant</pref></td></tr>
 			<tr><td><dfn>ariaAtomic</dfn></td><td><pref>aria-atomic</pref></td></tr>
 			<tr><td><dfn>ariaAutoComplete</dfn></td><td><pref>aria-autocomplete</pref></td></tr>
 			<tr><td><dfn>ariaBusy</dfn></td><td><sref>aria-busy</sref></td></tr>
@@ -13706,28 +13706,28 @@ button.ariaPressed; // null</pre>
 			<tr><td><dfn>ariaColIndex</dfn></td><td><pref>aria-colindex</pref></td></tr>
 			<tr><td><dfn>ariaColIndexText</dfn></td><td><pref>aria-colindextext</pref></td></tr>
 			<tr><td><dfn>ariaColSpan</dfn></td><td><pref>aria-colspan</pref></td></tr>
-			<!-- <tr><td><dfn>ariaControlsElements</dfn></td><td><pref>aria-controls</pref></td></tr> -->
+			<tr><td><dfn>ariaControlsElements</dfn></td><td><pref>aria-controls</pref></td></tr>
 			<tr><td><dfn>ariaCurrent</dfn></td><td><sref>aria-current</sref></td></tr>
-			<!-- <tr><td><dfn>ariaDescribedByElements</dfn></td><td><pref>aria-describedby</pref></td></tr> -->
+			<tr><td><dfn>ariaDescribedByElements</dfn></td><td><pref>aria-describedby</pref></td></tr>
 			<tr><td><dfn>ariaDescription</dfn></td><td><pref>aria-description</pref></td></tr>
-			<!-- <tr><td><dfn>ariaDetailsElements</dfn></td><td><pref>aria-details</pref></td></tr> -->
+			<tr><td><dfn>ariaDetailsElements</dfn></td><td><pref>aria-details</pref></td></tr>
 			<tr><td><dfn>ariaDisabled</dfn></td><td><sref>aria-disabled</sref></td></tr>
-			<!-- <tr><td><dfn>ariaErrorMessageElement</dfn></td><td><pref>aria-errormessage</pref></td></tr> -->
+			<tr><td><dfn>ariaErrorMessageElement</dfn></td><td><pref>aria-errormessage</pref></td></tr>
 			<tr><td><dfn>ariaExpanded</dfn></td><td><sref>aria-expanded</sref></td></tr>
-			<!-- <tr><td><dfn>ariaFlowToElements</dfn></td><td><pref>aria-flowto</pref></td></tr> -->
+			<tr><td><dfn>ariaFlowToElements</dfn></td><td><pref>aria-flowto</pref></td></tr>
 			<tr><td><dfn>ariaHasPopup</dfn></td><td><pref>aria-haspopup</pref></td></tr>
 			<tr><td><dfn>ariaHidden</dfn></td><td><sref>aria-hidden</sref></td></tr>
 			<tr><td><dfn>ariaInvalid</dfn></td><td><sref>aria-invalid</sref></td></tr>
 			<tr><td><dfn>ariaKeyShortcuts</dfn></td><td><pref>aria-keyshortcuts</pref></td></tr>
 			<tr><td><dfn>ariaLabel</dfn></td><td><pref>aria-label</pref></td></tr>
-			<!-- <tr><td><dfn>ariaLabelledByElements</dfn></td><td><pref>aria-labelledby</pref></td></tr> -->
+			<tr><td><dfn>ariaLabelledByElements</dfn></td><td><pref>aria-labelledby</pref></td></tr>
 			<tr><td><dfn>ariaLevel</dfn></td><td><pref>aria-level</pref></td></tr>
 			<tr><td><dfn>ariaLive</dfn></td><td><pref>aria-live</pref></td></tr>
 			<tr><td><dfn>ariaModal</dfn></td><td><pref>aria-modal</pref></td></tr>
 			<tr><td><dfn>ariaMultiLine</dfn></td><td><pref>aria-multiline</pref></td></tr>
 			<tr><td><dfn>ariaMultiSelectable</dfn></td><td><pref>aria-multiselectable</pref></td></tr>
 			<tr><td><dfn>ariaOrientation</dfn></td><td><pref>aria-orientation</pref></td></tr>
-			<!-- <tr><td><dfn>ariaOwnsElements</dfn></td><td><pref>aria-owns</pref></td></tr> -->
+			<tr><td><dfn>ariaOwnsElements</dfn></td><td><pref>aria-owns</pref></td></tr>
 			<tr><td><dfn>ariaPlaceholder</dfn></td><td><pref>aria-placeholder</pref></td></tr>
 			<tr><td><dfn>ariaPosInSet</dfn></td><td><pref>aria-posinset</pref></td></tr>
 			<tr><td><dfn>ariaPressed</dfn></td><td><sref>aria-pressed</sref></td></tr>


### PR DESCRIPTION
Now that HTML spec defines reflection for Element and FrozenArray<Element> attributes
(see https://github.com/whatwg/html/pull/7934), we can add back these attributes to ARIA IDL.

This is simply a revert of #1260.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 504 Gateway Timeout :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 10, 2022, 4:27 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fmrego%2Faria%2Fe0490c3ad45e4e2460f57938e5704a07863bb727%2Findex.html%3FisPreview%3Dtrue)

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/aria%231755.)._
</details>
