### PR TITLE
Move the text "User agents MUST provide a way for assistive technologies to be notified when states change, either through DOM attribute change events or platform accessibility API events." from 6.5.1 to the end of section 6.5

### DIFF
--- a/index.html
+++ b/index.html
@@ -10348,7 +10348,7 @@ button.ariaPressed; // null</pre>
 				<li><pref>aria-valuenow</pref></li>
 				<li><pref>aria-valuetext</pref></li>
 			</ul>
-			<p>Widget attributes might be mapped by a <a>user agent</a> to platform <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> <a>state</a>, for access by <a>assistive technologies</a>, or they might be accessed directly from the <abbr title="Document Object Model">DOM</abbr>. User agents MUST provide a way for assistive technologies to be notified when states change, either through <abbr title="Document Object Model">DOM</abbr> attribute change <a>events</a> or platform accessibility <abbr title="Application Programing Interfaces">API</abbr> events.</p>
+			<p>Widget attributes might be mapped by a <a>user agent</a> to platform <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> <a>state</a>, for access by <a>assistive technologies</a>, or they might be accessed directly from the <abbr title="Document Object Model">DOM</abbr>.</p>
 		</section>
 		<section id="attrs_liveregions">
 			<h3>Live Region Attributes</h3>
@@ -10392,6 +10392,10 @@ button.ariaPressed; // null</pre>
 				<li><pref>aria-setsize</pref></li>
 			</ul>
 		</section>
+	</section>
+	<section id="state_changes">
+		<h3>State change notification</h3>
+		<p> User agents MUST provide a way for assistive technologies to be notified when states change, either through <abbr title="Document Object Model">DOM</abbr> attribute change <a>events</a> or platform accessibility <abbr title="Application Programing Interfaces">API</abbr> events.</p>
 	</section>
 	<section id="state_prop_def">
 		<h2>Definitions of States and Properties (all aria-* attributes)</h2>


### PR DESCRIPTION
Fixes #732


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1811.html" title="Last updated on Sep 20, 2022, 12:57 AM UTC (56e508b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1811/bcf44d1...56e508b.html" title="Last updated on Sep 20, 2022, 12:57 AM UTC (56e508b)">Diff</a>