### PR TITLE
Add explicit value calculations for textbox and searchbox role

### DIFF
--- a/index.html
+++ b/index.html
@@ -7444,7 +7444,7 @@
 			<rdef>searchbox</rdef>
 			<div class="role-description">
 				<p>A type of textbox intended for specifying search criteria. See related <rref>textbox</rref> and <rref>search</rref>.</p>
-				<p class="note">User agents MUST expose the value of elements with role <code>searchbox</code> to <a>assistive technologies</a>. The value of a <code>searchbox</code> can be provided by a property from the host language or from the content of descendant elements.</p>
+				<p>User agents MUST expose the value of elements with role <code>searchbox</code> to <a>assistive technologies</a>. The value of a <code>searchbox</code> can be provided by a property from the host language or from the content of descendant elements.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -9257,8 +9257,8 @@
 				<p>A type of input that allows free-form text as its value.</p>
 				<p>If the <pref>aria-multiline</pref> <a>attribute</a> is <code>true</code>, the <a>widget</a> accepts line breaks within the input, as in an <abbr title="Hypertext Markup Language">HTML</abbr> <code>textarea</code>. Otherwise, this is a simple text box. The intended use is for languages that do not have a text input <a>element</a>, or cases in which an element with different <a>semantics</a> is repurposed as a text field.</p>
 				<!-- keep the following para synced with its equivalent in #aria-multiline -->
-				<p class="note">In most user agent implementations, the default behavior of the <kbd>ENTER</kbd> or <kbd>RETURN</kbd> key is different between the single-line and multi-line text fields in HTML. When user has focus in a single-line <code>&lt;input type="text"&gt;</code> element, the keystroke usually submits the form. When user has focus in a multi-line <code>&lt;textarea&gt;</code> element, the keystroke inserts a line break. The <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <code>textbox</code> role differentiates these types of boxes with the <pref>aria-multiline</pref> attribute, so authors are advised to be aware of this distinction when designing the field.</p>
-				<p class="note">User agents MUST expose the value of elements with role <code>textbox</code> to <a>assistive technologies</a>. The value of a <code>textbox</code> can be provided by a property from the host language or from the content of descendant elements.</p>
+				<p>In most user agent implementations, the default behavior of the <kbd>ENTER</kbd> or <kbd>RETURN</kbd> key is different between the single-line and multi-line text fields in HTML. When user has focus in a single-line <code>&lt;input type="text"&gt;</code> element, the keystroke usually submits the form. When user has focus in a multi-line <code>&lt;textarea&gt;</code> element, the keystroke inserts a line break. The <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <code>textbox</code> role differentiates these types of boxes with the <pref>aria-multiline</pref> attribute, so authors are advised to be aware of this distinction when designing the field.</p>
+				<p>User agents MUST expose the value of elements with role <code>textbox</code> to <a>assistive technologies</a>. The value of a <code>textbox</code> can be provided by a property from the host language or from the content of descendant elements.</p>
 
 			</div>
 			<table class="role-features">

--- a/index.html
+++ b/index.html
@@ -7444,7 +7444,9 @@
 			<rdef>searchbox</rdef>
 			<div class="role-description">
 				<p>A type of textbox intended for specifying search criteria. See related <rref>textbox</rref> and <rref>search</rref>.</p>
-				<p>User agents MUST expose the value of elements with role <code>searchbox</code> to <a>assistive technologies</a>. The value of a <code>searchbox</code> can be provided by a property from the host language or from the content of descendant elements.</p>
+				<p>User agents MUST expose the value of elements with role <code>searchbox</code> to <a>assistive technologies</a>.</p>
+				<p>If the <code>searchbox</code> element is a host language element that provides a value, such as an HTML <code>input</code> element, the value of the searchbox is the value of that element.</p>
+				<p>Otherwise, the value of the <code>searchbox</code> is represented by its descendant elements and can be determined using the same method used to compute the name of a <rref>button</rref> from its descendant content.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -9257,11 +9259,12 @@
 				<p>A type of input that allows free-form text as its value.</p>
 				<p>If the <pref>aria-multiline</pref> <a>attribute</a> is <code>true</code>, the <a>widget</a> accepts line breaks within the input, as in an <abbr title="Hypertext Markup Language">HTML</abbr> <code>textarea</code>. Otherwise, this is a simple text box. The intended use is for languages that do not have a text input <a>element</a>, or cases in which an element with different <a>semantics</a> is repurposed as a text field.</p>
 				<!-- keep the following para synced with its equivalent in #aria-multiline -->
-				<p>In most user agent implementations, the default behavior of the <kbd>ENTER</kbd> or <kbd>RETURN</kbd> key is different between the single-line and multi-line text fields in HTML. When user has focus in a single-line <code>&lt;input type="text"&gt;</code> element, the keystroke usually submits the form. When user has focus in a multi-line <code>&lt;textarea&gt;</code> element, the keystroke inserts a line break. The <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <code>textbox</code> role differentiates these types of boxes with the <pref>aria-multiline</pref> attribute, so authors are advised to be aware of this distinction when designing the field.</p>
-				<p>User agents MUST expose the value of elements with role <code>textbox</code> to <a>assistive technologies</a>. The value of a <code>textbox</code> can be provided by a property from the host language or from the content of descendant elements.</p>
-
+				<p class="note">In most user agent implementations, the default behavior of the <kbd>ENTER</kbd> or <kbd>RETURN</kbd> key is different between the single-line and multi-line text fields in HTML. When user has focus in a single-line <code>&lt;input type="text"&gt;</code> element, the keystroke usually submits the form. When user has focus in a multi-line <code>&lt;textarea&gt;</code> element, the keystroke inserts a line break. The <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <code>textbox</code> role differentiates these types of boxes with the <pref>aria-multiline</pref> attribute, so authors are advised to be aware of this distinction when designing the field.</p>
+				<p>User agents MUST expose the value of elements with role <code>textbox</code> to <a>assistive technologies</a>.</p>
+				<p>If the <code>textbox</code> element is a host language element that provides a value, such as an HTML <code>input</code> element, the value of the textbox is the value of that element.</p>
+				<p>Otherwise, the value of the <code>textbox</code> is represented by its descendant elements and can be determined using the same method used to compute the name of a <rref>button</rref> from its descendant content.</p>
 			</div>
-			<table class="role-features">
+			<table class="role-features">b
 				<caption>Characteristics:</caption>
 				<thead>
 					<tr>

--- a/index.html
+++ b/index.html
@@ -7444,6 +7444,7 @@
 			<rdef>searchbox</rdef>
 			<div class="role-description">
 				<p>A type of textbox intended for specifying search criteria. See related <rref>textbox</rref> and <rref>search</rref>.</p>
+				<p class="note">User agents MUST expose the value of elements with role <code>searchbox</code> to <a>assistive technologies</a>. The value of a <code>searchbox</code> can be provided by a property from the host language or from the content of descendant elements.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -9257,6 +9258,8 @@
 				<p>If the <pref>aria-multiline</pref> <a>attribute</a> is <code>true</code>, the <a>widget</a> accepts line breaks within the input, as in an <abbr title="Hypertext Markup Language">HTML</abbr> <code>textarea</code>. Otherwise, this is a simple text box. The intended use is for languages that do not have a text input <a>element</a>, or cases in which an element with different <a>semantics</a> is repurposed as a text field.</p>
 				<!-- keep the following para synced with its equivalent in #aria-multiline -->
 				<p class="note">In most user agent implementations, the default behavior of the <kbd>ENTER</kbd> or <kbd>RETURN</kbd> key is different between the single-line and multi-line text fields in HTML. When user has focus in a single-line <code>&lt;input type="text"&gt;</code> element, the keystroke usually submits the form. When user has focus in a multi-line <code>&lt;textarea&gt;</code> element, the keystroke inserts a line break. The <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <code>textbox</code> role differentiates these types of boxes with the <pref>aria-multiline</pref> attribute, so authors are advised to be aware of this distinction when designing the field.</p>
+				<p class="note">User agents MUST expose the value of elements with role <code>textbox</code> to <a>assistive technologies</a>. The value of a <code>textbox</code> can be provided by a property from the host language or from the content of descendant elements.</p>
+
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>


### PR DESCRIPTION
Fix for https://github.com/w3c/aria/issues/1720. Added verbiage to explain how values for searchboxes and textboxes are calculated.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chlane/aria_calculations_textbox_searchbox/pull/1780.html" title="Last updated on Aug 29, 2022, 6:57 PM UTC (0acfd33)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1780/413dcf9...chlane:0acfd33.html" title="Last updated on Aug 29, 2022, 6:57 PM UTC (0acfd33)">Diff</a>