### PR TITLE
Removed excess confusing language

### DIFF
--- a/index.html
+++ b/index.html
@@ -6303,7 +6303,6 @@
 				<p>Example use cases:</p>
 				<ul>
 					<li>An element whose content is completely presentational (like a spacer image, decorative graphic, or clearing element);</li>
-					<li>An image that is in a container with the <rref>img</rref> <a>role</a> (all children of an <rref>img</rref> are automatically presentational);</li>
 					<li>An element used as an additional markup "hook" for <abbr title="Cascading Style Sheets">CSS</abbr>; or</li>
 					<li>A layout table and/or any of its associated rows, cells, etc.</li>
 				</ul>

--- a/index.html
+++ b/index.html
@@ -6303,7 +6303,7 @@
 				<p>Example use cases:</p>
 				<ul>
 					<li>An element whose content is completely presentational (like a spacer image, decorative graphic, or clearing element);</li>
-					<li>An image that is in a container with the <rref>img</rref> <a>role</a> and where the full text alternative is available and is marked up with <pref>aria-labelledby</pref> and (if needed) <pref>aria-describedby</pref>;</li>
+					<li>An image that is in a container with the <rref>img</rref> <a>role</a> (all children of an <rref>img</rref> are automatically presentational);</li>
 					<li>An element used as an additional markup "hook" for <abbr title="Cascading Style Sheets">CSS</abbr>; or</li>
 					<li>A layout table and/or any of its associated rows, cells, etc.</li>
 				</ul>


### PR DESCRIPTION
If merged, this PR removes excess language in one of the examples for `role presentation`, as it was unnecessarily complex and causing confusion.
 
Resolves #1455


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1787.html" title="Last updated on Aug 29, 2023, 4:45 PM UTC (5fb951e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1787/2617046...5fb951e.html" title="Last updated on Aug 29, 2023, 4:45 PM UTC (5fb951e)">Diff</a>