### PR TITLE
Add accessibility tree definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -6307,7 +6307,7 @@
 					<li>An element used as an additional markup "hook" for <abbr title="Cascading Style Sheets">CSS</abbr>; or</li>
 					<li>A layout table and/or any of its associated rows, cells, etc.</li>
 				</ul>
-				<p>For any element with a role of presentation and which is not focusable, the user agent MUST NOT expose the implicit native semantics of the element (the role and its states and properties) to accessibility <abbr title="Application Programing Interfaces">APIs</abbr>. However, the user agent MUST expose content and descendant elements that do not have an explicit or inherited role of presentation. Thus, the <code>presentation</code> role causes a given element to be treated as having no role or to be removed from the accessibility tree, but does not cause the content contained within the element to be removed from the accessibility tree.</p>
+				<p>For any element with a role of presentation and which is not focusable, the user agent MUST NOT expose the implicit native semantics of the element (the role and its states and properties) to accessibility <abbr title="Application Programing Interfaces">APIs</abbr>. However, the user agent MUST expose content and descendant elements that do not have an explicit or inherited role of presentation. Thus, the <code>presentation</code> role causes a given element to be treated as having no role or to be removed from the <a>accessibility tree</a>, but does not cause the content contained within the element to be removed from the accessibility tree.</p>
 				<p>For example, the following two markup snippets will be exposed similarly to an accessibility <abbr title="Application Programing Interface">API</abbr>.</p>
 				<pre class="example highlight"><span class="comment">&lt;!-- 1. role="presentation" negates the implicit 'heading' role semantics but does not affect the contents, including the nested hyperlink. --&gt;</span>
 &lt;h1 role="presentation"&gt; Sample Content &lt;a href="...">let's go!&lt;/a> &lt;/h1&gt;
@@ -12572,7 +12572,7 @@ button.ariaPressed; // null</pre>
 		<div class="property" id="aria-relevant">
 			<pdef>aria-relevant</pdef>
 			<div class="property-description">
-				<p><a>Indicates</a> what notifications the user agent will trigger when the accessibility tree within a live region is modified. See related <pref>aria-atomic</pref>.</p>
+				<p><a>Indicates</a> what notifications the user agent will trigger when the <a>accessibility tree</a> within a live region is modified. See related <pref>aria-atomic</pref>.</p>
 				<p>The <a>attribute</a> is represented as a space-separated list of the following <span>values</span>: <code>additions</code>, <code>removals</code>, <code>text</code>; or a single catch-all value <code>all</code>.</p>
 				<p>This is used to describe <a>semantically</a> meaningful changes, as opposed to merely presentational ones. For example, nodes that are removed from the top of a log are merely removed for purposes of creating room for other entries, and the removal of them does not have meaning. However, in the case of a buddy list, removal of a buddy name indicates that they are no longer online, and this is a meaningful <a>event</a>. In that case <pref>aria-relevant</pref> will be set to <code>all</code>. When the <pref>aria-relevant</pref> attribute is not provided, the default value, <code>additions text</code>, indicates that text modifications and node additions are relevant, but that node removals are irrelevant.</p>
 				<p class="note"><pref>aria-relevant</pref> values of removals or all are to be used sparingly. Assistive technologies only need to be informed of content removal when its removal represents an important change, such as a buddy leaving a chat room.</p>
@@ -12619,7 +12619,7 @@ button.ariaPressed; // null</pre>
 				<tbody>
 					<tr>
 						<th class="value-name" scope="row">additions</th>
-						<td class="value-description">Element nodes are added to the accessibility tree within the live region.</td>
+						<td class="value-description">Element nodes are added to the <a>accessibility tree</a> within the live region.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row"><strong class="default">additions text (default)</strong></th>
@@ -12631,11 +12631,11 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">removals</th>
-						<td class="value-description">Text content, a text alternative, or an element node within the live region is removed from the accessibility tree.</td>
+						<td class="value-description">Text content, a text alternative, or an element node within the live region is removed from the <a>accessibility tree</a>.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">text</th>
-						<td class="value-description">Text content or a text alternative is added to any descendant in the accessibility tree of the live region.</td>
+						<td class="value-description">Text content or a text alternative is added to any descendant in the <a>accessibility tree</a> of the live region.</td>
 					</tr>
 				</tbody>
 			</table>
@@ -13311,7 +13311,7 @@ button.ariaPressed; // null</pre>
 	</section>
 </section>
 <section class="normative" id="accessibility_tree">
-	<h1>Accessibility Tree</h1>
+	<h1><dfn class="export">Accessibility Tree</dfn></h1>
 	<p>The <a class="termref">accessibility tree</a> and the DOM tree are parallel structures. The <a class="termref">accessibility tree</a> includes the user interface objects of the <a>user agent</a> and the objects of the document. <a>Accessible objects</a> are created in the accessibility tree for every DOM element that should be exposed to an <a>assistive technology</a>, either because it may fire an accessibility <a>event</a> or because it has a [=ARIA/property=], <a>relationship</a> or feature which needs to be exposed.</p>
 	<section id="tree_exclusion">
 	  <h2>Excluding Elements from the Accessibility Tree</h2>


### PR DESCRIPTION
Add the Accessibility Tree section as the definiton of an accessibility tree


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1784.html" title="Last updated on Aug 30, 2022, 10:19 PM UTC (28441c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1784/ece14a1...28441c6.html" title="Last updated on Aug 30, 2022, 10:19 PM UTC (28441c6)">Diff</a>