### PR TITLE
Clarify menuitem[|radio|checkbox] menubar

### DIFF
--- a/index.html
+++ b/index.html
@@ -5216,7 +5216,7 @@
 			<rdef>menuitem</rdef>
 			<div class="role-description">
 				<p>An option in a set of choices contained by a <rref>menu</rref> or <rref>menubar</rref>.</p>
-				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>menuitem</code> are <a>accessibility children</a> of an element with role <rref>menu</rref> or an element with role <rref>group</rref> that is an <a>accessibility child</a> of an element with role <rref>menu</rref>.</p>
+				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>menuitem</code> are <a>accessibility children</a> of an element with role <rref>menu</rref>, <rref>menubar</rref>, or an element with role <rref>group</rref> that is an <a>accessibility child</a> of an element with role <rref>menu</rref> or <rref>menubar</rref>.</p>
 				<p>Authors MAY disable a menu item with the <sref>aria-disabled</sref> attribute. If the menu item has its <pref>aria-haspopup</pref> attribute set to <code>true</code>, it indicates that the menu item can be used to launch a sub-level menu, and authors SHOULD display a new sub-level menu when the menu item is activated.</p>
 				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu items are <a>accessibility descendants</a> of an element with role <rref>menu</rref> or <rref>menubar</rref>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
 			</div>
@@ -5325,7 +5325,7 @@
 			<rdef>menuitemcheckbox</rdef>
 			<div class="role-description">
 				<p>A <rref>menuitem</rref> with a checkable state whose possible <span>values</span> are <code>true</code>, <code>false</code>, or <code>mixed</code>.</p>
-				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>menuitemcheckbox</code> are <a>accessibility children</a> of an element with role <rref>menu</rref> or an element with role <rref>group</rref> that is the <a>accessibility child</a> of an element with role <rref>menu</rref>.</p>
+				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>menuitemcheckbox</code> are <a>accessibility children</a> of an element with role <rref>menu</rref>, <rref>menubar</rref>, or an element with role <rref>group</rref> that is an <a>accessibility child</a> of an element with role <rref>menu</rref> or <rref>menubar</rref>.</p>
 				<p>The <sref>aria-checked</sref> <a>attribute</a> of a <code>menuitemcheckbox</code> indicates whether the menu item is checked (<code>true</code>), unchecked (<code>false</code>), or represents a sub-level menu of other menu items that have a mixture of checked and unchecked values (<code>mixed</code>).</p>
 				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu item checkboxes are the <a>accessibility descendants</a> of an element with role <rref>menu</rref> or <rref>menubar</rref>. Authors MAY separate menu items into sets by use of a <rref>separator</rref> or an element with an equivalent role from the native markup language.</p>
 			</div>
@@ -5425,7 +5425,7 @@
 			<rdef>menuitemradio</rdef>
 			<div class="role-description">
 				<p>A checkable <rref>menuitem</rref> in a set of elements with the same role, only one of which can be checked at a time.</p>
-				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>menuitemradio</code> are <a>accessibility children</a> of an element with role <rref>menu</rref> or of an element with role <rref>group</rref> that is the <a>accessibility child</a> of an element with role <rref>menu</rref>.</p>
+				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>menuitemradio</code> are <a>accessibility children</a> of an element with role <rref>menu</rref>, <rref>menubar</rref>, or an element with role <rref>group</rref> that is an <a>accessibility child</a> of an element with role <rref>menu</rref> or <rref>menubar</rref>.</p>
 				<p>Authors SHOULD enforce that only one <code>menuitemradio</code> in a group can be checked at the same time. When one item in the group is checked, the previously checked item becomes unchecked (its <sref>aria-checked</sref> <a>attribute</a> becomes <code>false</code>).</p>
 				<!-- keep previous sentence synced with radiogroup, etc. -->
 				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu item radios are <a>accessibility descendants</a> of an element with role <rref>menu</rref> or <rref>menubar</rref>.</p>


### PR DESCRIPTION
Closes https://github.com/w3c/aria/issues/2140

Explicitly notes in second paragraph description for each of `menuitem`, `menuitemcheckbox` and `menuitemradio` that they are allowed in `menubar` as well as `menu`. Makes consistent with _Characteristics_ table for all 5 as well as final paragraph of description of first 3.
