### PR TITLE
Editorial: update PR checklist for monorepo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,27 +4,15 @@ Describe Change Here!
 
 <!--- IF EDITORIAL or CHORE, delete the rest of this template -->
 
-# PR tracking
-Check these when the relevant issue or PR has been made, OR after you have confirmed the
-related change is not necessary (add N/A). Leave unchecked if you are unsure. Read the
-[Process Document](https://github.com/w3c/aria/wiki/ARIA-WG-Process-Document/_edit) or
-[Test Overview](https://github.com/w3c/aria/wiki/ARIA-Test-Overview) for more information.
-
-* [ ] Related Core AAM Issue/PR:
-* [ ] Related AccName Issue/PR:
-* [ ] Any other dependent changes?
-
 # Test, Documentation and Implementation tracking
-Once this PR and all related PRs have been  approved by the working group, tests
-should be written and issues should be opened on browsers. Add N/A and check when not
-applicable.
+Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.
 
-* [ ] Related APG Issue/PR:
-* [ ] MDN Issue/PR:
 * [ ] "author MUST" tests:
 * [ ] "user agent MUST" tests:
-* [ ] Browser implementations (link to issue or when done, link to commit):
+* [ ] Browser implementations (link to issue or commit):
    * WebKit:
    * Gecko:
    * Blink:
 * [ ] Does this need AT implementations?
+* [ ] Related APG Issue/PR:
+* [ ] MDN Issue/PR:


### PR DESCRIPTION
To land with monorepo merges.