### PR TITLE
Editorial: Add missing implicit values section for timer role

### DIFF
--- a/index.html
+++ b/index.html
@@ -9555,6 +9555,12 @@
 						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
 						<td class="role-presentational-inherited"> </td>
 					</tr>
+					<tr>
+						<th class="implicit-values-head" scope="row">Implicit Value for Role:</th>
+						<td class="implicit-values">
+							Default for <pref>aria-live</pref> is <code class="default">off</code>.
+						</td>
+					</tr>
 				</tbody>
 			</table>
 		</div>


### PR DESCRIPTION
Closes #1904

The timer role table was missing that it has an implicit value for aria-live. This patch adds that missing row.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Epigenetic/aria/pull/1905.html" title="Last updated on Apr 1, 2023, 6:05 PM UTC (d678d10)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1905/6207a61...Epigenetic:d678d10.html" title="Last updated on Apr 1, 2023, 6:05 PM UTC (d678d10)">Diff</a>