### PR TITLE
Refactor identification of global states and properties

### DIFF
--- a/common/script/aria.js
+++ b/common/script/aria.js
@@ -179,15 +179,6 @@ function ariaAttributeReferences() {
           }
           globalSPIndex += '</li>\n';
         }
-        parentNode = document.querySelector('#global_states');
-        if (parentNode) {
-          node = parentNode.querySelector('.placeholder');
-          if (node) {
-            l = document.createElement('ul');
-            l.innerHTML = globalSPIndex;
-            parentNode.replaceChild(l, node);
-          }
-        }
         // there is only one role that uses the global properties
         parentNode = document.querySelector(
           '#roletype td.role-properties span.placeholder'
@@ -203,6 +194,28 @@ function ariaAttributeReferences() {
             node.replaceChild(l, parentNode);
           }
         }
+        // Annotate global attribute references
+        const globalAttrNodes = document.querySelectorAll('[data-annotate-global-attrs]');
+        globalAttrNodes.forEach(function (parentNode) {
+          const attrNodes = parentNode.querySelectorAll('pref, sref');
+          attrNodes.forEach(function (attrNode) {
+            const matchedAttrs = globalSP.filter(obj => {
+              return obj.title === attrNode.innerText
+            })
+            if (matchedAttrs.length === 1) {
+              const globalAttr = matchedAttrs[0];
+              let annotation = ' (Global)';
+              if (globalAttr.prohibited) {
+                annotation = ' (Global, except where prohibited)';
+              }
+              else if (globalAttr.deprecated) {
+                annotation = ' (Global use deprecated in ARIA 1.2)';
+              }
+              const textNode = document.createTextNode(annotation);
+              attrNode.parentNode.insertBefore(textNode, attrNode.nextSibling);
+            }
+          });
+        });
       }
 
       // what about roles?

--- a/index.html
+++ b/index.html
@@ -10294,22 +10294,6 @@ button.ariaPressed; // null</pre>
 			</section>
 		</section>
 	</section>
-	<section data-cite="HTML">
-		<h2>Translatable Attributes</h2>
-		<p>The HTML specification states that other specifications can define <a data-cite="html/dom.html#translatable-attributes">translatable attributes</a>. The language and directionality of each attribute value is the same as the <a data-cite="html/dom.html#language">language</a> and <a data-cite="html/dom.html#the-directionality">directionality</a> of the element.</p>
-		<p>To be understandable by assistive technology users, the values of the following <a>states</a> and [=ARIA/properties=] are <a data-cite="html/dom.html#translatable-attributes">translatable attributes</a> and should be translated when a page is localized:</p>
-		<ul>
-			<li><pref>aria-label</pref></li>
-			<li><pref>aria-placeholder</pref></li>
-			<li><pref>aria-roledescription</pref></li>
-			<li><pref>aria-valuetext</pref></li>
-		</ul>
-	</section>
-	<section id="global_states">
-		<h2>Global States and Properties</h2>
-		<p>Some <a>states</a> and [=ARIA/properties=] are applicable to all host language [=elements=] regardless of whether a <a>role</a> is applied. The following global states and properties are supported by all roles and by all base markup elements unless otherwise prohibited. If a role prohibits use of any global states or properties, those states or properties are listed as prohibited in the characteristics table included in the section that defines the role.</p>
-		<p class="placeholder">Placeholder for global states and properties</p>
-	</section>
 	<section id="state_prop_taxonomy" data-cite="dom">
 		<h2>Taxonomy of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> States and Properties</h2>
 		<p>States and properties are categorized as follows:</p>
@@ -10318,12 +10302,15 @@ button.ariaPressed; // null</pre>
 			<li><a href="#attrs_liveregions">Live Region Attributes</a></li>
 			<li><a href="#attrs_dragdrop">Drag-and-Drop Attributes</a></li>
 			<li><a href="#attrs_relationships">Relationship Attributes</a></li>
+			<li><a href="#attrs_other">Other Attributes</a></li>
 		</ol>
+		<p class="note">Some <a>states</a> and [=ARIA/properties=] are applicable to all host language [=elements=] regardless of whether a <a>role</a> is applied. These global states and properties are supported by all roles and by all base markup elements unless otherwise prohibited. If a role prohibits use of any global states or properties, those states or properties are listed as prohibited in the characteristics table included in the section that defines the role.</p>
 		<section id="attrs_widgets">
 			<h3>Widget Attributes</h3>
 			<p>This section contains [=attributes=] specific to common user interface [=elements=] found on <abbr title="Graphical User Interface">GUI</abbr> systems or in rich internet applications which receive user input and process user actions. These attributes are used to support the <a href="#widget_roles">widget roles</a>.</p>
-			<ul>
+			<ul data-annotate-global-attrs>
 				<li><pref>aria-autocomplete</pref></li>
+				<li><pref>aria-braillelabel</pref></li>
 				<li><sref>aria-checked</sref></li>
 				<li><sref>aria-disabled</sref></li>
 				<li><pref>aria-errormessage</pref></li>
@@ -10331,6 +10318,7 @@ button.ariaPressed; // null</pre>
 				<li><pref>aria-haspopup</pref></li>
 				<li><sref>aria-hidden</sref></li>
 				<li><sref>aria-invalid</sref></li>
+				<li><pref>aria-keyshortcuts</pref></li>
 				<li><pref>aria-label</pref></li>
 				<li><pref>aria-level</pref></li>
 				<li><pref>aria-modal</pref></li>
@@ -10353,7 +10341,7 @@ button.ariaPressed; // null</pre>
 		<section id="attrs_liveregions">
 			<h3>Live Region Attributes</h3>
 			<p>This section contains [=attributes=] specific to <a>live regions</a> in rich internet applications. These attributes may be applied to any <a>element</a>. The purpose of these attributes is to indicate that content changes may occur without the element having focus, and to provide <a>assistive technologies</a> with information on how to process those content updates. Some <a>roles</a> specify a default value for the <pref>aria-live</pref> attribute specific to that role. An example of a live region is a ticker section that lists updating stock quotes. User agents MAY ignore changes triggered by direct user action on an <a>element</a> inside a live region (e.g., editing the value of a text field).</p>
-			<ul>
+			<ul data-annotate-global-attrs>
 				<li><pref>aria-atomic</pref></li>
 				<li><sref>aria-busy</sref></li>
 				<li><pref>aria-live</pref></li>
@@ -10363,7 +10351,7 @@ button.ariaPressed; // null</pre>
 		<section id="attrs_dragdrop">
 			<h3>Drag-and-Drop Attributes</h3>
 			<p>This section lists [=attributes=] which indicate information about drag-and-drop interface [=elements=], such as draggable elements and their drop targets. Drop target information will be rendered visually by the author and provided to <a>assistive technologies</a> through an alternate modality.</p>
-			<ul>
+			<ul data-annotate-global-attrs>
 				<li><pref>aria-dropeffect</pref></li>
 				<li><sref>aria-grabbed</sref></li>
 			</ul>
@@ -10371,7 +10359,7 @@ button.ariaPressed; // null</pre>
 		<section id="attrs_relationships">
 			<h3>Relationship Attributes</h3>
 			<p>This section lists [=attributes=] that indicate <a>relationships</a> or associations between [=elements=] which cannot be readily determined from the document structure.</p>
-			<ul>
+			<ul data-annotate-global-attrs>
 				<li><pref>aria-activedescendant</pref></li>
 				<li><pref>aria-colcount</pref></li>
 				<li><pref>aria-colindex</pref></li>
@@ -10392,6 +10380,26 @@ button.ariaPressed; // null</pre>
 				<li><pref>aria-setsize</pref></li>
 			</ul>
 		</section>
+		<section id="attrs_other">
+			<h3>Other Attributes</h3>
+			<ul data-annotate-global-attrs>
+				<li><pref>aria-brailleroledescription</pref></li>
+				<li><sref>aria-current</sref></li>
+				<li><pref>aria-description</pref></li>
+				<li><pref>aria-roledescription</pref></li>
+			</ul>
+		</section>
+	</section>
+	<section data-cite="HTML">
+		<h2>Translatable Attributes</h2>
+		<p>The HTML specification states that other specifications can define <a data-cite="html/dom.html#translatable-attributes">translatable attributes</a>. The language and directionality of each attribute value is the same as the <a data-cite="html/dom.html#language">language</a> and <a data-cite="html/dom.html#the-directionality">directionality</a> of the element.</p>
+		<p>To be understandable by assistive technology users, the values of the following <a>states</a> and [=ARIA/properties=] are <a data-cite="html/dom.html#translatable-attributes">translatable attributes</a> and should be translated when a page is localized:</p>
+		<ul>
+			<li><pref>aria-label</pref></li>
+			<li><pref>aria-placeholder</pref></li>
+			<li><pref>aria-roledescription</pref></li>
+			<li><pref>aria-valuetext</pref></li>
+		</ul>
 	</section>
 	<section id="state_prop_def">
 		<h2>Definitions of States and Properties (all aria-* attributes)</h2>


### PR DESCRIPTION
Closes #1823.

In reviewing the list of global states and properties, I found considerable overlap with the attributes already classified in the “6.6 Taxonomy...” section.  As @Jaws-test reported, I discovered only 6 attributes that were missing from Taxonomy:

- `aria-braillelabel`
- `aria-brailleroledescription`
- `aria-current`
- `aria-description`
- `aria-keyshortcuts`
- `aria-roledescription`

In this commit, I’m proposing a refactor which:

1. Adds the 6 missing states and properties to the Taxonomy section:

    * I put `aria-braillelabel` in the “Widget Attributes” category since its purpose is similar to `aria-label`, which had already been classified in that list.

    * I also put `aria-keyshortcuts` in the “Widget Attributes” category since it felt like it belongs there.

    * For now, I’ve put the remaining four in a new “Other Attributes” category since they didn’t appear to fit cleanly in any of the existing ones.

2. Updates `aria.js` to identify all _global_ attributes in the Taxonomy section with an annotation of “_(Global)_” or similar.

3. Removes the “Global States & Properties” section, but incorporates its descriptive language into the Taxonomy section.

4. Relocate the “Translatable Attributes” section so that the Taxonomy section may be more clearly understood as a _complete_ collection of all ARIA attributes.