### PR TITLE
[normative][author] clarify widget in trees can only be group and treeitem

### DIFF
--- a/index.html
+++ b/index.html
@@ -9700,6 +9700,7 @@
 				<p>A <rref>widget</rref> that allows the user to select one or more items from a hierarchically organized collection.</p>
 				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
 				<p>Elements with the role <code>tree</code> have an implicit <pref>aria-orientation</pref> value of <code>vertical</code>.</p>
+				<p>Authors MUST ensure that all [=ARIA/owned=] [=elements=] with a <rref>widget</rref> <a>role</a> have either role <code>treeitem</code> or role <rref>group</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -9700,7 +9700,7 @@
 				<p>A <rref>widget</rref> that allows the user to select one or more items from a hierarchically organized collection.</p>
 				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
 				<p>Elements with the role <code>tree</code> have an implicit <pref>aria-orientation</pref> value of <code>vertical</code>.</p>
-				<p>Authors MUST ensure that all [=ARIA/owned=] [=elements=] with a <rref>widget</rref> <a>role</a> have either role <code>treeitem</code> or role <rref>group</rref>.</p>
+				<p>Authors MUST ensure that all [=ARIA/owned=] [=elements=] with a <rref>widget</rref> <a>role</a> have either role <rref>treeitem</rref> or role <rref>group</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>


### PR DESCRIPTION
Resolves #1251


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/pkra/aria/pull/1793.html" title="Last updated on Sep 7, 2022, 6:42 PM UTC (a0e8f8d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1793/bcf44d1...pkra:a0e8f8d.html" title="Last updated on Sep 7, 2022, 6:42 PM UTC (a0e8f8d)">Diff</a>