### PR TITLE
Editorial: Update lone reference of "alternative text" to "text alternative"

### DIFF
--- a/index.html
+++ b/index.html
@@ -5987,7 +5987,7 @@
 &lt;span&gt; Sample Content &lt;a href="...">let's go!&lt;/a> &lt;/span&gt;
 </pre>
 				<p>In HTML, the <code>&lt;img&gt;</code> <a>element</a> is treated as a single entity regardless of the type of image file. Consequently, using <code>role="none"</code> or <code>role="presentation"</code> on an HTML <code>img</code> is equivalent to using <code>aria-hidden="true"</code>. In order to make the image contents accessible, authors can embed the object using an <code>&lt;object&gt;</code> or <code>&lt;iframe&gt;</code> <a>element</a>, or use inline <abbr title="Scalable Vector Graphics">SVG</abbr> code, and follow the accessibility guidelines for the image content.</p>
-				<p>Authors SHOULD NOT provide meaningful alternative text (for example, use <code>alt=""</code> in HTML) when the <code>none</code>/<code>presentation</code> role is applied to an image.</p>
+				<p>Authors SHOULD NOT provide a meaningful text alternative (for example, use <code>alt=""</code> in HTML) when the <code>none</code>/<code>presentation</code> role is applied to an image.</p>
 				<p>In the following code sample, the containing <rref>img</rref> and is appropriately labeled by the caption paragraph. In this example the <code>img</code> element can be marked as <rref>none</rref>/<rref>presentation</rref> because the role and the text alternatives are provided by the containing element.</p>
 				<pre class="example highlight">&lt;div role="img" aria-labelledby="caption"&gt;
   &lt;img src="example.png" role="none" alt=""&gt;


### PR DESCRIPTION
Closes [#2059](https://github.com/w3c/aria/issues/2059) 

In ARIA 1.2, there is a single reference to "alternative text" in the `presentation` role description section however, all other instances in the spec use the term "text alternative". For consistency, this PR updates the lone instance of "alternative text" to "text alternative".

**NOTE**: This aligns with WCAG which has no instances of the term "alternative text".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2062.html" title="Last updated on Oct 19, 2023, 5:27 PM UTC (d50c04d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2062/75f7ad7...d50c04d.html" title="Last updated on Oct 19, 2023, 5:27 PM UTC (d50c04d)">Diff</a>