### PR TITLE
Tabpanel relationships - editorial change ("either by ... or by ..." replaced with "by ... and/or by")

### DIFF
--- a/index.html
+++ b/index.html
@@ -9057,7 +9057,7 @@
 			<rdef>tabpanel</rdef>
 			<div class="role-description">
 				<p>A container for the resources associated with a <rref>tab</rref>, where each <rref>tab</rref> is contained in a <rref>tablist</rref>.</p>
-				<p>Authors SHOULD associate a <code>tabpanel</code> <a>element</a> with its <rref>tab</rref>, either by using the <pref>aria-controls</pref> attribute on the tab to reference the tab panel, or by using the  <pref>aria-labelledby</pref> attribute on the tab panel to reference the tab.</p>
+				<p>Authors SHOULD associate a <code>tabpanel</code> <a>element</a> with its <rref>tab</rref>, by using the <pref>aria-controls</pref> attribute on the tab to reference the tab panel, and/or by using the <pref>aria-labelledby</pref> attribute on the tab panel to reference the tab.</p>
 				<!-- keep following para synced with its counterpart in #tablist -->
 				<p><rref>tablist</rref> elements are typically placed near, usually preceding, a series of <rref>tabpanel</rref> elements. See the <cite><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> for details on implementing a tab set design pattern.</p>
 			</div>


### PR DESCRIPTION
Closes #2032

ARIA currently recommends using the "aria-controls" OR "aria-labelledby" attributes to associate a tabpanel element with its tab. According to ARIA best practices, both attributes can and should be used.

Editorial change


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/giacomo-petri/aria/pull/2053.html" title="Last updated on Sep 29, 2023, 9:24 AM UTC (c914ae6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2053/a86496d...giacomo-petri:c914ae6.html" title="Last updated on Sep 29, 2023, 9:24 AM UTC (c914ae6)">Diff</a>