### PR TITLE
Editorial: add `<menu>` to `list` role

### DIFF
--- a/index.html
+++ b/index.html
@@ -4575,6 +4575,7 @@
 							<ul>
 								<li><code>&lt;[^ol^]&gt;</code> in HTML</li>
 								<li><code>&lt;[^ul^]&gt;</code> in HTML</li>
+								<li><code>&lt;[^menu^]&gt;</code> in HTML</li>
 							</ul>
 						</td>
 					</tr>


### PR DESCRIPTION
From [the Living Standard](https://html.spec.whatwg.org/multipage/grouping-content.html#the-menu-element):

> The [menu](https://html.spec.whatwg.org/multipage/grouping-content.html#the-menu-element) element is simply a semantic alternative to [ul](https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element) to express an unordered list of commands (a "toolbar").

According to [ARIA in HTML](https://w3c.github.io/html-aria/#el-menu), its implicit role is `list`.