### PR TITLE
Editorial: minor revisions to deletion role description

### DIFF
--- a/index.html
+++ b/index.html
@@ -2928,7 +2928,7 @@
 		<div class="role" id="deletion">
 			<rdef>deletion</rdef>
 			<div class="role-description">
-				<p>A deletion contains content that is marked as removed or content that is being suggested for removal. See related <rref>insertion</rref>.</p>
+				<p>A deletion represents content that is marked as removed, content that is being suggested for removal, or content that is no longer relevant in the context of its accompanying content. See related <rref>insertion</rref>.</p>
 				<p>Deletions are typically used to either mark differences between two versions of content or to designate content suggested for removal in scenarios where multiple people are revising content.</p>
 			</div>
 			<table class="role-features">
@@ -2954,7 +2954,12 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;del&gt;</code> in [[HTML]]</td>
+						<td class="role-related">
+							<ul>
+								<li><code>&lt;del&gt;</code> in [[HTML]]</li>
+								<li><code>&lt;s&gt;</code> in [[HTML]]</li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -4253,7 +4258,9 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;ins&gt;</code> in [[HTML]]</td>
+						<td class="role-related">
+							<code>&lt;ins&gt;</code> in [[HTML]]
+						</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>

--- a/index.html
+++ b/index.html
@@ -4258,9 +4258,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related">
-							<code>&lt;ins&gt;</code> in [[HTML]]
-						</td>
+						<td class="role-related"><code>&lt;ins&gt;</code> in [[HTML]]</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>


### PR DESCRIPTION
Related to [HTML AAM issue 416](https://github.com/w3c/html-aam/issues/416)

Previously the WG thought it reasonable to revise HTML's `<s>` element to map to the `deletion` role, allowing the opportunity to better expose content that is no longer relevant.   This PR is contingent on the merging of the HTML AAM PR to resolve the above linked issue (HTML AAM PR will be linked to via reference to this issue, once submitted).

There are no further tests or normative updates needed for this spec - the necessary implementation requests will be made via the HTML AAM PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1834.html" title="Last updated on Oct 20, 2022, 5:17 PM UTC (90157c5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1834/be8f3c9...90157c5.html" title="Last updated on Oct 20, 2022, 5:17 PM UTC (90157c5)">Diff</a>