### PR TITLE
GitHub issue template fix - remove extra 'at'

### DIFF
--- a/.github/ISSUE_TEMPLATE/editorial.md
+++ b/.github/ISSUE_TEMPLATE/editorial.md
@@ -10,7 +10,7 @@ assignees: ''
 
 # Describe the change
 
-# Link to the version of the specification or documentation you were looking at at.
+# Link to the version of the specification or documentation you were looking at
 
 Link to documentation:
 


### PR DESCRIPTION
removes an extra "at." from the end of the second heading.

Other bits to consider before this otherwise quick typo PR is merged:

1. "Link to documentation:" rendering as a paragraph - not sure if that's also meant to be a heading or if it's representative of placeholder content?  
2. The headings are being rendered as `<h1>`s since they're using the single `#` markdown for headings.  Is that what we want here?   Maybe a bit persnickety to bring this up, but also does go against the general a11y best practice for using level 1 headings.  This would apply to all the recent issue/pr templates.
