### PR TITLE
Add search role’s base concept pointing to HTML spec. Fix #1898

### DIFF
--- a/index.html
+++ b/index.html
@@ -7428,7 +7428,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"> </td>
+						<td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-search-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>search</code></a></td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>

--- a/index.html
+++ b/index.html
@@ -7428,7 +7428,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-search-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>search</code></a></td>
+						<td class="role-base"><abbr title="Hypertext Markup Language">HTML</abbr> <code>[^search^]</code></td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>


### PR DESCRIPTION
Claiming #1898 – with a link directly to the HTML spec.

Couple of things I noted along the way that informed this task, however small:

- The reference style I chose here ("direct link to the correct element in the spec") is only used for 3 other base concepts. The rest use the style: `<code>&lt;button&gt;</code> in [[HTML]]`, with "HTML" being an inline reference pointing to the doc’s Normative references section. I found the direct links more helpful so chose that.
- This uses the same link (`https://www.w3.org/TR/html5/grouping-content.html`) to the HTML spec as other Base Concept links for consistency, but this URL 307-redirects to the WHATWG living standard at`https://html.spec.whatwg.org/multipage/grouping-content.html`. It’d be nice to avoid this redirect but felt consistency mattered more, though the HTML link in "Normative references" also points to the WHATWG multi-page spec.

I’ll happily revisit this if it’s better to use the no-direct-link reference for consistency. And clean up other definitions as a separate PR if it helps.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/thibaudcolas/aria/pull/1900.html" title="Last updated on Mar 31, 2023, 11:29 PM UTC (c53bdb5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1900/9033f63...thibaudcolas:c53bdb5.html" title="Last updated on Mar 31, 2023, 11:29 PM UTC (c53bdb5)">Diff</a>