### PR TITLE
Editorial: Normalize HTML spec references using xref

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,58 @@ The set of class values currently defined are:
 
 *Todo: we should add versions for the other docs*
 
+#### References to Other W3C Specs
+
+When referencing other W3C specifications such as <a
+href="https://html.spec.whatwg.org/">HTML</a> and <a
+href="https://dom.spec.whatwg.org/">DOM</a>, we can take advantage of ReSpec’s
+<a href="https://github.com/w3c/respec/wiki/xref">`xref`</a> feature to
+automatically generate canonical links in context.
+
+In the text below, for example, `xref` will automatically convert “`[^button^]`”
+into a link to the definition of the `<button>` element in the HTML
+spec:
+
+```html
+A [^button^] performs an operation when pressed.
+```
+
+When authoring text for the ARIA spec, you can [search `xref`’s collection of
+exported terms](https://respec.org/xref/) to find the correct syntax for the
+desired specification. By default, the ARIA spec’s `xref` configuration will
+attempt to resolve terms for the following specs:
+
+- [DOM](https://dom.spec.whatwg.org/)
+- [HTML](https://html.spec.whatwg.org/)
+- [Accessible Name and Description
+  Computation](https://www.w3.org/TR/accname-1.2/)
+- [Core Accessibility API Mappings](https://www.w3.org/TR/core-aam-1.2/)
+- [Infra](https://infra.spec.whatwg.org/)
+
+If you wish to reference a spec that is not included in ARIA’s default `xref`
+configuration, you must specify it with a `data-cite` attribute.  For example,
+the following markup references [“nullable
+type”](https://respec.org/xref/?term=nullable+type) and
+[“DOMString”](https://respec.org/xref/?term=DOMString) from the Web IDL spec:
+
+```html
+<section data-cite="webidl">
+    <p>
+        All ARIA attributes reflect in IDL as [=nullable type|nullable=]
+        {{DOMString}} attributes.
+    </p>
+</section>
+```
+
+In some cases, a term may be defined in multiple specifications with the same
+`xref` syntax.  For example, [“`[=range=]`” is defined in both the DOM and
+Internationalization Glossary specs](https://respec.org/xref/?term=range). The
+`data-cite` attribute can also be used in these cases to disambiguate and target
+the intended spec.
+
+For more information, please refer to [`xref`’s auto-linking external references
+guide](https://github.com/w3c/respec/wiki/Auto-linking-external-references).
+
 ### Shared Resources
 
 The ARIA repositories share a common set of resources to reduce redundancy. Shared resources are in the [aria-common](https://github.com/w3c/aria-common/) repository, and copied to a "common" folder in this and other ARIA repositories. *It is important to make edits in the aria-common repository*; making edits in the common folder of another repository will allow the edits to be overridden.

--- a/index.html
+++ b/index.html
@@ -3626,7 +3626,10 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/html/grouping-content.html#the-div-element">HTML <code>div</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-span-element">HTML <code>span</code></a></td>
+						<td class="role-related">
+							HTML <code>[^div^]</code>,
+							HTML <code>[^span^]</code>
+						</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>

--- a/index.html
+++ b/index.html
@@ -836,7 +836,7 @@
 			</ul>
 		</section>
 	</section>
-	<section id="role_definitions" data-cite="dom">
+	<section id="role_definitions" data-cite="dom html">
 		<h2>Definition of Roles</h2>
 		<p>Below is an alphabetical list of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>roles</a> to be used by authors.</p>
 		<p>Abstract roles are used for the ontology. Authors MUST NOT use abstract roles in content.</p>
@@ -10181,7 +10181,7 @@
 		</div>
 	</section>
 </section>
-<section class="normative" id="states_and_properties" data-cite="dom">
+<section class="normative" id="states_and_properties" data-cite="html dom">
 	<h1>Supported States and Properties</h1>
 	<section id="statevsprop">
 		<h2>Clarification of States versus Properties</h2>

--- a/index.html
+++ b/index.html
@@ -10181,7 +10181,7 @@
 		</div>
 	</section>
 </section>
-<section class="normative" id="states_and_properties" data-cite="html dom">
+<section class="normative" id="states_and_properties" data-cite="dom html">
 	<h1>Supported States and Properties</h1>
 	<section id="statevsprop">
 		<h2>Clarification of States versus Properties</h2>

--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
 <section id="sotd">
 	<p>The Accessible Rich Internet Applications Working Group seeks feedback on any aspect of the specification. When submitting feedback, please consider issues in the context of the companion documents. To comment, <a href="https://github.com/w3c/aria/issues/new">file an issue in the <abbr title="World Wide Web Consortium">W3C</abbr> ARIA GitHub repository</a>. If this is not feasible, send email to <a href="mailto:public-aria@w3.org?subject=Comment%20on%20WAI-ARIA%201.2">public-aria@w3.org</a> (<a href="http://lists.w3.org/Archives/Public/public-aria/">comment archive</a>). In-progress updates to the document can be viewed in the <a href="http://w3c.github.io/aria/">publicly visible editors' draft</a>.</p>
 </section>
-<section class="informative" id="introduction" data-cite="dom">
+<section class="informative" id="introduction">
 	<h1>Introduction</h1>
 	<p>The goals of this specification include:</p>
 	<ul>
@@ -222,7 +222,7 @@
 		<p>Aside from using <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> markup to improve what is exposed to accessibility APIs, user agents behave as they would natively. Assistive technologies react to the extra information in the accessibility API as they already do for the same information on non-web content. User agents that are not assistive technologies, however, need do nothing beyond providing appropriate updates to the accessibility API.</p>
 		<p>The <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> specification neither requires nor forbids user agents from enhancing native presentation and interaction behaviors on the basis of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> markup. Mainstream user agents might expose <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> navigational landmarks (for example, as a dialog box or through a keyboard command) with the intention to facilitate navigation for all users. User agents are encouraged to maximize their usefulness to users, including users without disabilities. </p>
 		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is intended to provide missing semantics so that the intent of the author can be conveyed to assistive technologies. Generally, authors using <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> will provide the appropriate presentation and interaction features. Over time, host languages can add <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> equivalents, such as new form controls, that are implemented as standard accessible user interface controls by the user agent. This allows authors to use them instead of custom <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> enabled user interface components. In this case the user agent would support the native host language feature. Developers of host languages that implement <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> are advised to continue supporting <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics when they do not adversely conflict with implicit host language semantics, as <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics more clearly reflect the intent of the author if the host language features are inadequate to meet the author's needs.</p>
-		</section>
+	</section>
 	<section id="co-evolution">
 		<h2>Co-Evolution of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> and Host Languages</h2>
 		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is intended to augment semantics in supporting languages like [[HTML]] and [[SVG2]], or to be used as an accessibility enhancement technology in other markup-based languages that do not explicitly include support for ARIA. It clarifies semantics to assistive technologies when authors create new types of objects, via style and script, that are not yet directly supported by the language of the page, because the invention of new types of objects is faster than standardized support for them appears in web languages.</p>
@@ -249,7 +249,7 @@
 		<p>While some assistive technologies interact with these accessibility APIs, others might access the content directly from the <abbr title="Document Object Model">DOM</abbr>. These technologies can restructure, simplify, style, or reflow the content to help a different set of users. Common use cases for these types of adaptations might be the aging population, persons with cognitive impairments, or persons in environments that interfere with use of their tools. For example, the availability of regional navigational landmarks can allow for a mobile device adaptation that shows only portions of the content at any one time based on its semantics. This could reduce the amount of information the user needs to process at any one time. In other situations it might be appropriate to replace a custom user interface control with something that is easier to navigate with a keyboard, or touch screen device.</p>
 	</section>
 </section>
-<section class="informative" id="terms" data-cite="dom">
+<section class="informative" id="terms">
 	<h1>Important Terms</h1>
 	<div>
 		<p>While some terms are defined in place, the following definitions are used throughout this document. </p>
@@ -260,7 +260,7 @@
 				  <a href="https://developer.apple.com/documentation/appkit/nsaccessibility">Mac <abbr title="OS Ten">OS X</abbr> Accessibility Protocol</a> [[AXAPI]], the <cite><a href="https://developer.gnome.org/atk/unstable/">Linux/Unix Accessibility Toolkit</a></cite> [[ATK]] and <cite><a href="https://developer.gnome.org/libatspi/stable/">Assistive Technology Service Provider Interface</a></cite> [[AT-SPI]], and <a href="https://wiki.linuxfoundation.org/accessibility/iaccessible2/start">IAccessible2</a> [[IAccessible2]].</p>
 			</dd>
 			<dt><dfn data-export="">Accessible object</dfn></dt>
-			<dd data-cite="dom">
+			<dd>
 			  <p>A [=nodes|node=] in the <a class="termref">accessibility tree</a> of a platform <a>accessibility <abbr title="application programming interface">API</abbr></a>. Accessible objects expose various <a class="termref">states</a>, [=ARIA/properties=], and <a class="termref">events</a> for use by <a>assistive technologies</a>.  In the context of markup languages (e.g., HTML and SVG) in general, and of WAI-ARIA in particular, markup [=elements=] and their [=attributes=] are represented as accessible objects.  </p>
 			</dd>
 			<dt><dfn data-export="">Assistive Technologies</dfn></dt>
@@ -435,7 +435,7 @@
 		<p>As the technology evolves, sometimes new ways to meet a use case become available, that work better than a feature that was previously defined. But because of existing implementation of the older feature, that feature cannot be removed from the conformance model without rendering formerly conforming content non-conforming. In this case, the older feature is marked as "deprecated". This indicates that the feature is allowed in the conformance model and expected to be supported by user agents, but it is recommended that authors do not use it for new content. In future versions of the specification, if the feature is no longer widely used, the feature could be removed and no longer expected to be supported by user agents.</p>
 	</section>
 </section>
-<section class="normative" id="usage" data-cite="dom">
+<section class="normative" id="usage">
 	<h1>Using <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr></h1>
 	<p>Complex web applications become inaccessible when <a>assistive technologies</a> cannot determine the <a>semantics</a> behind portions of a document or when the user is unable to effectively navigate to all parts of it in a usable way (see <cite><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite>). <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> divides the semantics into <a>roles</a> (the type defining a user interface element) and <a>states</a> and [=ARIA/properties=] supported by the roles.</p>
 	<p>Authors need to associate [=elements=] in the document to a WAI-ARIA role and the appropriate states and properties (aria-* [=attributes=]) during its life-cycle, unless the elements already have the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantics</a> for states and properties. In these instances the equivalent host language states and properties take precedence to avoid a conflict while the role attribute will take precedence over the implicit role of the host language element.</p>
@@ -836,7 +836,7 @@
 			</ul>
 		</section>
 	</section>
-	<section id="role_definitions" data-cite="dom html">
+	<section id="role_definitions">
 		<h2>Definition of Roles</h2>
 		<p>Below is an alphabetical list of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>roles</a> to be used by authors.</p>
 		<p>Abstract roles are used for the ontology. Authors MUST NOT use abstract roles in content.</p>
@@ -10181,7 +10181,7 @@
 		</div>
 	</section>
 </section>
-<section class="normative" id="states_and_properties" data-cite="dom html">
+<section class="normative" id="states_and_properties">
 	<h1>Supported States and Properties</h1>
 	<section id="statevsprop">
 		<h2>Clarification of States versus Properties</h2>
@@ -10230,7 +10230,7 @@
 			<p>These are generic types for states and properties, but do not define specific representation. See <a href="#state_property_processing">State and Property Attribute Processing</a> for details on how these values are expressed and handled in host languages.</p>
 		</section>
 	</section>
-	<section>
+	<section data-cite="webidl">
 		<h2>ARIA Attributes</h2>
 		<section id="enumerated-attribute-values">
 			<h3>Multi-value Attribute Values</h3>
@@ -10330,7 +10330,7 @@ button.ariaPressed; // null</pre>
 			</section>
 		</section>
 	</section>
-	<section data-cite="HTML">
+	<section>
 		<h2>Translatable Attributes</h2>
 		<p>The HTML specification states that other specifications can define <a data-cite="html/dom.html#translatable-attributes">translatable attributes</a>. The language and directionality of each attribute value is the same as the <a data-cite="html/dom.html#language">language</a> and <a data-cite="html/dom.html#the-directionality">directionality</a> of the element.</p>
 		<p>To be understandable by assistive technology users, the values of the following <a>states</a> and [=ARIA/properties=] are <a data-cite="html/dom.html#translatable-attributes">translatable attributes</a> and should be translated when a page is localized:</p>
@@ -10346,7 +10346,7 @@ button.ariaPressed; // null</pre>
 		<p>Some <a>states</a> and [=ARIA/properties=] are applicable to all host language [=elements=] regardless of whether a <a>role</a> is applied. The following global states and properties are supported by all roles and by all base markup elements unless otherwise prohibited. If a role prohibits use of any global states or properties, those states or properties are listed as prohibited in the characteristics table included in the section that defines the role.</p>
 		<p class="placeholder">Placeholder for global states and properties</p>
 	</section>
-	<section id="state_prop_taxonomy" data-cite="dom">
+	<section id="state_prop_taxonomy">
 		<h2>Taxonomy of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> States and Properties</h2>
 		<p>States and properties are categorized as follows:</p>
 		<ol>
@@ -13407,7 +13407,7 @@ button.ariaPressed; // null</pre>
           </ul>
 	</section>
 </section>
-<section class="normative" id="host_languages" data-cite="dom">
+<section class="normative" id="host_languages">
 	<h1>Implementation in Host Languages</h1>
 	<p>The <a>roles</a>, <a>state</a>, and [=ARIA/properties=] defined in this specification do not form a complete web language or format. They are intended to be used in the context of a host language. This section discusses how host languages are to implement <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>, to ensure that the markup specified here will integrate smoothly and effectively with the host language markup.</p>
 	<p>Although markup languages look alike superficially, they do not share language definition infrastructure. To accommodate differences in language-building approaches, the requirements are both general and modularization-specific. While allowing for differences in how the specifications are written, the intent is to maintain consistency in how the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> information looks to authors and how it is manipulated in the <abbr title="Document Object Model">DOM</abbr> by scripts.</p>
@@ -13508,7 +13508,7 @@ button.ariaPressed; // null</pre>
 			<li><rref>region</rref></li>
 		</ul>
 	</section>
-	<section id="document-handling_author-errors_states-properties" data-cite="dom">
+	<section id="document-handling_author-errors_states-properties">
 		<h3>States and Properties</h3>
 			<p>In general, [=user agents=] do not do much validation of <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> [=ARIA/properties=]. User agents MAY do some minor validation on request and enforce things like <pref>aria-posinset</pref> being within 1 and <pref>aria-setsize</pref>, inclusive. User agents are not  responsible for logical validation, such as the following:</p>
 				<ol>
@@ -13654,7 +13654,7 @@ button.ariaPressed; // null</pre>
 	<p>Conforming user agents MUST implement the following IDL interface.</p>
 	<section id="ARIAMixin" class="normative" data-dfn-for="ARIAMixin" data-link-for="ARIAMixin">
 		<h2>Interface Mixin <dfn>ARIAMixin</dfn></h2>
-		<pre class="idl">
+		<pre class="idl" data-cite="webidl">
 			interface mixin ARIAMixin {
 				[CEReactions] attribute DOMString? role;
 				[CEReactions] attribute Element? ariaActiveDescendantElement;
@@ -13819,7 +13819,7 @@ button.ariaPressed; // null</pre>
 
 		<p>User agents MUST include <code>ARIAMixin</code> on <code>Element</code>:</p>
 
-		<pre class="idl">
+		<pre class="idl" data-cite="webidl">
 			Element includes ARIAMixin;
 		</pre>
 

--- a/index.html
+++ b/index.html
@@ -502,7 +502,7 @@
         Authors MAY use <pref>aria-activedescendant</pref> to inform <a>assistive technologies</a> which descendant of a <rref>widget</rref> element is treated as having keyboard focus in the user interface if the role of the widget element supports <code>aria-activedescendant</code>.
         This is often a more convenient way of providing keyboard navigation within widgets, such as a <rref>listbox</rref>, where the widget occupies only one stop in the page <kbd>Tab</kbd> sequence and other keys, typically arrow keys, are used to focus elements inside the widget.
       </p>
-	    <p>Typically, the author will use host language <a>semantics</a> to put the widget in the <kbd>Tab</kbd> sequence (e.g., <code>tabindex="0"</code> in <abbr title="Hypertext Markup Language">HTML</abbr>) and <code>aria-activedescendant</code> to point to the ID of the currently active descendant. The author, not the user agent, is responsible for styling the currently active descendant to show it has keyboard focus. The author cannot use <code>:<span class="css-selector">focus</span></code> to style the currently active descendant since the actual focus is on the container.</p>
+	    <p>Typically, the author will use host language <a>semantics</a> to put the widget in the <kbd>Tab</kbd> sequence (e.g., <code>tabindex="0"</code> in HTML) and <code>aria-activedescendant</code> to point to the ID of the currently active descendant. The author, not the user agent, is responsible for styling the currently active descendant to show it has keyboard focus. The author cannot use <code>:<span class="css-selector">focus</span></code> to style the currently active descendant since the actual focus is on the container.</p>
 	    <p>More information on managing focus can be found in the <a href="#keyboard" class="practices">Developing a Keyboard Interface</a> section of the <cite><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</cite>.</p>
 	  </section>
 	  <section id="managingfocus_useragents">
@@ -561,12 +561,12 @@
 		<section id="baseConcept">
 			<h3>Base Concept</h3>
 			<p>Informative data about <a>objects</a> that are considered prototypes for the <a>role</a>. Base concept is similar to type, but without inheritance of limitations and properties. Base concepts are designed as a substitute for inheritance for external concepts. A base concept is like a <a href="#relatedConcept">related concept</a> except that the base concept is almost identical to the role definition.</p>
-			<p>For example, the <rref>checkbox</rref> defined in this document has similar functionality and anticipated behavior to a <code>&lt;input type="checkbox"&gt;</code> defined in [[HTML]]. Therefore, a <rref>checkbox</rref> has an [[HTML]] <code>checkbox</code> as a <code>baseConcept</code>. However, if the original [[HTML]] checkbox baseConcept definition is modified, the definition of a <rref>checkbox</rref> in this document will not be affected, because there is no actual inheritance of the respective type.</p>
+			<p>For example, the <rref>checkbox</rref> defined in this document has similar functionality and anticipated behavior to a <code>&lt;input type="[^input/type/checkbox^]"&gt;</code> defined in HTML. Therefore, a <rref>checkbox</rref> has an [[HTML]] <code>checkbox</code> as a <code>baseConcept</code>. However, if the original [[HTML]] checkbox baseConcept definition is modified, the definition of a <rref>checkbox</rref> in this document will not be affected, because there is no actual inheritance of the respective type.</p>
 		</section>
 	</section>
 	<section id="Properties">
 		<h2>Characteristics of Roles</h2>
-		<p>Roles are defined and described by their characteristics. Characteristics define the structural function of a role, such as what a role is, concepts behind it, and what instances the role can or must contain. In the case of <a>widgets</a> this also includes how it interacts with the <a>user agent</a> based on mapping to <abbr title="Hypertext Markup Language">HTML</abbr> forms. States and properties from <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> that are supported by the role are also indicated.</p>
+		<p>Roles are defined and described by their characteristics. Characteristics define the structural function of a role, such as what a role is, concepts behind it, and what instances the role can or must contain. In the case of <a>widgets</a> this also includes how it interacts with the <a>user agent</a> based on mapping to HTML forms. States and properties from <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> that are supported by the role are also indicated.</p>
 		<p>Roles define the following characteristics. </p>
 		<section id="isAbstract">
 			<h3>Abstract Roles</h3>
@@ -621,7 +621,7 @@
 				<dt>Values</dt>
 				<dd>One of the following values:
 					<ol>
-						<li>author: name comes from values provided by the author in explicit markup features such as the <pref>aria-label</pref> attribute, the <pref>aria-labelledby</pref> attribute, or the host language labeling mechanism, such as the <code>alt</code> or <code>title</code> attributes in <abbr title="Hypertext Markup Language">HTML</abbr>, with HTML <code>title</code> attribute having the lowest precedence for specifying a text alternative.</li>
+						<li>author: name comes from values provided by the author in explicit markup features such as the <pref>aria-label</pref> attribute, the <pref>aria-labelledby</pref> attribute, or the host language labeling mechanism, such as the <code>alt</code> or <code>title</code> attributes in HTML, with HTML <code>title</code> attribute having the lowest precedence for specifying a text alternative.</li>
 						<li>contents: name comes from the text value of the <a>element</a> node. Although this might be allowed in addition to "author" in some <a>roles</a>, this is used in content only if higher priority "author" features are not provided. Priority is defined by the <a href="#mapping_additional_nd_te" class="accname">accessible name and description computation</a> algorithm [[ACCNAME-1.2]].</li>
             <li>prohibited: the element does not support name from author. Authors MUST NOT use the <pref>aria-label</pref> or <pref>aria-labelledby</pref> attributes to name the element.</li>
 					</ol>
@@ -1144,7 +1144,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;article&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^article^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -1232,9 +1232,7 @@
           </tr>
           <tr>
             <th class="role-base-head" scope="row">Base Concept:</th>
-            <td class="role-base">
-                <a href="https://www.w3.org/TR/html5/grouping-content.html#the-dl-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dl</code></a>
-            </td>
+            <td class="role-base"><code>&lt;[^dl^]&gt;</code> in HTML</td>
           </tr>
           <tr>
             <th class="role-related-head" scope="row">Related Concepts:</th>
@@ -1324,7 +1322,7 @@
           </tr>
           <tr>
             <th class="role-base-head" scope="row">Base Concept:</th>
-            <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dt-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dt</code></a></td>
+            <td class="role-base"><code>&lt;[^dt^]&gt;</code> in HTML</td>
           </tr>
           <tr>
             <th class="role-related-head" scope="row">Related Concepts:</th>
@@ -1411,7 +1409,7 @@
           </tr>
           <tr>
             <th class="role-base-head" scope="row">Base Concept:</th>
-            <td class="role-base"><a href="https://www.w3.org/TR/html5/grouping-content.html#the-dd-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>dd</code></a></td>
+            <td class="role-base"><code>&lt;[^dd^]&gt;</code> in HTML</td>
           </tr>
           <tr>
             <th class="role-related-head" scope="row">Related Concepts:</th>
@@ -1504,7 +1502,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;header&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^header^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -1581,7 +1579,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;blockquote&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^blockquote^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -1656,7 +1654,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><code>&lt;button&gt;</code> in [[HTML]]</td>
+						<td class="role-base"><code>&lt;[^button^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -1813,9 +1811,11 @@
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
 						<td class="role-related">
-							<code>&lt;caption&gt;</code> in [[HTML]] <br>
-							<code>&lt;figcaption&gt;</code> in [[HTML]] <br>
-							<code>&lt;legend&gt;</code> in [[HTML]]
+							<ul>
+								<li><code>&lt;[^caption^]&gt;</code> in HTML</li>
+								<li><code>&lt;[^figcaption^]&gt;</code> in HTML</li>
+								<li><code>&lt;[^legend^]&gt;</code> in HTML</li>
+							</ul>
 						</td>
 					</tr>
 					<tr>
@@ -1906,7 +1906,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><code>&lt;td&gt;</code> in [[HTML]]</td>
+						<td class="role-base"><code>&lt;[^td^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -2007,7 +2007,7 @@
 						<th class="role-related-head" scope="row">Related Concepts:</th>
 						<td class="role-related">
 							<ul>
-								<li><code>&lt;input[type="checkbox"]&gt;</code> in [[HTML]]</li>
+								<li><code>&lt;input type="[^input/type/checkbox^]"&gt;</code> in HTML</li>
 								<li><rref>option</rref></li>
 							</ul>
 						</td>
@@ -2111,9 +2111,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related">
-							<code>&lt;code&gt;</code> in [[HTML]]
-						</td>
+						<td class="role-related"><code>&lt;[^code^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2176,7 +2174,7 @@
 			<div class="role-description">
 				<p>A cell containing header information for a column.</p>
 				<p><code>columnheader</code> can be used as a column header in a table or grid. It could also be used in a pie chart to show a similar <a>relationship</a> in the data.</p>
-				<p>The <code>columnheader</code> establishes a relationship between it and all cells in the corresponding column. It is the structural equivalent to an <abbr title="Hypertext Markup Language">HTML</abbr> <code>th</code> <a>element</a> with a column scope.</p>
+				<p>The <code>columnheader</code> establishes a relationship between it and all cells in the corresponding column. It is the structural equivalent to an HTML <code>th</code> <a>element</a> with a column scope.</p>
 				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>columnheader</code> are contained in, or [=ARIA/owned=] by, an element with the role <rref>row</rref>.</p>
 				<p>Applying the <sref>aria-selected</sref> state on a columnheader MUST not cause the user agent to automatically propagate the <sref>aria-selected</sref> state to all the cells in the corresponding column. An author MAY choose to propagate selection in this manner depending on the specific application.</p>
 				<p>While the <code>columnheader</code> role can be used in both interactive grids and non-interactive tables, the use of <pref>aria-readonly</pref> and <pref>aria-required</pref> is only applicable to interactive elements. Therefore, authors SHOULD NOT use <pref>aria-required</pref> or <pref>aria-readonly</pref> in a <code>columnheader</code> that descends from a <rref>table</rref>, and user agents SHOULD NOT expose either property to <a>assistive technologies</a> unless the <code>columnheader</code> descends from a <rref>grid</rref>.</p>
@@ -2212,7 +2210,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><code>&lt;th[scope="col"]&gt;</code> in [[HTML]]</td>
+						<td><code>&lt;th scope="[^th/scope/col^]"&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -2360,9 +2358,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related">
-							<code>&lt;select&gt;</code> in [[HTML]]
-						</td>
+						<td class="role-related"><code>&lt;[^select^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2641,7 +2637,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;aside&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^aside^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2801,7 +2797,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;footer&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^footer^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2961,8 +2957,8 @@
 						<th class="role-related-head" scope="row">Related Concepts:</th>
 						<td class="role-related">
 							<ul>
-								<li><code>&lt;del&gt;</code> in [[HTML]]</li>
-								<li><code>&lt;s&gt;</code> in [[HTML]]</li>
+								<li><code>&lt;[^del^]&gt;</code> in HTML</li>
+								<li><code>&lt;[^s^]&gt;</code> in HTML</li>
 							</ul>
 						</td>
 					</tr>
@@ -3021,7 +3017,7 @@
 		<div class="role" id="dialog">
 			<rdef>dialog</rdef>
 			<div class="role-description">
-				<p>A dialog is a descendant window of the primary window of a web application. For <abbr title="Hypertext Markup Language">HTML</abbr> pages, the primary application window is the entire web document, i.e., the <code>body</code> element.</p>
+				<p>A dialog is a descendant window of the primary window of a web application. For HTML pages, the primary application window is the entire web document, i.e., the <code>body</code> element.</p>
 				<p>Dialogs are most often used to prompt the user to enter or respond to information. A dialog that is designed to interrupt workflow is usually modal. See related <rref>alertdialog</rref>.</p>
 				<p>Authors MUST provide an accessible name for a dialog, which can be done with the <pref>aria-label</pref> or <pref>aria-labelledby</pref> attribute.</p>
 				<p>Authors SHOULD ensure that all dialogs (both modal and non-modal) have at least one focusable descendant element. Authors SHOULD focus an element in the modal dialog when it is displayed, and authors SHOULD manage focus of modal dialogs.</p>
@@ -3291,7 +3287,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;em&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^em^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -3468,9 +3464,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related">
-							<code>&lt;figure&gt;</code> in [[HTML]]
-						</td>
+						<td class="role-related"><code>&lt;[^figure^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -3549,7 +3543,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><code>&lt;form&gt;</code> in [[HTML]]</td>
+						<td class="role-base"><code>&lt;[^form^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -3602,7 +3596,7 @@
 			<rdef>generic</rdef>
 			<div class="role-description">
 				<p>A nameless container <a>element</a> that has no semantic meaning on its own.</p>
-				<p>The <code>generic</code> role is intended for use as the implicit role of generic elements in host languages (such as <abbr title="Hypertext Markup Language">HTML</abbr> <code>div</code> or <code>span</code>), so is primarily for implementors of user agents. Authors SHOULD NOT use this role in content. Authors MAY use <rref>presentation</rref> or <rref>none</rref> to remove implicit accessibility semantics, or a semantic container role such as <rref>group</rref> to semantically group descendants in a named container.</p>
+				<p>The <code>generic</code> role is intended for use as the implicit role of generic elements in host languages (such as HTML <code>div</code> or <code>span</code>), so is primarily for implementors of user agents. Authors SHOULD NOT use this role in content. Authors MAY use <rref>presentation</rref> or <rref>none</rref> to remove implicit accessibility semantics, or a semantic container role such as <rref>group</rref> to semantically group descendants in a named container.</p>
 				<p>Like an element with role <rref>presentation</rref>, an element with role <code>generic</code> can provide a limited number of accessible states and properties for its descendants, such as <pref>aria-live</pref> attributes. However, unlike elements with role <rref>presentation</rref>, <code>generic</code> elements are exposed in <a>accessibility APIs</a> so that assistive technologies can gather certain properties such as layout and bounds.</p>
 			</div>
 			<table class="role-features">
@@ -3632,7 +3626,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><a href="https://www.w3.org/TR/html/grouping-content.html#the-div-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>div</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-span-element"><abbr title="Hypertext Markup Language">HTML</abbr> <code>span</code></a></td>
+						<td class="role-related"><a href="https://www.w3.org/TR/html/grouping-content.html#the-div-element">HTML <code>div</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-span-element">HTML <code>span</code></a></td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -3743,7 +3737,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><code>&lt;table&gt;</code> in [[HTML]]</td>
+						<td class="role-base"><code>&lt;[^table^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -3839,7 +3833,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><code>&lt;td&gt;</code> in [[HTML]]</td>
+						<td class="role-base"><code>&lt;[^td^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -3939,7 +3933,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;fieldset&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^fieldset^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -4022,7 +4016,15 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;h1&gt;</code>, <code>&lt;h2&gt;</code>, <code>&lt;h3&gt;</code>, <code>&lt;h4&gt;</code>, <code>&lt;h5&gt;</code>, and <code>&lt;h6&gt;</code> in [[HTML]]</td>
+						<td class="role-related">
+							<code>&lt;[^h1^]&gt;</code>,
+							<code>&lt;[^h2^]&gt;</code>,
+							<code>&lt;[^h3^]&gt;</code>,
+							<code>&lt;[^h4^]&gt;</code>,
+							<code>&lt;[^h5^]&gt;</code>, and
+							<code>&lt;[^h6^]&gt;</code>
+							in HTML
+						</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -4118,7 +4120,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;img&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^img^]&gt;</code> in HTML</td>
 
 					</tr>
 					<tr>
@@ -4263,7 +4265,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;ins&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^ins^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -4403,7 +4405,7 @@
 			<rdef>link</rdef>
 			<div class="role-description">
 				<p>An interactive reference to an internal or external resource that, when activated, causes the user agent to navigate to that resource. See related <rref>button</rref>.</p>
-				<p>If this is a native link in the host language (such as an <abbr title="Hypertext Markup Language">HTML</abbr> anchor with an <code>href</code> value), activating the link causes the <a>user agent</a> to navigate to that resource. If this is a simulated link, the web application author is responsible for managing navigation.</p>
+				<p>If this is a native link in the host language (such as an HTML anchor with an <code>href</code> value), activating the link causes the <a>user agent</a> to navigate to that resource. If this is a simulated link, the web application author is responsible for managing navigation.</p>
 				<p class="note">If pressing the link triggers an action but does not change browser focus or page location, authors are advised to consider using the <rref>button</rref> role instead of the <code>link</code> role.</p>
 			</div>
 			<table class="role-features">
@@ -4435,9 +4437,8 @@
 						<th class="role-related-head" scope="row">Related Concepts:</th>
 						<td class="role-related">
 							<ul>
-								<li><code>&lt;a&gt;</code> in [[HTML]]</li>
-								<li><code>&lt;link&gt;</code> in [[HTML]]</li>
-
+								<li><code>&lt;[^a^]&gt;</code> in HTML</li>
+								<li><code>&lt;[^link^]&gt;</code> in HTML</li>
 							</ul>
 						</td>
 					</tr>
@@ -4526,8 +4527,8 @@
 						<th class="role-base-head" scope="row">Base Concept:</th>
 						<td class="role-base">
 							<ul>
-								<li><code>&lt;ol&gt;</code> in [[HTML]]</li>
-								<li><code>&lt;ul&gt;</code> in [[HTML]]</li>
+								<li><code>&lt;[^ol^]&gt;</code> in HTML</li>
+								<li><code>&lt;[^ul^]&gt;</code> in HTML</li>
 							</ul>
 						</td>
 					</tr>
@@ -4582,7 +4583,7 @@
 			<rdef>listbox</rdef>
 			<div class="role-description">
 				<p>A <a>widget</a> that allows the user to select one or more items from a list of choices. See related <rref>combobox</rref> and <rref>list</rref>.</p>
-				<p>Items within the list are static and, unlike standard <abbr title="Hypertext Markup Language">HTML</abbr> <code>select</code> [=elements=], can contain images. List boxes contain children whose <a>role</a> is <rref>option</rref> or elements whose <a>role</a> is <rref>group</rref> which in turn contain children whose <a>role</a> is <rref>option</rref>.</p>
+				<p>Items within the list are static and, unlike standard HTML <code>select</code> [=elements=], can contain images. List boxes contain children whose <a>role</a> is <rref>option</rref> or elements whose <a>role</a> is <rref>group</rref> which in turn contain children whose <a>role</a> is <rref>option</rref>.</p>
 				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of <rref>option</rref> descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
 				<p>Elements with the role <code>listbox</code> have an implicit <pref>aria-orientation</pref> value of <code>vertical</code>.</p>
 			</div>
@@ -4620,7 +4621,7 @@
 						<td class="role-related">
 							<ul>
 								<li><rref>list</rref></li>
-								<li><code>&lt;select&gt;</code> in [[HTML]]</li>
+								<li><code>&lt;[^select^]&gt;</code> in HTML</li>
 							</ul>
 						</td>
 					</tr>
@@ -4714,7 +4715,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><code>&lt;li&gt;</code> in [[HTML]]</td>
+						<td class="role-base"><code>&lt;[^li^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -4895,7 +4896,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;main&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^main^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -4974,7 +4975,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;mark&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^mark^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -5744,14 +5745,14 @@
 			<rdef>meter</rdef>
 			<div class="role-description">
 				<p>An <a>element</a> that represents a scalar measurement within a known range, or a fractional value. See related <rref>progressbar</rref>.</p>
-				<p>Authors MAY set <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> to indicate the minimum and maximum values for the <code>meter</code>. Otherwise, their implicit values follow the same rules as <code>&lt;input[type="range"]&gt;</code> in [[HTML]]:</p>
+				<p>Authors MAY set <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> to indicate the minimum and maximum values for the <code>meter</code>. Otherwise, their implicit values follow the same rules as <code>&lt;input type="[^input/type/range^]"&gt;</code> in HTML:</p>
 				<ul>
 					<li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero).</li>
 					<li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100.</li>
 				</ul>
 				<p>The value of <pref>aria-valuenow</pref> MUST NOT fall below or exceed the computed values of <code>aria-valuemin</code> and <code>aria-valuemax</code>, respectively.</p>
 				<p>Authors SHOULD NOT use the <code>meter</code> role to indicate progress; the <rref>progressbar</rref> role exists to address that need.</p>
-				<p class="note">Presently, there are no <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> properties corresponding to the <code>low</code>, <code>optimum</code>, and <code>high</code> attributes supported on the <code>&lt;meter&gt;</code> element in [[HTML]]. The addition of these properties will be considered for ARIA version 1.3.</p>
+				<p class="note">Presently, there are no <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> properties corresponding to the <code>[^meter/low^]</code>, <code>[^meter/optimum^]</code>, and <code>[^meter/high^]</code> attributes supported on the <code>&lt;[^meter^]&gt;</code> element in HTML. The addition of these properties will be considered for ARIA version 1.3.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -5780,7 +5781,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;meter&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^meter^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -5867,7 +5868,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;nav&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^nav^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -6077,7 +6078,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><code>&lt;option&gt;</code> in [[HTML]]</td>
+						<td class="role-base"><code>&lt;[^option^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -6194,7 +6195,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><a href="https://www.w3.org/tr/html5/forms.html#password-state-(type=password)"><abbr title="Hypertext Markup Language">HTML</abbr> <code>input[type="password"]</code></a></td>
+						<td class="role-base"><a href="https://www.w3.org/tr/html5/forms.html#password-state-(type=password)">HTML <code>input[type="password"]</code></a></td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -6274,7 +6275,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;p&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^p^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -6352,14 +6353,14 @@
 <span class="comment">&lt;!-- 2. A span has an implicit 'generic' role and no other attributes important to accessibility, so only its content is exposed, including the hyperlink. --&gt;</span>
 &lt;span&gt; Sample Content &lt;a href="...">let's go!&lt;/a> &lt;/span&gt;
 </pre>
-				<p>In <abbr title="Hypertext Markup Language">HTML</abbr>, the <code>&lt;img&gt;</code> <a>element</a> is treated as a single entity regardless of the type of image file. Consequently, using <code>role="presentation"</code> or <code>role="none"</code> on an <abbr title="Hypertext Markup Language">HTML</abbr> <code>img</code> is equivalent to using <code>aria-hidden="true"</code>. In order to make the image contents accessible, authors can embed the object using an <code>&lt;object&gt;</code> or <code>&lt;iframe&gt;</code> <a>element</a>, or use inline <abbr title="Scalable Vector Graphics">SVG</abbr> code, and follow the accessibility guidelines for the image content.</p>
-				<p>Authors SHOULD NOT provide meaningful alternative text (for example, use <code>alt=""</code> in <abbr title="Hypertext Markup Language">HTML</abbr>) when the <code>presentation</code> role is applied to an image.</p>
+				<p>In HTML, the <code>&lt;img&gt;</code> <a>element</a> is treated as a single entity regardless of the type of image file. Consequently, using <code>role="presentation"</code> or <code>role="none"</code> on an HTML <code>img</code> is equivalent to using <code>aria-hidden="true"</code>. In order to make the image contents accessible, authors can embed the object using an <code>&lt;object&gt;</code> or <code>&lt;iframe&gt;</code> <a>element</a>, or use inline <abbr title="Scalable Vector Graphics">SVG</abbr> code, and follow the accessibility guidelines for the image content.</p>
+				<p>Authors SHOULD NOT provide meaningful alternative text (for example, use <code>alt=""</code> in HTML) when the <code>presentation</code> role is applied to an image.</p>
 				<p>In the following code sample, the containing <rref>img</rref> and is appropriately labeled by the caption paragraph. In this example the <code>img</code> element can be marked as presentation because the role and the text alternatives are provided by the containing element.</p>
 				<pre class="example highlight">&lt;div role="img" aria-labelledby="caption"&gt;
   &lt;img src="example.png" role="presentation" alt=""&gt;
   &lt;p id="caption"&gt;A visible text caption labeling the image.&lt;/p&gt;
 &lt;/div&gt;</pre>
-				<p>In the following code sample, because the anchor (<abbr title="Hypertext Markup Language">HTML</abbr> <code>a</code> element) is acting as the treeitem, the list item (<abbr title="Hypertext Markup Language">HTML</abbr> <code>li</code> element) is assigned an explicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role of presentation to override the user agent's implicit native semantics for list items.</p>
+				<p>In the following code sample, because the anchor (HTML <code>a</code> element) is acting as the treeitem, the list item (HTML <code>li</code> element) is assigned an explicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role of presentation to override the user agent's implicit native semantics for list items.</p>
 				<pre class="example highlight">
 &lt;ul role="tree"&gt;
   &lt;li role="presentation"&gt;
@@ -6368,9 +6369,9 @@
   …
 &lt;/ul&gt;</pre>
 				<h5>Presentational Role Inheritance</h5>
-				<p>The <code>presentation</code> role is used on an element that has implicit native semantics, meaning that there is a default accessibility <abbr title="Application Programing Interface">API</abbr> role for the element. Some elements are only complete when additional descendant elements are provided. For example, in <abbr title="Hypertext Markup Language">HTML</abbr>, table elements (matching the <rref>table</rref> role) require <code>tr</code> descendants (which have an implicit <rref>row</rref> <a>role</a>), which in turn require <code>th</code> or <code>td</code> children (the <rref>columnheader</rref> or <rref>rowheader</rref> and <rref>cell</rref> roles, respectively). Similarly, lists require list item children. The descendant elements that complete the semantics of an element are described in <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> as <a href="#mustContain">required owned elements</a>.</p>
+				<p>The <code>presentation</code> role is used on an element that has implicit native semantics, meaning that there is a default accessibility <abbr title="Application Programing Interface">API</abbr> role for the element. Some elements are only complete when additional descendant elements are provided. For example, in HTML, table elements (matching the <rref>table</rref> role) require <code>tr</code> descendants (which have an implicit <rref>row</rref> <a>role</a>), which in turn require <code>th</code> or <code>td</code> children (the <rref>columnheader</rref> or <rref>rowheader</rref> and <rref>cell</rref> roles, respectively). Similarly, lists require list item children. The descendant elements that complete the semantics of an element are described in <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> as <a href="#mustContain">required owned elements</a>.</p>
 				<p>When an explicit or inherited role of <code>presentation</code> is applied to an element with the implicit semantic of a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role that has <a href="#mustContain">required owned elements</a>, in addition to the element with the explicit role of <code>presentation</code>, the user agent MUST apply an inherited role of presentation to any owned elements that do not have an explicit role defined. Also, when an explicit or inherited role of presentation is applied to a host language element which has required children as defined by the host language specification, in addition to the element with the explicit role of presentation, the user agent MUST apply an inherited role of presentation to any required children that do not have an explicit role defined.</p>
-				<p>For any element with an explicit or inherited role of presentation and which is not focusable, user agents MUST ignore role-specific <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties for that element. For example, in <abbr title="Hypertext Markup Language">HTML</abbr>, a <code>ul</code> or <code>ol</code> element with a role of <code>presentation</code> will have the implicit native semantics of its <code>li</code> elements removed because the <rref>list</rref> role to which the <code>ul</code> or <code>ol</code> corresponds has a <a href="#mustContain">required owned element</a> of <rref>listitem</rref>. Likewise, the implicit native semantics of an <abbr title="Hypertext Markup Language">HTML</abbr> <code>table</code> element's <code>thead</code>/<code>tbody</code>/<code>tfoot</code>/<code>tr</code>/<code>th</code>/<code>td</code> descendants will also be removed, because the <abbr title="Hypertext Markup Language">HTML</abbr> specification indicates that these are required structural descendants of the <code>table</code> element.</p>
+				<p>For any element with an explicit or inherited role of presentation and which is not focusable, user agents MUST ignore role-specific <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties for that element. For example, in HTML, a <code>ul</code> or <code>ol</code> element with a role of <code>presentation</code> will have the implicit native semantics of its <code>li</code> elements removed because the <rref>list</rref> role to which the <code>ul</code> or <code>ol</code> corresponds has a <a href="#mustContain">required owned element</a> of <rref>listitem</rref>. Likewise, the implicit native semantics of an HTML <code>table</code> element's <code>thead</code>/<code>tbody</code>/<code>tfoot</code>/<code>tr</code>/<code>th</code>/<code>td</code> descendants will also be removed, because the HTML specification indicates that these are required structural descendants of the <code>table</code> element.</p>
 				<p class="note">Only the implicit native semantics of elements that correspond to <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a href="#mustContain">required owned elements</a> are removed. All other content remains intact, including nested tables or lists, unless those elements also have an explicit role of <code>presentation</code> specified.</p>
 				<p>For example, according to an accessibility <abbr title="Application Programing Interface">API</abbr>, the following markup elements would appear to have identical role semantics (no roles) and identical content.</p>
 				<pre class="example highlight"><span class="comment">&lt;!-- 1. [role="presentation"] negates the implicit 'list' and 'listitem' role semantics but does not affect the contents. --&gt;</span>
@@ -6474,7 +6475,7 @@
 			<div class="role-description">
 				<p>An <a>element</a> that displays the progress status for tasks that take a long time.</p>
 				<p>A progressbar indicates that the user's request has been received and the application is making progress toward completing the requested action.</p>
-				<p>Authors MAY set <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> to indicate the minimum and maximum progress indicator values. Otherwise, their implicit values follow the same rules as <code>&lt;input[type="range"]&gt;</code> in [[HTML]]:</p>
+				<p>Authors MAY set <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> to indicate the minimum and maximum progress indicator values. Otherwise, their implicit values follow the same rules as <code>&lt;input type="[^input/type/range^]"&gt;</code> in HTML:</p>
 					<ul>
 						<li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero).</li>
 						<li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100.</li>
@@ -6605,7 +6606,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;input[type="radio"]&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;input type="[^input/type/radio^]"&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -6864,7 +6865,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;section&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^section^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -7018,7 +7019,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><code>&lt;tr&gt;</code> in [[HTML]]</td>
+						<td class="role-base"><code>&lt;[^tr^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -7103,7 +7104,7 @@
 			<rdef>rowgroup</rdef>
 			<div class="role-description">
 				<p>A structure containing one or more row elements in a tabular container.</p>
-				<p>The <code>rowgroup</code> role establishes a <a>relationship</a> between [=ARIA/owned=] <rref>row</rref> elements. It is a structural equivalent to the <code>thead</code>, <code>tfoot</code>, and <code>tbody</code> elements in an <abbr title="Hypertext Markup Language">HTML</abbr> <code>table</code> <a>element</a>.</p>
+				<p>The <code>rowgroup</code> role establishes a <a>relationship</a> between [=ARIA/owned=] <rref>row</rref> elements. It is a structural equivalent to the <code>thead</code>, <code>tfoot</code>, and <code>tbody</code> elements in an HTML <code>table</code> <a>element</a>.</p>
 				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>rowgroup</code> are contained in, or [=ARIA/owned=] by, an element with the role <rref>grid</rref>, <rref>table</rref>, or <rref>treegrid</rref>.</p>
 				<p class="note">The <code>rowgroup</code> role exists, in part, to support role symmetry in HTML, and allows for the propagation of presentation inheritance on HTML <code>table</code> elements with an explicit <code>presentation</code> role applied.</p>
 				<p class="note">This role does not differentiate between types of row groups (e.g., <code>thead</code> vs. <code>tbody</code>), but an issue has been raised for <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 2.0.</p>
@@ -7131,7 +7132,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><code>&lt;tbody&gt;</code>, <code>&lt;tfoot&gt;</code> and <code>&lt;thead&gt;</code>in [[HTML]]</td>
+						<td class="role-base"><code>&lt;[^tbody^]&gt;</code>, <code>&lt;[^tfoot^]&gt;</code> and <code>&lt;[^thead^]&gt;</code>in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -7190,7 +7191,7 @@
 			<rdef>rowheader</rdef>
 			<div class="role-description">
 				<p>A cell containing header information for a row.</p>
-				<p>The <rref>rowheader</rref> role can be used to identify a cell as a header for a row in a <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>. The rowheader establishes a <a>relationship</a> between it and all cells in the corresponding row. It is a structural equivalent to setting <code>scope="row"</code> on an <abbr title="Hypertext Markup Language">HTML</abbr> <code>th</code> <a>element</a>.</p>
+				<p>The <rref>rowheader</rref> role can be used to identify a cell as a header for a row in a <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>. The rowheader establishes a <a>relationship</a> between it and all cells in the corresponding row. It is a structural equivalent to setting <code>scope="row"</code> on an HTML <code>th</code> <a>element</a>.</p>
 				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>rowheader</code> are contained in, or [=ARIA/owned=] by, an element with the role <rref>row</rref>.</p>
 				<p>Applying the <sref>aria-selected</sref> state on a rowheader MUST NOT cause the user agent to automatically propagate the <sref>aria-selected</sref> state to all the cells in the corresponding row. An author MAY choose to propagate selection in this manner depending on the specific application.</p>
 				<p>While the <code>rowheader</code> role can be used in both interactive grids and non-interactive tables, the use of <sref>aria-expanded</sref>, <pref>aria-readonly</pref>, and <pref>aria-required</pref> is only applicable to interactive elements. Therefore, authors SHOULD NOT use <sref>aria-expanded</sref>, <pref>aria-readonly</pref>, or <pref>aria-required</pref> in a <code>rowheader</code> that descends from a <rref>table</rref>, and user agents SHOULD NOT expose these properties to <a>assistive technologies</a> unless the <code>rowheader</code> descends from a <rref>grid</rref> or <rref>treegrid</rref>.</p>
@@ -7225,7 +7226,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><code>&lt;th[scope="row"]&gt;</code> in [[HTML]]</td>
+						<td class="role-base"><code>&lt;th scope="[^th/scope/row^]"&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -7290,12 +7291,12 @@
 				<p>A graphical object that controls the scrolling of content within a viewing area, regardless of whether the content is fully displayed within the viewing area.</p>
 				<p>A scrollbar represents the current value and range of possible values via the size of the scrollbar and position of the thumb with respect to the visible range of the orientation (horizontal or vertical) it controls. Its orientation represents the orientation of the scrollbar and the scrolling effect on the viewing area controlled by the scrollbar. It is typically possible to add to or subtract from the current value by using directional keys such as arrow keys.</p>
 				<p>Authors MUST set the <pref>aria-controls</pref> attribute on the scrollbar element to reference the scrollable area it controls.</p>
-				<p>Authors MAY set <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> to indicate the minimum and maximum thumb position. Otherwise, their implicit values follow the same rules as <code>&lt;input[type="range"]&gt;</code> in [[HTML]]:</p>
+				<p>Authors MAY set <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> to indicate the minimum and maximum thumb position. Otherwise, their implicit values follow the same rules as <code>&lt;input type="[^input/type/range^]"&gt;</code> in HTML:</p>
 				<ul>
 				    <li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero).</li>
 				    <li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100.</li>
 				</ul>
-				<p>Authors MUST set the <pref>aria-valuenow</pref> attribute to indicate the current thumb position. If aria-valuenow is missing or has an unexpected value, browsers MAY implement the repair techniques specified in the <a href="#authorErrorDefaultValuesTable">section describing handling author errors in states and properties</a>, which are equivalent to the repair techniques for <code>&lt;input[type="range"]&gt;</code> in [[HTML]].</p>
+				<p>Authors MUST set the <pref>aria-valuenow</pref> attribute to indicate the current thumb position. If aria-valuenow is missing or has an unexpected value, browsers MAY implement the repair techniques specified in the <a href="#authorErrorDefaultValuesTable">section describing handling author errors in states and properties</a>, which are equivalent to the repair techniques for <code>&lt;input type="[^input/type/range^]"&gt;</code> in HTML.</p>
 				<p>Elements with the role <code>scrollbar</code> have an implicit <pref>aria-orientation</pref> value of <code>vertical</code>.</p>
 				<p class="note">Assistive technologies generally will render the value of <pref>aria-valuenow</pref> as a percent of a range between the value of <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref>, unless <pref>aria-valuetext</pref> is specified. It is best to set the values for <pref>aria-valuemin</pref>, <pref>aria-valuemax</pref>, and <pref>aria-valuenow</pref> in a manner that is appropriate for this calculation.</p>
 			</div>
@@ -7505,7 +7506,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><code>&lt;input[type="search"]&gt;</code> in [[HTML]]</td>
+						<td class="role-base"><code>&lt;input type="[^input/type/search^]"&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -7807,7 +7808,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;hr&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^hr^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -7873,12 +7874,12 @@
 			<div class="role-description">
 				<p>An input where the user selects a value from within a given range.</p>
 				<p>A slider represents the current value and range of possible values via the size of the slider and position of the thumb. It is typically possible to add to or subtract from the current value by using directional keys such as arrow keys.</p>
-				<p>Authors MAY set the <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> attributes.	Otherwise, their implicit values follow the same rules as <code>&lt;input[type="range"]&gt;</code> in [[HTML]]:</p>
+				<p>Authors MAY set the <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> attributes.	Otherwise, their implicit values follow the same rules as <code>&lt;input type="[^input/type/range^]"&gt;</code> in HTML:</p>
 				<ul>
 				    <li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero). </li>
 				    <li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100. </li>
 				</ul>
-				<p>Authors MUST set the <pref>aria-valuenow</pref> attribute. If aria-valuenow is missing or has an unexpected value, browsers MAY implement the repair techniques specified in the <a href="#authorErrorDefaultValuesTable">section describing handling author errors in states and properties</a>, which are equivalent to the repair techniques for <code>&lt;input[type="range"]&gt;</code> in [[HTML]].</p>
+				<p>Authors MUST set the <pref>aria-valuenow</pref> attribute. If aria-valuenow is missing or has an unexpected value, browsers MAY implement the repair techniques specified in the <a href="#authorErrorDefaultValuesTable">section describing handling author errors in states and properties</a>, which are equivalent to the repair techniques for <code>&lt;input type="[^input/type/range^]"&gt;</code> in HTML.</p>
 				<p>Elements with the role <code>slider</code> have an implicit <pref>aria-orientation</pref> value of <code>horizontal</code>.</p>
 			</div>
 			<table class="role-features">
@@ -7985,7 +7986,7 @@
 				<p>A <code>spinbutton</code> typically allows users to change its displayed value by activating increment and decrement buttons that step through a set of allowed values. Some implementations display the value in an text field that allows editing and typing but typically limits input in ways that help prevent invalid values.</p>
 				<p>Although a <code>spinbutton</code> is similar in appearance to many presentations of <code>select</code>, it is advisable to use <code>spinbutton</code> when working with known ranges (especially in the case of large ranges) as opposed to distinct options. For example, a <code>spinbutton</code> representing a range from 1 to 1,000,000 would provide much better performance than a <code>select</code> <a>widget</a> representing the same values.</p>
 				<p>Authors MAY create a <code>spinbutton</code> with children or owned elements, but MUST limit those elements to a <rref>textbox</rref> and/or two <rref title="button">buttons</rref>. Alternatively, authors MAY apply the <rref>spinbutton</rref> role to a text input and create sibling buttons to support the increment and decrement functions.</p>
-				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>. When a <code>spinbutton</code> receives focus, authors SHOULD ensure focus is placed on the <rref>textbox</rref> element if one is present, and on the <code>spinbutton</code> itself otherwise. Authors SHOULD also ensure the <kbd>up</kbd> and <kbd>down</kbd> arrows on a keyboard perform the increment and decrement functions and that the increment and decrement <rref>button</rref> elements are <em>NOT</em> included in the primary navigation ring, e.g., the Tab ring in <abbr title="Hypertext Markup Language">HTML</abbr>.</p>
+				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>. When a <code>spinbutton</code> receives focus, authors SHOULD ensure focus is placed on the <rref>textbox</rref> element if one is present, and on the <code>spinbutton</code> itself otherwise. Authors SHOULD also ensure the <kbd>up</kbd> and <kbd>down</kbd> arrows on a keyboard perform the increment and decrement functions and that the increment and decrement <rref>button</rref> elements are <em>NOT</em> included in the primary navigation ring, e.g., the Tab ring in HTML.</p>
 				<p>Authors SHOULD set the <pref>aria-valuenow</pref> attribute when the <rref>spinbutton</rref> has a value. Authors SHOULD set the <pref>aria-valuemin</pref> attribute when there is a minimum value, and the <pref>aria-valuemax</pref> attribute when there is a maximum value.</p>
 			</div>
 			<table class="role-features">
@@ -8121,7 +8122,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;output&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^output^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -8207,7 +8208,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;strong&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^strong^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -8365,7 +8366,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;sub&gt;</code> and <code>&lt;sup&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^sub^]&gt;</code> and <code>&lt;[^sup^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -8555,7 +8556,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;sub&gt;</code> and <code>&lt;sup&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^sub^]&gt;</code> and <code>&lt;[^sup^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -8813,7 +8814,7 @@
 			<div class="role-description">
 				<p>A <rref>section</rref> containing data arranged in rows and columns. See related <rref>grid</rref>.</p>
 				<p>The <code>table</code> role is intended for tabular containers which are not interactive. If the tabular container maintains a selection state, provides its own two-dimensional navigation, or allows the user to rearrange or otherwise manipulate its contents or the display thereof, authors SHOULD use <rref>grid</rref> or <rref>treegrid</rref> instead.</p>
-				<p>Authors SHOULD prefer the use of the host language's semantics for table whenever possible, such as the <code>&lt;table&gt;</code> element in [[HTML]].</p>
+				<p>Authors SHOULD prefer the use of the host language's semantics for table whenever possible, such as the <code>&lt;[^table^]&gt;</code> element in HTML.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -8838,7 +8839,7 @@
 					</tr>
 					<tr>
 						<th class="role-base-head" scope="row">Base Concept:</th>
-						<td class="role-base"><code>&lt;table&gt;</code> in [[HTML]]</td>
+						<td class="role-base"><code>&lt;[^table^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
@@ -9110,7 +9111,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;dfn&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^dfn^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -9291,7 +9292,7 @@
 			<rdef>textbox</rdef>
 			<div class="role-description">
 				<p>A type of input that allows free-form text as its value.</p>
-				<p>If the <pref>aria-multiline</pref> <a>attribute</a> is <code>true</code>, the <a>widget</a> accepts line breaks within the input, as in an <abbr title="Hypertext Markup Language">HTML</abbr> <code>textarea</code>. Otherwise, this is a simple text box. The intended use is for languages that do not have a text input <a>element</a>, or cases in which an element with different <a>semantics</a> is repurposed as a text field.</p>
+				<p>If the <pref>aria-multiline</pref> <a>attribute</a> is <code>true</code>, the <a>widget</a> accepts line breaks within the input, as in an HTML <code>textarea</code>. Otherwise, this is a simple text box. The intended use is for languages that do not have a text input <a>element</a>, or cases in which an element with different <a>semantics</a> is repurposed as a text field.</p>
 				<!-- keep the following para synced with its equivalent in #aria-multiline -->
 				<p class="note">In most user agent implementations, the default behavior of the <kbd>ENTER</kbd> or <kbd>RETURN</kbd> key is different between the single-line and multi-line text fields in HTML. When user has focus in a single-line <code>&lt;input type="text"&gt;</code> element, the keystroke usually submits the form. When user has focus in a multi-line <code>&lt;textarea&gt;</code> element, the keystroke inserts a line break. The <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <code>textbox</code> role differentiates these types of boxes with the <pref>aria-multiline</pref> attribute, so authors are advised to be aware of this distinction when designing the field.</p>
 			</div>
@@ -9324,8 +9325,8 @@
 						<th class="role-related-head" scope="row">Related Concepts:</th>
 						<td class="role-related">
 							<ul>
-								<li><code>&lt;textarea&gt;</code> in [[HTML]]</li>
-								<li><code>&lt;input[type="text"]&gt;</code> in [[HTML]]</li>
+								<li><code>&lt;[^textarea^]&gt;</code> in HTML</li>
+								<li><code>&lt;input type="[^input/type/text^]"&gt;</code> in HTML</li>
 							</ul>
 						</td>
 					</tr>
@@ -9380,7 +9381,7 @@
 			<rdef>time</rdef>
 			<div class="role-description">
 				<p>An element that represents a specific point in time.</p>
-				<p class="note">At the present time, there are no <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> properties corresponding to the <code>datetime</code> attribute supported on <code>&lt;time&gt;</code> in [[HTML]]. The addition of this property will be considered for ARIA version 1.3.</p>
+				<p class="note">At the present time, there are no <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> properties corresponding to the <code>datetime</code> attribute supported on <code>&lt;[^time^]&gt;</code> in HTML. The addition of this property will be considered for ARIA version 1.3.</p>
 				<p>Authors SHOULD limit text contents to a valid date- or time-related string, or apply this future <code>datetime</code>-equivalent property to the element which has role <code>time</code>.</p>
 				<aside class="example">
 					<p>Examples of valid date- or time-related strings as text contents of an element with the <code>time</code> role:</p>
@@ -9425,7 +9426,7 @@
 					</tr>
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
-						<td class="role-related"><code>&lt;time&gt;</code> in [[HTML]]</td>
+						<td class="role-related"><code>&lt;[^time^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -11120,7 +11121,7 @@ button.ariaPressed; // null</pre>
 					<!--
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><cite><a href="https://www.w3.org/TR/2007/WD-xml-events-20070216/"><abbr title="Extensible Markup Language">XML</abbr> Events</a></cite> [[XML-EVENTS]] object hyperlink target in <cite><a href="https://www.w3.org/TR/2002/REC-xhtml1-20020801/"><abbr title="Hypertext Markup Language">HTML</abbr></a></cite> [[XHTML11]]</td>
+						<td class="property-related"><cite><a href="https://www.w3.org/TR/2007/WD-xml-events-20070216/"><abbr title="Extensible Markup Language">XML</abbr> Events</a></cite> [[XML-EVENTS]] object hyperlink target in <cite><a href="https://www.w3.org/TR/2002/REC-xhtml1-20020801/">HTML</a></cite> [[XHTML11]]</td>
 					</tr>
 					-->
 					<tr>
@@ -11243,9 +11244,9 @@ button.ariaPressed; // null</pre>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
 						<td class="property-related">
 							<ul>
-								<li><code>&lt;label&gt;</code> in [[HTML]]</li>
+								<li><code>&lt;[^label^]&gt;</code> in HTML</li>
 								<li>online help</li>
-								<li><abbr title="Hypertext Markup Language">HTML</abbr> table cell headers</li>
+								<li>HTML table cell headers</li>
 							</ul>
 						</td>
 					</tr>
@@ -11287,7 +11288,7 @@ button.ariaPressed; // null</pre>
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><code>title</code> attribute in [[HTML]]</td>
+						<td class="property-related"><code>[^html-global/title^]</code> attribute in HTML</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -11974,7 +11975,7 @@ button.ariaPressed; // null</pre>
 			<div class="property-description">
 				<p><a>Defines</a> a string value that labels the current element. See related <pref>aria-labelledby</pref>.</p>
 				<p>The purpose of <pref>aria-label</pref> is the same as that of <pref>aria-labelledby</pref>. It provides the user with a recognizable name of the object. The most common <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> mapping for a label is the <a class="informative">accessible name</a> property.</p>
-				<p>Most host languages provide an attribute that could be used to name the element (e.g., the <code>title</code> attribute in [[HTML]]), yet this could present a browser tooltip. In the cases where DOM content or a tooltip is undesirable, authors MAY set the accessible name of the element using <pref>aria-label</pref>, if the element does not <a href="#prohibitedattributes">prohibit</a> use of the attribute. If the label text is available in the DOM (i.e. typically visible text content), authors SHOULD use <pref>aria-labelledby</pref> and SHOULD NOT use <pref>aria-label</pref>. There might be instances where the name of an element cannot be determined programmatically from the DOM, and there are cases where referencing DOM content is not the desired user experience. Authors MUST NOT specify <code>aria-label</code> on an element which has an explicit or implicit WAI-ARIA role where <code>aria-label</code> is <a href="#prohibitedattributes">prohibited</a>. As required by the <a href="#textalternativecomputation">accessible name and description computation</a>, user agents give precedence to <pref>aria-labelledby</pref> over <pref>aria-label</pref> when computing the accessible name property.</p>
+				<p>Most host languages provide an attribute that could be used to name the element (e.g., the <code>[^html-global/title^]</code> attribute in HTML), yet this could present a browser tooltip. In the cases where DOM content or a tooltip is undesirable, authors MAY set the accessible name of the element using <pref>aria-label</pref>, if the element does not <a href="#prohibitedattributes">prohibit</a> use of the attribute. If the label text is available in the DOM (i.e. typically visible text content), authors SHOULD use <pref>aria-labelledby</pref> and SHOULD NOT use <pref>aria-label</pref>. There might be instances where the name of an element cannot be determined programmatically from the DOM, and there are cases where referencing DOM content is not the desired user experience. Authors MUST NOT specify <code>aria-label</code> on an element which has an explicit or implicit WAI-ARIA role where <code>aria-label</code> is <a href="#prohibitedattributes">prohibited</a>. As required by the <a href="#textalternativecomputation">accessible name and description computation</a>, user agents give precedence to <pref>aria-labelledby</pref> over <pref>aria-label</pref> when computing the accessible name property.</p>
 			</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>
@@ -12025,7 +12026,7 @@ button.ariaPressed; // null</pre>
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><code>&lt;label&gt;</code> in [[HTML]]</td>
+						<td class="property-related"><code>&lt;[^label^]&gt;</code> in HTML</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -12405,7 +12406,7 @@ button.ariaPressed; // null</pre>
 				<p><a>Defines</a> a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value. A hint could be a sample value or a brief description of the expected format.</p>
 				<p>Authors SHOULD NOT use <pref>aria-placeholder</pref> instead of a label as their purposes are different: The label indicates what kind of information is expected. The placeholder text is a hint about the expected value. See related <pref>aria-labelledby</pref> and <pref>aria-label</pref>.</p>
 				<p>Authors SHOULD present this hint to the user by displaying the hint text at any time the control's <span>value</span> is the empty string. This includes cases where the control first receives focus, and when users remove a previously-entered value.</p>
-				<p class="note">As is the case with the related <code>placeholder</code> attribute in [[HTML]], use of placeholder text as a replacement for a displayed label can reduce the accessibility and usability of the control for a range of users including older users and users with cognitive, mobility, fine motor skill or vision impairments. While the hint given by the control's label is shown at all times, the short hint given in the placeholder attribute is only shown before the user enters a value. Furthermore, placeholder text might be mistaken for a pre-filled value, and as commonly implemented the default color of the placeholder text provides insufficient contrast and the lack of a separate visible label reduces the size of the hit region available for setting focus on the control.</p>
+				<p class="note">As is the case with the related <code>[^input/placeholder^]</code> attribute in HTML, use of placeholder text as a replacement for a displayed label can reduce the accessibility and usability of the control for a range of users including older users and users with cognitive, mobility, fine motor skill or vision impairments. While the hint given by the control's label is shown at all times, the short hint given in the placeholder attribute is only shown before the user enters a value. Furthermore, placeholder text might be mistaken for a pre-filled value, and as commonly implemented the default color of the placeholder text provides insufficient contrast and the lack of a separate visible label reduces the size of the hit region available for setting focus on the control.</p>
 				<p class="note">The following examples do not use the HTML <code>label</code> element as it cannot be used to label HTML elements with <code>contenteditable</code>.</p>
 				<p>The following example shows a <rref>searchbox</rref> in which the user has entered a value:</p>
 				<pre class="example highlight">
@@ -12429,7 +12430,7 @@ button.ariaPressed; // null</pre>
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><code>placeholder</code> attribute in [[HTML]]</td>
+						<td class="property-related"><code>[^input/placeholder^]</code> attribute in HTML</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -12576,7 +12577,7 @@ button.ariaPressed; // null</pre>
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><code>readonly</code> attribute in [[HTML]]</td>
+						<td class="property-related"><code>[^input/readonly^]</code> attribute in HTML</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -12702,7 +12703,7 @@ button.ariaPressed; // null</pre>
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><code>required</code> attribute in [[HTML]]</td>
+						<td class="property-related"><code>[^input/required^]</code> attribute in HTML</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -13224,7 +13225,7 @@ button.ariaPressed; // null</pre>
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><code>&lt;input type="range"&gt;</code> element <code>max</code> attribute in [[HTML]]</td>
+						<td class="property-related"><code>&lt;input type="[^input/type/range^]"&gt;</code> element <code>[^input/max^]</code> attribute in HTML</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -13259,7 +13260,7 @@ button.ariaPressed; // null</pre>
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><code>&lt;input type="range"&gt;</code> element <code>min</code> attribute in [[HTML]]</td>
+						<td class="property-related"><code>&lt;input type="[^input/type/range^]"&gt;</code> element <code>[^input/min^]</code> attribute in HTML</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -13298,7 +13299,7 @@ button.ariaPressed; // null</pre>
 				<tbody>
 					<tr>
 						<th class="property-related-head" scope="row">Related Concepts:</th>
-						<td class="property-related"><code>&lt;input type="range"&gt;</code> element <code>value</code> attribute in [[HTML]]</td>
+						<td class="property-related"><code>&lt;input type="[^input/type/range^]"&gt;</code> element <code>[^input/value^]</code> attribute in HTML</td>
 					</tr>
 					<tr>
 						<th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -13435,7 +13436,7 @@ button.ariaPressed; // null</pre>
 	</section>
 	<section id="host_general_focus">
 		<h2>Focus Navigation</h2>
-		<p>An implementing host language MUST provide support for the author to make all interactive elements focusable, that is, any renderable or event-receiving elements. An implementing host language MUST provide a facility to allow web authors to define whether these focusable, interactive elements appear in the default tab navigation order. The <code>tabindex</code> <a>attribute</a> in <abbr title="Hypertext Markup Language">HTML</abbr> is an example of one implementation.</p>
+		<p>An implementing host language MUST provide support for the author to make all interactive elements focusable, that is, any renderable or event-receiving elements. An implementing host language MUST provide a facility to allow web authors to define whether these focusable, interactive elements appear in the default tab navigation order. The <code>tabindex</code> <a>attribute</a> in HTML is an example of one implementation.</p>
 	</section>
 	<section id="implicit_semantics">
 		<h2>Implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Semantics</h2>


### PR DESCRIPTION
Closes #1903

A little editorial cleanup to normalize the way we reference HTML spec definitions for elements and attributes.  I’ll leave a few notes in context below.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/adampage/aria/pull/1906.html" title="Last updated on Apr 17, 2023, 9:15 PM UTC (4f8ea7e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1906/6207a61...adampage:4f8ea7e.html" title="Last updated on Apr 17, 2023, 9:15 PM UTC (4f8ea7e)">Diff</a>