### PR TITLE
Remove verbiage regarding combobox values

### DIFF
--- a/index.html
+++ b/index.html
@@ -2928,7 +2928,7 @@
 		<div class="role" id="deletion">
 			<rdef>deletion</rdef>
 			<div class="role-description">
-				<p>A deletion contains content that is marked as removed or content that is being suggested for removal. See related <rref>insertion</rref>.</p>
+				<p>A deletion represents content that is marked as removed, content that is being suggested for removal, or content that is no longer relevant in the context of its accompanying content. See related <rref>insertion</rref>.</p>
 				<p>Deletions are typically used to either mark differences between two versions of content or to designate content suggested for removal in scenarios where multiple people are revising content.</p>
 			</div>
 			<table class="role-features">
@@ -2954,7 +2954,12 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;del&gt;</code> in [[HTML]]</td>
+						<td class="role-related">
+							<ul>
+								<li><code>&lt;del&gt;</code> in [[HTML]]</li>
+								<li><code>&lt;s&gt;</code> in [[HTML]]</li>
+							</ul>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>


### PR DESCRIPTION
[Closes #1720](https://github.com/w3c/aria/issues/1720)

<!--- IF EDITORIAL or CHORE, delete the rest of this template -->

Removed verbiage regarding combobox values which includes a MUST statement.
#https://github.com/w3c/aria/issues/1720


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chlane/aria/pull/1871.html" title="Last updated on Feb 9, 2023, 10:06 PM UTC (4c47628)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1871/f91a328...chlane:4c47628.html" title="Last updated on Feb 9, 2023, 10:06 PM UTC (4c47628)">Diff</a>