### PR TITLE
clarifying existing live region announcement behavior on creation/rendering of new live regions

### DIFF
--- a/index.html
+++ b/index.html
@@ -851,6 +851,7 @@
 		<section id="live_region_roles">
 			<h3>Live Region Roles</h3>
 			<p>The following <a>roles</a> are <a>live regions</a> and can be modified by <a href="#attrs_liveregions">live region attributes</a>.</p>
+			<p>Typically, assistive technology only speaks <em>changes</em> to a live region, not the initial contents of a live region. To ensure content in a live region is announced, authors SHOULD create an rendered but empty live region as early as possible (such as on page load), and then add content to the live region when the author wishes it to be announced. The exception to this live region convention is <code>alert</code>, due to system accessiblity notifications events required for the role. While an <rref>alert</rref> is a live region, its content is announced by assistive technology when the alert is rendered on the page and when the content changes.</p>
 			<ul>
 				<li><rref>alert</rref></li>
 				<li><rref>log</rref></li>
@@ -877,8 +878,8 @@
 			<rdef>alert</rdef>
 			<div class="role-description">
 				<p>A type of <a>live region</a> with important, and usually time-sensitive, information. See related <rref>alertdialog</rref> and <rref>status</rref>.</p>
-				<p>Alerts are used to convey messages that might be immediately important to users. In the case of audio warnings, alerts provide an accessible alternative for hearing-impaired users. The <code>alert</code> <a>role</a> is applied to the element containing the alert message. An <code>alert</code> is a specialized form of the <rref>status</rref> role, which is processed as an atomic <a>live region</a>.</p>
-				<p>Alerts are assertive live regions, which means they cause immediate notification for assistive technology users. If the operating system allows, the <a>user agent</a> SHOULD fire a system alert <a>event</a> through the accessibility API when the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> alert is created.</p>
+				<p>Alerts are used to convey messages that will be immediately important to users. In the case of audio warnings, alerts provide an accessible alternative for Deaf or hard-of-hearing users. The <code>alert</code> <a>role</a> is applied to the element containing the alert message.</p>
+				<p>Alert is a special type of assertive live region that is intended to cause immediate notification for assistive technology users. If the operating system allows, the <a>user agent</a> SHOULD fire a system alert <a>event</a> through the accessibility API when the alert is rendered.</p>
 				<p>Neither authors nor user agents are required to set or manage focus to an alert in order for it to be processed. Since alerts are not required to receive focus, authors SHOULD NOT require users to close an alert. If an author desires focus to move to a message when it is conveyed, the author SHOULD use <rref>alertdialog</rref> instead of <code>alert</code>.</p>
 				<p>Elements with the role <code>alert</code> have an implicit <pref>aria-live</pref> value of <code>assertive</code>, and an implicit <pref>aria-atomic</pref> value of <code>true</code>.</p>
 			</div>
@@ -966,6 +967,7 @@
 			<div class="role-description">
 				<p>A type of dialog that contains an alert message, where initial focus goes to an <a>element</a> within the dialog. See related <rref>alert</rref> and <rref>dialog</rref>.</p>
 				<p>Alert dialogs are used to convey messages to alert the user. The <code>alertdialog</code> <a>role</a> goes on the [=nodes|node=] containing both the alert message and the rest of the dialog. Content authors SHOULD make alert dialogs modal by ensuring that, while the <code>alertdialog</code> is shown, keyboard and mouse interactions only operate within the dialog. See <pref>aria-modal</pref>.</p>
+				<p>Alertdialog is a special type of dialog that is intended to cause an immediate, alert-level notification for assistive technology users. If the operating system allows, the <a>user agent</a> SHOULD fire a system alert <a>event</a> through the accessibility API when the alerdialog is rendered.</p>
 				<p>Unlike <rref>alert</rref>, <code>alertdialog</code> can receive a response from the user. For example, to confirm that the user understands the alert being generated. When the alert dialog is displayed, authors SHOULD set focus to an active element within the alert dialog, such as a form control or confirmation button. The <a>user agent</a> SHOULD fire a system alert <a>event</a> through the accessibility API when the alert is created, provided one is specified by the intended <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a>.</p>
 				<p>Authors SHOULD use <pref>aria-describedby</pref> on an <code>alertdialog</code> to reference the alert message element in the dialog. If they do not, an <a>assistive technology</a> can resort to its internal recovery mechanism to determine the contents of the alert message.</p>
 			</div>


### PR DESCRIPTION
Closes #1216

Codifies existing UA behavior for live regions, especially in the context of creation and initial rendering, where only `alert` live regions are announced.

<!--- IF EDITORIAL or CHORE, delete the rest of this template -->

# PR tracking
Check these when the relevant issue or PR has been made, OR after you have confirmed the
related change is not necessary (add N/A). Leave unchecked if you are unsure. Read the
[Process Document](https://github.com/w3c/aria/wiki/ARIA-WG-Process-Document/_edit) or
[Test Overview](https://github.com/w3c/aria/wiki/ARIA-Test-Overview) for more information.

* [x] Related Core AAM Issue/PR: N/A
* [x] Related AccName Issue/PR: N/A
* [x] Any other dependent changes? None

# Test, Documentation and Implementation tracking
Once this PR and all related PRs have been been approved by the working group, tests
should be written and issues should be opened on browsers. Add N/A and check when not
applicable.

* [x] WPT Tests: Not yet testable.
* [x] Does this need AT implementations? No.
