### PR TITLE
Editorial: Clarification of Combobox Role and aria-haspopup Attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -2060,7 +2060,7 @@
 				Authors MUST set <sref>aria-expanded</sref> to <code>true</code> on an element with role <code>combobox</code> when it is expanded and <code>false</code> when it is collapsed.
 				</p>
 				<p>
-				Elements with the role <code>combobox</code> have an implicit <pref>aria-haspopup</pref> value of <code>listbox</code>. If the <code>combobox</code> popup element has a role other than <rref>listbox</rref>, authors MUST specify a value of <rref>tree</rref>, <rref>grid</rref>, or <rref>dialog</rref>, for <pref>aria-haspopup</pref> that corresponds to the role of its popup.
+				Elements with the role <code>combobox</code> have an implicit <pref>aria-haspopup</pref> value of <code>listbox</code>. If the <code>combobox</code> popup element has a role other than <rref>listbox</rref>, authors MUST specify an <pref>aria-haspopup</pref> value of <rref>tree</rref>, <rref>grid</rref>, or <rref>dialog</rref> that corresponds to the role of its popup.
 				</p>
 				<p>
 				If the user interface includes an additional icon that allows the visibility of the popup to be controlled via pointer and touch events, authors SHOULD ensure that element has role <rref>button</rref>, that it is focusable but not included in the page <kbd>Tab</kbd> sequence, and that it is not a descendant of the element with role <code>combobox</code>.

--- a/index.html
+++ b/index.html
@@ -2060,12 +2060,7 @@
 				Authors MUST set <sref>aria-expanded</sref> to <code>true</code> on an element with role <code>combobox</code> when it is expanded and <code>false</code> when it is collapsed.
 				</p>
 				<p>
-				Authors MUST ensure the popup element associated with a <code>combobox</code> has a role of <rref>listbox</rref>, <rref>tree</rref>, <rref>grid</rref>, or <rref>dialog</rref>.
-				When the popup is displayed, authors MUST set <pref>aria-controls</pref> on a <code>combobox</code> element to a value that refers to the <code>combobox</code> popup element.
-				</p>
-				<p>
-				Elements with the role <code>combobox</code> have an implicit <pref>aria-haspopup</pref> value of <code>listbox</code>.
-				If the <code>combobox</code> popup element has a role other than <rref>listbox</rref>, authors MUST specify a value for <pref>aria-haspopup</pref> that corresponds to the role of its popup.
+				Elements with the role <code>combobox</code> have an implicit <pref>aria-haspopup</pref> value of <code>listbox</code>. If the <code>combobox</code> popup element has a role other than <rref>listbox</rref>, authors MUST specify a value of <rref>tree</rref>, <rref>grid</rref>, or <rref>dialog</rref>, for <pref>aria-haspopup</pref> that corresponds to the role of its popup.
 				</p>
 				<p>
 				If the user interface includes an additional icon that allows the visibility of the popup to be controlled via pointer and touch events, authors SHOULD ensure that element has role <rref>button</rref>, that it is focusable but not included in the page <kbd>Tab</kbd> sequence, and that it is not a descendant of the element with role <code>combobox</code>.


### PR DESCRIPTION
… Requirements #2132

Closes #2132

The current specification text has two separate paragraphs describing the aria-haspopup attribute value requirements on a combobox—which are essentially the same. These have a conflict on the MUST use of aria-haspopup that pops up a Listbox. The proposed amendment aims to merge these paragraphs to enhance clarity, ensuring a clear understanding between the role combobox and the aria-haspopup values.

+@KateZhaoTR


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/LaurenceRLewis/aria/pull/2134.html" title="Last updated on Mar 1, 2024, 5:47 AM UTC (37fa11e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2134/7508624...LaurenceRLewis:37fa11e.html" title="Last updated on Mar 1, 2024, 5:47 AM UTC (37fa11e)">Diff</a>