### PR TITLE
"cell" and "treegrid" roles are the only ones without any reference to the "owned" definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -1921,7 +1921,7 @@
 			<rdef>cell</rdef>
 			<div class="role-description">
 				<p>A cell in a tabular container. See related <rref>gridcell</rref>.</p>
-				<p>Authors MUST ensure [=elements=] with <a>role</a> cell are contained in, or owned by, an element with the <a>role</a> <rref>row</rref>.</p>
+				<p>Authors MUST ensure [=elements=] with <a>role</a> cell are contained in, or [=ARIA/owned=] by, an element with the <a>role</a> <rref>row</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -9883,7 +9883,7 @@
 			<div class="role-description">
 				<p>A <rref>grid</rref> whose rows can be expanded and collapsed in the same manner as for a <rref>tree</rref>.</p>
 				<!-- make sure the following para remains synced with its counterpart in #grid -->
-				<p>If <pref>aria-readonly</pref> is set on an <a>element</a> with <a>role</a> <code>treegrid</code>, [=user agents=] MUST propagate the value to all <rref>gridcell</rref> elements owned by the <code>treegrid</code> and expose the value in the accessibility API. An author MAY override the propagated value of <pref>aria-readonly</pref> for an individual <rref>gridcell</rref> element.</p>
+				<p>If <pref>aria-readonly</pref> is set on an <a>element</a> with <a>role</a> <code>treegrid</code>, [=user agents=] MUST propagate the value to all <rref>gridcell</rref> elements [=ARIA/owned=] by the <code>treegrid</code> and expose the value in the accessibility API. An author MAY override the propagated value of <pref>aria-readonly</pref> for an individual <rref>gridcell</rref> element.</p>
 				<p>When the <pref>aria-readonly</pref> attribute is applied to a focusable <rref>gridcell</rref>, it indicates whether the content contained in the <rref>gridcell</rref> is editable. The <pref>aria-readonly</pref> attribute does not represent availability of functions for navigating or manipulating the <code>treegrid</code> itself.</p>
 				<p>In a <code>treegrid</code> that provides content editing functions, if the content of a focusable <rref>gridcell</rref> element is not editable, authors MAY set <pref>aria-readonly</pref> to <code>true</code> on the <rref>gridcell</rref> element. However, if a <code>treegrid</code> presents a collection of elements that do not support <pref>aria-readonly</pref>, such as a collection of <rref>link</rref> elements, it is not necessary for the author to specify a value for <pref>aria-readonly</pref>.</p>
 				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>


### PR DESCRIPTION
Editorial change

"cell" and "treegrid" roles are the only ones containing "owned by" without any reference to the "owned" definition. For the other roles, there is at list one (usually the 1st one) "owned" anchor to its definition.

Added anchors also to "cell" and "treegrid" roles for a better understanding and comprehension of the requirements.

- https://w3c.github.io/aria/#cell
- https://w3c.github.io/aria/#treegrid

Closes #1976


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/giacomo-petri/aria/pull/1977.html" title="Last updated on Jul 7, 2023, 7:37 PM UTC (6056b29)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/1977/fa72d49...giacomo-petri:6056b29.html" title="Last updated on Jul 7, 2023, 7:37 PM UTC (6056b29)">Diff</a>