### PR TITLE
Editorial: change heading level on "Note regarding the ARIA 1.1 none role."

### DIFF
--- a/index.html
+++ b/index.html
@@ -4067,7 +4067,7 @@
 			<div class="role-description">
 				<p>A container for a collection of [=elements=] that form an image. See synonym <rref>img</rref>.</p>
 				<div class="note" id="role-image-note-image">
-					<h5>Note regarding the ARIA 1.3 <code>image</code> role.</h5>
+					Note regarding the ARIA 1.3 <code>image</code> role.
 					<p>The <code>image</code> was added to ARIA in version 1.3 as a
 					synonym of the ARIA 1.0 <rref>img</rref> role. The <code>image</code>
 					role improves syntactic consistency with the names of other roles,
@@ -5907,7 +5907,7 @@
 			<div class="role-description">
 				<p>An <a>element</a> whose implicit native role semantics will not be mapped to the <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a>. See synonym <rref>presentation</rref>.</p>
 				<div class="note" id="role-none-note-none">
-					<h5>Note regarding the ARIA 1.1 <code>none</code> role.</h5>
+					Note regarding the ARIA 1.1 <code>none</code> role.
 					<p>In ARIA 1.1, the working group introduced <code>none</code> as a synonym to the <rref>presentation</rref> role, due to author confusion surrounding the intended meaning of the word "presentation" or "presentational." Many individuals erroneously consider <code>role="presentation"</code> to be synonymous with <code>aria-hidden="true"</code>, and we believe <code>role="none"</code> conveys the actual meaning more unambiguously.</p>
 				</div>
 			</div>

--- a/index.html
+++ b/index.html
@@ -6298,7 +6298,7 @@
 			<div class="role-description">
 				<p>An <a>element</a> whose implicit native role semantics will not be mapped to the <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a>. See synonym <rref>none</rref>.</p>
 				<div class="note" id="role-presentation-note-none">
-					<h5>Note regarding the ARIA 1.1 <rref>none</rref> role.</h5>
+					<h3>Note regarding the ARIA 1.1 <rref>none</rref> role.</h3>
 					<p>In ARIA 1.1, the working group introduced <rref>none</rref> as a synonym to the <code>presentation</code> role, due to author confusion surrounding the intended meaning of the word "presentation" or "presentational." Many individuals erroneously consider <code>role="presentation"</code> to be synonymous with <code>aria-hidden="true"</code>, and we believe <code>role="none"</code> conveys the actual meaning more unambiguously.</p>
 				</div>
 				<p>The intended use is when an element is used to change the look of the page but does not have all the functional, interactive, or structural relevance implied by the element type, or may be used to provide for an accessible fallback in older browsers that do not support <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>.</p>

--- a/index.html
+++ b/index.html
@@ -6298,7 +6298,7 @@
 			<div class="role-description">
 				<p>An <a>element</a> whose implicit native role semantics will not be mapped to the <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a>. See synonym <rref>none</rref>.</p>
 				<div class="note" id="role-presentation-note-none">
-					<h3>Note regarding the ARIA 1.1 <rref>none</rref> role.</h3>
+					Note regarding the ARIA 1.1 <rref>none</rref> role.
 					<p>In ARIA 1.1, the working group introduced <rref>none</rref> as a synonym to the <code>presentation</code> role, due to author confusion surrounding the intended meaning of the word "presentation" or "presentational." Many individuals erroneously consider <code>role="presentation"</code> to be synonymous with <code>aria-hidden="true"</code>, and we believe <code>role="none"</code> conveys the actual meaning more unambiguously.</p>
 				</div>
 				<p>The intended use is when an element is used to change the look of the page but does not have all the functional, interactive, or structural relevance implied by the element type, or may be used to provide for an accessible fallback in older browsers that do not support <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>.</p>


### PR DESCRIPTION
closes #1773 

It's been a minute since this was discussed so let me know if this isn't the solution we want. But I simply adjusted the heading level to fall in line with the programmatically generated heading and make sense with the heading above it 🏄🏽


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dakahn/aria/pull/1816.html" title="Last updated on Sep 29, 2022, 4:22 PM UTC (5b46146)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1816/bcf44d1...dakahn:5b46146.html" title="Last updated on Sep 29, 2022, 4:22 PM UTC (5b46146)">Diff</a>