### PR TITLE
Editorial: correction for `aria-roledescription` example

### DIFF
--- a/index.html
+++ b/index.html
@@ -12820,7 +12820,7 @@ button.ariaPressed; // null</pre>
 				<pre class="example highlight">&lt;article aria-roledescription="slide" id="slide" aria-labelledby="slideheading"&gt;
 &lt;h1 id="slideheading">Quarterly Report&lt;/h1&gt;
 &lt;!-- remaining slide contents --&gt;
-&lt;/section&gt;</pre>
+&lt;/article&gt;</pre>
 				<p>In the previous examples, a screen reader user might hear "Quarterly Report, slide" rather than the more vague "Quarterly Report, article" or "Quarterly Report, group."</p>
 			</div>
 			<table class="property-features">


### PR DESCRIPTION
Closes #1952 

Editorial change to correct the closing tag used for the `aria-roledescription` example.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jlp-craigmorten/aria/pull/1953.html" title="Last updated on Jun 12, 2023, 4:31 PM UTC (a79a33e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1953/fdfbf10...jlp-craigmorten:a79a33e.html" title="Last updated on Jun 12, 2023, 4:31 PM UTC (a79a33e)">Diff</a>