### PR TITLE
Update "Hidden from all users" term definition's prepositional usage ("to"->"for")

### DIFF
--- a/common/terms.html
+++ b/common/terms.html
@@ -85,7 +85,7 @@
     </dd>
     <dt><dfn>Hidden</dfn></dt>
     <dd>
-        <p>Indicates that the <a>element</a> is not visible, <a>perceivable</a>, or interactive to <em>any</em> user. An element is considered <em>hidden</em> if it or any one of its ancestor elements is not rendered or is explicitly hidden.</p>
+        <p>Indicates that the <a>element</a> is not visible, <a>perceivable</a>, or interactive for <em>any</em> user. An element is considered <em>hidden</em> if it or any one of its ancestor elements is not rendered or is explicitly hidden.</p>
     </dd>
     <dt><dfn data-lt="informative|non-normative">Informative</dfn></dt>
     <dd>

--- a/common/terms.html
+++ b/common/terms.html
@@ -85,7 +85,7 @@
     </dd>
     <dt><dfn>Hidden</dfn></dt>
     <dd>
-        <p>Indicates that the <a>element</a> is not visible, <a>perceivable</a>, or interactive for <em>any</em> user. An element is considered <em>hidden</em> if it or any one of its ancestor elements is not rendered or is explicitly hidden.</p>
+        <p>Indicates that the <a>element</a> is not visible, <a>perceivable</a>, or interactive to <em>any</em> user. An element is considered <em>hidden</em> if it or any one of its ancestor elements is not rendered or is explicitly hidden.</p>
     </dd>
     <dt><dfn data-lt="informative|non-normative">Informative</dfn></dt>
     <dd>

--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@
 			  <p>Related: <a href="#tree_exclusion">Excluding Elements in the Accessibility Tree</a>, [=element/hidden from all users=], <sref>aria-hidden</sref>.<p>
 			<dt><dfn data-dfn-for="element" data-lt="hide from all users" data-export="">Hidden From All Users</dfn></dt>
 			<dd>
-			  <p>Indicates that the <a>element</a> is not visible, <a>perceivable</a>, or interactive to <em>any</em> user. Note that an <a>element</a> can be [=element/hidden=] but not [=element/hidden from all users=] by using <code>aria-hidden</code>.</p>
+			  <p>Indicates that the <a>element</a> is not visible, <a>perceivable</a>, or interactive for <em>any</em> user. Note that an <a>element</a> can be [=element/hidden=] but not [=element/hidden from all users=] by using <code>aria-hidden</code>.</p>
 			  <p>Related: <a href="#tree_exclusion">Excluding Elements in the Accessibility Tree</a>, [=element/hidden=], <sref>aria-hidden</sref>.<p>
 			</dd>
 			<dt><dfn>Identifies</dfn></dt>


### PR DESCRIPTION
The current v1.3 ARIA editor's draft states the following for the ["Hidden From All Users"](https://w3c.github.io/aria/#dfn-hide-from-all-users) term definition: 

> Indicates that the [element](https://dom.spec.whatwg.org/#concept-element) is not visible, [perceivable](https://w3c.github.io/aria/#dfn-perceivable), or interactive to any user.

Proposing the following update changing the word "to" to "for" which may be the more appropriate/grammatically correct preposition to use:

> Indicates that the [element](https://dom.spec.whatwg.org/#concept-element) is not visible, [perceivable](https://w3c.github.io/aria/#dfn-perceivable), or interactive for any user.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2080.html" title="Last updated on Nov 16, 2023, 11:11 PM UTC (6c0dff7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2080/5bd87f4...6c0dff7.html" title="Last updated on Nov 16, 2023, 11:11 PM UTC (6c0dff7)">Diff</a>