### PR TITLE
Remove aria-expanded from listbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -4641,7 +4641,6 @@
 						<td class="role-properties">
 							<ul>
 								<li><pref>aria-errormessage</pref></li>
-								<li><sref>aria-expanded</sref></li>
 								<li><sref>aria-invalid</sref></li>
 								<li><pref>aria-multiselectable</pref></li>
 								<li><pref>aria-readonly</pref></li>


### PR DESCRIPTION
Closes #1026

TL:DR; I believe the history of this is that it was added when the expandable listbox was proposed as an alternative to the ARIA 1.1 combobox pattern. Now that we have the updated combobox pattern, there doesn't seem to be any benefit to keeping `aria-expanded` supported on listbox.

I wasn't sure if the best approach was to remove the attribute entirely (as in this PR), or:
- keep it in the table, but with "**(deprecated)**" after it, similar to the "(deprecated on this role in ARIA 1.2)" we have for former global attrs.
- add a note in the listbox section about it being deprecated in ARIA 1.X

<!--- IF EDITORIAL or CHORE, delete the rest of this template -->

<!--- Check these once you have confirmed the related change is not necessary or created an issue/PR and added the link here -->

* [x] Related Core AAM Issue/PR: N/A
* [x] Related AccName Issue/PR: N/A
* [x] Related APG Issue/PR: N/A (expandable listbox example already removed)
* [x] Any other dependent changes? N/A

# Implementation tracking

* [ ] validator tests
* [ ] WPT tests: [LINK]()
* [ ] Browser implementations (link to issue or when done, link to commit):
   * WebKit: [ISSUE]()
   * Gecko: [ISSUE]()
   * Blink: [ISSUE]()
* [ ] Does this need AT implementations?
