### PR TITLE
Fix for "name required" for tab at 5.2.8.4 and 5.2.8.5

### DIFF
--- a/index.html
+++ b/index.html
@@ -8749,7 +8749,7 @@
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-						<td class="role-namerequired"> True </td>
+						<td class="role-namerequired">True</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>


### PR DESCRIPTION
Addresses [1768](https://github.com/w3c/aria/issues/1768)

(name required) is missing for "tab" on 5.2.8.4 and 5.2.8.5. The query is searching the "Accessible Name Required:" value to be "True". There were extra spaces around that value so the string read "True&nbsp;" instead of "True".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/SalazarJosh/aria/pull/1771.html" title="Last updated on Jul 20, 2022, 9:32 PM UTC (bda2db6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1771/6d46a9a...SalazarJosh:bda2db6.html" title="Last updated on Jul 20, 2022, 9:32 PM UTC (bda2db6)">Diff</a>