### PR TITLE
Clarification for exposure of generic elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -3637,7 +3637,8 @@
 			<div class="role-description">
 				<p>A nameless container <a>element</a> that has no semantic meaning on its own.</p>
 				<p>The <code>generic</code> role is intended for use as the implicit role of generic elements in host languages (such as HTML <code>div</code> or <code>span</code>), so is primarily for implementors of user agents. Authors SHOULD NOT use this role in content. Authors MAY use <rref>presentation</rref> or <rref>none</rref> to remove implicit accessibility semantics, or a semantic container role such as <rref>group</rref> to semantically group descendants in a named container.</p>
-				<p>Like an element with role <rref>presentation</rref>, an element with role <code>generic</code> can provide a limited number of accessible states and properties for its descendants, such as <pref>aria-live</pref> attributes. However, unlike elements with role <rref>presentation</rref>, <code>generic</code> elements are exposed in <a>accessibility APIs</a> so that assistive technologies can gather certain properties such as layout and bounds.</p>
+				<p>Like an element with role <rref>presentation</rref>, an element with role <code>generic</code> can provide a limited number of accessible states and properties for its descendants, such as <pref>aria-live</pref> attributes.</p>
+<p>User agents MAY ignore <code>generic</code> elements which do not provide such useful state or properties which assistive technology would find useful to expose. However, unlike elements with role <rref>presentation</rref>, <code>generic</code> elements are exposed in <a>accessibility APIs</a> when such attributes have been specified.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>


### PR DESCRIPTION
closes https://github.com/w3c/html-aam/issues/489

reworded the last paragraph of the generic definition to indicate that it can be ignored when not providing information important to the a11y tree, but if it does provide such information, then the generic element should be exposed.
