### PR TITLE
Illustrate how attributes and properties could be distinct concepts

### DIFF
--- a/index.html
+++ b/index.html
@@ -5935,7 +5935,7 @@
 					  &lt;p>If you find any variations in results, please let us know!&lt;/p>
 					&lt;/div>
 					&lt;p>...&lt;/p>
-				</pre>		
+				</pre>
 				<p>In cases where an element with role <rref>note</rref> has been determined to need a programmatic association with the content it supplements, authors can use one of the following mechanisms to associate the elements:</p>
 				<ul>
 					<li>If the <code>note</code> contains structured or interactive content (for example, a link, button, list, table, etc.) use <pref>aria-details</pref>.</li>
@@ -5947,7 +5947,7 @@
 					&lt;button aria-details="info-note">Get Started&lt;/button>
 					...
 					&lt;div role="note" id="info-note">
-					  &lt;p>Need more information before you get started?&lt;/p> 
+					  &lt;p>Need more information before you get started?&lt;/p>
 					  &lt;p>Visit our &lt;a href="...">product description page&lt;/a> to get all the information you need.&lt;/p>
 					&lt;/div>
 				</pre>
@@ -12310,8 +12310,51 @@ button.ariaPressed; // null</pre>
 		<div class="property" id="aria-orientation">
 			<pdef>aria-orientation</pdef>
 			<div class="property-description">
-				<p><a>Indicates</a> whether the element's orientation is horizontal, vertical, or unknown/ambiguous.</p>
-				<p class="note">In ARIA 1.1, the default value for <pref>aria-orientation</pref> changed from <code>horizontal</code> to <code>undefined</code>. Implicit defaults are defined on some roles (e.g., <rref>slider</rref> defaults to horizontal; <rref>scrollbar</rref> defaults to vertical) but remain undefined on roles where an expected default orientation is ambiguous (e.g., <rref>radiogroup</rref>).</p>
+				<p>The <pref>aria-orientation</pref> attribute <a>indicates</a> whether the element's orientation is horizontal, vertical, or role-dependent/unknown/ambiguous.</p>
+
+			    <p>The <pref>aria-orientation</pref> attribute is an <a>enumerated attribute</a> with the following keywords and states:
+				<table>
+					<thead>
+						<tr>
+							<th scope="col">Keyword</th>
+							<th scope="col">State
+							<th scope="col">Description</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<th class="value-name" scope="row"><code>horizontal</code></th>
+							<td>horizontal</td>
+							<td class="value-description">The element is oriented horizontally.</td>
+						</tr>
+						<tr>
+							<th class="value-name" scope="row"><code>undefined</code></th>
+							<td>undefined</td>
+							<td class="value-description">The element's orientation is unknown/ambiguous.</td>
+						</tr>
+						<tr>
+							<th class="value-name" scope="row"><code>vertical</code></th>
+							<td>vertical</td>
+							<td class="value-description">The element is oriented vertically.</td>
+						</tr>
+					</tbody>
+				</table>
+
+			    <p>The <pref>aria-orientation</pref> attribute's <a>invalid value default</a> and <a>missing value default</a> are the undefined state.
+
+				<p class="note">In ARIA 1.1, the default value for <pref>aria-orientation</pref> changed from <code>horizontal</code> to <code>undefined</code>.</p>
+
+				<p>The state of the <pref>aria-orientation</pref> property of an element <var>element</var> is computed as follows:
+
+				<ol>
+				 <li><p>If the <var>element</var>'s <pref>aria-orientation</pref> attribute state is not undefined, then return the <var>element</var>'s <pref>aria-orientation</pref> attribute state.</p></li>
+
+				 <li><p>If the <var>element</var>'s computed role is <rref>listbox</rref>, <rref>menu</rref>, <rref>scrollbar</rref>, or <rref>tree</rref>, then return the vertical state.</p></li>
+
+				 <li><p>If the <var>element</var>'s computed role is <rref>menubar</rref>, <rref>separator</rref>, <rref>slider</rref>, <rref>tablist</rref>, or <rref>toolbar</rref>, then return the horizontal state.</p></li>
+
+				 <li><p>Return the undefined state.</p></li>
+				</ol>
 			</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>
@@ -12337,29 +12380,6 @@ button.ariaPressed; // null</pre>
 					<tr>
 						<th class="property-value-head" scope="row">Value:</th>
 						<td class="property-value"><a href="#valuetype_token">token</a></td>
-					</tr>
-				</tbody>
-			</table>
-			<table class="value-descriptions">
-				<caption>Values:</caption>
-				<thead>
-					<tr>
-						<th scope="col">Value</th>
-						<th scope="col">Description</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<th class="value-name" scope="row">horizontal</th>
-						<td class="value-description">The element is oriented horizontally.</td>
-					</tr>
-					<tr>
-						<th class="value-name" scope="row"><strong class="default">undefined (default)</strong></th>
-						<td class="value-description">The element's orientation is unknown/ambiguous.</td>
-					</tr>
-					<tr>
-						<th class="value-name" scope="row">vertical</th>
-						<td class="value-description">The element is oriented vertically.</td>
 					</tr>
 				</tbody>
 			</table>


### PR DESCRIPTION
This could be a potential solution to #1895. The idea here would be to define all the ARIA attributes in terms of DOM/HTML types. This example shows what aria-orientation would look like defined as an enumerated attribute.

And then separately define how identically-named ARIA properties end up using those attributes to compute their own state for use by AT.

I think applying this throughout would resolve a lot of ambiguity and would help end up solving the reflect problem as well.

Closes #????

Describe Change Here!

<!--- IF EDITORIAL or CHORE, delete the rest of this template -->

# PR tracking
Check these when the relevant issue or PR has been made, OR after you have confirmed the
related change is not necessary (add N/A). Leave unchecked if you are unsure. Read the
[Process Document](https://github.com/w3c/aria/wiki/ARIA-WG-Process-Document/_edit) or
[Test Overview](https://github.com/w3c/aria/wiki/ARIA-Test-Overview) for more information.

* [ ] Related Core AAM Issue/PR:
* [ ] Related AccName Issue/PR:
* [ ] Related APG Issue/PR:
* [ ] Any other dependent changes?

# Implementation tracking

* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests:
* [ ] Browser implementations (link to issue or when done, link to commit):
   * WebKit:
   * Gecko:
   * Blink:
* [ ] Does this need AT implementations?
