### PR TITLE
Treat undefined and null the same when setting IDL

### DIFF
--- a/index.html
+++ b/index.html
@@ -10312,6 +10312,10 @@
 			<a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> for the attribute.
 			On getting, a missing ARIA attribute will return <code>null</code>. ARIA attributes are not validated on get.
 			If an ARIA value is invalid, on getting, it will return its set value as a literal string, and will not return an invalid value default.</p>
+			<p class="note">
+			Note: Although <a href="#enumerated-attribute-values-html">setting a new value</a> that is nullish (<code>null</code> or <code>undefined</code>) will remove the content attribute,
+			when getting, a missing ARIA attribute will always return <code>null</code>.
+			</p>
 		</section>
 		<section id="os-aapi-attribute-mapping">
 			<h3>Operating System Accessibility API mapping of multi-value ARIA attributes</h3>
@@ -10323,9 +10327,9 @@
 			<h3>ARIA nullable DOMString Attributes</h3>
 			<p>As noted in [[[#typemapping]]], attributes are included in host languages, and the syntax for representation of WAI-ARIA types is governed by the host language.</p>
 			<p>The following algorithm should be used for ARIA nullable {{DOMString}} attributes in HTML:</p>
-			<p>On getting, if the corresponding content attribute is not present, then the IDL attribute must return null,
+			<p>On getting, if the corresponding content attribute is not present, then the IDL attribute must return <code>null</code>,
 			otherwise, the IDL attribute must get the value in a transparent, case-preserving manner.
-			On setting, if the new value is null, the content attribute must be removed, and otherwise,
+			On setting, if the new value is nullish (<code>null</code>code> or <code>undefined</code>), the content attribute must be removed, and otherwise,
 			the content attribute must be set to the specified new value in a transparent, case-preserving manner.</p>
 			<p class="note">
 			Note: As of ARIA 1.2, all ARIA attributes exposed via IDL are defined as nullable {{DOMString}}s. This matches the current implementation of all major rendering engines. This specification change should result in no implementation changes; it will merely represent the current reality of web engines.


### PR DESCRIPTION
Closes #1858

This aligns with the de-facto behavior of Chromium and WebKit on setting ARIA-reflected IDL string attributes.

In short: both `null` and `undefined` remove the attribute during setting, but a missing attribute always returns `null` from the getter. (This too aligns with de-facto Chromium/WebKit behavior.)

[Related bug on Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1853209).

FYI @alice per discussion in AOM meeting.

<!--- IF EDITORIAL or CHORE, delete the rest of this template -->

# PR tracking
Check these when the relevant issue or PR has been made, OR after you have confirmed the
related change is not necessary (add N/A). Leave unchecked if you are unsure. Read the
[Process Document](https://github.com/w3c/aria/wiki/ARIA-WG-Process-Document/_edit) or
[Test Overview](https://github.com/w3c/aria/wiki/ARIA-Test-Overview) for more information.

* [ ] Related Core AAM Issue/PR:
* [ ] Related AccName Issue/PR:
* [ ] Related APG Issue/PR:
* [ ] Any other dependent changes?

# Implementation tracking

* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests:
* [x] Browser implementations (link to issue or when done, link to commit):
   * WebKit (complete):  https://bugs.webkit.org/show_bug.cgi?id=184676
   * Gecko (incomplete): https://bugzilla.mozilla.org/show_bug.cgi?id=1853209
   * Blink (complete): https://bugs.chromium.org/p/chromium/issues/detail?id=844540
* [ ] Does this need AT implementations?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nolanlawson/aria/pull/2057.html" title="Last updated on Oct 6, 2023, 9:23 PM UTC (8a7a48a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2057/9b2a146...nolanlawson:8a7a48a.html" title="Last updated on Oct 6, 2023, 9:23 PM UTC (8a7a48a)">Diff</a>