### PR TITLE
Add statemment about translating in keyshortcuts

### DIFF
--- a/index.html
+++ b/index.html
@@ -12007,7 +12007,7 @@ button.ariaPressed; // null</pre>
 				<p>User agents MUST NOT change keyboard behavior in response to the <code>aria-keyshortcuts</code> attribute. Authors MUST handle scripted keyboard events to process <code>aria-keyshortcuts</code>. The <code>aria-keyshortcuts</code> attribute exposes the existence of these shortcuts so that assistive technologies can communicate this information to users.</p>
 				<p>Authors SHOULD provide a way to expose keyboard shortcuts so that all users can discover them, such as through the use of a tooltip. Authors MUST ensure that <code>aria-keyshortcuts</code> applied to disabled elements are unavailable.</p>
 				<p>Authors SHOULD avoid implementing shortcut keys that inhibit operating system, user agent, or assistive technology functionality. This requires the author to carefully consider both which keys to assign and the contexts and conditions in which the keys are available to the user. For guidance, see the keyboard shortcuts section of the <cite><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite>.</p>
-				<p>If the page is translated authors SHOULD consider whether the keyboard shortcut is valid in the translated language or whether it needs to be changed.</p>
+				<p>Authors SHOULD consider whether the keyboard shortcut will be valid in each language and physical keyboard layout, and consider localizing the shortcut in languages, locales, and common hardware keyboard configurations.</p>
 			</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -12007,6 +12007,7 @@ button.ariaPressed; // null</pre>
 				<p>User agents MUST NOT change keyboard behavior in response to the <code>aria-keyshortcuts</code> attribute. Authors MUST handle scripted keyboard events to process <code>aria-keyshortcuts</code>. The <code>aria-keyshortcuts</code> attribute exposes the existence of these shortcuts so that assistive technologies can communicate this information to users.</p>
 				<p>Authors SHOULD provide a way to expose keyboard shortcuts so that all users can discover them, such as through the use of a tooltip. Authors MUST ensure that <code>aria-keyshortcuts</code> applied to disabled elements are unavailable.</p>
 				<p>Authors SHOULD avoid implementing shortcut keys that inhibit operating system, user agent, or assistive technology functionality. This requires the author to carefully consider both which keys to assign and the contexts and conditions in which the keys are available to the user. For guidance, see the keyboard shortcuts section of the <cite><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite>.</p>
+				<p>If the page is translated authors SHOULD consider whether the keyboard shortcut is valid in the translated language or whether it needs to be changed.</p>
 			</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>


### PR DESCRIPTION
Fixes #1910

Add statemment about translating in keyshortcuts

Not editorial but doesn't require any implementation


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2041.html" title="Last updated on Sep 29, 2023, 11:06 PM UTC (941e380)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2041/bb56584...941e380.html" title="Last updated on Sep 29, 2023, 11:06 PM UTC (941e380)">Diff</a>