### PR TITLE
add proposed header and footer roles

### DIFF
--- a/index.html
+++ b/index.html
@@ -3549,6 +3549,84 @@
 				</tbody>
 			</table>
 		</div>
+		<div class="role" id="footer">
+			<rdef>footer</rdef>
+			<div class="role-description">
+				<p>A set of user interface objects and information representing information about its closest ancestral content group. For instance, a <code>footer</code> can include information about who wrote the specific section of content, such as an <rref>article</rref>. It can contain links to related documents, copyright information or other indices and colophon specific to the current section of the page.</p>
+				<p>A <code>footer</code> does not represent information about the parent document, or globally repeating content found across multiple pages related to the website. For such content, the <rref>contentinfo</rref> role would be more appropriate.</p>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent"><rref>section</rref></td>
+					</tr>
+					<tr>
+						<th class="role-children-head" scope="row">Subclass Roles:</th>
+						<td class="role-children">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"><code>&lt;[^footer^]&gt;</code> in HTML</td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"><code>&lt;[^fieldset^]&gt;</code> in HTML</td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Accessibility Parent Roles:</th>
+						<td class="role-scope"> </td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Allowed Accessibility Child Roles:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">author</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired"> </td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational"> </td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
 		<div class="role" id="form">
 			<rdef>form</rdef>
 			<div class="role-description">
@@ -3999,6 +4077,84 @@
 								<li><sref>aria-disabled</sref></li>
 							</ul>
 						</td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">author</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired"> </td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational"> </td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div class="role" id="header">
+			<rdef>header</rdef>
+			<div class="role-description">
+				<p>A set of user interface objects and information that represents a collection of introductory items for the element's closest ancestral content group. For instance, a <code>header</code> can include the heading, introductory statement and related meta data for a section of content, for instance a <rref>region</rref> or <rref>article</rref>, within a web page.</p>
+				<p>A <code>header</code> does not represent site-oriented or globally repeating content found across multiple pages of a website. For such content, the <rref>banner</rref> role would be more appropriate.</p>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent"><rref>section</rref></td>
+					</tr>
+					<tr>
+						<th class="role-children-head" scope="row">Subclass Roles:</th>
+						<td class="role-children">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"><code>&lt;[^header^]&gt;</code> in HTML</td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"><code>&lt;[^fieldset^]&gt;</code> in HTML</td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Accessibility Parent Roles:</th>
+						<td class="role-scope"> </td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Allowed Accessibility Child Roles:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties"> </td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>


### PR DESCRIPTION
adds proposed header and footer roles to allow authors to identify areas of the page that would fit the more general HTML definition for the elements of the same name (and would not be considered landmark elements).

These would also allow for the respective HTML elements to expose these new roles - essentially 'renamed' group roles - if they are given properties important to accessibility (focusable, named) but are not meeting the conditions to be exposed as banner / contentinfo landmarks.  The alternative is to just expose the elements as groups, which is doable, but arguably also overloads the use of the group role.

Closes #1915

Quick draft of potential mappings for these, which would go into core aam as a new PR if we want to include these roles in ARIA.  Or, if we do not want to include new roles but _still_ want to surface these elements as more than just 'groups' per my above comment, then these mappings could go into HTML AAM for the scenario where they'd apply.

```
MSAA IA2
    Role: ROLE_SYSTEM_GROUPING
    Object Attribute: xml-roles:header

UIA
    Control Type: Group
    Localized Control Type: header

ATK
    Role: ROLE_PANEL
    Object Attribute: xml-roles:header

AX API
    AXRole: AXGroup
    AXSubrole: <nil>
    AXRoleDescription: header

=====

MSAA IA2
    Role: ROLE_SYSTEM_GROUPING
    Object Attribute: xml-roles:footer

UIA
    Control Type: Group
    Localized Control Type: footer

ATK
    Role: ROLE_PANEL
    Object Attribute: xml-roles:footer

AX API
    AXRole: AXGroup
    AXSubrole: <nil>
    AXRoleDescription: footer
```


# PR tracking
Check these when the relevant issue or PR has been made, OR after you have confirmed the
related change is not necessary (add N/A). Leave unchecked if you are unsure. Read the
[Process Document](https://github.com/w3c/aria/wiki/ARIA-WG-Process-Document/_edit) or
[Test Overview](https://github.com/w3c/aria/wiki/ARIA-Test-Overview) for more information.

* [ ] Related Core AAM Issue/PR:
* [ ] Related AccName Issue/PR:
* [ ] Related APG Issue/PR:
* [ ] Any other dependent changes?

# Implementation tracking

* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests:
* [ ] Browser implementations (link to issue or when done, link to commit):
   * WebKit:
   * Gecko:
   * Blink:
* [ ] Does this need AT implementations?
