### PR TITLE
Update right angle bracket for Example 48

### DIFF
--- a/index.html
+++ b/index.html
@@ -13545,7 +13545,7 @@ button.ariaPressed; // null</pre>
 	  <pre class="example highlight">
 &lt;div role="list" aria-owns="child"&gt;&lt;/div&gt;
 &lt;div id="child"&gt;
-  &lt;div&gt; role="listitem"&gt;The "list" is my accessibility parent.&lt;/div&gt;
+  &lt;div role="listitem"&gt;The "list" is my accessibility parent.&lt;/div&gt;
 &lt;/div&gt;
           </pre>
 	</section>


### PR DESCRIPTION
Closes #2060

Fix incorrect placement of the right angle bracket:
`<div> role="listitem">The "list" is my accessibility parent.</div>`

Link: https://w3c.github.io/aria/#example-48

Editorial


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/giacomo-petri/aria/pull/2061.html" title="Last updated on Oct 11, 2023, 1:16 PM UTC (f8c6450)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2061/9b2a146...giacomo-petri:f8c6450.html" title="Last updated on Oct 11, 2023, 1:16 PM UTC (f8c6450)">Diff</a>