### PR TITLE
Broken references in Accessible Rich Internet Applications (WAI-ARIA) 1.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -13870,13 +13870,13 @@ el.getAttribute("aria-label"); // Returns "Publish"</pre>
 <section class="informative">
 	<h2>Privacy and Security Considerations</h2>
 	<p>This specification introduces no new security considerations.</p>
-	<p>In accordance with <a href="https://w3ctag.github.io/design-principles/#do-not-expose-use-of-assistive-tech">Web Platform Design Principles</a>, this specification provides no programmatic interface to determine if information is being used by Assistive Technologies. However, this specification does allow an author to present different information to users of Assistive Technologies from the information available to users who do not use Assistive Technologies. This is possible using many features of the ARIA specification, just as this is possible using many other parts of the web technology stack. This content disparity could be abused to perform <a href="https://www.w3.org/TR/fingerprinting-guidance/#active-0">active fingerprinting</a> of users of Assistive Technologies.</p>
+	<p>In accordance with <a data-cite="design-principles/#do-not-expose-use-of-assistive-tech">Web Platform Design Principles</a>, this specification provides no programmatic interface to determine if information is being used by Assistive Technologies. However, this specification does allow an author to present different information to users of Assistive Technologies from the information available to users who do not use Assistive Technologies. This is possible using many features of the ARIA specification, just as this is possible using many other parts of the web technology stack. This content disparity could be abused to perform <a data-cite="fingerprinting-guidance/#active-0">active fingerprinting</a> of users of Assistive Technologies.</p>
 </section>
 <section class="informative appendix" id="typemapping">
 	<h2>Mapping WAI-ARIA Value types to languages</h2>
-	<p class="note">The HTML column of the table below is advisory. Guidance on use of WAI-ARIA state and properties in HTML is provided in <a href="https://www.w3.org/TR/html-aria/#allowed-aria-roles-states-and-properties">Allowed ARIA roles, states and properties  </a> ([[HTML-ARIA]].</p>
-	<p class="note">The suggested mappings for true/false values in HTML use <a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of <code>true</code> and <code>false</code>, instead of using the HTML boolean value type. <!--@@ can't rely on attribute absence because of default value in true/false/undefined case.--></p>
-	<p>The table below provides recommended mappings between WAI-ARIA state and property types and attribute types from [[HTML]], <cite><a href="https://www.w3.org/TR/xmlschema11-2/"><abbr title="Extensible Markup Language">XML</abbr> Schema Datatypes</a></cite> [[XMLSCHEMA11-2]], [[SVG2]], and SGML.</p>
+	<p class="note">The HTML column of the table below is advisory. Guidance on use of WAI-ARIA state and properties in HTML is provided in <a data-cite="html-aria/#docconformance">Document conformance requirements for use of ARIA attributes in HTML</a> ([[HTML-ARIA]].</p>
+	<p class="note">The suggested mappings for true/false values in HTML use <a data-cite="html/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of <code>true</code> and <code>false</code>, instead of using the HTML boolean value type. <!--@@ can't rely on attribute absence because of default value in true/false/undefined case.--></p>
+	<p>The table below provides recommended mappings between WAI-ARIA state and property types and attribute types from [[[HTML]]] and [[[XMLSCHEMA11-2]]].</p>
 	<p>Languages not listed below might have appropriate value types defined in the language. If they do not, we recommend XML Schema Datatypes for general purpose XML languages. Documents using DTDs instead of schemas will not be able to validate automatically and require additional processing on WAI-ARIA attributes.</p>
 	<table>
 		<tr>
@@ -13886,53 +13886,53 @@ el.getAttribute("aria-label"); // Returns "Publish"</pre>
 		</tr>
 		<tr>
 			<td>true/false</td>
-			<td><a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of &quot;true&quot; and &quot;false&quot;</td>
-			<td><a href="https://www.w3.org/TR/xmlschema11-2/#boolean">boolean</a></td>
+			<td><a data-cite="html/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of &quot;true&quot; and &quot;false&quot;</td>
+			<td><a data-cite="xmlschema11-2/#boolean">boolean</a></td>
 		</tr>
 		<tr>
 			<td>true/false/undefined</td>
-			<td><a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of <code>true</code>, <code>false</code>, and <code>undefined</code></td>
-			<td><a href="https://www.w3.org/TR/xmlschema11-2/#NMTOKEN">NMTOKEN</a> with an <a href="https://www.w3.org/TR/xmlschema11-2/#NMTOKEN">enumeration constraint</a> allowing values of <code>true</code>, <code>false</code>, and <code>undefined</code></td>
+			<td><a data-cite="html/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of <code>true</code>, <code>false</code>, and <code>undefined</code></td>
+			<td><a data-cite="xmlschema11-2/#NMTOKEN">NMTOKEN</a> with an <a href="https://www.w3.org/TR/xmlschema11-2/#NMTOKEN">enumeration constraint</a> allowing values of <code>true</code>, <code>false</code>, and <code>undefined</code></td>
 		</tr>
 		<tr>
 			<td>tristate</td>
-			<td><a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of &quot;true&quot;, &quot;false&quot;, and &quot;mixed&quot;</td>
-			<td><a href="https://www.w3.org/TR/xmlschema11-2/#NMTOKEN">NMTOKEN</a> with an <a href="https://www.w3.org/TR/xmlschema11-2/#NMTOKEN">enumeration constraint</a> allowing values of &quot;true&quot;, &quot;false&quot;, and &quot;mixed&quot;</td>
+			<td><a data-cite="html/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of &quot;true&quot;, &quot;false&quot;, and &quot;mixed&quot;</td>
+			<td><a data-cite="xmlschema11-2/#NMTOKEN">NMTOKEN</a> with an <a href="https://www.w3.org/TR/xmlschema11-2/#NMTOKEN">enumeration constraint</a> allowing values of &quot;true&quot;, &quot;false&quot;, and &quot;mixed&quot;</td>
 		</tr>
 		<tr>
 			<td>number</td>
-			<td><a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#floating-point-numbers">Floating-point numbers</a></td>
-			<td><a href="https://www.w3.org/TR/xmlschema11-2/#decimal">decimal</a></td>
+			<td><a data-cite="html/common-microsyntaxes.html#floating-point-numbers">Floating-point numbers</a></td>
+			<td><a data-cite="xmlschema11-2/#decimal">decimal</a></td>
 		</tr>
 		<tr>
 			<td>integer</td>
-			<td><a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#floating-point-numbers">Non-negative integer</a></td>
-			<td><a href="https://www.w3.org/TR/xmlschema11-2/#integer">integer</a></td>
+			<td><a data-cite="html/common-microsyntaxes.html#floating-point-numbers">Non-negative integer</a></td>
+			<td><a data-cite="xmlschema11-2/#integer">integer</a></td>
 		</tr>
 		<tr>
 			<td>token</td>
-			<td><a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a></td>
-			<td><a href="https://www.w3.org/TR/xmlschema11-2/#NMTOKEN">NMTOKEN</a> with an <a href="https://www.w3.org/TR/xmlschema11-2/#NMTOKEN">enumeration constraint</a> allowing values listed in the state or property definition</td>
+			<td><a data-cite="html/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a></td>
+			<td><a data-cite="xmlschema11-2/#NMTOKEN">NMTOKEN</a> with an <a data-cite="xmlschema11-2/#dt-enumeration">enumeration constraint</a> allowing values listed in the state or property definition</td>
 		</tr>
 		<tr>
 			<td>token list</td>
-			<td><a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#space-separated-tokens">Space-separated tokens</a></td>
-			<td><a href="https://www.w3.org/TR/xmlschema11-2/#NMTOKENS">NMTOKENS</a> with an <a href="https://www.w3.org/TR/xmlschema11-2/#NMTOKEN">enumeration constraint</a> allowing values listed in the state or property definition</td>
+			<td><a data-cite="html/common-microsyntaxes.html#space-separated-tokens">Space-separated tokens</a></td>
+			<td><a data-cite="xmlschema11-2/#NMTOKENS">NMTOKENS</a> with an <a data-cite="xmlschema11-2/#dt-enumeration">enumeration constraint</a> allowing values listed in the state or property definition</td>
 		</tr>
 		<tr>
 			<td>ID reference</td>
-			<td>The value of a defined <a href="https://html.spec.whatwg.org/multipage/dom.html#the-id-attribute">id attribute</a> on another element</td>
-			<td><a href="https://www.w3.org/TR/xmlschema11-2/#IDREF">IDREF</a></td>
+			<td>The value of a defined <a data-cite="html/dom.html#the-id-attribute">id attribute</a> on another element</td>
+			<td><a data-cite="xmlschema11-2/#IDREF">IDREF</a></td>
 		</tr>
 		<tr>
 			<td>ID reference list</td>
-			<td>The value of one or more defined <a href="https://html.spec.whatwg.org/multipage/dom.html#the-id-attribute">id attributes</a> on other element(s), represented as <a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#space-separated-tokens">Space-separated tokens</a></td>
-			<td><a href="https://www.w3.org/TR/xmlschema11-2/#IDREFS">IDREFS</a></td>
+			<td>The value of one or more defined <a data-cite="html/dom.html#the-id-attribute">id attributes</a> on other element(s), represented as <a data-cite="html/common-microsyntaxes.html#space-separated-tokens">Space-separated tokens</a></td>
+			<td><a data-cite="xmlschema11-2/#IDREFS">IDREFS</a></td>
 		</tr>
 		<tr>
 			<td>string</td>
 			<td>No value constraints</td>
-			<td><a href="https://www.w3.org/TR/xmlschema11-2/#string">string</a></td>
+			<td><a data-cite="xmlschema11-2/#string">string</a></td>
 		</tr>
 	</table>
 </section>

--- a/index.html
+++ b/index.html
@@ -13874,7 +13874,7 @@ el.getAttribute("aria-label"); // Returns "Publish"</pre>
 </section>
 <section class="informative appendix" id="typemapping">
 	<h2>Mapping WAI-ARIA Value types to languages</h2>
-	<p class="note">The HTML column of the table below is advisory. Guidance on use of WAI-ARIA state and properties in HTML is provided in <a data-cite="html-aria/#docconformance">Document conformance requirements for use of ARIA attributes in HTML</a> ([[HTML-ARIA]].</p>
+	<p class="note">The HTML column of the table below is advisory. Guidance on use of WAI-ARIA state and properties in HTML is provided in <a data-cite="html-aria/#docconformance">Document conformance requirements for use of ARIA attributes in HTML</a> ([[HTML-ARIA]]).</p>
 	<p class="note">The suggested mappings for true/false values in HTML use <a data-cite="html/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of <code>true</code> and <code>false</code>, instead of using the HTML boolean value type. <!--@@ can't rely on attribute absence because of default value in true/false/undefined case.--></p>
 	<p>The table below provides recommended mappings between WAI-ARIA state and property types and attribute types from [[[HTML]]] and [[[XMLSCHEMA11-2]]].</p>
 	<p>Languages not listed below might have appropriate value types defined in the language. If they do not, we recommend XML Schema Datatypes for general purpose XML languages. Documents using DTDs instead of schemas will not be able to validate automatically and require additional processing on WAI-ARIA attributes.</p>


### PR DESCRIPTION
Fixes #1923

Fix reference for issue 1923

Also modifies nearby references to use data-cite rather than absolute references


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/1924.html" title="Last updated on Apr 25, 2023, 4:00 PM UTC (6328144)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1924/eeaad35...6328144.html" title="Last updated on Apr 25, 2023, 4:00 PM UTC (6328144)">Diff</a>