### PR TITLE
Updated instances of contradiction regarding focus management

### DIFF
--- a/index.html
+++ b/index.html
@@ -3732,7 +3732,7 @@
 				<p>A composite <rref>widget</rref> containing a collection of one or more rows with one or more cells where some or all cells in the grid are focusable by using methods of two-dimensional navigation, such as directional arrow keys.</p>
 				<p>The <code>grid</code> role does not imply a specific visual, e.g., tabular, presentation. It describes <a>relationships</a> among [=elements=]. It can be used for purposes as simple as grouping a collection of checkboxes or navigation links or as complex as creating a full-featured spreadsheet application.</p>
 				<p>The cell elements of a <code>grid</code> have role <rref>gridcell</rref>. Authors MAY designate a cell as a row or column header by using either the <rref>rowheader</rref> or <rref>columnheader</rref> <a>role</a> in lieu of the <rref>gridcell</rref> role. Authors MUST ensure elements with role <rref>gridcell</rref>, <rref>columnheader</rref>, or <rref>rowheader</rref> are [=ARIA/owned=] by elements with role <rref>row</rref>, which are in turn owned by an element with role <rref>rowgroup</rref>, or <code>grid</code>.</p>
-				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants of a <code>grid</code> as described in <a href="#managingfocus">Managing Focus</a>. When a user is navigating the <code>grid</code> content with a keyboard, authors SHOULD set focus as follows:</p>
+				<p>To be <a>keyboard accessible</a>, authors MUST manage focus of descendants of a <code>grid</code> as described in <a href="#managingfocus">Managing Focus</a>. When a user is navigating the <code>grid</code> content with a keyboard, authors SHOULD set focus as follows:</p>
 				<ul>
 					<li>If a <rref>gridcell</rref> contains a single interactive <rref>widget</rref> that will not consume arrow key presses when it receives focus, such as a <rref>checkbox</rref>, <rref>button</rref>, or <rref>link</rref>, authors MAY set focus on the interactive element contained in that cell. This allows the contained widget to be directly operable.</li>
 					<li>Otherwise, authors SHOULD ensure the element that receives focus is a <rref>gridcell</rref>, <rref>rowheader</rref>, or <rref>columnheader</rref> element.</li>
@@ -4630,7 +4630,7 @@
 			<div class="role-description">
 				<p>A <a>widget</a> that allows the user to select one or more items from a list of choices. See related <rref>combobox</rref> and <rref>list</rref>.</p>
 				<p>Items within the list are static and, unlike standard HTML <code>select</code> [=elements=], can contain images. List boxes contain children whose <a>role</a> is <rref>option</rref> or elements whose <a>role</a> is <rref>group</rref> which in turn contain children whose <a>role</a> is <rref>option</rref>.</p>
-				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of <rref>option</rref> descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
+				<p>To be <a>keyboard accessible</a>, authors MUST manage focus of <rref>option</rref> descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
 				<p>Elements with the role <code>listbox</code> have an implicit <pref>aria-orientation</pref> value of <code>vertical</code>.</p>
 			</div>
 			<table class="role-features">
@@ -5290,7 +5290,7 @@
 			<div class="role-description">
 				<p>A type of <a>widget</a> that offers a list of choices to the user.</p>
 				<p>A menu is often a list of common actions or functions that the user can invoke. The <code>menu</code> <a>role</a> is appropriate when a list of menu items is presented in a manner similar to a menu on a desktop application.</p>
-				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
+				<p>To be <a>keyboard accessible</a>, authors MUST manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
 				<p>Elements with the role <code>menu</code> have an implicit <pref>aria-orientation</pref> value of <code>vertical</code>.</p>
 			</div>
 			<table class="role-features">
@@ -5389,7 +5389,7 @@
 			<div class="role-description">
 				<p>A presentation of <rref>menu</rref> that usually remains visible and is usually presented horizontally.</p>
 				<p>The <code>menubar</code> <a>role</a> is used to create a menu bar similar to those found in Windows, Mac, and Gnome desktop applications. A menu bar is used to create a consistent set of frequently used commands. Authors SHOULD ensure that <code>menubar</code> interaction is similar to the typical menu bar interaction in a desktop graphical user interface.</p>
-				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
+				<p>To be <a>keyboard accessible</a>, authors MUST manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
 				<p>Elements with the role <code>menubar</code> have an implicit <pref>aria-orientation</pref> value of <code>horizontal</code>.</p>
 			</div>
 			<table class="role-features">
@@ -8958,7 +8958,7 @@
 			<rdef>tablist</rdef>
 			<div class="role-description">
 				<p>A list of <rref>tab</rref> [=elements=], which are references to <rref>tabpanel</rref> elements.</p>
-				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
+				<p>To be <a>keyboard accessible</a>, authors MUST manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
 
 				<!-- keep following para synced with its counterpart in #tab -->
 				<p>For a single-selectable <rref>tablist</rref>, authors SHOULD [=element/hide from all users=] other <code>tabpanel</code> [=elements=] until the user selects the tab associated with that tabpanel. For a multi-selectable <rref>tablist</rref>, authors SHOULD ensure that the <rref>tab</rref> for each visible <rref>tabpanel</rref> has the <sref>aria-expanded</sref> <a>attribute</a> set to <code>true</code>, and that the <code>tabs</code> associated with the remaining [=element/hidden from all users=] <code>tabpanel</code> elements have their <sref>aria-expanded</sref> attributes set to <code>false</code>.</p>
@@ -9798,7 +9798,7 @@
 			<rdef>tree</rdef>
 			<div class="role-description">
 				<p>A <rref>widget</rref> that allows the user to select one or more items from a hierarchically organized collection.</p>
-				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
+				<p>To be <a>keyboard accessible</a>, authors MUST manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
 				<p>Elements with the role <code>tree</code> have an implicit <pref>aria-orientation</pref> value of <code>vertical</code>.</p>
 			</div>
 			<table class="role-features">
@@ -9897,7 +9897,7 @@
 				<p>If <pref>aria-readonly</pref> is set on an <a>element</a> with <a>role</a> <code>treegrid</code>, [=user agents=] MUST propagate the value to all <rref>gridcell</rref> elements [=ARIA/owned=] by the <code>treegrid</code> and expose the value in the accessibility API. An author MAY override the propagated value of <pref>aria-readonly</pref> for an individual <rref>gridcell</rref> element.</p>
 				<p>When the <pref>aria-readonly</pref> attribute is applied to a focusable <rref>gridcell</rref>, it indicates whether the content contained in the <rref>gridcell</rref> is editable. The <pref>aria-readonly</pref> attribute does not represent availability of functions for navigating or manipulating the <code>treegrid</code> itself.</p>
 				<p>In a <code>treegrid</code> that provides content editing functions, if the content of a focusable <rref>gridcell</rref> element is not editable, authors MAY set <pref>aria-readonly</pref> to <code>true</code> on the <rref>gridcell</rref> element. However, if a <code>treegrid</code> presents a collection of elements that do not support <pref>aria-readonly</pref>, such as a collection of <rref>link</rref> elements, it is not necessary for the author to specify a value for <pref>aria-readonly</pref>.</p>
-				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
+				<p>To be <a>keyboard accessible</a>, authors MUST manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>


### PR DESCRIPTION
## Summary 

If merged, this PR resolves issue #1987 

## Description

Changed instances where spec contradicted itself with respect to focus management as a responsibility of authors. 

Per managing focus instructions: 

> Authors MUST manage focus on the following container roles:
>
> [grid](https://w3c.github.io/aria/#grid)
> [listbox](https://w3c.github.io/aria/#listbox)
> [menu](https://w3c.github.io/aria/#menu)
> [menubar](https://w3c.github.io/aria/#menubar)
> [radiogroup](https://w3c.github.io/aria/#radiogroup)
> [tree](https://w3c.github.io/aria/#tree)
> [treegrid](https://w3c.github.io/aria/#treegrid)
> [tablist](https://w3c.github.io/aria/#tablist)

I've updated these places where SHOULD was used in the keyboard accessibility sections instead of MUST. 

NOTE: there are still two places where SHOULD was left in, because they are not part of this list: dialog and spinbutton.

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [X] "author MUST" tests: n/a
* [X] "user agent MUST" tests: n/a
* [X] Browser implementations (link to issue or commit): n/a
   * WebKit:
   * Gecko:
   * Blink:
* [ ] ACT review?
* [X] Does this need AT implementations? n/a
* [X] Related APG Issue/PR: n/a
* [X] MDN Issue/PR: n/a


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2015.html" title="Last updated on Jul 17, 2025, 9:16 PM UTC (e956dc6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2015/bf10d80...e956dc6.html" title="Last updated on Jul 17, 2025, 9:16 PM UTC (e956dc6)">Diff</a>