### PR TITLE
Editorial: Updated accessibility children example 44 to clarify accessibility children exclusions

### DIFF
--- a/index.html
+++ b/index.html
@@ -13505,7 +13505,7 @@ button.ariaPressed; // null</pre>
   &lt;div role="listitem"&gt;Accessibility Child 4&lt;/div&gt;
 &lt;/div&gt;
           </pre>
-          <p>In the following example, the first <rref>list</rref> element has no accessibility children, where as the second <rref>list</rref> element has one accessibility child, specifically the listitem with ID value "reparented".</p>
+          <p>In the following example, the first <rref>list</rref> element has no accessibility children, where as the second <rref>list</rref> element has one accessibility child, specifically the <rref>listitem</rref> with ID value "reparented".</p>
 	  <pre class="example highlight">
 &lt;div role="list"&gt;
   &lt;div role="listitem" aria-hidden="true"&gt;Excluded element&lt;/div&gt;

--- a/index.html
+++ b/index.html
@@ -13505,7 +13505,7 @@ button.ariaPressed; // null</pre>
   &lt;div role="listitem"&gt;Accessibility Child 4&lt;/div&gt;
 &lt;/div&gt;
           </pre>
-          <p>In the following example, the <rref>list</rref> element has no accessibility children:</p>
+          <p>In the following example, the first <rref>list</rref> element has no accessibility children, where as the second <rref>list</rref> element has one accessibility child, specifically the listitem with ID value "reparented".</p>
 	  <pre class="example highlight">
 &lt;div role="list"&gt;
   &lt;div role="listitem" aria-hidden="true"&gt;Excluded element&lt;/div&gt;

--- a/index.html
+++ b/index.html
@@ -13511,7 +13511,7 @@ button.ariaPressed; // null</pre>
   &lt;div role="listitem" aria-hidden="true"&gt;Excluded element&lt;/div&gt;
   &lt;div role="listitem" id="reparented"&gt;Reparented element&lt;/div&gt;
 &lt;/div&gt;
-&lt;div aria-owns="reparented"&gt;&lt;/div&gt;
+&lt;div role="list" aria-owns="reparented"&gt;&lt;/div&gt;
           </pre>
           <p>The <dfn data-export="" data-lt="accessibility descendant|accessibility descendants">accessibility descendants</dfn> of a DOM element are all DOM elements which correspond to descendants of the corresponding <a>accessible object</a> in the <a class="termref">accessibility tree</a>.</p>
           <p>The <dfn data-export="" data-lt="accessibility parent|parent element|parent">accessibility parent</dfn> of a DOM element is the parent of the corresponding <a>accessible object</a> in the <a>accessibility tree</a>. In terms of the DOM, the accessibility parent is one of the following:</p>


### PR DESCRIPTION
Closes #2021

This PR aims to improve clarity regarding the 2nd exclusion related to the "accessibility children" definition

> All DOM elements whose corresponding [accessible object](https://w3c.github.io/aria/#dfn-accessible-object) have been reparented in the [accessibility tree](https://w3c.github.io/aria/#dfn-accessibility-tree) via [aria-owns](https://w3c.github.io/aria/#aria-owns).

by updating the relevant example, and explicitly confirming that the second list indeed contains one accessibility child.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Sep 7, 2023, 5:27 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fgiacomo-petri%2Faria%2Fa015c7faea5f5181dbadc4175e286719590944cc%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: http://labs.w3.org/spec-generator/uploads/8f0tnv/index.html?isPreview=true%3FisPreview%3Dtrue&publishDate=2023-09-07
ReSpec version: 34.1.6
File a bug: https://github.com/w3c/respec/
Error: undefined

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/aria%232027.)._
</details>
