### PR TITLE
Allude to other widgets that allow group in group role definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -3897,7 +3897,7 @@
 			<div class="role-description">
 				<p>A set of user interface <a>objects</a> that is not intended to be included in a page summary or table of contents by <a>assistive technologies</a>.</p>
 				<p>Contrast with <rref>region</rref>, which is a grouping of user interface objects that will be included in a page summary or table of contents.</p>
-				<p>Authors SHOULD use a <code>group</code> to form a logical collection of items in a <a>widget</a>, such as children in a tree widget forming a collection of siblings in a hierarchy. However, when a <code>group</code> is used in the context of a <rref>listbox</rref>, authors MUST limit its children to <rref>option</rref> elements. Therefore, proper handling of <code>group</code> by authors and assistive technologies is determined by the context in which it is provided.</p>
+				<p>Authors SHOULD use a <code>group</code> to form a logical collection of items in a <a>widget</a>, such as children in a tree widget forming a collection of siblings in a hierarchy. However, when a <code>group</code> is used in the context of a <rref>listbox</rref>, for example, authors MUST limit its children to <rref>option</rref> elements. Therefore, proper handling of <code>group</code> by authors and assistive technologies is determined by the context in which it is provided.</p>
 				<p>Authors MAY nest <code>group</code> elements. If a section is significant enough to warrant inclusion in the web page's table of contents, the author SHOULD assign it a <a>role</a> of <rref>region</rref> or a <a href="#landmark_roles">standard landmark role</a>.</p>
 			</div>
 			<table class="role-features">

--- a/validator-tests/listbox-group-children-must-be-option.html
+++ b/validator-tests/listbox-group-children-must-be-option.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en-US">
-<head><title>In the context of a listbox, the children of a group element must be option elements.</title></head>
+<head><title>In the context of a listbox, for example, the children of a group element must be option elements.</title></head>
 <body>
   <!--
   URL: https://www.w3.org/TR/wai-aria-1.2/#group
-  RULE: "when a group is used in the context of a listbox, authors MUST limit
+  RULE: "when a group is used in the context of a listbox, for example, authors MUST limit
   * its children to option elements."
   -->
 


### PR DESCRIPTION
#1777 

Updates definition to show that `listbox` is just an example
<img width="686" alt="Screen Shot 2022-08-31 at 1 42 49 PM" src="https://user-images.githubusercontent.com/20210594/187778163-9989e03b-dc09-4dd8-966c-f2408824f688.png">


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ariellalgilmore/aria/pull/1786.html" title="Last updated on Aug 31, 2022, 8:43 PM UTC (bf68b4e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1786/2617046...ariellalgilmore:bf68b4e.html" title="Last updated on Aug 31, 2022, 8:43 PM UTC (bf68b4e)">Diff</a>