### PR TITLE
m. typo in two landmark statements.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3522,8 +3522,8 @@
 				<p>Authors MUST give each element with role <code>form</code> a brief label that describes the purpose of the form. Authors SHOULD reference a visible label with <pref>aria-labelledby</pref> if a visible label is present. Authors SHOULD include the label inside of a heading whenever possible. The heading MAY be an instance of the standard host language heading element or an instance of an element with role <rref>heading</rref>.</p>
 				<p>If an author uses a script to submit a form based on a user action that would otherwise not trigger an <code>onsubmit</code> event (for example, a form submission triggered by the user changing a form element's value), the author SHOULD provide the user with advance notification of the behavior.</p>
 				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>form</code>.
-  				[=User agents=] SHOULD treat elements with role <code>form</code> and have an accessible name as navigational <a>landmarks</a>.
-  				[=User agents=] MAY enable users to quickly navigate to elements with role <code>form</code>.</p>
+					[=User agents=] SHOULD treat elements with role <code>form</code> and an accessible name as navigational <a>landmarks</a>.
+					[=User agents=] MAY enable users to quickly navigate to elements with role <code>form</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -6833,8 +6833,8 @@
 				<p>Authors SHOULD limit use of the region role to sections containing content with a purpose that is not accurately described by one of the other <a href="#landmark_roles">landmark roles</a>, such as <rref>main</rref>, <rref>complementary</rref>, or <rref>navigation</rref>.</p>
 				<p>Authors MUST give each element with role region a brief label that describes the purpose of the content in the region. Authors SHOULD reference a visible label with <pref>aria-labelledby</pref> if a visible label is present. Authors SHOULD include the label inside of a heading whenever possible. The heading MAY be an instance of the standard host language heading element or an instance of an element with role <rref>heading</rref>.</p>
 				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>region</code>.
-  				[=User agents=] SHOULD treat elements with role <code>region</code> and have an accessible name as navigational <a>landmarks</a>.
-  				[=User agents=] MAY enable users to quickly navigate to elements with role <code>region</code>.</p>
+					[=User agents=] SHOULD treat elements with role <code>region</code> and an accessible name as navigational <a>landmarks</a>.
+					[=User agents=] MAY enable users to quickly navigate to elements with role <code>region</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>


### PR DESCRIPTION
typo in two landmark statements.

For some reason, those two lines also had mismatched whitespace compared to the rest of the file, so I corrected that since it affected the line I was committing.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1919.html" title="Last updated on Apr 20, 2023, 8:33 AM UTC (39c0701)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1919/eeaad35...39c0701.html" title="Last updated on Apr 20, 2023, 8:33 AM UTC (39c0701)">Diff</a>