### PR TITLE
Updated the characteristics table of "caption" role

### DIFF
--- a/index.html
+++ b/index.html
@@ -1760,11 +1760,11 @@
 		<div class="role" id="caption">
 			<rdef>caption</rdef>
 			<div class="role-description">
-				<p>Visible content that names, or describes a <rref>group</rref>, <rref>figure</rref>, <rref>table</rref>, <rref>grid</rref>, <rref>radiogroup</rref>, or <rref>treegrid</rref>.</p>
+				<p>Visible content that names, or describes a <rref>figure</rref>, <rref>grid</rref>, <rref>group</rref>, <rref>radiogroup</rref>, <rref>table</rref> or <rref>treegrid</rref>.</p>
 				<p>When using <code>caption</code> authors SHOULD ensure:</p>
 				<ul>
-					<li>The <code>caption</code> is a descendant of a <rref>group</rref>, <rref>figure</rref>, <rref>grid</rref>, <rref>radiogroup</rref>, <rref>table</rref>, or <rref>treegrid</rref>.</li>
-					<li>The <code>caption</code> is the first non-<code>generic</code> descendant of a <rref>group</rref>, <rref>radiogroup</rref>, <rref>grid</rref>, <rref>table</rref>, or <rref>treegrid</rref>.</li>
+					<li>The <code>caption</code> is a descendant of a <rref>figure</rref>, <rref>grid</rref>, <rref>group</rref>, <rref>radiogroup</rref>, <rref>table</rref>, or <rref>treegrid</rref>.</li>
+					<li>The <code>caption</code> is the first non-<code>generic</code> descendant of a <rref>grid</rref>, <rref>group</rref>, <rref>radiogroup</rref>, <rref>table</rref> or <rref>treegrid</rref>.</li>
 					<li>The <code>caption</code> is the first or last non-<code>generic</code> descendant of a <rref>figure</rref>.</li>
 				</ul>
 				<p>If the <code>caption</code> represents an accessible name for its containing element, authors SHOULD specify <pref>aria-labelledby</pref> on the containing element to reference the element with role <code>caption</code>.</p>
@@ -1864,6 +1864,8 @@
 							<ul>
 								<li><rref>figure</rref></li>
 								<li><rref>grid</rref></li>
+								<li><rref>group</rref></li>
+								<li><rref>radiogroup</rref></li>
 								<li><rref>table</rref></li>
 								<li><rref>treegrid</rref></li>
 							</ul>


### PR DESCRIPTION
Proposal:

while reviewing the specs for the caption role, I've realised that the characteristics table, in particular the "Required Accessibility Parent Roles" row, is not fully reflecting the requirements listed above.

- I've updated the "Required Accessibility Parent Roles" table content, adding also "group" and "radiogroup".
- I've also sorted the list of "Required Accessibility Parent Roles" by alphabetical order (both in text and in table).

Closes: #1974


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/giacomo-petri/aria/pull/1975.html" title="Last updated on Jul 7, 2023, 12:57 PM UTC (c425a48)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1975/fa72d49...giacomo-petri:c425a48.html" title="Last updated on Jul 7, 2023, 12:57 PM UTC (c425a48)">Diff</a>