### PR TITLE
Update from PR #1018 for nameFrom: heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -617,9 +617,11 @@
 				<dd>One of the following values:
 					<ol>
 						<li>author: name comes from values provided by the author in explicit markup features such as the <pref>aria-label</pref> attribute, the <pref>aria-labelledby</pref> attribute, or the host language labeling mechanism, such as the <code>alt</code> or <code>title</code> attributes in <abbr title="Hypertext Markup Language">HTML</abbr>, with HTML <code>title</code> attribute having the lowest precedence for specifying a text alternative.</li>
-						<li>contents: name comes from the text value of the <a>element</a> node. Although this may be allowed in addition to "author" in some <a>roles</a>, this is used in content only if higher priority "author" features are not provided. Priority is defined by the <a href="#mapping_additional_nd_te" class="accname">accessible name and description computation</a> algorithm [[ACCNAME-1.2]].</li>
+						<li>heading: name comes from the text value of the first descendant (i.e., depth first) <a>element</a> node with the role of <code>heading</code>. Although "heading" may be allowed in addition to "author" in some <a>roles</a>, "heading" is used in content only if higher priority "author" features are not provided.</li>
+						<li>contents: name comes from the text value of the <a>element</a> node. Although this may be allowed in addition to "author" in some <a>roles</a>, this is used in content only if higher priority "author" features are not provided.</li>
             <li>prohibited: the element does not support name from author. Authors MUST NOT use the <pref>aria-label</pref> or <pref>aria-labelledby</pref> attributes to name the element.</li>
 					</ol>
+					<p>Priority is defined by the <a href="#mapping_additional_nd_te" class="accname">accessible name and description computation</a> algorithm. [[ACCNAME-1.3]]<p>
 				</dd>
 			</dl>
 			<section id="namecomputation">
@@ -634,21 +636,22 @@
 				<h4>Accessible Name and Description Computation</h4>
 				<p><a href="#mapping_additional_nd_te" class="accname">Accessible Name and Description Computation</a> is defined in the Accessible Name and Description specification.</p>
 			</section>
-            <section id="namefromauthor">
-                <h4>Roles Supporting Name from Author</h4>
-                <div id="index_fromauthor">
-                </div>
+			<section id="namefromauthor">
+				<h4>Roles Supporting Name from Author</h4>
+				<div id="index_fromauthor"></div>
 			</section>
-            <section id="namefromcontent">
-                <h4>Roles Supporting Name from Content</h4>
-                <div id="index_fromcontent">
-                </div>
+			<section id="namefromheading">
+				<h4>Roles Supporting Name from Heading</h4>
+				<div id="index_fromheading"></div>
+			</section>
+			<section id="namefromcontent">
+				<h4>Roles Supporting Name from Content</h4>
+				<div id="index_fromcontent"></div>
 			</section>
 			<section id="namefromprohibited">
-                <h4>Roles which cannot be named (Name prohibited)</h4>
-                <div id="index_fromprohibited">
-                </div>
-            </section>
+				<h4>Roles which cannot be named (Name prohibited)</h4>
+				<div id="index_fromprohibited"></div>
+			</section>
 		</section>
 		<section id="childrenArePresentational">
 			<h3>Presentational Children</h3>
@@ -988,7 +991,12 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom">
+ 							<ul>
+ 								<li>author</li>
+ 								<li>heading</li>
+ 							</ul>
+ 						</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -1168,7 +1176,12 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom">
+ 							<ul>
+ 								<li>author</li>
+ 								<li>heading</li>
+ 							</ul>
+ 						</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -2660,7 +2673,12 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom">
+ 							<ul>
+ 								<li>author</li>
+ 								<li>heading</li>
+ 							</ul>
+ 						</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -3018,7 +3036,6 @@
 			<div class="role-description">
 				<p>A dialog is a descendant window of the primary window of a web application. For <abbr title="Hypertext Markup Language">HTML</abbr> pages, the primary application window is the entire web document, i.e., the <code>body</code> element.</p>
 				<p>Dialogs are most often used to prompt the user to enter or respond to information. A dialog that is designed to interrupt workflow is usually modal. See related <rref>alertdialog</rref>.</p>
-				<p>Authors MUST provide an accessible name for a dialog, which can be done with the <pref>aria-label</pref> or <pref>aria-labelledby</pref> attribute.</p>
 				<p>Authors SHOULD ensure that all dialogs (both modal and non-modal) have at least one focusable descendant element. Authors SHOULD focus an element in the modal dialog when it is displayed, and authors SHOULD manage focus of modal dialogs.</p>
 				<p class="note">In the description of this role, the term "web application" does not refer to the <rref>application</rref> role, which specifies specific assistive technology behaviors.</p>
 			</div>
@@ -3073,7 +3090,12 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom">
+ 							<ul>
+ 								<li>author</li>
+ 								<li>heading</li>
+ 							</ul>
+ 						</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
@@ -6802,7 +6824,7 @@
 			<div class="role-description">
 				<p>A <rref>landmark</rref> containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.</p>
 				<p>Authors SHOULD limit use of the region role to sections containing content with a purpose that is not accurately described by one of the other <a href="#landmark_roles">landmark roles</a>, such as <rref>main</rref>, <rref>complementary</rref>, or <rref>navigation</rref>.</p>
-				<p>Authors MUST give each element with role region a brief label that describes the purpose of the content in the region. Authors SHOULD reference a visible label with <pref>aria-labelledby</pref> if a visible label is present. Authors SHOULD include the label inside of a heading whenever possible. The heading MAY be an instance of the standard host language heading element or an instance of an element with role <rref>heading</rref>.</p>
+				<p>Authors MUST give each element with a region role a brief label that describes the purpose of the region. For host languages that support elements with the default role of region (e.g., HTML <code>section</code>), authors would need to specify an explicit <code>role="region"</code> on the element to enable the nameFrom: heading technique.</p>
 				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>region</code>.
   				[=User agents=] SHOULD treat elements with role <code>region</code> and have an accessible name as navigational <a>landmarks</a>.
   				[=User agents=] MAY enable users to quickly navigate to elements with role <code>region</code>.</p>
@@ -6858,7 +6880,12 @@
 					</tr>
 					<tr>
 						<th class="role-namefrom-head" scope="row">Name From:</th>
-						<td class="role-namefrom">author</td>
+						<td class="role-namefrom">
+ 							<ul>
+ 								<li>author</li>
+ 								<li>heading</li>
+ 							</ul>
+ 						</td>
 					</tr>
 					<tr>
 						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>


### PR DESCRIPTION
Closes #899

Adds `nameFrom: heading` (this overcomes PR #1018)

Will update these along the way after further discussion.

* [ ] Related AccName Issue/PR:
* [ ] Related APG Issue/PR:

# Implementation tracking

* [ ] validator tests
* [ ] WPT tests: [LINK]()
* [ ] Browser implementations (link to issue or when done, link to commit):
   * WebKit: [ISSUE]()
   * Gecko: [ISSUE]()
   * Blink: [ISSUE]()
* [x] Does this need AT implementations? Unlikely. Should be a engine-specific change.
