### PR TITLE
Adds support for posinset/setsize in toolbars

### DIFF
--- a/index.html
+++ b/index.html
@@ -1401,6 +1401,7 @@
 				<p>An input that allows for user-triggered actions when clicked or pressed. See related <rref>link</rref>.</p>
 				<p>Buttons are mostly used for discrete actions. Standardizing the appearance of buttons enhances the user's recognition of the <a>widgets</a> as buttons and allows for a more compact display in toolbars.</p>
 				<p>Buttons support the optional <a>attribute</a> <sref>aria-pressed</sref>. Buttons with a non-empty <sref>aria-pressed</sref> attribute are toggle buttons. When <sref>aria-pressed</sref> is <code>true</code> the button is in a "pressed" <a>state</a>, when <sref>aria-pressed</sref> is <code>false</code> it is not pressed. If the attribute is not present, the button is a simple command button.</p>
+                <p>Authors MAY set <pref>aria-setsize</pref> and <a>aria-posinset</a> on elements with this role when they are <a>accessibility children</a> of <rref>toolbar</rref> with only elements with a <rref>group</rref> role intervening.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -1452,7 +1453,9 @@
 								<li><sref>aria-disabled</sref></li>
 								<li><pref>aria-haspopup</pref></li>
 								<li><sref>aria-expanded</sref></li>
+                                <li><pref>aria-posinset</pref></li>
 								<li><sref>aria-pressed</sref></li>
+                                <li><pref>aria-setsize</pref></li>
 							</ul>
 						</td>
 					</tr>
@@ -1748,6 +1751,7 @@
 			<div class="role-description">
 				<p>A checkable input that has three possible <span>values</span>: <code>true</code>, <code>false</code>, or <code>mixed</code>.</p>
 				<p>The <sref>aria-checked</sref> <a>attribute</a> of a <code>checkbox</code> indicates whether the input is checked (<code>true</code>), unchecked (<code>false</code>), or represents a group of [=elements=] that have a mixture of checked and unchecked values (<code>mixed</code>). Many checkboxes do not use the <code>mixed</code> value, and thus are effectively boolean checkboxes.</p>
+                <p>Authors MAY set <pref>aria-setsize</pref> and <a>aria-posinset</a> on elements with this role when they are <a>accessibility children</a> of <rref>toolbar</rref> with only elements with a <rref>group</rref> role intervening.</p>
 				<p class="note">
 					Due to the strong native semantics of HTML's native checkbox, authors are advised against using <code>aria-checked</code> on an <code>input type=checkbox</code>. Rather, use the native <code>checked</code> attribute or the <code>indeterminate</code> IDL attribute to specify the checkbox's "checked" or "mixed" state, respectively.
 				</p>
@@ -1809,8 +1813,10 @@
 								<li><pref>aria-errormessage</pref></li>
 								<li><sref>aria-expanded</sref></li>
 								<li><sref>aria-invalid</sref></li>
+                                <li><pref>aria-posinset</pref></li>
 								<li><pref>aria-readonly</pref></li>
 								<li><pref>aria-required</pref></li>
+                                <li><pref>aria-setsize</pref></li>
 							</ul>
 						</td>
 					</tr>
@@ -4185,6 +4191,7 @@
 			<div class="role-description">
 				<p>An interactive reference to an internal or external resource that, when activated, causes the user agent to navigate to that resource. See related <rref>button</rref>.</p>
 				<p>If this is a native link in the host language (such as an HTML anchor with an <code>href</code> value), activating the link causes the <a>user agent</a> to navigate to that resource. If this is a simulated link, the web application author is responsible for managing navigation.</p>
+                <p>Authors MAY set <pref>aria-setsize</pref> and <a>aria-posinset</a> on elements with this role when they are <a>accessibility children</a> of <rref>toolbar</rref> with only elements with a <rref>group</rref> role intervening.</p>
 				<p class="note">If pressing the link triggers an action but does not change browser focus or page location, authors are advised to consider using the <rref>button</rref> role instead of the <code>link</code> role.</p>
 			</div>
 			<table class="role-features">
@@ -4240,6 +4247,8 @@
 								<li><sref>aria-disabled</sref></li>
 								<li><sref>aria-expanded</sref></li>
 								<li><pref>aria-haspopup</pref></li>
+                                <li><pref>aria-posinset</pref></li>
+                                <li><pref>aria-setsize</pref></li>
 							</ul>
 						</td>
 					</tr>
@@ -6267,6 +6276,7 @@
 				</p>
 				<p>The author SHOULD supply a <span>value</span> for <pref>aria-valuenow</pref> unless the value is indeterminate, in which case the author SHOULD omit the <pref>aria-valuenow</pref> attribute.
 				Authors SHOULD update this value when the visual progress indicator is updated. If the <code>progressbar</code> is describing the loading progress of a particular region of a page, authors SHOULD both use <pref>aria-describedby</pref> to reference the progressbar status, and set the <sref>aria-busy</sref> attribute to <code>true</code> on the region until it is finished loading. It is not possible for the user to alter the value of a <code>progressbar</code> because it is always read-only.</p>
+                <p>Authors MAY set <pref>aria-setsize</pref> and <a>aria-posinset</a> on elements with this role when they are <a>accessibility children</a> of <rref>toolbar</rref> with only elements with a <rref>group</rref> role intervening.</p>
 				<p class="note">Assistive technologies generally will render the value of <pref>aria-valuenow</pref> as a percent of a range between the value of <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref>, unless <pref>aria-valuetext</pref> is specified.</p>
 			</div>
 			<table class="role-features">
@@ -6317,7 +6327,12 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"> </td>
+						<td class="role-properties">
+                            <ul>
+                                <li><pref>aria-posinset</pref></li>
+                                <li><pref>aria-setsize</pref></li>
+                            </ul>
+                        </td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -7264,6 +7279,7 @@
 			<rdef>searchbox</rdef>
 			<div class="role-description">
 				<p>A type of textbox intended for specifying search criteria. See related <rref>textbox</rref> and <rref>search</rref>.</p>
+                <p>Authors MAY set <pref>aria-setsize</pref> and <a>aria-posinset</a> on elements with this role when they are <a>accessibility children</a> of <rref>toolbar</rref> with only elements with a <rref>group</rref> role intervening.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -7300,7 +7316,12 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"> </td>
+						<td class="role-properties">
+                            <ul>
+                                <li><pref>aria-posinset</pref></li>
+                                <li><pref>aria-setsize</pref></li>
+                            </ul>
+                        </td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -7557,6 +7578,7 @@
 				</ul>
 				<p>In applications where there is more than one focusable <code>separator</code>, authors SHOULD provide an accessible name for each one.</p>
 				<p>Elements with the role <code>separator</code> have an implicit <pref>aria-orientation</pref> value of <code>horizontal</code>.</p>
+                <p>If the <code>separator</code> is focusable, authors MAY set <pref>aria-setsize</pref> and <a>aria-posinset</a> on elements with this role when they are <a>accessibility children</a> of <rref>toolbar</rref> with only elements with a <rref>group</rref> role intervening.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -7610,6 +7632,8 @@
 							<ul>
 								<li><sref>aria-disabled</sref> (if focusable)</li>
 								<li><pref>aria-orientation</pref></li>
+                                <li><pref>aria-posinset</pref> (if focusable)</li>
+                                <li><pref>aria-setsize</pref> (if focusable)</li>
 								<li><pref>aria-valuemax</pref> (if focusable)</li>
 								<li><pref>aria-valuemin</pref> (if focusable)</li>
 								<li><pref>aria-valuetext</pref> (if focusable)</li>
@@ -7663,6 +7687,7 @@
 				</ul>
 				<p>Authors MUST set the <pref>aria-valuenow</pref> attribute. If aria-valuenow is missing or has an unexpected value, browsers MAY implement the repair techniques specified in the <a href="#authorErrorDefaultValuesTable">section describing handling author errors in states and properties</a>, which are equivalent to the repair techniques for <code>&lt;input type="[^input/type/range^]"&gt;</code> in HTML.</p>
 				<p>Elements with the role <code>slider</code> have an implicit <pref>aria-orientation</pref> value of <code>horizontal</code>.</p>
+                <p>Authors MAY set <pref>aria-setsize</pref> and <a>aria-posinset</a> on elements with this role when they are <a>accessibility children</a> of <rref>toolbar</rref> with only elements with a <rref>group</rref> role intervening.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -7720,7 +7745,9 @@
 								<li><pref>aria-haspopup</pref></li>
 								<li><sref>aria-invalid</sref></li>
 								<li><pref>aria-orientation</pref></li>
+                                <li><pref>aria-posinset</pref></li>
 								<li><pref>aria-readonly</pref></li>
+                                <li><pref>aria-setsize</pref></li>
 								<li><pref>aria-valuemax</pref></li>
 								<li><pref>aria-valuemin</pref></li>
 							</ul>
@@ -7770,6 +7797,7 @@
 				<p>Authors MAY create a <code>spinbutton</code> with <a>accessibility children</a>, but MUST limit those elements to a <rref>textbox</rref> and/or two <rref title="button">buttons</rref>. Alternatively, authors MAY apply the <rref>spinbutton</rref> role to a text input and create sibling buttons to support the increment and decrement functions.</p>
 				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>. When a <code>spinbutton</code> receives focus, authors SHOULD ensure focus is placed on the <rref>textbox</rref> element if one is present, and on the <code>spinbutton</code> itself otherwise. Authors SHOULD also ensure the <kbd>up</kbd> and <kbd>down</kbd> arrows on a keyboard perform the increment and decrement functions and that the increment and decrement <rref>button</rref> elements are <em>NOT</em> included in the primary navigation ring, e.g., the Tab ring in HTML.</p>
 				<p>Authors SHOULD set the <pref>aria-valuenow</pref> attribute when the <rref>spinbutton</rref> has a value. Authors SHOULD set the <pref>aria-valuemin</pref> attribute when there is a minimum value, and the <pref>aria-valuemax</pref> attribute when there is a maximum value.</p>
+                <p>Authors MAY set <pref>aria-setsize</pref> and <a>aria-posinset</a> on elements with this role when they are <a>accessibility children</a> of <rref>toolbar</rref> with only elements with a <rref>group</rref> role intervening.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -7824,8 +7852,10 @@
 							<ul>
 								<li><pref>aria-errormessage</pref></li>
 								<li><sref>aria-invalid</sref></li>
+                                <li><pref>aria-posinset</pref></li>
 								<li><pref>aria-readonly</pref></li>
 								<li><pref>aria-required</pref></li>
+                                <li><pref>aria-setsize</pref></li>
 								<li><pref>aria-valuemax</pref></li>
 								<li><pref>aria-valuemin</pref></li>
 								<li><pref>aria-valuenow</pref></li>
@@ -8401,6 +8431,7 @@
 			<div class="role-description">
 				<p>A type of checkbox that represents on/off values, as opposed to checked/unchecked values. See related <rref>checkbox</rref>.</p>
 				<p>The <sref>aria-checked</sref> <a>attribute</a> of a <code>switch</code> indicates whether the input is on (<code>true</code>) or off (<code>false</code>). The <code>mixed</code> value is invalid, and user agents MUST treat a <code>mixed</code> value as equivalent to <code>false</code> for this role.</p>
+                <p>Authors MAY set <pref>aria-setsize</pref> and <a>aria-posinset</a> on elements with this role when they are <a>accessibility children</a> of <rref>toolbar</rref> with only elements with a <rref>group</rref> role intervening.</p>
 				<p class="note">A <code>switch</code> provides approximately the same functionality as a <code>checkbox</code> and toggle <code>button</code>, but makes it possible for assistive technologies to present the widget in a fashion consistent with its on-screen appearance.</p>
 			</div>
 			<table class="role-features">
@@ -8450,7 +8481,12 @@
 					</tr>
 					<tr>
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
-						<td class="role-properties"> </td>
+						<td class="role-properties">
+                            <ul>
+                                <li><pref>aria-posinset</pref></li>
+                                <li><pref>aria-setsize</pref></li>
+                            </ul>
+                        </td>
 					</tr>
 					<tr>
 						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -9087,6 +9123,7 @@
 						<li>an icon of a user silhouette, where the textbox is also visibly labeled or provided an accessible name of "name" or "username"; and</li>
 						<li>a graphical status indicator, such as a gauge to represent characters remaining, which represents dynamically updating text available outside of the textbox.</li>
 					</ul>
+                <p>Authors MAY set <pref>aria-setsize</pref> and <a>aria-posinset</a> on elements with this role when they are <a>accessibility children</a> of <rref>toolbar</rref> with only elements with a <rref>group</rref> role intervening.</p>
 				<!-- keep the following para synced with its equivalent in #aria-multiline -->
 				<p class="note">In most user agent implementations, the default behavior of the <kbd>ENTER</kbd> or <kbd>RETURN</kbd> key is different between the single-line and multi-line text fields in HTML. When user has focus in a single-line <code>&lt;input type="text"&gt;</code> element, the keystroke usually submits the form. When user has focus in a multi-line <code>&lt;textarea&gt;</code> element, the keystroke inserts a line break. The <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <code>textbox</code> role differentiates these types of boxes with the <pref>aria-multiline</pref> attribute, so authors are advised to be aware of this distinction when designing the field.</p>
 			</div>
@@ -9139,8 +9176,10 @@
 								<li><sref>aria-invalid</sref></li>
 								<li><pref>aria-multiline</pref></li>
 								<li><pref>aria-placeholder</pref></li>
+                                <li><pref>aria-posinset</pref></li>
 								<li><pref>aria-readonly</pref></li>
 								<li><pref>aria-required</pref></li>
+                                <li><pref>aria-setsize</pref></li>
 							</ul>
 						</td>
 					</tr>
@@ -9367,6 +9406,7 @@
 				<p>The toolbar is often a subset of functions found in a <rref>menubar</rref>, designed to reduce user effort in using these functions. Authors MUST supply a label on each toolbar when the application contains more than one toolbar.</p>
 				<p>Authors MAY manage focus of descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
 				<p>Elements with the role <code>toolbar</code> have an implicit <pref>aria-orientation</pref> value of <code>horizontal</code>.</p>
+                <p>Authors MAY set <pref>aria-setsize</pref> and <a>aria-posinset</a> on focusable interactive <a>accessibility children</a> of the role <code>toolbar</code> that don't have a <a href="#scope">required accessibility parent role</a>. Authors MUST NOT set <pref>aria-setsize</pref> and <a>aria-posinset</a> values scoped to the <code>toolbar</code> on <a href="#mustContain">allowed accessibility child roles</a> of any <rref>composite</rref> <rref>widget</rref> that already provides indexing.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>


### PR DESCRIPTION
Closes https://github.com/w3c/aria/issues/2158

Outlines which roles within `toolbar` can accept `aria-setsize` and `aria-posinset`.

<!--- IF EDITORIAL or CHORE, delete the rest of this template -->

# PR tracking
Check these when the relevant issue or PR has been made, OR after you have confirmed the
related change is not necessary (add N/A). Leave unchecked if you are unsure. Read the
[Process Document](https://github.com/w3c/aria/wiki/ARIA-WG-Process-Document/_edit) or
[Test Overview](https://github.com/w3c/aria/wiki/ARIA-Test-Overview) for more information.

* [ ] Related Core AAM Issue/PR:
* [ ] Related AccName Issue/PR:
* [ ] Any other dependent changes?

# Test, Documentation and Implementation tracking
Once this PR and all related PRs have been  approved by the working group, tests
should be written and issues should be opened on browsers. Add N/A and check when not
applicable.

* [ ] Related APG Issue/PR:
* [ ] MDN Issue/PR:
* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests:
* [ ] Browser implementations (link to issue or when done, link to commit):
   * WebKit:
   * Gecko:
   * Blink:
* [ ] Does this need AT implementations?
