### PR TITLE
Remove group as allowed child of tree

### DIFF
--- a/index.html
+++ b/index.html
@@ -9827,10 +9827,7 @@
 					<tr>
 						<th class="role-mustcontain-head" scope="row">Allowed Accessibility Child Roles:</th>
 						<td class="role-mustcontain">
-							<ul>
-								<li><rref>group</rref> with <a>accessibility child</a> <rref>treeitem</rref></li>
-								<li><rref>treeitem</rref></li>
-							</ul>
+							<li><rref>treeitem</rref></li>
 						</td>
 					</tr>
 					<tr>


### PR DESCRIPTION
Closes #2014

Removes group as an allowed accessibility child of tree to fix inconsistency with definition of treeitem. Direct children of tree can only be parent nodes or end nodes. Leaf nodes must be a child of a group that is a child of a parent node treitem. Even in a virtualized tree, if the elements that represent the ancestry of rendered nodes were not present in the DOM, the tree would be inoperable.

# PR tracking
Check these when the relevant issue or PR has been made, OR after you have confirmed the
related change is not necessary (add N/A). Leave unchecked if you are unsure. Read the
[Process Document](https://github.com/w3c/aria/wiki/ARIA-WG-Process-Document/_edit) or
[Test Overview](https://github.com/w3c/aria/wiki/ARIA-Test-Overview) for more information.

* [x] Related Core AAM Issue/PR: not required
* [x] Related AccName Issue/PR: not required
* [x] Related APG Issue/PR: not required

# Implementation tracking

* [x] "author MUST" tests: https://github.com/act-rules/act-rules.github.io/issues/2309
* [x] "user agent MUST" tests: not required
* [x] Browser implementations: not required
* [x] Does this need AT implementations? no


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2094.html" title="Last updated on Feb 14, 2025, 8:49 AM UTC (694277d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2094/b5a3d7f...694277d.html" title="Last updated on Feb 14, 2025, 8:49 AM UTC (694277d)">Diff</a>