### PR TITLE
editorial: split out security and privacy sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -13741,8 +13741,11 @@ el.getAttribute("aria-label"); // Returns "Publish"</pre>
 
 </section>
 <section class="informative">
-	<h2>Privacy and Security Considerations</h2>
+	<h2>Security Considerations</h2>
 	<p>This specification introduces no new security considerations.</p>
+</section>
+<section>
+	<h2>Privacy Considerations</h2>
 	<p>In accordance with <a data-cite="design-principles#do-not-expose-use-of-assistive-tech">Web Platform Design Principles</a>, this specification provides no programmatic interface to determine if information is being used by Assistive Technologies. However, this specification does allow an author to present different information to users of Assistive Technologies from the information available to users who do not use Assistive Technologies. This is possible using many features of the ARIA specification, just as this is possible using many other parts of the web technology stack. This content disparity could be abused to perform <a data-cite="fingerprinting-guidance#active-0">active fingerprinting</a> of users of Assistive Technologies.</p>
 </section>
 <section class="informative appendix" id="typemapping">

--- a/index.html
+++ b/index.html
@@ -13744,7 +13744,7 @@ el.getAttribute("aria-label"); // Returns "Publish"</pre>
 	<h2>Security Considerations</h2>
 	<p>This specification introduces no new security considerations.</p>
 </section>
-<section>
+<section class="informative">
 	<h2>Privacy Considerations</h2>
 	<p>In accordance with <a data-cite="design-principles#do-not-expose-use-of-assistive-tech">Web Platform Design Principles</a>, this specification provides no programmatic interface to determine if information is being used by Assistive Technologies. However, this specification does allow an author to present different information to users of Assistive Technologies from the information available to users who do not use Assistive Technologies. This is possible using many features of the ARIA specification, just as this is possible using many other parts of the web technology stack. This content disparity could be abused to perform <a data-cite="fingerprinting-guidance#active-0">active fingerprinting</a> of users of Assistive Technologies.</p>
 </section>


### PR DESCRIPTION
Fixes #2098
 Splits Privacy and security considerations per w3c requirements


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2099.html" title="Last updated on Jan 6, 2024, 6:27 AM UTC (704c8d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2099/e574d25...704c8d0.html" title="Last updated on Jan 6, 2024, 6:27 AM UTC (704c8d0)">Diff</a>