### PR TITLE
Editorial: move img def to image

### DIFF
--- a/index.html
+++ b/index.html
@@ -4115,6 +4115,7 @@
 			<rdef>image</rdef>
 			<div class="role-description">
 				<p>A container for a collection of [=elements=] that form an image. See synonym <rref>img</rref>.</p>
+				<p>An <code>img</code> can contain captions and descriptive text, as well as multiple image files that when viewed together give the impression of a single image. An <code>img</code> represents a single graphic within a document, whether or not it is formed by a collection of drawing <a>objects</a>. In order for an element with a <a>role</a> of <code>img</code> to be <a>perceivable</a>, authors MUST provide the element with an <a class="informative">accessible name</a>. This can be done using the <pref>aria-label</pref> or <pref>aria-labelledby</pref> attribute.</p>
 				<div class="note" id="role-image-note-image">
 					Note regarding the ARIA 1.3 <code>image</code> role.
 					<p>The <code>image</code> was added to ARIA in version 1.3 as a
@@ -4128,7 +4129,6 @@
 			<rdef>img</rdef>
 			<div class="role-description">
 				<p>A container for a collection of [=elements=] that form an image. See synonym <rref>image</rref>.</p>
-				<p>An <code>img</code> can contain captions and descriptive text, as well as multiple image files that when viewed together give the impression of a single image. An <code>img</code> represents a single graphic within a document, whether or not it is formed by a collection of drawing <a>objects</a>. In order for an element with a <a>role</a> of <code>img</code> to be <a>perceivable</a>, authors MUST provide the element with an <a class="informative">accessible name</a>. This can be done using the <pref>aria-label</pref> or <pref>aria-labelledby</pref> attribute.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>

--- a/index.html
+++ b/index.html
@@ -4118,17 +4118,11 @@
 				<p>An <code>img</code> can contain captions and descriptive text, as well as multiple image files that when viewed together give the impression of a single image. An <code>img</code> represents a single graphic within a document, whether or not it is formed by a collection of drawing <a>objects</a>. In order for an element with a <a>role</a> of <code>img</code> to be <a>perceivable</a>, authors MUST provide the element with an <a class="informative">accessible name</a>. This can be done using the <pref>aria-label</pref> or <pref>aria-labelledby</pref> attribute.</p>
 				<div class="note" id="role-image-note-image">
 					Note regarding the ARIA 1.3 <code>image</code> role.
-					<p>The <code>image</code> was added to ARIA in version 1.3 as a
+					<p>The <code>image</code> role was added to ARIA in version 1.3 as a
 					synonym of the ARIA 1.0 <rref>img</rref> role. The <code>image</code>
 					role improves syntactic consistency with the names of other roles,
 					which are complete words or concatenations of complete words.</p>
 				</div>
-			</div>
-		</div>
-		<div class="role" id="img">
-			<rdef>img</rdef>
-			<div class="role-description">
-				<p>A container for a collection of [=elements=] that form an image. See synonym <rref>image</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4158,7 +4152,6 @@
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
 						<td class="role-related"><code>&lt;[^img^]&gt;</code> in HTML</td>
-
 					</tr>
 					<tr>
 						<th class="role-scope-head" scope="row">Required Accessibility Parent Roles:</th>
@@ -4202,6 +4195,12 @@
 					</tr>
 				</tbody>
 			</table>
+		</div>
+		<div class="role" id="img">
+			<rdef>img</rdef>
+			<div class="role-description">
+				<p>A container for a collection of [=elements=] that form an image. See synonym <rref>image</rref>.</p>
+			</div>
 		</div>
 		<div class="role" id="input">
 			<rdef>input</rdef>


### PR DESCRIPTION
closes #1456 

moves the primary image definition text from the `img` role to the `image` role, as this is meant to serve as the new primary role between the two.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2076.html" title="Last updated on Nov 9, 2023, 8:51 PM UTC (235115f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2076/bb6baf1...235115f.html" title="Last updated on Nov 9, 2023, 8:51 PM UTC (235115f)">Diff</a>