### PR TITLE
Editorial: adds new 1.3 translatable attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -10401,8 +10401,11 @@ button.ariaPressed; // null</pre>
 		<p>To be understandable by assistive technology users, the values of the following <a>states</a> and [=ARIA/properties=] are <a data-cite="html/dom.html#translatable-attributes">translatable attributes</a> and should be translated when a page is localized:</p>
 		<ul>
 			<li><pref>aria-label</pref></li>
+			<li><pref>aria-colindextext</pref></li>
+			<li><pref>aria-description</pref></li>
 			<li><pref>aria-placeholder</pref></li>
 			<li><pref>aria-roledescription</pref></li>
+			<li><pref>aria-rowindextext</pref></li>
 			<li><pref>aria-valuetext</pref></li>
 		</ul>
 	</section>

--- a/index.html
+++ b/index.html
@@ -10400,9 +10400,11 @@ button.ariaPressed; // null</pre>
 		<p>The HTML specification states that other specifications can define <a data-cite="html/dom.html#translatable-attributes">translatable attributes</a>. The language and directionality of each attribute value is the same as the <a data-cite="html/dom.html#language">language</a> and <a data-cite="html/dom.html#the-directionality">directionality</a> of the element.</p>
 		<p>To be understandable by assistive technology users, the values of the following <a>states</a> and [=ARIA/properties=] are <a data-cite="html/dom.html#translatable-attributes">translatable attributes</a> and should be translated when a page is localized:</p>
 		<ul>
-			<li><pref>aria-label</pref></li>
+			<li><pref>aria-braillelabel</pref></li>
+			<li><pref>aria-brailleroledescription</pref></li>
 			<li><pref>aria-colindextext</pref></li>
 			<li><pref>aria-description</pref></li>
+			<li><pref>aria-label</pref></li>
 			<li><pref>aria-placeholder</pref></li>
 			<li><pref>aria-roledescription</pref></li>
 			<li><pref>aria-rowindextext</pref></li>


### PR DESCRIPTION
Closes #1316

Adds the new translatable attributes in 1.3 to the section


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2043.html" title="Last updated on Nov 4, 2023, 3:44 AM UTC (0de440c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2043/bb56584...0de440c.html" title="Last updated on Nov 4, 2023, 3:44 AM UTC (0de440c)">Diff</a>