### PR TITLE
Editorial: Update hidden term definition to match accname and core-aam

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,7 +309,10 @@
 			</dd>
 			<dt><dfn data-dfn-for="element" data-export="">Hidden</dfn></dt>
 			<dd>
-				<p>Indicates that the <a>element</a> is not visible, <a>perceivable</a>, or interactive to <em>any</em> user. An element is considered <em>hidden</em> if it or any one of its ancestor elements is not rendered or is explicitly hidden.</p>
+				<p>Indicates that the <a>element</a> is absent from the accessibility tree and is not exposed to accessibility APIs. An element is considered hidden if it or any one of its ancestor elements has been explicitly hidden, either by CSS properties <code>display:none</code>, <code>visibility:hidden</code> or <code>visibility:collapse</code>, or with the aria attribue <code>aria-hidden</code>.<p>
+			<dt><dfn data-dfn-for="element" data-lt="hide from all users" data-export="">Hidden From All Users</dfn></dt>
+			<dd>
+				<p>Indicates that the <a>element</a> is not visible, <a>perceivable</a>, or interactive to <em>any</em> user. An element is considered <em>hidden from all users</em> if it or any one of its ancestor elements is not rendered or is explicitly hidden from all users. In the ARIA specifications, it is important to understand an <a>element</a> can be [=element/hidden=] by removing it from the accessibility tree but not [=element/hidden from all users=] by the use of <code>aria-hidden</code>.</p>
 			</dd>
 			<dt><dfn>Identifies</dfn></dt>
 			<dd>
@@ -8675,7 +8678,7 @@
 				<p>Authors MUST ensure [=elements=] with <a>role</a> <rref>tab</rref> are contained in, or [=ARIA/owned=] by, an element with the role <rref>tablist</rref>.</p>
 				<p>Authors SHOULD ensure the <rref>tabpanel</rref> associated with the currently active tab is <a>perceivable</a> to the user.</p>
 				<!-- keep following para synced with its counterpart in #tablist -->
-				<p>For a single-selectable <rref>tablist</rref>, authors SHOULD hide other <code>tabpanel</code> [=elements=] from the user until the user selects the tab associated with that tabpanel. For a multi-selectable <rref>tablist</rref>, authors SHOULD ensure that the <rref>tab</rref> for each visible <rref>tabpanel</rref> has the <sref>aria-expanded</sref> <a>attribute</a> set to <code>true</code>, and that the <code>tabs</code> associated with the remaining hidden <code>tabpanel</code> elements have their <sref>aria-expanded</sref> attributes set to <code>false</code>.</p>
+				<p>For a single-selectable <rref>tablist</rref>, authors SHOULD [=element/hide from all users=] other <code>tabpanel</code> [=elements=] until the user selects the tab associated with that tabpanel. For a multi-selectable <rref>tablist</rref>, authors SHOULD ensure that the <rref>tab</rref> for each visible <rref>tabpanel</rref> has the <sref>aria-expanded</sref> <a>attribute</a> set to <code>true</code>, and that the <code>tabs</code> associated with the remaining [=element/hidden from all users=] <code>tabpanel</code> elements have their <sref>aria-expanded</sref> attributes set to <code>false</code>.</p>
 				<p>Authors SHOULD ensure that a selected tab has its <sref>aria-selected</sref> attribute set to <code>true</code>, that inactive tab elements have their <sref>aria-selected</sref> attribute set to <code>false</code>, and that the currently selected tab provides a visual indication that it is selected.</p>
         <p>In certain conditions, a user agent MAY provide an implicit value for <sref>aria-selected</sref> for each <rref>tab</rref> in a <rref>tablist</rref>, and if it does, the user agent MUST ensure the following conditions are met before providing an implicit value:</p>
         <ul>
@@ -8874,7 +8877,7 @@
 				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
 
 				<!-- keep following para synced with its counterpart in #tab -->
-				<p>For a single-selectable <rref>tablist</rref>, authors SHOULD hide other <code>tabpanel</code> [=elements=] from the user until the user selects the tab associated with that tabpanel. For a multi-selectable <rref>tablist</rref>, authors SHOULD ensure that the <rref>tab</rref> for each visible <rref>tabpanel</rref> has the <sref>aria-expanded</sref> <a>attribute</a> set to <code>true</code>, and that the <code>tabs</code> associated with the remaining hidden <code>tabpanel</code> elements have their <sref>aria-expanded</sref> attributes set to <code>false</code>.</p>
+				<p>For a single-selectable <rref>tablist</rref>, authors SHOULD [=element/hide from all users=] other <code>tabpanel</code> [=elements=] until the user selects the tab associated with that tabpanel. For a multi-selectable <rref>tablist</rref>, authors SHOULD ensure that the <rref>tab</rref> for each visible <rref>tabpanel</rref> has the <sref>aria-expanded</sref> <a>attribute</a> set to <code>true</code>, and that the <code>tabs</code> associated with the remaining [=element/hidden from all users=] <code>tabpanel</code> elements have their <sref>aria-expanded</sref> attributes set to <code>false</code>.</p>
 
 				<!-- keep following para synced with its counterpart in #tabpanel -->
 				<p><rref>tablist</rref> elements are typically placed near usually preceding, a series of <rref>tabpanel</rref> elements. See the <cite><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> for details on implementing a tab set design pattern.</p>
@@ -11479,8 +11482,8 @@ button.ariaPressed; // null</pre>
 				<p><a>Identifies</a> the <a>element</a> (or elements) that provides an error message for an <a>object</a>. See related <sref>aria-invalid</sref> and <pref>aria-describedby</pref>.</p>
 				<p>The <code>aria-errormessage</code> attribute references other elements that contain error message text. Authors MUST use <sref>aria-invalid</sref> in conjunction with <code>aria-errormessage</code>.</p>
 				<p>When the value of an object is not valid, <sref>aria-invalid</sref> is set to <code>true</code>, which indicates that the message contained by elements referenced by <code>aria-errormessage</code> is pertinent.</p>
-				<p>When an object is in a valid state, it has either <sref>aria-invalid</sref> set to <code>false</code> or it does not have the <sref>aria-invalid</sref> attribute. Authors MAY use <code>aria-errormessage</code> on an object that is currently valid, but only if the elements referenced by <code>aria-errormessage</code> are [=element/hidden=], because the message they contain is not pertinent.</p>
-				<p>When <code>aria-errormessage</code> is pertinent, authors MUST ensure the content is not hidden so users can navigate to and examine the error message. Similarly, when <code>aria-errormessage</code> is not pertinent, authors MUST either ensure the content is [=element/hidden=] or remove the <code>aria-errormessage</code> attribute or its value.</p>
+				<p>When an object is in a valid state, it has either <sref>aria-invalid</sref> set to <code>false</code> or it does not have the <sref>aria-invalid</sref> attribute. Authors MAY use <code>aria-errormessage</code> on an object that is currently valid, but only if the elements referenced by <code>aria-errormessage</code> are [=element/hidden from all users=], because the message they contain is not pertinent.</p>
+				<p>When <code>aria-errormessage</code> is pertinent, authors MUST ensure the content is not [=element/hidden from all users=] so users can navigate to and examine the error message. Similarly, when <code>aria-errormessage</code> is not pertinent, authors MUST either ensure the content is [=element/hidden from all users=] or remove the <code>aria-errormessage</code> attribute or its value.</p>
 				<p>User agents MUST NOT expose <code>aria-errormessage</code> for an object with an <sref>aria-invalid</sref> value of <code>false</code>.</p>
 				<p>Authors MAY call attention to a newly rendered error message with a live region by either applying an <pref>aria-live</pref> property or using one of the <a href="#live_region_roles">live region roles</a>, such as <rref>alert</rref>. A live region is appropriate when an error message is displayed to users after they have provided an invalid value.</p>
 				<p>A typical message describes what is wrong and informs users what is required. For example, an error message might be, <q>Invalid time: the time must be between 9:00 AM and 5:00 PM.</q> The following example code shows markup for an initial valid state and for a subsequent invalid state. Note the changes to <sref>aria-invalid</sref> on the text input <a>object</a>, and to <pref>aria-live</pref> on the <a>element</a> containing the text of the error message:</p>
@@ -11812,11 +11815,11 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">true</th>
-						<td class="value-description">The element is hidden from the accessibility API.</td>
+						<td class="value-description">The element is [=element/hidden=] from the accessibility API.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row"><strong class="default">undefined (default)</strong></th>
-						<td class="value-description">The element's hidden state is determined by the user agent based on whether it is rendered.</td>
+						<td class="value-description">The element's [=element/hidden=] state is determined by the user agent based on whether it is rendered.</td>
 					</tr>
 				</tbody>
 			</table>
@@ -13360,7 +13363,7 @@ button.ariaPressed; // null</pre>
 	</section>
 	<section id="tree_inclusion">
 	  <h2>Including Elements in the Accessibility Tree</h2>
-          <p>If not excluded from or marked as hidden in the accessibility tree per the rules above in <a href="#tree_exclusion">Excluding Elements in the Accessibility Tree</a>, user agents MUST provide an <a>accessible object</a> in the <a class="termref">accessibility tree</a> for <abbr title="Document Object Model">DOM</abbr> [=elements=] that meet any of the following criteria:</p>
+          <p>If not excluded from the accessibility tree per the rules above in <a href="#tree_exclusion">Excluding Elements in the Accessibility Tree</a>, user agents MUST provide an <a>accessible object</a> in the <a class="termref">accessibility tree</a> for <abbr title="Document Object Model">DOM</abbr> [=elements=] that meet any of the following criteria:</p>
           <ul>
             <li>Elements that are not [=element/hidden=] and may fire an <a>accessibility <abbr title="Application Program Interface">API</abbr></a> <a>event</a>, including:
               <ul>
@@ -13370,7 +13373,7 @@ button.ariaPressed; // null</pre>
 	        </li>
             <li>Elements that have an explicit role or a global <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> attribute and do not have <sref>aria-hidden</sref> set to <code>true</code>. (See <a href="#tree_exclusion">Excluding Elements in the Accessibility Tree</a> for additional guidance on <sref>aria-hidden</sref>.)</li>
             <li>Elements that are not [=element/hidden=] and have an ID that is referenced by another element via a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> property.
-            <p class="note">Text equivalents for hidden referenced objects may still be used in the <a href="#mapping_additional_nd" class="accname">name and description computation</a> even when not included in the accessibility tree.</p>
+            <p class="note">Text equivalents for [=element/hidden=] referenced objects may still be used in the <a href="#mapping_additional_nd" class="accname">name and description computation</a> even when not included in the accessibility tree.</p>
             </li>
           </ul>
 	</section>

--- a/index.html
+++ b/index.html
@@ -309,10 +309,12 @@
 			</dd>
 			<dt><dfn data-dfn-for="element" data-export="">Hidden</dfn></dt>
 			<dd>
-				<p>Indicates that the <a>element</a> is absent from the accessibility tree and is not exposed to accessibility APIs. An element is considered hidden if it or any one of its ancestor elements has been explicitly hidden, either by CSS properties <code>display:none</code>, <code>visibility:hidden</code> or <code>visibility:collapse</code>, or with the aria attribue <code>aria-hidden</code>.<p>
+			  <p>Indicates that the <a>element</a> is excluded from the accessibility tree and therefore not exposed to accessibility APIs.<p>
+			  <p>Related: <a href="#tree_exclusion">Excluding Elements in the Accessibility Tree</a>, [=element/hidden from all users=], <sref>aria-hidden</sref>.<p>
 			<dt><dfn data-dfn-for="element" data-lt="hide from all users" data-export="">Hidden From All Users</dfn></dt>
 			<dd>
-				<p>Indicates that the <a>element</a> is not visible, <a>perceivable</a>, or interactive to <em>any</em> user. An element is considered <em>hidden from all users</em> if it or any one of its ancestor elements is not rendered or is explicitly hidden from all users. In the ARIA specifications, it is important to understand an <a>element</a> can be [=element/hidden=] by removing it from the accessibility tree but not [=element/hidden from all users=] by the use of <code>aria-hidden</code>.</p>
+			  <p>Indicates that the <a>element</a> is not visible, <a>perceivable</a>, or interactive to <em>any</em> user. Note that an <a>element</a> can be [=element/hidden=] but not [=element/hidden from all users=] by using <code>aria-hidden</code>.</p>
+			  <p>Related: <a href="#tree_exclusion">Excluding Elements in the Accessibility Tree</a>, [=element/hidden=], <sref>aria-hidden</sref>.<p>
 			</dd>
 			<dt><dfn>Identifies</dfn></dt>
 			<dd>


### PR DESCRIPTION
Closes #1159

I introduced a new term, "hidden from all users", to capture the original definition of hidden, and changed the definition of "hidden" to mean what is means in the accname specification. 

The new definition of "hidden" also works in all cases where "hidden" is referenced in core-aam and the most of the aria spec. When necessary, I changed "hidden" to "hidden from all users" -- which is only in the tab panel definition.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1856.html" title="Last updated on Feb 9, 2023, 6:12 AM UTC (710ba4f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1856/88d8616...710ba4f.html" title="Last updated on Feb 9, 2023, 6:12 AM UTC (710ba4f)">Diff</a>