### PR TITLE
Typo issue: accessibility children definition contains wrong li closing tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -13488,8 +13488,8 @@ button.ariaPressed; // null</pre>
           </ul>
           <p>And excludes the following:
           <ul>
-            <li>All DOM elements that have no corresponding <a>accessible object</a> because they have been <a href="#tree_exclusion">excluded from the accessibility tree</a>./li>
-            <li>All DOM elements whose corresponding <a>accessible object</a> have been reparented in the <a>accessibility tree</a> via <pref>aria-owns</pref>./li>
+            <li>All DOM elements that have no corresponding <a>accessible object</a> because they have been <a href="#tree_exclusion">excluded from the accessibility tree</a>.</li>
+            <li>All DOM elements whose corresponding <a>accessible object</a> have been reparented in the <a>accessibility tree</a> via <pref>aria-owns</pref>.</li>
           </ul>
           </p>
           <p>In the following example, the <rref>list</rref> element has four accessibility children:</p>


### PR DESCRIPTION
Closes #2019

While reviewing the accessibility children definition, I've encountered a typo issue (wrong closing li tag).
HTML updated accordingly *(editorial only)*.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/giacomo-petri/aria/pull/2020.html" title="Last updated on Aug 30, 2023, 3:22 PM UTC (b1a4458)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2020/bf10d80...giacomo-petri:b1a4458.html" title="Last updated on Aug 30, 2023, 3:22 PM UTC (b1a4458)">Diff</a>