### PR TITLE
Revised complementary definition re: DOM hierarchy

### DIFF
--- a/index.html
+++ b/index.html
@@ -2603,7 +2603,7 @@
 		<div class="role" id="complementary">
 			<rdef>complementary</rdef>
 			<div class="role-description">
-				<p>A <rref>landmark</rref> that is designed to be complementary to the main content at a similar level in the DOM hierarchy, but remaining meaningful when separated from the main content.</p>
+				<p>A <rref>landmark</rref> that is designed to be complementary to the main content, but would remain meaningful if it were to be separated from the main content. Complementary content is ideally placed at a similar level in the DOM hierarchy to the main content. For instance, as a sibling in the DOM hierarchy, or as a direct child of the main content.</p>
 				<p>There are various types of content that would appropriately have this <a>role</a>. For example, in the case of a portal, this may include but not be limited to show times, current weather, related articles, or stocks to watch. The complementary role indicates that contained content is relevant to the main content. If the complementary content is completely separable from the main content, it may be appropriate to use a more general role.</p>
 				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>complementary</code>.
   				[=user agents=] SHOULD treat elements with role <code>complementary</code> as navigational <a>landmarks</a>.


### PR DESCRIPTION
resolves #1396

Clarifies that complementary content at a 'similar level' could be a sibling to the main content, or a direct child of the main content.  This better aligns with the permissiveness of HTML's `<aside>` element which has no requirements of not being allowed within a `<main>`. 
Related: https://github.com/w3c/html-aam/pull/350


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1779.html" title="Last updated on Aug 18, 2022, 2:19 PM UTC (e4c7be8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1779/413dcf9...e4c7be8.html" title="Last updated on Aug 18, 2022, 2:19 PM UTC (e4c7be8)">Diff</a>