### PR TITLE
[core-aam PR 228]  feat: add aria-actions mapping

### DIFF
--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -205,7 +205,7 @@
 	      <li><cite>ATK - Accessibility Toolkit</cite> [[ATK]] and <cite>Assistive Technology Service Provider Interface</cite> [[AT-SPI]], referred to hereafter as "ATK/AT-SPI"</li>
 	      <li><cite>macOS Accessibility Protocol</cite> [[AXAPI]]</li>
 	    </ul>
-	    <p>The <cite><a href="http://www.w3.org/TR/wai-aria-implementation/">WAI-ARIA 1.0 User Agent Implementation Guide</a></cite> included mappings for [[UIA-EXPRESS]], also known as IAccessibleEx</cite>, which was implemented in Microsoft Internet Explorer 8.0 - 11. New implementations are strongly encouraged to use [[[UI-AUTOMATION]]] instead.</p>
+	    <p>The <cite><a href="http://www.w3.org/TR/wai-aria-implementation/">WAI-ARIA 1.0 User Agent Implementation Guide</a></cite> included mappings for [[UIA-EXPRESS]], also known as IAccessibleEx, which was implemented in Microsoft Internet Explorer 8.0 - 11. New implementations are strongly encouraged to use [[[UI-AUTOMATION]]] instead.</p>
 	    <p>If user agent developers need to expose information using other accessibility <abbr title="Application Programming Interfaces">APIs</abbr>, it is recommended that they work closely with the developer of the platform where the <abbr title="application programming interface">API</abbr> runs, and assistive technology developers on that platform.</p>
 	  </section>
   <section>

--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -1,139 +1,105 @@
-<!DOCTYPE html>
+<!doctype html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-<head>
-<title>Core Accessibility API Mappings 1.2</title>
-<meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
-<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-<script src="../common/script/resolveReferences.js" class="remove"></script>
-<script src="../common/script/utility.js" class="remove"></script>
-<script src="../common/biblio.js" class="remove" defer></script>
+  <head>
+    <title>Core Accessibility API Mappings 1.2</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+    <script src="../common/script/resolveReferences.js" class="remove"></script>
+    <script src="../common/script/utility.js" class="remove"></script>
+    <script src="../common/biblio.js" class="remove" defer></script>
 
-<link href="../common/css/mapping-tables.css" rel="stylesheet" type="text/css"/>
-<link href="../common/css/common.css" rel="stylesheet" type="text/css"/>
-<link href="css/core-aam.css" rel="stylesheet" type="text/css"/>
+    <link href="../common/css/mapping-tables.css" rel="stylesheet" type="text/css" />
+    <link href="../common/css/common.css" rel="stylesheet" type="text/css" />
+    <link href="css/core-aam.css" rel="stylesheet" type="text/css" />
 
-<script class="remove">
-  var respecConfig = {
-    github: "w3c/core-aam",
-    doJsonLd: true,
-    lint: true,
-    
-    // specification status (e.g., WD, LC, NOTE, etc.). If in doubt use ED.
-    specStatus:           "CRD",
-    crEnd:                "2023-01-02",
-    implementationReportURI: "https://w3c.github.io/test-results/core-aam-1.2/",
-    
-    //perEnd:               "2013-07-23",
-    //publishDate:           "2013-08-22",
+    <script class="remove">
+      var respecConfig = {
+        github: "w3c/core-aam",
+        doJsonLd: true,
+        lint: true,
 
-    // the specifications short name, as in http://www.w3.org/TR/short-name/
-    shortName:            "core-aam-1.2",
-          
-    // if you wish the publication date to be other than today, set this
-    //publishDate:  "2014-12-11",
-    copyrightStart:  "2014",
+        // specification status (e.g., WD, LC, NOTE, etc.). If in doubt use ED.
+        specStatus: "CRD",
+        crEnd: "2023-01-02",
+        implementationReportURI: "https://w3c.github.io/test-results/core-aam-1.2/",
 
-    // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
-    // and its maturity status
-    //previousPublishDate:  "2014-06-12",
-    previousMaturity:     "CR",
-    prevRecURI:           "https://www.w3.org/TR/core-aam-1.1/",
-    //previousDiffURI:      "http://www.w3.org/TR/2014/REC-wai-aria-implementation-20140320/",
+        //perEnd:               "2013-07-23",
+        //publishDate:           "2013-08-22",
 
-    // if there a publicly available Editors Draft, this is the link
-    edDraftURI:           "https://w3c.github.io/core-aam/",
+        // the specifications short name, as in http://www.w3.org/TR/short-name/
+        shortName: "core-aam-1.2",
 
-    // if this is a LCWD, uncomment and set the end of its review period
-    // lcEnd: "2012-02-21",
+        // if you wish the publication date to be other than today, set this
+        //publishDate:  "2014-12-11",
+        copyrightStart: "2014",
 
-    // editors, add as many as you like
-    // only "name" is required
-    editors:  [
-        {
-          name: "Valerie Young",
-          company: "Igalia, S.L.",
-          companyURL: "https://www.igalia.com",
-          w3cid: 107953
-        },
-        {
-          name: "Alexander Surkov",
-          company: "Igalia, S.L.",
-          companyURL: "https://www.igalia.com",
-          w3cid: 51089
-        },
-        { name: "Michael Cooper",
-          company: "W3C",
-          companyURL: "https://www.w3.org",
-          w3cid: 34017
-        }
-    ],
-    formerEditors: [
-        { name: "Joanmarie Diggs",
-          company: "Igalia, S.L.",
-          companyURL: "https://www.igalia.com",
-          w3cid: 68182,
-          note: "Editor until October 2022"
-        },
-        { name: "Richard Schwerdtfeger",
-          company: "Knowbility",
-          companyURL: "https://www.knowbility.org/",
-          w3cid: 2460,
-          note: "Editor until October 2017"
-        },
-        { name: "Joseph Scheuhammer",
-          company: "Inclusive Design Research Centre, OCAD University",
-          companyURL:"http://idrc.ocad.ca",
-          w3cid: 42279,
-          note: "Editor until May 2017"
-        },
-        { name: "Andi Snow-Weaver",
-          company: "IBM",
-          companyURL: "http://www.ibm.com",
-          w3cid: 35445,
-          note: "Editor until December 2012"
-        },
-        { name: "Aaron Leventhal",
-          company: "IBM",
-          companyURL: "http://www.ibm.com",
-          w3cid: 34329,
-          note: "Editor until January 2009"
-        },
-    ],
-    // authors, add as many as you like. 
-    // This is optional, uncomment if you have authors as well as editors.
-    // only "name" is required. Same format as editors.
+        // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
+        // and its maturity status
+        //previousPublishDate:  "2014-06-12",
+        previousMaturity: "CR",
+        prevRecURI: "https://www.w3.org/TR/core-aam-1.1/",
+        //previousDiffURI:      "http://www.w3.org/TR/2014/REC-wai-aria-implementation-20140320/",
 
-    authors:  [
-        { 
-          name: "Benjamin Beaudry",
-          company: "Microsoft Corp.", 
-          companyURL: "https://microsoft.com/",
-          note: "UIA",
-          w3cid: 40117
-        },
-        { 
-          name: "James Craig", 
-          company: "Apple, Inc.", 
-          companyURL: "https://apple.com/accessibility",
-          note: "AX API",
-          w3cid: 42459
-        },
-        { name: "Joanmarie Diggs",
-          company: "Igalia, S.L.",
-          companyURL: "https://www.igalia.com",
-          w3cid: 68182,
-          note: "ATK / AT-SPI"
-        },
-        { 
-          name: "Alexander Surkov", 
-          company: "Igalia, S.L.",
-          companyURL: "https://www.igalia.com",
-          note: "MSAA, IAccessible2",
-          w3cid: 51089
-        },
-    ],
+        // if there a publicly available Editors Draft, this is the link
+        edDraftURI: "https://w3c.github.io/core-aam/",
 
-	/*
+        // if this is a LCWD, uncomment and set the end of its review period
+        // lcEnd: "2012-02-21",
+
+        // editors, add as many as you like
+        // only "name" is required
+        editors: [
+          {
+            name: "Valerie Young",
+            company: "Igalia, S.L.",
+            companyURL: "https://www.igalia.com",
+            w3cid: 107953,
+          },
+          {
+            name: "Alexander Surkov",
+            company: "Igalia, S.L.",
+            companyURL: "https://www.igalia.com",
+            w3cid: 51089,
+          },
+          { name: "Michael Cooper", company: "W3C", companyURL: "https://www.w3.org", w3cid: 34017 },
+        ],
+        formerEditors: [
+          { name: "Joanmarie Diggs", company: "Igalia, S.L.", companyURL: "https://www.igalia.com", w3cid: 68182, note: "Editor until October 2022" },
+          { name: "Richard Schwerdtfeger", company: "Knowbility", companyURL: "https://www.knowbility.org/", w3cid: 2460, note: "Editor until October 2017" },
+          { name: "Joseph Scheuhammer", company: "Inclusive Design Research Centre, OCAD University", companyURL: "http://idrc.ocad.ca", w3cid: 42279, note: "Editor until May 2017" },
+          { name: "Andi Snow-Weaver", company: "IBM", companyURL: "http://www.ibm.com", w3cid: 35445, note: "Editor until December 2012" },
+          { name: "Aaron Leventhal", company: "IBM", companyURL: "http://www.ibm.com", w3cid: 34329, note: "Editor until January 2009" },
+        ],
+        // authors, add as many as you like.
+        // This is optional, uncomment if you have authors as well as editors.
+        // only "name" is required. Same format as editors.
+
+        authors: [
+          {
+            name: "Benjamin Beaudry",
+            company: "Microsoft Corp.",
+            companyURL: "https://microsoft.com/",
+            note: "UIA",
+            w3cid: 40117,
+          },
+          {
+            name: "James Craig",
+            company: "Apple, Inc.",
+            companyURL: "https://apple.com/accessibility",
+            note: "AX API",
+            w3cid: 42459,
+          },
+          { name: "Joanmarie Diggs", company: "Igalia, S.L.", companyURL: "https://www.igalia.com", w3cid: 68182, note: "ATK / AT-SPI" },
+          {
+            name: "Alexander Surkov",
+            company: "Igalia, S.L.",
+            companyURL: "https://www.igalia.com",
+            note: "MSAA, IAccessible2",
+            w3cid: 51089,
+          },
+        ],
+
+        /*
     alternateFormats: [
           { uri: 'aria-implementation-diff.html',
             label: "Diff from Previous Recommendation" } ,
@@ -143,9370 +109,11022 @@
             label: "PDF version" }
 	],
     */
-    
-    // Working group info
-	group: "aria",
-    
-    tocIntroductory: true,
-    //maxTocLevel: 4,
-    
-    // Spec URLs
-    ariaSpecURLs: {
-      "CR" : "https://w3c.github.io/aria/",
-      "CRD" : "https://w3c.github.io/aria/",
-      "PR" : "https://www.w3.org/TR/wai-aria/",
-      "REC": "https://www.w3.org/TR/wai-aria/"
-    },
-    accNameURLs: {
-      "CR" : "https://w3c.github.io/accname/",
-      "CRD": "https://w3c.github.io/accname/",
-      "PR" : "https://www.w3.org/TR/accname-1.2/",
-      "REC": "https://www.w3.org/TR/accname-1.2/"
-    },
 
-    preProcess: [ linkCrossReferences ],
-	postProcess: [ addPlatformMaintainers ],
-	xref: ["dom", "accname", "wai-aria", "infra"]
-  }
-</script>
-</head>
-<body>
-<section id="abstract">
-	<p>This document describes how [=user agents=]  should expose semantics of web content languages to <a class="termref">accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a>. This helps users with disabilities to obtain and interact with information using <a class="termref">assistive technologies</a>. Documenting these mappings promotes interoperable exposure of roles, states, properties, and events implemented by accessibility APIs and helps to ensure that this information appears in a manner consistent with author intent. </p>
-			<p>This Core Accessibility API Mappings specification defines support that applies across multiple content technologies, including general keyboard navigation support and mapping of general-purpose <a class="termref">roles</a>, states, and properties provided in Web content via <cite><a href="http://www.w3.org/TR/wai-aria-1.2/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr></a></cite> [[WAI-ARIA-1.2]]. Other Accessibility API Mappings specifications depend on and extend this Core specification for specific technologies, including native technology features and WAI-ARIA extensions. This document updates and will eventually supersede the guidance in the <a href="http://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1</a> [[CORE-AAM-1.1]] W3C Recommendation. It is part of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> suite described in the <a href="http://www.w3.org/WAI/intro/aria.php"><abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Overview</a>.</p>
-</section>
-<section id="sotd">
-	<p>The Accessible Rich Internet Applications Working Group seeks feedback on any aspect of the specification. When submitting feedback, please consider issues in the context of the companion documents. To comment, <a href="https://github.com/w3c/core-aam/issues/new">file an issue in the <abbr title="World Wide Web Consortium">W3C</abbr> core-aam GitHub repository</a>. If this is not feasible, send email to <a href="mailto:public-aria@w3.org?subject=Comment%20on%20Core-AAM%201.2">public-aria@w3.org</a> (<a href="http://lists.w3.org/Archives/Public/public-aria/">comment archive</a>). In-progress updates to the document may be viewed in the <a href="http://w3c.github.io/core-aam/">publicly visible editors' draft</a>.</p>
-</section>
-<section id="intro" class="informative">
-	<h2>Introduction</h2>
-	<p>The Core Accessibility API Mappings specifies how <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a class="termref">roles</a>, <a class="termref">states</a>, and [=ARIA/properties=] are expected to be exposed by user agents via platform accessibility <abbr title="Application Programming Interfaces">APIs</abbr>. It is part of a set of resources that define and support the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> specification which includes the following documents:</p>
-	<ul>
-          <li><cite><a class="specref" href="">Accessible Rich Internet Applications (WAI-ARIA) 1.2</a></cite> [[WAI-ARIA-1.2]], a planned <abbr title="World Wide Web Consortium">W3C</abbr> recommendation, defines the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> standard.</li>
-          <li><cite><a href="http://www.w3.org/TR/wai-aria-practices/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices Guide</a></cite> [[WAI-ARIA-PRACTICES-1.2]], a planned W3C Working Group Note, describes how web content developers can develop accessible rich internet applications using <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>. It provides detailed advice and examples directed primarily to web application developers, yet also useful to user agent and developers of assistive technologies.</li>
-          <li><cite><a href="http://www.w3.org/TR/wai-aria-roadmap/">Roadmap for Accessible Rich Internet Applications (<abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Roadmap)</a></cite> [[WAI-ARIA-ROADMAP]], a planned W3C Working Group Note, defines the path to make rich web content accessible, including steps already taken, remaining future steps, and a time line.</li>
-	</ul>
-	<p>For an introduction to <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>, see the <a href="http://www.w3.org/WAI/intro/aria.php"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Overview</a>.</p>
-	  <section id="intro_aapi">
-	    <h3>Accessibility <abbr title="Application Programming Interfaces">APIs</abbr> </h3>
-            <p><a class="termref">Accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a> make it possible to communicate accessibility information about user interfaces to assistive technologies. This information includes:</p>
-            <ol>
-              <li>Descriptive properties (role, name, value, position, etc.)</li>
-              <li>Transient states (pressed, focused, etc.)</li>
-              <li>Events (text changed, button was clicked, checkbox was toggled)</li>
-              <li>Actions the user might take (click, check/toggle, drag, etc.)</li>
-              <li>Relationships (parent/child, description/described object, previous object/next object, etc.)</li>
-              <li>Textual content</li>
-            </ol>
-            <p>Accessibility <abbr title="Application Programming Interfaces">APIs</abbr> covered by this specification are:</p>
-	    <ul>
-              <li><abbr title="Microsoft Active Accessibility">MSAA</abbr> with <cite>IAccessible2 1.3</cite> [[IAccessible2]]</li>
-              <li><cite>User Interface Automation</cite> [[UI-AUTOMATION]]</li>
-	      <li><cite>ATK - Accessibility Toolkit</cite> [[ATK]] and <cite>Assistive Technology Service Provider Interface</cite> [[AT-SPI]], referred to hereafter as "ATK/AT-SPI"</li>
-	      <li><cite>macOS Accessibility Protocol</cite> [[AXAPI]]</li>
-	    </ul>
-	    <p>The <cite><a href="http://www.w3.org/TR/wai-aria-implementation/">WAI-ARIA 1.0 User Agent Implementation Guide</a></cite> included mappings for [[UIA-EXPRESS]], also known as IAccessibleEx, which was implemented in Microsoft Internet Explorer 8.0 - 11. New implementations are strongly encouraged to use [[[UI-AUTOMATION]]] instead.</p>
-	    <p>If user agent developers need to expose information using other accessibility <abbr title="Application Programming Interfaces">APIs</abbr>, it is recommended that they work closely with the developer of the platform where the <abbr title="application programming interface">API</abbr> runs, and assistive technology developers on that platform.</p>
-	  </section>
-  <section>
-      <h4>Comparing Accessibility APIs</h4>
-      <p>For various technological and historical reasons, accessibility APIs do not all work in the same way. In many cases, there is no simple one-to-one relationship between how each of them names or exposes roles, states, and properties to assistive technologies. The following subsections describe a few of the distinguishing characteristics of some of the APIs.</p>
-      <section>
-        <h5>ATK/AT-SPI</h5>
-        <p>MSAA, IAccessible2, UIA, and AX API each define an API that is shared by both the software application exposing information about its content and interactive components, and the assistive technology consuming that information. Conversely, Linux/GNOME separates that shared interface into its two aspects, each represented by a different accessibility API: ATK or AT-SPI.</p>
-        <p>ATK defines an interface that is implemented by software in order to expose accessibility information, whereas AT-SPI is a desktop service that gathers accessibility information from active applications and relays it to other interested applications, usually assistive technologies.</p>
-        <p>For example, the GNOME GUI toolkit [GTK], implements the relevant aspects of ATK for each widget (menu, combobox, checkbox, etc.) in order that GTK widgets expose accessibility information about themselves. AT-SPI then acquires the information from applications built with GTK and makes it available to interested parties.</p>
-        <p>ATK is most relevant to implementors, whereas AT-SPI is relevant to consumers. In the context of mapping WAI-ARIA roles, states and properties, user agents are implementors and use ATK. Assistive Technologies are consumers, and use AT-SPI.</p>
-      </section>
-      <section>
-        <h5>UIA (UI Automation)</h5>
-      	<p>UI Automation expresses every element of the application user interface as an automation element. Automation elements form the nodes of the application accessibility tree, that can be queried, traversed and interacted with by automation clients.</p>
-      	<p>There are several concepts central to UI Automation:</p>
-	<ul>
-		<li>Automation element - controls and some application content are presented as automation elements.</li>
-		<li>Element properties - Automation elements have several common properties describing native framework element characteristics in an agnostic way that all automation clients can understand. There are several ways to access element property values, described below.</li>
-		<li>Control Patterns - Some common interactivity in different frameworks is expressed as control patterns in UIA, allowing different automation clients to interact with controls using common programmatic interfaces.</li>
-		<li>Events - Similar to other accessibility APIs, automation elements support various events that allow automation providers to notify clients on important state changes.</li>
-      	</ul>
-      	<p>All automation elements inherit from the <code>IUIAutomationElement</code> interface and all properties that are not specific to a particular control pattern can be queried through that interface. There are several ways to access UI Automation element properties:</p>
-	<ul>
-		<li>Direct property accessors to the current values - <code>Current{PropertyName}</code>, e.g. <code>IUIAutomationElement::CurrentName</code> for the <code>Name</code> property</li>
-		<li>Cached property accessors - <code>Cached{PropertyName}</code>, e.g. <code>IUIAutomationElement::CachedName</code> for the <code>Name</code> property. Using cached values is preferred when providers and clients are used in remote environments.</li>
-		<li><code>GetCurrentPropertyValue</code> and passing the UIA Property ID enumeration value corresponding to that property to get the current value, e.g. <code>IUIAutomationElement::GetCurrentPropertyValue(UIA_NamePropertyId)</code> for the <code>Name</code> property.</li>
-		<li><code>GetCachedPropertyValue</code> and passing the UIA Property ID enumeration value corresponding to that property to get the cached value, e.g. <code>IUIAutomationElement::GetCachedPropertyValue(UIA_NamePropertyId)</code> for the <code>Name</code> property.</li>
-      	</ul>
-	<p>Properties for specific UIA control patterns are queried the same way using relevant control pattern interfaces. Taking Toggle Pattern as an example, to query the ToggleState property clients can use IUIAutomationTogglePattern::CurrentToggleState or IUIAutomationTogglePattern::GetCurrentPropertyValue(UIA_ToggleToggleStatePropertyId) to get the current value.</p>
-      	<p>The property mappings in this specification provide the <code>{PropertyName}</code> and do not specify all specific ways to access the property value. Automation clients can access current or cached values using conventions described above, depending on specific needs and coding style conventions.</p>
-      </section>
-      <section>
-        <h5>Accessible Names and Descriptions</h5>
-        <p>Each platform accessibility API includes a way to assign and retrieve <a class="termref" data-cite="accname-1.2#dfn-accessible-name">accessible name</a> and <a class="termref" data-cite="accname-1.2#dfn-accessible-description">accessible description</a> properties for each <a class="termref">accessible object</a> created in the <a class="termref">accessibility tree</a>. How these properties are implemented and what they are called vary depending on the API.</p>
-        <p>For instance, in MSAA, all <a class="termref">accessible objects</a> support the <code>accName</code> property, which stores the object's <a class="termref" data-cite="accname-1.2#dfn-accessible-name">accessible name</a>. Where the object also supports having an <a class="termref" data-cite="accname-1.2#dfn-accessible-description">accessible description</a>, MSAA stores this property in the object's <code>accDescription</code> property.</p>
-        <p>Software using ATK can read and write to an object's <code>accessible-name</code> and <code>accessible-description</code> properties. In turn, AT-SPI can query the values of those properties through its <code>atspi_accessible_get_name</code> and <code>atspi_accessible_get_description</code> functions.</p>
-        <p>Automation elements in the UIA accessibility tree have a <code>Name</code> property. Where the object also supports having an <a class="termref" data-cite="accname-1.2#dfn-accessible-description">accessible description</a>, UIA stores this property in the object's <code>FullDescription</code> property.</p>
-        <p>The approach to <a class="termref" data-cite="accname-1.2#dfn-accessible-name">accessible names</a> and <a class="termref" data-lt="accessible description" data-cite="accname-1.2#dfn-accessible-description">accessible descriptions</a> in AX API is somewhat different to the other platform APIs. <a class="termref" data-cite="accname-1.2#dfn-accessible-name">Accessible names</a> are exposed using the <code>AXTitle</code> property when the name is visually rendered, while the <code>AXDescription</code> property is used when the object's name is not rendered visually. An object's <a class="termref" data-cite="accname-1.2#dfn-accessible-description">accessible description</a>, where provided by <a class="state-reference" href="#aria-description"><code>aria-description</code></a> or <a class="state-reference" href="#aria-describedby"><code>aria-describedby</code></a>, should be exposed in the <code>accessibilityCustomContent</code> API. Otherwise, it should be exposed as <code>AXHelp</code>.</p>
-        <p>For more detail, see the <a class="accname" href="">Accessible Name and Description Computation</a> specification.</p>
-      </section>
+        // Working group info
+        group: "aria",
+
+        tocIntroductory: true,
+        //maxTocLevel: 4,
+
+        // Spec URLs
+        ariaSpecURLs: {
+          CR: "https://w3c.github.io/aria/",
+          CRD: "https://w3c.github.io/aria/",
+          PR: "https://www.w3.org/TR/wai-aria/",
+          REC: "https://www.w3.org/TR/wai-aria/",
+        },
+        accNameURLs: {
+          CR: "https://w3c.github.io/accname/",
+          CRD: "https://w3c.github.io/accname/",
+          PR: "https://www.w3.org/TR/accname-1.2/",
+          REC: "https://www.w3.org/TR/accname-1.2/",
+        },
+
+        preProcess: [linkCrossReferences],
+        postProcess: [addPlatformMaintainers],
+        xref: ["dom", "accname", "wai-aria", "infra"],
+      };
+    </script>
+  </head>
+  <body>
+    <section id="abstract">
+      <p>
+        This document describes how [=user agents=] should expose semantics of web content languages to <a class="termref">accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a
+        >. This helps users with disabilities to obtain and interact with information using <a class="termref">assistive technologies</a>. Documenting these mappings promotes interoperable exposure of
+        roles, states, properties, and events implemented by accessibility APIs and helps to ensure that this information appears in a manner consistent with author intent.
+      </p>
+      <p>
+        This Core Accessibility API Mappings specification defines support that applies across multiple content technologies, including general keyboard navigation support and mapping of
+        general-purpose <a class="termref">roles</a>, states, and properties provided in Web content via
+        <cite
+          ><a href="http://www.w3.org/TR/wai-aria-1.2/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr></a></cite
+        >
+        [[WAI-ARIA-1.2]]. Other Accessibility API Mappings specifications depend on and extend this Core specification for specific technologies, including native technology features and WAI-ARIA
+        extensions. This document updates and will eventually supersede the guidance in the <a href="http://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1</a> [[CORE-AAM-1.1]] W3C
+        Recommendation. It is part of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> suite described in the
+        <a href="http://www.w3.org/WAI/intro/aria.php"><abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Overview</a>.
+      </p>
     </section>
-</section>
-<section id="conformance">
-<section>
-<h3>RFC-2119 Keywords</h3>
-<p>RFC-2119 keywords are formatted in uppercase and contained in a <code>strong</code> element with <code>class="rfc2119"</code>. When the keywords shown above are used, but do not share this format, they do not convey formal information in the RFC 2119 sense, and are merely explanatory, i.e., informative. As much as possible, such usages are avoided in this specification.</p>
-</section>
-<section>
-<h3>Normative and Informative Sections</h3>
-<p>The indication whether a section is normative or non-normative (informative) applies to the entire section including sub-sections.</p>
-<p>Informative sections provide information useful to understanding the specification. Such sections may contain examples of recommended practice, but it is not required to follow such recommendations in order to conform to this specification.</p>
-</section>
-<section>
-<h3>Features Deprecated in WAI-ARIA</h3>
-<p>The WAI-ARIA specification <a href="#deprecated" class="specref">lists some features as deprecated</a>. Although this means authors are encouraged not to use such features, it is expected that the features could still be used in legacy content. Therefore, it is important that user agents continue to map these features to accessibility APIs, and doing so is part of conformance to this specification. When future versions of the WAI-ARIA specification change such features from deprecated to removed, they will be removed from the mappings as well and user agents will no longer be asked to continue support for those features.</p>
-</section>
-</section>
-<section class="informative" id="glossary">
-  <h2>Important Terms</h2>
-  <div>
-		<p>While some terms are defined in place, the following definitions are used throughout this document. </p>
-		<dl class="termlist">
-			<dt><dfn data-export="">Accessibility Subtree</dfn></dt>
-			<dd>
-				<p>An [=accessible object=] in the <a>accessibility tree</a> and its descendants in that tree. It does not include objects which have relationships other than parent-child in that tree. For example, it does not include objects linked via <a class="specref" href="#aria-flowto">aria-flowto</a> unless those objects are also descendants in the <a>accessibility tree</a>.</p>
-			</dd>
-			<dt><dfn data-export="">Activation behavior</dfn></dt>
-			<dd>
-				<p>The action taken when an <a>event</a>, typically initiated by users through an input device, causes an element to fulfill a defined role. The role may be defined for that element by the host language, or by author-defined variables, or both. The role for any given element may be a generic action, or may be unique to that element. For example, the activation behavior of an <abbr title="Hypertext Markup Language">HTML</abbr> or <abbr title="Scalable Vector Graphics">SVG</abbr> <code>&lt;a&gt;</code> element shall be to cause the user agent to traverse the link specified in the <code>href</code> attribute, with the further optional parameter of specifying the browsing context for the traversal (such as the current window or tab, a named window, or a new window); the activation behavior of an <abbr title="Hypertext Markup Language">HTML</abbr> <code>&lt;input&gt;</code> element with the <code>type</code> attribute value <code>submit</code> shall be to send the values of the form elements to an author-defined <abbr title="Internationalized Resource Identifiers">IRI</abbr> by the author-defined <abbr title="Hypertext Transfer Protocol">HTTP</abbr> method.</p>
-			</dd>
-		</dl>
-	</div>
-</section>
-<section id="mapping">
-	<h2>Mapping <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> to Accessibility <abbr title="Application Programming Interfaces">APIs</abbr></h2>
-	<section id="mapping_general">
-		<h3>General rules for exposing <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> semantics</h3>
-		<p>Where supported by the platform <a class="termref">Accessibility API</a>, [=user agents=] expose <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref">semantics</a> through the  standard mechanisms of the desktop accessibility <abbr title="application programming interface">API</abbr>. For example, for  <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref">widgets</a>, compare how the widget is exposed in a similar desktop  widget. In general most <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> widget capabilities are exposed through  the <a class="termref">role</a>, value, Boolean <a class="termref">states</a>, and relations of the accessibility <abbr title="application programming interface">API</abbr>.</p>
-	    <p>With respect to <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 1.0 and 1.1, accessibility <abbr title="application programming interfaces">APIs</abbr> operate in one direction only.  User agents publish <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> information (roles, states, and properties) via an accessibility <abbr title="application programming interface">API</abbr>, and an <abbr title="assistive technology">AT</abbr> can acquire that information using the same <abbr title="application programming interface">API</abbr>.  However, the other direction is not supported.  <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 1.0 and 1.1 do not define mechanisms for assistive technologies to directly modify <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> information.</p>
-		<p>The terms "exposing", "mapping", and "including" refer to the creation of <a class="termref">accessible object</a> <a class="termref" data-lt="node">nodes</a> within the <a class="termref">accessibility tree</a>, and populating these objects with <a class="termref">Accessibility API</a> specific <a class="termref">states</a> and [=ARIA/properties=].</p>
-  </section>
-	<section id="mapping_conflicts">
-		<h3>Conflicts between native markup semantics and <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr></h3>
-		  <p><abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr>  roles, states, and properties are intended to add <a class="termref">semantic</a> information when native host language <a class="termref">elements</a> with these semantics are not available, and are generally used on elements that have no native semantics of their own. They can also be used on elements that have similar but not identical semantics to the intended object (for instance, a nested list could be used to represent a tree structure). This method can be  part of a fallback strategy for older browsers that have no <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> implementation, or because native presentation of the repurposed element reduces the amount of style and/or script needed. Except for the cases outlined below, [=user agents=] MUST always use the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> semantics to define how it exposes the element to <a class="termref">accessibility APIs</a>, rather than using the host language semantics.</p>
-		  <p>Host languages can have features that have implicit <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> semantics corresponding to <a class="termref">roles</a>. When a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role is provided that has a corresponding role in the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents MUST use the semantic of the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role for processing, not the native semantic, unless the role requires <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties whose attributes are explicitly forbidden on the native element by the host language.  Values for roles do not conflict in the same way as values for states and properties, and because authors are expected to have a valid reason to provide a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role even on elements that would not normally be repurposed. For example, spin buttons are typically constructed from text fields (<code>&lt;input  type=&quot;text&quot;&gt;</code>) in order to get most of the default keyboard support.  But, the native role, &quot;text field&quot;, is not correct because it does not properly communicate the additional features of a spin button.  The author adds the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role of <code>spinbutton</code> (<code>&lt;input type=&quot;text&quot; role=&quot;spinbutton&quot; ...&gt;</code>) so that the control is properly mapped in the accessibility <abbr title="Application Programming Interface">API</abbr>. When a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role is provided that does not have a corresponding role in the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents MAY expose the native semantic in addition to the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role. If the host language element is overridden by a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role whose semantics or structure is not equivalent to the native host language semantics or to a subclass of those semantics, then treat any child elements having roles specified as Allowed Accessibility Child Roles as having <a href="#role-map-presentation">presentation</a> or <a href="#role-map-none">none</a>.</p>
-		  <p class="note">The above text differs slightly from the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> specification. The requirement for user agents to expose the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role instead of the native role was intended to only apply in cases where there is a direct mapping from the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role to a corresponding role in the accessibility <abbr title="Application Programming Interface">API</abbr>. The wording of the requirement is not clear in the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> specification, however, and has been interpreted differently by implementers. The requirement has been clarified here and an additional statement added to indicate that user agents may expose native semantics if there is not a direct mapping to a role in the accessibility <abbr title="Application Programming Interface">API</abbr>. Because there are differing implementations, authors will be advised against adding such <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> roles to native elements that have their own semantics in the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Authoring Practices Guide.</p>
-      <p>When <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties correspond to host language features that have the same implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantic, it can be problematic if the values become out of sync. For example, the <abbr title="Hypertext Markup Language">HTML</abbr> <code>checked</code> attribute and the <code>aria-checked</code> attribute could have conflicting values. Therefore to prevent providing conflicting states and properties to assistive technologies, host languages will explicitly declare where the use of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attributes on a host language element conflict with native attributes for that element. When a host language declares a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a class="termref">attribute</a> to be in direct semantic conflict with a native attribute for a given element, user agents MUST ignore the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attribute and instead use the host language attribute with the same implicit semantic. </p>
-      <p>Host languages might also document features that cannot be overridden with <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> (these are called &quot;strong native semantics&quot;). These can be features that have implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics as well as features where the processing would be uncertain if the semantics were changed with <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>. While conformance checkers might signal an error or warning when a <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role is used on elements with strong native semantics, user agents MUST still use the value of the semantic of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role when exposing the element to accessibility <abbr title="Application Programming Interfaces">APIs</abbr>.</p>
-  </section>
-	<section id="mapping_nodirect">
-		<h3>Exposing attributes that do not directly map to accessibility <abbr title="application programming interface">API</abbr> properties</h3>
-		  <p>Platform <a class="termref">accessibility APIs</a> might have features that are not in <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr>. Likewise, <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> exposes capabilities that are not supported by accessibility <abbr title="Application Programming Interfaces">APIs</abbr> at the time of publication. There typically is not a one to one relationship between all <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref">attributes</a> and platform accessibility <abbr title="application programming interfaces">APIs</abbr>. When <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref">roles</a>, <a class="termref">states</a> and [=ARIA/properties=] do not directly map to an  accessibility <abbr title="application programming interface">API</abbr>, and there is a mechanism in the <abbr title="application programming interface">API</abbr> to expose the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role, states, and properties and their values, [=user agents=]  MUST expose the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr>  data using that mechanism as follows: </p>
+    <section id="sotd">
+      <p>
+        The Accessible Rich Internet Applications Working Group seeks feedback on any aspect of the specification. When submitting feedback, please consider issues in the context of the companion
+        documents. To comment, <a href="https://github.com/w3c/core-aam/issues/new">file an issue in the <abbr title="World Wide Web Consortium">W3C</abbr> core-aam GitHub repository</a>. If this is
+        not feasible, send email to <a href="mailto:public-aria@w3.org?subject=Comment%20on%20Core-AAM%201.2">public-aria@w3.org</a> (<a href="http://lists.w3.org/Archives/Public/public-aria/"
+          >comment archive</a
+        >). In-progress updates to the document may be viewed in the <a href="http://w3c.github.io/core-aam/">publicly visible editors' draft</a>.
+      </p>
+    </section>
+    <section id="intro" class="informative">
+      <h2>Introduction</h2>
+      <p>
+        The Core Accessibility API Mappings specifies how <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a class="termref">roles</a>, <a class="termref">states</a>, and
+        [=ARIA/properties=] are expected to be exposed by user agents via platform accessibility <abbr title="Application Programming Interfaces">APIs</abbr>. It is part of a set of resources that
+        define and support the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> specification which includes the following documents:
+      </p>
       <ul>
-        <li>In IAccessible2 and <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>, use object attributes to expose <a class="termref">semantics</a> that are not directly supported in the <abbr title="application programming interfaces">APIs</abbr>. Object attributes are name-value pairs that are loosely specified, and very flexible for exposing things where there is no specific interface in an accessibility <abbr title="application programming interface">API</abbr>. For example, at this time, the <a class="property-reference" href="#aria-live"><code>aria-live</code></a> attribute can be exposed via an object attribute because accessibility <abbr title="application programming interfaces">APIs</abbr> have no such property available. Specific rules for exposing object attribute name-value pairs are described throughout this document, and rules for the general cases  are in <a href="#mapping_state-property">State and Property Mapping</a>.</li>
-        <li>In Microsoft <abbr title="User Interface Automation">UIA</abbr>, use the <code>AriaRole</code> and <code>AriaProperties</code> properties to expose semantics that are not directly supported in the control type.</li>
+        <li>
+          <cite><a class="specref" href="">Accessible Rich Internet Applications (WAI-ARIA) 1.2</a></cite> [[WAI-ARIA-1.2]], a planned
+          <abbr title="World Wide Web Consortium">W3C</abbr> recommendation, defines the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> standard.
+        </li>
+        <li>
+          <cite
+            ><a href="http://www.w3.org/TR/wai-aria-practices/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices Guide</a></cite
+          >
+          [[WAI-ARIA-PRACTICES-1.2]], a planned W3C Working Group Note, describes how web content developers can develop accessible rich internet applications using
+          <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>. It provides detailed advice and examples directed primarily to web application developers, yet also useful to user agent
+          and developers of assistive technologies.
+        </li>
+        <li>
+          <cite
+            ><a href="http://www.w3.org/TR/wai-aria-roadmap/">Roadmap for Accessible Rich Internet Applications (<abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Roadmap)</a></cite
+          >
+          [[WAI-ARIA-ROADMAP]], a planned W3C Working Group Note, defines the path to make rich web content accessible, including steps already taken, remaining future steps, and a time line.
+        </li>
       </ul>
-      <p class="note">MSAA does not provide a mechanism for exposing attributes that do not map directly to the <abbr title="application programming interface">API</abbr> and among implementers, there is no agreement on how to do it.</p>
-      <p>User agents MUST also expose the entire role string through this mechanism and MAY also expose <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attributes and values through this mechanism even when there is a direct mapping to an accessibility <abbr title="application programming interface">API</abbr>.</p>
-		  <p>Browser implementers are advised to publicly document their <abbr title="application programming interface">API</abbr> methods for exposing any relevant information, so that <a class="termref">assistive technology</a> developers can use the <abbr title="application programming interface">API</abbr> to support user features.</p>
-	</section>
-	<section id="mapping_role">
-		<h2>Role mapping</h2>
-		<p>Platform <a class="termref">accessibility APIs</a> traditionally have had a finite set of predefined <a class="termref">roles</a> that are expected by <a class="termref">assistive technologies</a> on that platform and only one or two roles may be exposed. In  contrast, <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> allows multiple roles to be specified as an ordered set of space-separated valid role tokens. The additional roles are fallback roles similar to the concept of specifying multiple fonts in case the first choice font type is not supported.</p>
-		<section id="roleMappingGeneralRules">
-		  <h2>General rules</h2>
-		  <p id="exposeRoleString">User agents MUST expose the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role string if the <abbr title="application programming interface">API</abbr> supports a mechanism to do so. This allows assistive technologies to do their own  additional processing of roles. </p>
-		  <ul>
-			<li><abbr title="Microsoft Active Accessibility">MSAA</abbr>: <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd373608(v=vs.85).aspx" title="Object Roles (Windows)">not supported</a>. User agents SHOULD NOT expose a custom role in MSAA's <code>accRole</code> property.</li>
-			<li>IAccessible2: expose as an object attribute pair (<code>xml-roles:&quot;string&quot;</code>)</li>
-			<li><abbr title="User Interface Automation">UIA</abbr>: expose as <code>AriaRole</code> property. The <code>AriaRole property</code> can also support secondary roles using a space as a separator.</li>
-			<li><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>: expose as an object attribute pair (<code>xml-roles:&quot;string&quot;</code>)</li>
-		  </ul>
+      <p>
+        For an introduction to <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>, see the
+        <a href="http://www.w3.org/WAI/intro/aria.php"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Overview</a>.
+      </p>
+      <section id="intro_aapi">
+        <h3>Accessibility <abbr title="Application Programming Interfaces">APIs</abbr></h3>
+        <p>
+          <a class="termref">Accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a> make it possible to communicate accessibility information about user interfaces to assistive
+          technologies. This information includes:
+        </p>
+        <ol>
+          <li>Descriptive properties (role, name, value, position, etc.)</li>
+          <li>Transient states (pressed, focused, etc.)</li>
+          <li>Events (text changed, button was clicked, checkbox was toggled)</li>
+          <li>Actions the user might take (click, check/toggle, drag, etc.)</li>
+          <li>Relationships (parent/child, description/described object, previous object/next object, etc.)</li>
+          <li>Textual content</li>
+        </ol>
+        <p>Accessibility <abbr title="Application Programming Interfaces">APIs</abbr> covered by this specification are:</p>
+        <ul>
+          <li><abbr title="Microsoft Active Accessibility">MSAA</abbr> with <cite>IAccessible2 1.3</cite> [[IAccessible2]]</li>
+          <li><cite>User Interface Automation</cite> [[UI-AUTOMATION]]</li>
+          <li><cite>ATK - Accessibility Toolkit</cite> [[ATK]] and <cite>Assistive Technology Service Provider Interface</cite> [[AT-SPI]], referred to hereafter as "ATK/AT-SPI"</li>
+          <li><cite>macOS Accessibility Protocol</cite> [[AXAPI]]</li>
+        </ul>
+        <p>
+          The <cite><a href="http://www.w3.org/TR/wai-aria-implementation/">WAI-ARIA 1.0 User Agent Implementation Guide</a></cite> included mappings for [[UIA-EXPRESS]], also known as IAccessibleEx,
+          which was implemented in Microsoft Internet Explorer 8.0 - 11. New implementations are strongly encouraged to use [[[UI-AUTOMATION]]] instead.
+        </p>
+        <p>
+          If user agent developers need to expose information using other accessibility <abbr title="Application Programming Interfaces">APIs</abbr>, it is recommended that they work closely with the
+          developer of the platform where the <abbr title="application programming interface">API</abbr> runs, and assistive technology developers on that platform.
+        </p>
+      </section>
+      <section>
+        <h4>Comparing Accessibility APIs</h4>
+        <p>
+          For various technological and historical reasons, accessibility APIs do not all work in the same way. In many cases, there is no simple one-to-one relationship between how each of them names
+          or exposes roles, states, and properties to assistive technologies. The following subsections describe a few of the distinguishing characteristics of some of the APIs.
+        </p>
+        <section>
+          <h5>ATK/AT-SPI</h5>
+          <p>
+            MSAA, IAccessible2, UIA, and AX API each define an API that is shared by both the software application exposing information about its content and interactive components, and the assistive
+            technology consuming that information. Conversely, Linux/GNOME separates that shared interface into its two aspects, each represented by a different accessibility API: ATK or AT-SPI.
+          </p>
+          <p>
+            ATK defines an interface that is implemented by software in order to expose accessibility information, whereas AT-SPI is a desktop service that gathers accessibility information from
+            active applications and relays it to other interested applications, usually assistive technologies.
+          </p>
+          <p>
+            For example, the GNOME GUI toolkit [GTK], implements the relevant aspects of ATK for each widget (menu, combobox, checkbox, etc.) in order that GTK widgets expose accessibility information
+            about themselves. AT-SPI then acquires the information from applications built with GTK and makes it available to interested parties.
+          </p>
+          <p>
+            ATK is most relevant to implementors, whereas AT-SPI is relevant to consumers. In the context of mapping WAI-ARIA roles, states and properties, user agents are implementors and use ATK.
+            Assistive Technologies are consumers, and use AT-SPI.
+          </p>
+        </section>
+        <section>
+          <h5>UIA (UI Automation)</h5>
+          <p>
+            UI Automation expresses every element of the application user interface as an automation element. Automation elements form the nodes of the application accessibility tree, that can be
+            queried, traversed and interacted with by automation clients.
+          </p>
+          <p>There are several concepts central to UI Automation:</p>
+          <ul>
+            <li>Automation element - controls and some application content are presented as automation elements.</li>
+            <li>
+              Element properties - Automation elements have several common properties describing native framework element characteristics in an agnostic way that all automation clients can understand.
+              There are several ways to access element property values, described below.
+            </li>
+            <li>
+              Control Patterns - Some common interactivity in different frameworks is expressed as control patterns in UIA, allowing different automation clients to interact with controls using common
+              programmatic interfaces.
+            </li>
+            <li>Events - Similar to other accessibility APIs, automation elements support various events that allow automation providers to notify clients on important state changes.</li>
+          </ul>
+          <p>
+            All automation elements inherit from the <code>IUIAutomationElement</code> interface and all properties that are not specific to a particular control pattern can be queried through that
+            interface. There are several ways to access UI Automation element properties:
+          </p>
+          <ul>
+            <li>Direct property accessors to the current values - <code>Current{PropertyName}</code>, e.g. <code>IUIAutomationElement::CurrentName</code> for the <code>Name</code> property</li>
+            <li>
+              Cached property accessors - <code>Cached{PropertyName}</code>, e.g. <code>IUIAutomationElement::CachedName</code> for the <code>Name</code> property. Using cached values is preferred
+              when providers and clients are used in remote environments.
+            </li>
+            <li>
+              <code>GetCurrentPropertyValue</code> and passing the UIA Property ID enumeration value corresponding to that property to get the current value, e.g.
+              <code>IUIAutomationElement::GetCurrentPropertyValue(UIA_NamePropertyId)</code> for the <code>Name</code> property.
+            </li>
+            <li>
+              <code>GetCachedPropertyValue</code> and passing the UIA Property ID enumeration value corresponding to that property to get the cached value, e.g.
+              <code>IUIAutomationElement::GetCachedPropertyValue(UIA_NamePropertyId)</code> for the <code>Name</code> property.
+            </li>
+          </ul>
+          <p>
+            Properties for specific UIA control patterns are queried the same way using relevant control pattern interfaces. Taking Toggle Pattern as an example, to query the ToggleState property
+            clients can use IUIAutomationTogglePattern::CurrentToggleState or IUIAutomationTogglePattern::GetCurrentPropertyValue(UIA_ToggleToggleStatePropertyId) to get the current value.
+          </p>
+          <p>
+            The property mappings in this specification provide the <code>{PropertyName}</code> and do not specify all specific ways to access the property value. Automation clients can access current
+            or cached values using conventions described above, depending on specific needs and coding style conventions.
+          </p>
+        </section>
+        <section>
+          <h5>Accessible Names and Descriptions</h5>
+          <p>
+            Each platform accessibility API includes a way to assign and retrieve <a class="termref" data-cite="accname-1.2#dfn-accessible-name">accessible name</a> and
+            <a class="termref" data-cite="accname-1.2#dfn-accessible-description">accessible description</a> properties for each <a class="termref">accessible object</a> created in the
+            <a class="termref">accessibility tree</a>. How these properties are implemented and what they are called vary depending on the API.
+          </p>
+          <p>
+            For instance, in MSAA, all <a class="termref">accessible objects</a> support the <code>accName</code> property, which stores the object's
+            <a class="termref" data-cite="accname-1.2#dfn-accessible-name">accessible name</a>. Where the object also supports having an
+            <a class="termref" data-cite="accname-1.2#dfn-accessible-description">accessible description</a>, MSAA stores this property in the object's <code>accDescription</code> property.
+          </p>
+          <p>
+            Software using ATK can read and write to an object's <code>accessible-name</code> and <code>accessible-description</code> properties. In turn, AT-SPI can query the values of those
+            properties through its <code>atspi_accessible_get_name</code> and <code>atspi_accessible_get_description</code> functions.
+          </p>
+          <p>
+            Automation elements in the UIA accessibility tree have a <code>Name</code> property. Where the object also supports having an
+            <a class="termref" data-cite="accname-1.2#dfn-accessible-description">accessible description</a>, UIA stores this property in the object's <code>FullDescription</code> property.
+          </p>
+          <p>
+            The approach to <a class="termref" data-cite="accname-1.2#dfn-accessible-name">accessible names</a> and
+            <a class="termref" data-lt="accessible description" data-cite="accname-1.2#dfn-accessible-description">accessible descriptions</a> in AX API is somewhat different to the other platform
+            APIs. <a class="termref" data-cite="accname-1.2#dfn-accessible-name">Accessible names</a> are exposed using the <code>AXTitle</code> property when the name is visually rendered, while the
+            <code>AXDescription</code> property is used when the object's name is not rendered visually. An object's
+            <a class="termref" data-cite="accname-1.2#dfn-accessible-description">accessible description</a>, where provided by
+            <a class="state-reference" href="#aria-description"><code>aria-description</code></a> or <a class="state-reference" href="#aria-describedby"><code>aria-describedby</code></a
+            >, should be exposed in the <code>accessibilityCustomContent</code> API. Otherwise, it should be exposed as <code>AXHelp</code>.
+          </p>
+          <p>For more detail, see the <a class="accname" href="">Accessible Name and Description Computation</a> specification.</p>
+        </section>
+      </section>
     </section>
-		<section id="roleMappingComputedRole">
-		  <h2>Computed Role</h2>
-      <p>The `computedrole` of an element is a string that represents the role of the element as computed by the browser engine. The `computedrole` is used primarily for the purposes of developer tools and specification comformance and interoperability testing.</p>
-      <p class="note">User agents provide this role string, for example, in developer tools, and in response to the WebDriver function <a href="https://w3c.github.io/webdriver/#get-computed-role">`getComputedRole`</a>, which is used for <a href="https://github.com/w3c/aria/blob/main/documentation/tests.md">interoperability testing of ARIA, HTML-AAM, and other specifications</a>.</p>
-      <aside class="example">
+    <section id="conformance">
+      <section>
+        <h3>RFC-2119 Keywords</h3>
+        <p>
+          RFC-2119 keywords are formatted in uppercase and contained in a <code>strong</code> element with <code>class="rfc2119"</code>. When the keywords shown above are used, but do not share this
+          format, they do not convey formal information in the RFC 2119 sense, and are merely explanatory, i.e., informative. As much as possible, such usages are avoided in this specification.
+        </p>
+      </section>
+      <section>
+        <h3>Normative and Informative Sections</h3>
+        <p>The indication whether a section is normative or non-normative (informative) applies to the entire section including sub-sections.</p>
+        <p>
+          Informative sections provide information useful to understanding the specification. Such sections may contain examples of recommended practice, but it is not required to follow such
+          recommendations in order to conform to this specification.
+        </p>
+      </section>
+      <section>
+        <h3>Features Deprecated in WAI-ARIA</h3>
+        <p>
+          The WAI-ARIA specification <a href="#deprecated" class="specref">lists some features as deprecated</a>. Although this means authors are encouraged not to use such features, it is expected
+          that the features could still be used in legacy content. Therefore, it is important that user agents continue to map these features to accessibility APIs, and doing so is part of conformance
+          to this specification. When future versions of the WAI-ARIA specification change such features from deprecated to removed, they will be removed from the mappings as well and user agents will
+          no longer be asked to continue support for those features.
+        </p>
+      </section>
+    </section>
+    <section class="informative" id="glossary">
+      <h2>Important Terms</h2>
+      <div>
+        <p>While some terms are defined in place, the following definitions are used throughout this document.</p>
+        <dl class="termlist">
+          <dt><dfn data-export="">Accessibility Subtree</dfn></dt>
+          <dd>
+            <p>
+              An [=accessible object=] in the <a>accessibility tree</a> and its descendants in that tree. It does not include objects which have relationships other than parent-child in that tree. For
+              example, it does not include objects linked via <a class="specref" href="#aria-flowto">aria-flowto</a> unless those objects are also descendants in the <a>accessibility tree</a>.
+            </p>
+          </dd>
+          <dt><dfn data-export="">Activation behavior</dfn></dt>
+          <dd>
+            <p>
+              The action taken when an <a>event</a>, typically initiated by users through an input device, causes an element to fulfill a defined role. The role may be defined for that element by the
+              host language, or by author-defined variables, or both. The role for any given element may be a generic action, or may be unique to that element. For example, the activation behavior of
+              an <abbr title="Hypertext Markup Language">HTML</abbr> or <abbr title="Scalable Vector Graphics">SVG</abbr> <code>&lt;a&gt;</code> element shall be to cause the user agent to traverse
+              the link specified in the <code>href</code> attribute, with the further optional parameter of specifying the browsing context for the traversal (such as the current window or tab, a
+              named window, or a new window); the activation behavior of an <abbr title="Hypertext Markup Language">HTML</abbr> <code>&lt;input&gt;</code> element with the <code>type</code> attribute
+              value <code>submit</code> shall be to send the values of the form elements to an author-defined <abbr title="Internationalized Resource Identifiers">IRI</abbr> by the author-defined
+              <abbr title="Hypertext Transfer Protocol">HTTP</abbr> method.
+            </p>
+          </dd>
+        </dl>
+      </div>
+    </section>
+    <section id="mapping">
+      <h2>Mapping <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> to Accessibility <abbr title="Application Programming Interfaces">APIs</abbr></h2>
+      <section id="mapping_general">
+        <h3>General rules for exposing <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> semantics</h3>
+        <p>
+          Where supported by the platform <a class="termref">Accessibility API</a>, [=user agents=] expose <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr>
+          <a class="termref">semantics</a> through the standard mechanisms of the desktop accessibility <abbr title="application programming interface">API</abbr>. For example, for
+          <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref">widgets</a>, compare how the widget is exposed in a similar desktop widget. In general most
+          <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> widget capabilities are exposed through the <a class="termref">role</a>, value, Boolean <a class="termref">states</a>, and
+          relations of the accessibility <abbr title="application programming interface">API</abbr>.
+        </p>
+        <p>
+          With respect to <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 1.0 and 1.1, accessibility <abbr title="application programming interfaces">APIs</abbr> operate in one
+          direction only. User agents publish <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> information (roles, states, and properties) via an accessibility
+          <abbr title="application programming interface">API</abbr>, and an <abbr title="assistive technology">AT</abbr> can acquire that information using the same
+          <abbr title="application programming interface">API</abbr>. However, the other direction is not supported. <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 1.0 and 1.1 do
+          not define mechanisms for assistive technologies to directly modify <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> information.
+        </p>
+        <p>
+          The terms "exposing", "mapping", and "including" refer to the creation of <a class="termref">accessible object</a> <a class="termref" data-lt="node">nodes</a> within the
+          <a class="termref">accessibility tree</a>, and populating these objects with <a class="termref">Accessibility API</a> specific <a class="termref">states</a> and [=ARIA/properties=].
+        </p>
+      </section>
+      <section id="mapping_conflicts">
+        <h3>Conflicts between native markup semantics and <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr></h3>
+        <p>
+          <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> roles, states, and properties are intended to add <a class="termref">semantic</a> information when native host language
+          <a class="termref">elements</a> with these semantics are not available, and are generally used on elements that have no native semantics of their own. They can also be used on elements that
+          have similar but not identical semantics to the intended object (for instance, a nested list could be used to represent a tree structure). This method can be part of a fallback strategy for
+          older browsers that have no <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> implementation, or because native presentation of the repurposed element reduces the amount of
+          style and/or script needed. Except for the cases outlined below, [=user agents=] MUST always use the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> semantics to define
+          how it exposes the element to <a class="termref">accessibility APIs</a>, rather than using the host language semantics.
+        </p>
+        <p>
+          Host languages can have features that have implicit <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> semantics corresponding to <a class="termref">roles</a>. When a
+          <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role is provided that has a corresponding role in the accessibility
+          <abbr title="Application Programming Interface">API</abbr>, user agents MUST use the semantic of the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role for processing,
+          not the native semantic, unless the role requires <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties whose attributes are explicitly forbidden on the
+          native element by the host language. Values for roles do not conflict in the same way as values for states and properties, and because authors are expected to have a valid reason to provide
+          a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role even on elements that would not normally be repurposed. For example, spin buttons are typically constructed from
+          text fields (<code>&lt;input type=&quot;text&quot;&gt;</code>) in order to get most of the default keyboard support. But, the native role, &quot;text field&quot;, is not correct because it
+          does not properly communicate the additional features of a spin button. The author adds the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role of
+          <code>spinbutton</code> (<code>&lt;input type=&quot;text&quot; role=&quot;spinbutton&quot; ...&gt;</code>) so that the control is properly mapped in the accessibility
+          <abbr title="Application Programming Interface">API</abbr>. When a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role is provided that does not have a corresponding role
+          in the accessibility <abbr title="Application Programming Interface">API</abbr>, user agents MAY expose the native semantic in addition to the
+          <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role. If the host language element is overridden by a
+          <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role whose semantics or structure is not equivalent to the native host language semantics or to a subclass of those
+          semantics, then treat any child elements having roles specified as Allowed Accessibility Child Roles as having <a href="#role-map-presentation">presentation</a> or
+          <a href="#role-map-none">none</a>.
+        </p>
+        <p class="note">
+          The above text differs slightly from the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> specification. The requirement for user agents to expose the
+          <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role instead of the native role was intended to only apply in cases where there is a direct mapping from the
+          <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role to a corresponding role in the accessibility <abbr title="Application Programming Interface">API</abbr>. The wording
+          of the requirement is not clear in the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> specification, however, and has been interpreted differently by implementers. The
+          requirement has been clarified here and an additional statement added to indicate that user agents may expose native semantics if there is not a direct mapping to a role in the accessibility
+          <abbr title="Application Programming Interface">API</abbr>. Because there are differing implementations, authors will be advised against adding such
+          <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> roles to native elements that have their own semantics in the
+          <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Authoring Practices Guide.
+        </p>
+        <p>
+          When <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties correspond to host language features that have the same implicit
+          <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantic, it can be problematic if the values become out of sync. For example, the
+          <abbr title="Hypertext Markup Language">HTML</abbr> <code>checked</code> attribute and the <code>aria-checked</code> attribute could have conflicting values. Therefore to prevent providing
+          conflicting states and properties to assistive technologies, host languages will explicitly declare where the use of
+          <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attributes on a host language element conflict with native attributes for that element. When a host language declares a
+          <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a class="termref">attribute</a> to be in direct semantic conflict with a native attribute for a given element, user
+          agents MUST ignore the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attribute and instead use the host language attribute with the same implicit semantic.
+        </p>
+        <p>
+          Host languages might also document features that cannot be overridden with <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> (these are called &quot;strong native
+          semantics&quot;). These can be features that have implicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics as well as features where the processing would be
+          uncertain if the semantics were changed with <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>. While conformance checkers might signal an error or warning when a
+          <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role is used on elements with strong native semantics, user agents MUST still use the value of the semantic of the
+          <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role when exposing the element to accessibility <abbr title="Application Programming Interfaces">APIs</abbr>.
+        </p>
+      </section>
+      <section id="mapping_nodirect">
+        <h3>Exposing attributes that do not directly map to accessibility <abbr title="application programming interface">API</abbr> properties</h3>
+        <p>
+          Platform <a class="termref">accessibility APIs</a> might have features that are not in <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr>. Likewise,
+          <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> exposes capabilities that are not supported by accessibility
+          <abbr title="Application Programming Interfaces">APIs</abbr> at the time of publication. There typically is not a one to one relationship between all
+          <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref">attributes</a> and platform accessibility <abbr title="application programming interfaces">APIs</abbr>.
+          When <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref">roles</a>, <a class="termref">states</a> and [=ARIA/properties=] do not directly map to an
+          accessibility <abbr title="application programming interface">API</abbr>, and there is a mechanism in the <abbr title="application programming interface">API</abbr> to expose the
+          <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role, states, and properties and their values, [=user agents=] MUST expose the
+          <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> data using that mechanism as follows:
+        </p>
+        <ul>
+          <li>
+            In IAccessible2 and <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>, use object attributes to expose
+            <a class="termref">semantics</a> that are not directly supported in the <abbr title="application programming interfaces">APIs</abbr>. Object attributes are name-value pairs that are
+            loosely specified, and very flexible for exposing things where there is no specific interface in an accessibility <abbr title="application programming interface">API</abbr>. For example,
+            at this time, the <a class="property-reference" href="#aria-live"><code>aria-live</code></a> attribute can be exposed via an object attribute because accessibility
+            <abbr title="application programming interfaces">APIs</abbr> have no such property available. Specific rules for exposing object attribute name-value pairs are described throughout this
+            document, and rules for the general cases are in <a href="#mapping_state-property">State and Property Mapping</a>.
+          </li>
+          <li>
+            In Microsoft <abbr title="User Interface Automation">UIA</abbr>, use the <code>AriaRole</code> and <code>AriaProperties</code> properties to expose semantics that are not directly
+            supported in the control type.
+          </li>
+        </ul>
+        <p class="note">
+          MSAA does not provide a mechanism for exposing attributes that do not map directly to the <abbr title="application programming interface">API</abbr> and among implementers, there is no
+          agreement on how to do it.
+        </p>
+        <p>
+          User agents MUST also expose the entire role string through this mechanism and MAY also expose <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attributes and values
+          through this mechanism even when there is a direct mapping to an accessibility <abbr title="application programming interface">API</abbr>.
+        </p>
+        <p>
+          Browser implementers are advised to publicly document their <abbr title="application programming interface">API</abbr> methods for exposing any relevant information, so that
+          <a class="termref">assistive technology</a> developers can use the <abbr title="application programming interface">API</abbr> to support user features.
+        </p>
+      </section>
+      <section id="mapping_role">
+        <h2>Role mapping</h2>
+        <p>
+          Platform <a class="termref">accessibility APIs</a> traditionally have had a finite set of predefined <a class="termref">roles</a> that are expected by
+          <a class="termref">assistive technologies</a> on that platform and only one or two roles may be exposed. In contrast,
+          <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> allows multiple roles to be specified as an ordered set of space-separated valid role tokens. The additional roles are
+          fallback roles similar to the concept of specifying multiple fonts in case the first choice font type is not supported.
+        </p>
+        <section id="roleMappingGeneralRules">
+          <h2>General rules</h2>
+          <p id="exposeRoleString">
+            User agents MUST expose the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role string if the <abbr title="application programming interface">API</abbr> supports a
+            mechanism to do so. This allows assistive technologies to do their own additional processing of roles.
+          </p>
+          <ul>
+            <li>
+              <abbr title="Microsoft Active Accessibility">MSAA</abbr>:
+              <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd373608(v=vs.85).aspx" title="Object Roles (Windows)">not supported</a>. User agents SHOULD NOT expose a custom role in
+              MSAA's <code>accRole</code> property.
+            </li>
+            <li>IAccessible2: expose as an object attribute pair (<code>xml-roles:&quot;string&quot;</code>)</li>
+            <li>
+              <abbr title="User Interface Automation">UIA</abbr>: expose as <code>AriaRole</code> property. The <code>AriaRole property</code> can also support secondary roles using a space as a
+              separator.
+            </li>
+            <li>
+              <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>: expose as an object attribute pair
+              (<code>xml-roles:&quot;string&quot;</code>)
+            </li>
+          </ul>
+        </section>
+        <section id="roleMappingComputedRole">
+          <h2>Computed Role</h2>
+          <p>
+            The `computedrole` of an element is a string that represents the role of the element as computed by the browser engine. The `computedrole` is used primarily for the purposes of developer
+            tools and specification comformance and interoperability testing.
+          </p>
+          <p class="note">
+            User agents provide this role string, for example, in developer tools, and in response to the WebDriver function
+            <a href="https://w3c.github.io/webdriver/#get-computed-role">`getComputedRole`</a>, which is used for
+            <a href="https://github.com/w3c/aria/blob/main/documentation/tests.md">interoperability testing of ARIA, HTML-AAM, and other specifications</a>.
+          </p>
+          <aside class="example">
+            <!-- ReSpec needs these examples to be unindented. -->
+            <pre>
+&lt;button&gt; &lt;!-- computedrole returns "button" --&gt;
 
-<!-- ReSpec needs these examples to be unindented. -->
-<pre>&lt;button&gt; &lt;!-- computedrole returns "button" --&gt;
-
-&lt;a href="#" role="button"&gt; &lt;!-- computedrole returns "button" --&gt;</pre>
-
-      </aside>
-      <p>When an element has a role but is not contained in the required context (for example, an orphaned `listitem` without the required accessible parent of role `list`), User Agents MUST ignore the role token, and return the `computedrole` as if the ignored role token had not been included.</p>
-      <aside class="example">
-
-<!-- ReSpec needs these examples to be unindented. -->
-<pre>&lt;div role="listitem"&gt; &lt;!-- Author error: orphaned listitem. computedrole returns "generic" --&gt;
+&lt;a href="#" role="button"&gt; &lt;!-- computedrole returns "button" --&gt;</pre
+            >
+          </aside>
+          <p>
+            When an element has a role but is not contained in the required context (for example, an orphaned `listitem` without the required accessible parent of role `list`), User Agents MUST ignore
+            the role token, and return the `computedrole` as if the ignored role token had not been included.
+          </p>
+          <aside class="example">
+            <!-- ReSpec needs these examples to be unindented. -->
+            <pre>
+&lt;div role="listitem"&gt; &lt;!-- Author error: orphaned listitem. computedrole returns "generic" --&gt;
 
 &lt;div role="list"&gt; &lt;!-- computedrole returns "list" --&gt;
-  &lt;div role="listitem"&gt; &lt;!-- computedrole returns "listitem" in the required context. --&gt;</pre>
+  &lt;div role="listitem"&gt; &lt;!-- computedrole returns "listitem" in the required context. --&gt;</pre
+            >
+          </aside>
+          <p>
+            When host language elements do not have an exact or equivalent mapping to a valid, non-abstract role, the related Accessibilty API Mapping extension specification MAY specify a unique
+            `computedrole` string as the return value for interoperability testing purposes, such as `&lt;video&gt; -&gt; "html-video"` in [[HTML-AAM]]. However, authors MUST NOT use any
+            host-language-prefixed `computedrole` string in the `role` attribute (such as `html-video`), unless the token also matches valid, defined role (such as `dpub-chapter`). User Agents MUST
+            ignore any abstract or invalid role token.
+          </p>
+          <aside class="example">
+            <!-- ReSpec needs these examples to be unindented. -->
+            <pre>
+&lt;video&gt; &lt;!-- computedrole returns "html-video" --&gt;
 
-      </aside>
-      <p>When host language elements do not have an exact or equivalent mapping to a valid, non-abstract role, the related Accessibilty API Mapping extension specification MAY specify a unique `computedrole` string as the return value for interoperability testing purposes, such as `&lt;video&gt; -&gt; "html-video"` in [[HTML-AAM]]. However, authors MUST NOT use any host-language-prefixed `computedrole` string in the `role` attribute (such as `html-video`), unless the token also matches valid, defined role (such as `dpub-chapter`). User Agents MUST ignore any abstract or invalid role token.</p>
-      <aside class="example">
-
-<!-- ReSpec needs these examples to be unindented. -->
-<pre>&lt;video&gt; &lt;!-- computedrole returns "html-video" --&gt;
-
-&lt;main role="html-video"&gt; &lt;!-- Author error. computedrole returns "main" --&gt;</pre>
-
-      </aside>
-    </section>
-    <section id="mapping_role_table">
-		<h3>Role Mapping Tables</h3>
-<h4 id=role-map-alert><code>alert</code></h4>
-<table aria-labelledby=role-map-alert>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#alert"><code>alert</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>alert</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_ALERT</code></span><br>
-        <span class="event">Event: The user agent SHOULD fire <code>EVENT_SYSTEM_ALERT</code>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>alert</code></span><br>
-        <span class="property">LiveSetting: <code>Assertive (2)</code></span><br>
-        <span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_NOTIFICATION</code></span><br>
-        <span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXApplicationAlert</code></span><br>
-        <span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-alertdialog><code>alertdialog</code></h4>
-<table aria-labelledby=role-map-alertdialog>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#alertdialog"><code>alertdialog</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>alertdialog</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_DIALOG</code></span><br>
-        <span class="event">Event: The user agent SHOULD fire <code>EVENT_SYSTEM_ALERT</code>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Pane</code></span><br>
-        <span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_ALERT</code></span><br>
-        <span class="property">Interface: <code>Window</code></span><br>
-        <span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXApplicationAlertDialog</code></span><br>
-        <span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-application><code>application</code></h4>
-<table aria-labelledby=role-map-application>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#application"><code>application</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>application</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_APPLICATION</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Pane</code></span><br>
-        <span class="property">Localized Control Type: <code>application</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_EMBEDDED</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXWebApplication</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-article><code>article</code></h4>
-<table aria-labelledby=role-map-article>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#article"><code>article</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>article</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_DOCUMENT</code></span><br>
-        <span class="property">State: <code>STATE_SYSTEM_READONLY</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:article</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>article</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_ARTICLE</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:article</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXDocumentArticle</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-banner><code>banner</code></h4>
-<table aria-labelledby=role-map-banner>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#banner"><code>banner</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>banner</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:banner</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>banner</code></span><br>
-        <span class="property">Landmark Type: <code>Custom</code></span><br>
-        <span class="property">Localized Landmark Type: <code>banner</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_LANDMARK</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:banner</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXLandmarkBanner</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-blockquote><code>blockquote</code></h4>
-<table aria-labelledby=role-map-blockquote>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#blockquote"><code>blockquote</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>blockquote</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br>
-        <span class="property">Role: <code>IA2_ROLE_BLOCK_QUOTE</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>blockquote</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_BLOCK_QUOTE</code></span><br>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-button><code>button</code> with default values for <code>aria-pressed</code> and <code>aria-haspopup</code></h4>
-<table aria-labelledby=role-map-button>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#button"><code>button</code></a> with default values for <a class="property-reference" href="#aria-pressed"><code>aria-pressed</code></a> and <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>button</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_PUSHBUTTON</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Button</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_PUSH_BUTTON</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXButton</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-button-haspopup><code>button</code> with non-<code>false</code> value for <code>aria-haspopup</code></h4>
-<table aria-labelledby=role-map-button-haspopup>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#button"><code>button</code></a> with non-<code>false</code> value for <code>aria-haspopup</code>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>button</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_BUTTONMENU</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Button</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_PUSH_BUTTON</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXPopUpButton</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-button-pressed><code>button</code> with defined value for <code>aria-pressed</code></h4>
-<table aria-labelledby=role-map-button-pressed>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#button"><code>button</code></a> with defined value for <a class="property-reference" href="#aria-pressed"><code>aria-pressed</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>button</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_PUSHBUTTON</code></span><br>
-        <span class="property">Role: <code>IA2_ROLE_TOGGLE_BUTTON</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Button</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_TOGGLE_BUTTON</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXCheckBox</code></span><br>
-        <span class="property">AXSubrole: <code>AXToggle</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-caption><code>caption</code></h4>
-<table aria-labelledby=role-map-caption>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#caption"><code>caption</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>caption</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br>
-        <span class="property">Role: <code>IA2_ROLE_CAPTION</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Text</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_CAPTION</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-cell><code>cell</code></h4>
-<table aria-labelledby=role-map-cell>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#cell"><code>cell</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>cell</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_CELL</code></span><br>
-        <span class="property">Interface: <code>IAccessibleTableCell</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>DataItem</code></span><br>
-        <span class="property">Localized Control Type: <code>item</code></span><br>
-        <span class="property">Control Pattern: <code>GridItem</code></span><br>
-        <span class="property">Control Pattern: <code>TableItem</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_TABLE_CELL</code></span><br>
-        <span class="property">Interface: <code>TableCell</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXCell</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-checkbox><code>checkbox</code></h4>
-<table aria-labelledby=role-map-checkbox>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#checkbox"><code>checkbox</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>checkbox</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_CHECKBUTTON</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Checkbox</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_CHECK_BOX</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXCheckBox</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-code><code>code</code></h4>
-<table aria-labelledby=role-map-code>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#code"><code>code</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>code</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:code</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Text</code></span><br>
-        <span class="property">Localized Control Type: <code>code</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_STATIC</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:code</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXCodeStyleGroup</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-columnheader><code>columnheader</code></h4>
-<table aria-labelledby=role-map-columnheader>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#columnheader"><code>columnheader</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>columnheader</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_COLUMNHEADER</code></span><br>
-        <span class="property">Interface: <code>IAccessibleTableCell</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>DataItem</code></span><br>
-        <span class="property">Localized Control Type: <code>column header</code></span><br>
-        <span class="property">Control Pattern: <code>GridItem</code></span><br>
-        <span class="property">Control Pattern: <code>TableItem</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_COLUMN_HEADER</code></span><br>
-        <span class="property">Interface: <code>TableCell</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXCell</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-combobox><code>combobox</code></h4>
-<table aria-labelledby=role-map-combobox>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#combobox"><code>combobox</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>combobox</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_COMBOBOX</code></span><br>
-        <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br>
-        <span class="property">State: <code>STATE_SYSTEM_COLLAPSED</code> if <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a> is not <code>&quot;true&quot;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Combobox</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_COMBO_BOX</code></span><br>
-        <span class="property">State: <code>STATE_EXPANDABLE</code></span><br>
-        <span class="property">State: <code>STATE_HAS_POPUP</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXComboBox</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-comment><code>comment</code></h4>
-<table aria-labelledby=role-map-comment>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#comment"><code>comment</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>comment</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>IA2_ROLE_COMMENT</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:comment</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>comment</code></span><br>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_COMMENT</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:comment</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-complementary><code>complementary</code></h4>
-<table aria-labelledby=role-map-complementary>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#complementary"><code>complementary</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>complementary</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:complementary</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>complementary</code></span><br>
-        <span class="property">Landmark Type: <code>Custom</code></span><br>
-        <span class="property">Localized Landmark Type: <code>complementary</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_LANDMARK</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:complementary</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXLandmarkComplementary</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-contentinfo><code>contentinfo</code></h4>
-<table aria-labelledby=role-map-contentinfo>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#contentinfo"><code>contentinfo</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>contentinfo</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:contentinfo</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>content information</code></span><br>
-        <span class="property">Landmark Type: <code>Custom</code></span><br>
-        <span class="property">Localized Landmark Type: <code>content information</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_LANDMARK</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:contentinfo</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXLandmarkContentInfo</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-definition><code>definition</code></h4>
-<table aria-labelledby=role-map-definition>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#definition"><code>definition</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>definition</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Object Attribute: <code>xml-roles:definition</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>definition</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_DESCRIPTION_VALUE</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:definition</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXDefinition</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-deletion><code>deletion</code></h4>
-<table aria-labelledby=role-map-deletion>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#deletion"><code>deletion</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>deletion</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>IA2_ROLE_CONTENT_DELETION</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Text</code></span><br>
-        <span class="property">Localized Control Type: <code>deletion</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_CONTENT_DELETION</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:deletion</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXDeleteStyleGroup</code></span><br>
-        <span class="property">AXAttributedStringForTextMarkerRange: contains <code>AXIsSuggestedDeletion = 1;</code> for all text contained in a <code>deletion</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-dialog><code>dialog</code></h4>
-<table aria-labelledby=role-map-dialog>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#dialog"><code>dialog</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>dialog</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_DIALOG</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Pane</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_DIALOG</code></span><br>
-        <span class="property">Interface: <code>Window</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXApplicationDialog</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-directory><code>directory</code></h4>
-<table aria-labelledby=role-map-directory>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#directory"><code>directory</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p>list</p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>List</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_LIST</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXList</code></span><br>
-        <span class="property">AXSubrole: <code>AXContentList</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-document><code>document</code></h4>
-<table aria-labelledby=role-map-document>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#document"><code>document</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>document</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_DOCUMENT</code></span><br>
-        <span class="property">State: <code>STATE_SYSTEM_READONLY</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Document</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_DOCUMENT_FRAME</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXDocument</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-emphasis><code>emphasis</code></h4>
-<table aria-labelledby=role-map-emphasis>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#emphasis"><code>emphasis</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>emphasis</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:emphasis</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Text</code></span><br>
-        <span class="property">Localized Control Type: <code>emphasis</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_STATIC</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:emphasis</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXEmphasisStyleGroup</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-feed><code>feed</code></h4>
-<table aria-labelledby=role-map-feed>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#feed"><code>feed</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>feed</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:feed</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>feed</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_PANEL</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:feed</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXApplicationGroup</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-figure><code>figure</code></h4>
-<table aria-labelledby=role-map-figure>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#figure"><code>figure</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>figure</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:figure</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>figure</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_PANEL</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:figure</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-form><code>form</code> with an accessible name</h4>
-<table aria-labelledby=role-map-form>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#form"><code>form</code></a> with an accessible name
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>form</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>IA2_ROLE_FORM</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:form</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>form</code></span><br>
-        <span class="property">Landmark Type: <code>Form</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_LANDMARK</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:form</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXLandmarkForm</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-form-nameless><code>form</code> without an accessible name</h4>
-<table aria-labelledby=role-map-form-nameless>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#form"><code>form</code></a> without an accessible name
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>form</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-generic><code>generic</code></h4>
-<table aria-labelledby=role-map-generic>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#generic"><code>generic</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>generic</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br>
-        <span class="property">Role: <code>IA2_ROLE_SECTION</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_SECTION</code></span><br>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-grid><code>grid</code></h4>
-<table aria-labelledby=role-map-grid>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#grid"><code>grid</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>grid</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_TABLE</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:grid</code></span><br>
-        <span class="property">Interface: <code>IAccessibleTable2</code></span><br>
-        <span class="method">Method: <code>IAccessible::accSelect()</code></span><br>
-        <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>DataGrid</code></span><br>
-        <span class="property">Control Pattern: <code>Grid</code></span><br>
-        <span class="property">Control Pattern: <code>Table</code></span><br>
-        <span class="property">Control Pattern: <code>Selection</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_TABLE</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:grid</code></span><br>
-        <span class="property">Interface: <code>Table</code></span><br>
-        <span class="property">Interface: <code>Selection</code></span>
-        <p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXTable</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-        <span class="property">AXColumnHeaderUIElements: a list of pointers to the columnheader elements</span><br>
-        <span class="property">AXHeader: a pointer to the row or group containing those columnheader elements</span><br>
-        <span class="property">AXRowHeaderUIElements: a list of pointers to the rowheader elements</span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-gridcell><code>gridcell</code></h4>
-<table aria-labelledby=role-map-gridcell>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#gridcell"><code>gridcell</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>gridcell</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_CELL</code></span><br>
-        <span class="property">Interface: <code>IAccessibleTableCell</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>DataItem</code></span><br>
-        <span class="property">Localized Control Type: <code>item</code></span><br>
-        <span class="property">Control Pattern: <code>SelectionItem</code></span><br>
-        <span class="property">Control Pattern: <code>GridItem</code></span><br>
-        <span class="property">Control Pattern: <code>TableItem</code></span><br>
-        <span class="property">SelectionItem.SelectionContainer: the containing <code>grid</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_TABLE_CELL</code></span><br>
-        <span class="property">Interface: <code>TableCell</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXCell</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-group><code>group</code></h4>
-<table aria-labelledby=role-map-group>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#group"><code>group</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>group</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_PANEL</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXApplicationGroup</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-heading><code>heading</code></h4>
-<table aria-labelledby=role-map-heading>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#heading"><code>heading</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>heading</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>IA2_ROLE_HEADING</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:heading</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Text</code></span><br>
-        <span class="property">Localized Control Type: <code>heading</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_HEADING</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXHeading</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-image><code>image</code></h4>
-<table aria-labelledby=role-map-image>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#image"><code>image</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>image</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_GRAPHIC</code></span><br>
-        <span class="property">Interface: <code>IAccessibleImage</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Image</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_IMAGE</code></span><br>
-        <span class="property">Interface: <code>Image</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXImage</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-img><code>img</code></h4>
-<table aria-labelledby=role-map-img>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#img"><code>img</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>image</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_GRAPHIC</code></span><br>
-        <span class="property">Interface: <code>IAccessibleImage</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Image</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_IMAGE</code></span><br>
-        <span class="property">Interface: <code>Image</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXImage</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-insertion><code>insertion</code></h4>
-<table aria-labelledby=role-map-insertion>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#insertion"><code>insertion</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>insertion</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>IA2_ROLE_CONTENT_INSERTION</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Text</code></span><br>
-        <span class="property">Localized Control Type: <code>insertion</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_CONTENT_INSERTION</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:insertion</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXInsertStyleGroup</code></span><br>
-        <span class="property">AXAttributedStringForTextMarkerRange: contains <code>AXIsSuggestedInsertion = 1;</code> for all text contained in a <code>insertion</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-link><code>link</code></h4>
-<table aria-labelledby=role-map-link>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#link"><code>link</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>link</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_LINK</code></span><br>
-        <span class="property">State: <code>STATE_SYSTEM_LINKED</code></span><br>
-        <span class="property">State: <code>STATE_SYSTEM_LINKED</code></span> on its descendants<br>
-        <span class="property">Interface: <code>IAccessibleHypertext</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>HyperLink</code></span><br>
-        <span class="property">Control Pattern: <code>Value</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_LINK</code></span><br>
-        <span class="property">Interface: <code>HyperlinkImpl</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXLink</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-list><code>list</code></h4>
-<table aria-labelledby=role-map-list>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#list"><code>list</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>list</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span><br>
-        <span class="property">State: <code>STATE_SYSTEM_READONLY</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>List</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_LIST</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXList</code></span><br>
-        <span class="property">AXSubrole: <code>AXContentList</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-listbox><code>listbox</code> without an accessibility parent of <code>combobox</code></h4>
-<table aria-labelledby=role-map-listbox>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#listbox"><code>listbox</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>listbox</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span><br>
-        <span class="method">Method: <code>IAccessible::accSelect()</code></span><br>
-        <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>List</code></span><br>
-        <span class="property">Control Pattern: <code>Selection</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_LIST_BOX</code></span><br>
-        <span class="property">Interface: <code>Selection</code></span>
-        <p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXList</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-listbox-in-combobox><code>listbox</code> with an accessibility parent of <code>combobox</code></h4>
-<table aria-labelledby=role-map-listbox-in-combobox>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#listbox"><code>listbox</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>listbox</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span><br>
-        <span class="method">Method: <code>IAccessible::accSelect()</code></span><br>
-        <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>List</code></span><br>
-        <span class="property">Control Pattern: <code>Selection</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_MENU</code></span><br>
-        <span class="property">Interface: <code>Selection</code></span>
-        <p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXList</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-listitem><code>listitem</code></h4>
-<table aria-labelledby=role-map-listitem>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#listitem"><code>listitem</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>listitem</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_LISTITEM</code></span><br>
-        <span class="property">State: <code>STATE_SYSTEM_READONLY</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>ListItem</code></span><br>
-        <span class="property">Control Pattern: <code>SelectionItem</code></span><br>
-        <span class="property">SelectionItem.SelectionContainer: the containing <code>list</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_LIST_ITEM</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-log><code>log</code></h4>
-<table aria-labelledby=role-map-log>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#log"><code>log</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>log</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Object Attribute: <code>xml-roles:log</code></span><br>
-        <span class="property">Object Attribute: <code>container-live:polite</code></span><br>
-        <span class="property">Object Attribute: <code>live:polite</code></span><br>
-        <span class="property">Object Attribute: <code>container-live-role:log</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>log</code></span><br>
-        <span class="property">LiveSetting: <code>Polite (1)</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_LOG</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:log</code></span><br>
-        <span class="property">Object Attribute: <code>container-live:polite</code></span><br>
-        <span class="property">Object Attribute: <code>live:polite</code></span><br>
-        <span class="property">Object Attribute: <code>container-live-role:log</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXApplicationLog</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-main><code>main</code></h4>
-<table aria-labelledby=role-map-main>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#main"><code>main</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>main</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:main</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>main</code></span><br>
-        <span class="property">Landmark Type: <code>Main</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_LANDMARK</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:main</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXLandmarkMain</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-mark><code>mark</code></h4>
-<table aria-labelledby=role-map-mark>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#mark"><code>mark</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>mark</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br>
-        <span class="property">Role: <code>IA2_ROLE_MARK</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:mark</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_MARK</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:mark</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXRoleDescription: <code>highlight</code></span><br>
-        <span class="property">AXAttributedStringForTextMarkerRange: contains <code>AXHighlight = 1;</code> for all text contained in a <code>mark</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-marquee><code>marquee</code></h4>
-<table aria-labelledby=role-map-marquee>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#marquee"><code>marquee</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>marquee</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_ANIMATION</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:marquee</code></span><br>
-        <span class="property">Object Attribute: <code>container-live:off</code></span><br>
-        <span class="property">Object Attribute: <code>live:off</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>marquee</code></span><br>
-        <span class="property">LiveSetting: <code>Off (0)</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_MARQUEE</code></span><br>
-        <span class="property">Object Attribute: <code>container-live:off</code></span><br>
-        <span class="property">Object Attribute: <code>live:off</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXApplicationMarquee</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-math><code>math</code></h4>
-<table aria-labelledby=role-map-math>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#math"><code>math</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>math</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_EQUATION</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>math</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_MATH</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXDocumentMath</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-menu><code>menu</code></h4>
-<table aria-labelledby=role-map-menu>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#menu"><code>menu</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>menu</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_MENUPOPUP</code></span><br>
-        <span class="method">Method: <code>IAccessible::accSelect()</code></span><br>
-        <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Menu</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_MENU</code></span><br>
-        <span class="property">Interface: <code>Selection</code></span>
-        <p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXMenu</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-menubar><code>menubar</code></h4>
-<table aria-labelledby=role-map-menubar>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#menubar"><code>menubar</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>menubar</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_MENUBAR</code></span><br>
-        <span class="method">Method: <code>IAccessible::accSelect()</code></span><br>
-        <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>MenuBar</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_MENU_BAR</code></span><br>
-        <span class="property">Interface: <code>Selection</code></span>
-        <p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXMenuBar</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-menuitem><code>menuitem</code></h4>
-<table aria-labelledby=role-map-menuitem>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#menuitem"><code>menuitem</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>menuitem</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_MENUITEM</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>MenuItem</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_MENU_ITEM</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXMenuItem</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-menuitemcheckbox><code>menuitemcheckbox</code></h4>
-<table aria-labelledby=role-map-menuitemcheckbox>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#menuitemcheckbox"><code>menuitemcheckbox</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>menuitemcheckbox</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_CHECKBUTTON</code> or <code>ROLE_SYSTEM_MENUITEM</code></span><br>
-        <span class="property">Role: <code>IA2_ROLE_CHECK_MENU_ITEM</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>MenuItem</code></span><br>
-        <span class="property">Control Pattern: <code>Toggle</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_CHECK_MENU_ITEM</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXMenuItem</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-menuitemradio><code>menuitemradio</code></h4>
-<table aria-labelledby=role-map-menuitemradio>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#menuitemradio"><code>menuitemradio</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>menuitemradio</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_RADIOBUTTON</code> or <code>ROLE_SYSTEM_MENUITEM</code></span><br>
-        <span class="property">Role: <code>IA2_ROLE_RADIO_MENU_ITEM</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>MenuItem</code></span><br>
-        <span class="property">Control Pattern: <code>Toggle</code></span><br>
-        <span class="property">Control Pattern: <code>SelectionItem</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_RADIO_MENU_ITEM</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXMenuItem</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-meter><code>meter</code></h4>
-<table aria-labelledby=role-map-meter>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#meter"><code>meter</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>meter</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>IA2_ROLE_LEVEL_BAR</code></span><br>
-        <span class="property">Interface: <code>IAccessibleValue</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>ProgressBar</code></span><br>
-        <span class="property">Localized Control Type: <code>meter</code></span><br>
-        <span class="property">Control Pattern: <code>RangeValue</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_LEVEL_BAR</code></span><br>
-        <span class="property">Interface: <code>Value</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXLevelIndicator</code></span><br>
-        <span class="property">AXSubrole: <code>AXMeter</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-navigation><code>navigation</code></h4>
-<table aria-labelledby=role-map-navigation>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#navigation"><code>navigation</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>navigation</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:navigation</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>navigation</code></span><br>
-        <span class="property">Landmark Type: <code>Navigation</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_LANDMARK</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:navigation</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXLandmarkNavigation</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-none><code>none</code></h4>
-<table aria-labelledby=role-map-none>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#none"><code>none</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>none</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <p>For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>IA2_ROLE_TEXT_FRAME</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <p>For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it using the <code>text</code> pattern. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <p>For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>ROLE_SECTION</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <p>For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>AXGroup</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-note><code>note</code></h4>
-<table aria-labelledby=role-map-note>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#note"><code>note</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>note</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>IA2_ROLE_NOTE</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>note</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_COMMENT</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXDocumentNote</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-option><code>option</code> not inside <code>combobox</code></h4>
-<table aria-labelledby=role-map-option>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#option"><code>option</code></a> not inside <code>combobox</code>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>option</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_LISTITEM</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>ListItem</code></span><br>
-        <span class="property">Control Pattern: <code>Invoke</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_LIST_ITEM</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a><br></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXStaticText</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-option-in-combobox><code>option</code> inside <code>combobox</code></h4>
-<table aria-labelledby=role-map-option-in-combobox>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#option"><code>option</code></a> inside <code>combobox</code>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>option</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_LISTITEM</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>ListItem</code></span><br>
-        <span class="property">Control Pattern: <code>Invoke</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_MENU_ITEM</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a><br></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXStaticText</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-paragraph><code>paragraph</code></h4>
-<table aria-labelledby=role-map-paragraph>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#paragraph"><code>paragraph</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>paragraph</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br>
-        <span class="property">Role: <code>IA2_ROLE_PARAGRAPH</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Text</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_PARAGRAPH</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-presentation><code>presentation</code></h4>
-<table aria-labelledby=role-map-presentation>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#presentation"><code>presentation</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>none</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <p>For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>IA2_ROLE_TEXT_FRAME</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <p>For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it using the <code>text</code> pattern. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <p>For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>ROLE_SECTION</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <p>For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the <a class="termref">accessibility tree</a>, expose it as <code>AXGroup</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-progressbar><code>progressbar</code></h4>
-<table aria-labelledby=role-map-progressbar>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#progressbar"><code>progressbar</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>progressbar</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_PROGRESSBAR</code></span><br>
-        <span class="property">State: <code>STATE_SYSTEM_READONLY</code></span><br>
-        <span class="property">Interface: <code>IAccessibleValue</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>ProgressBar</code></span><br>
-        <span class="property">Control Pattern: <code>RangeValue</code> if <code>aria-valuenow</code>, <code>aria-valuemax</code>, or <code>aria-valuemin</code></span> is present
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_PROGRESS_BAR</code></span><br>
-        <span class="property">Interface: <code>Value</code></span>
-        <p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the value via the accessibility API, user agents MUST return <code>false</code> for all <code>Value</code> methods that provide a means to modify the value.</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXProgressIndicator</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-radio><code>radio</code></h4>
-<table aria-labelledby=role-map-radio>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#radio"><code>radio</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>radio</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_RADIOBUTTON</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>RadioButton</code></span><br>
-        <span class="property">Control Pattern: <code>Toggle</code></span><br>
-        <span class="property">Control Pattern: <code>SelectionItem</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_RADIO_BUTTON</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXRadioButton</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-radiogroup><code>radiogroup</code></h4>
-<table aria-labelledby=role-map-radiogroup>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#radiogroup"><code>radiogroup</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>radiogroup</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>List</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_PANEL</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXRadioGroup</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-region><code>region</code> with an accessible name</h4>
-<table aria-labelledby=role-map-region>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#region"><code>region</code></a> with an accessible name
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>region</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:region</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>region</code></span><br>
-        <span class="property">Landmark Type: <code>Custom</code></span><br>
-        <span class="property">Localized Landmark Type: <code>region</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_LANDMARK</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:region</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXLandmarkRegion</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-region-nameless><code>region</code> without an accessible name</h4>
-<table aria-labelledby=role-map-region-nameless>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#region"><code>region</code></a> without an accessible name
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p>Use native host language role.</p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-row><code>row</code> not inside <code>treegrid</code></h4>
-<table aria-labelledby=role-map-row>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#row"><code>row</code></a> not inside <code>treegrid</code>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>row</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_ROW</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>DataItem</code></span><br>
-        <span class="property">Localized Control Type: <code>row</code></span><br>
-        <span class="property">Control Pattern: <code>SelectionItem</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_TABLE_ROW</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXRow</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-row-in-treegrid><code>row</code> inside <code>treegrid</code></h4>
-<table aria-labelledby=role-map-row-in-treegrid>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#row"><code>row</code></a> inside <code>treegrid</code>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>row</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_OUTLINEITEM</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>DataItem</code></span><br>
-        <span class="property">Localized Control Type: <code>row</code></span><br>
-        <span class="property">Control Pattern: <code>SelectionItem</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_TABLE_ROW</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXRow</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-rowgroup><code>rowgroup</code></h4>
-<table aria-labelledby=role-map-rowgroup>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#rowgroup"><code>rowgroup</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>rowgroup</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_PANEL</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-rowheader><code>rowheader</code></h4>
-<table aria-labelledby=role-map-rowheader>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#rowheader"><code>rowheader</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>rowheader</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_ROWHEADER</code></span><br>
-        <span class="property">Interface: <code>IAccessibleTableCell</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>HeaderItem</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_ROW_HEADER</code></span><br>
-        <span class="property">Interface: <code>TableCell</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXCell</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-scrollbar><code>scrollbar</code></h4>
-<table aria-labelledby=role-map-scrollbar>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#scrollbar"><code>scrollbar</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>scrollbar</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_SCROLLBAR</code></span><br>
-        <span class="property">Interface: <code>IAccessibleValue</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>ScrollBar</code></span><br>
-        <span class="property">Control Pattern: <code>RangeValue</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_SCROLL_BAR</code></span><br>
-        <span class="property">Interface: <code>Value</code></span>
-        <p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the value via the accessibility API, user agents MUST return <code>false</code> for all <code>Value</code> methods that provide a means to modify the value.</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXScrollBar</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-search><code>search</code></h4>
-<table aria-labelledby=role-map-search>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#search"><code>search</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>search</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:search</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>search</code></span><br>
-        <span class="property">Landmark Type: <code>Search</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_LANDMARK</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:search</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXLandmarkSearch</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-searchbox><code>searchbox</code></h4>
-<table aria-labelledby=role-map-searchbox>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#searchbox"><code>searchbox</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>searchbox</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span><br>
-        <span class="property">Object Attribute: <code>text-input-type:search</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Edit</code></span><br>
-        <span class="property">Localized Control Type: <code>search box</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_ENTRY</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:searchbox</code></span><br>
-        <span class="property">Interface: <code>EditableText</code> if <a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a> is not <code>&quot;true&quot;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXTextField</code></span><br>
-        <span class="property">AXSubrole: <code>AXSearchField</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-separator><code>separator</code> (non-focusable)</h4>
-<table aria-labelledby=role-map-separator>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#separator"><code>separator</code></a> (non-focusable)
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>seperator</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_SEPARATOR</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Separator</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_SEPARATOR</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXSplitter</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-separator-focusable><code>separator</code> (focusable)</h4>
-<table aria-labelledby=role-map-separator-focusable>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#separator"><code>separator</code></a> (focusable)
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>seperator</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_SEPARATOR</code></span><br>
-        <span class="property">Interface: <code>IAccessibleValue</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Thumb</code></span><br>
-        <span class="property">Control Pattern: <code>RangeValue</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_SEPARATOR</code></span><br>
-        <span class="property">Interface: <code>Value</code></span>
-        <p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the value via the accessibility API, user agents MUST return <code>false</code> for all <code>Value</code> methods that provide a means to modify the value.</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXSplitter</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-slider><code>slider</code></h4>
-<table aria-labelledby=role-map-slider>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#slider"><code>slider</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>slider</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_SLIDER</code></span><br>
-        <span class="property">Interface: <code>IAccessibleValue</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Slider</code></span><br>
-        <span class="property">Control Pattern: <code>RangeValue</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_SLIDER</code></span><br>
-        <span class="property">Interface: <code>Value</code></span>
-        <p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the value via the accessibility API, user agents MUST return <code>false</code> for all <code>Value</code> methods that provide a means to modify the value.</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXSlider</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-spinbutton><code>spinbutton</code></h4>
-<table aria-labelledby=role-map-spinbutton>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#spinbutton"><code>spinbutton</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>spinbutton</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_SPINBUTTON</code></span><br>
-        <span class="property">Interface: <code>IAccessibleValue</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Spinner</code></span><br>
-        <span class="property">Control Pattern: <code>RangeValue</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_SPIN_BUTTON</code></span><br>
-        <span class="property">Interface: <code>Value</code></span>
-        <p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the value via the accessibility API, user agents MUST return <code>false</code> for all <code>Value</code> methods that provide a means to modify the value.</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXIncrementor</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-status><code>status</code></h4>
-<table aria-labelledby=role-map-status>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#status"><code>status</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>status</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_STATUSBAR</code></span><br>
-        <span class="property">Object Attribute: <code>container-live:polite</code></span><br>
-        <span class="property">Object Attribute: <code>live:polite</code></span><br>
-        <span class="property">Object Attribute: <code>container-live-role:status</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>status</code></span><br>
-        <span class="property">LiveSetting: <code>Polite (1)</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_STATUSBAR</code></span><br>
-        <span class="property">Object Attribute: <code>container-live:polite</code></span><br>
-        <span class="property">Object Attribute: <code>live:polite</code></span><br>
-        <span class="property">Object Attribute: <code>container-live-role:status</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXApplicationStatus</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-strong><code>strong</code></h4>
-<table aria-labelledby=role-map-strong>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#strong"><code>strong</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>strong</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:strong</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Text</code></span><br>
-        <span class="property">Localized Control Type: <code>strong</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_STATIC</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:strong</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXStrongStyleGroup</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-subscript><code>subscript</code></h4>
-<table aria-labelledby=role-map-subscript>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#subscript"><code>subscript</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>subscript</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br>
-        <span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br>
-        <span class="property">Text Attribute: <code>text-position:sub</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Text</code></span><br>
-        <span class="property">Styles used are exposed by <code>IsSubscript</code> attribute of the <code>TextRange</code> Control Pattern implemented on the accessible object.</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_SUBSCRIPT</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXSubscriptStyleGroup</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-suggestion><code>suggestion</code></h4>
-<table aria-labelledby=role-map-suggestion>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#suggestion"><code>suggestion</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>suggestion</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>IA2_ROLE_SUGGESTION</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:suggestion</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>suggestion</code></span><br>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_SUGGESTION</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:suggestion</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXAttributedStringForTextMarkerRange: contains <code>AXIsSuggestion = 1;</code> for all text contained in a <code>suggestion</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-superscript><code>superscript</code></h4>
-<table aria-labelledby=role-map-superscript>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#superscript"><code>superscript</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>superscript</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br>
-        <span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br>
-        <span class="property">Text Attribute: <code>text-position:super</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Text</code></span><br>
-        <span class="property">Styles used are exposed by <code>IsSuperscript</code> attribute of the <code>TextRange</code> Control Pattern implemented on the accessible object.</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_SUPERSCRIPT</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXSuperscriptStyleGroup</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-switch><code>switch</code></h4>
-<table aria-labelledby=role-map-switch>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#switch"><code>switch</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>switch</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_CHECKBUTTON</code></span><br>
-        <span class="property">Role: <code>IA2_ROLE_TOGGLE_BUTTON</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:switch</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Button</code></span><br>
-        <span class="property">Localized Control Type: <code>toggleswitch</code></span><br>
-        <span class="property">Control Pattern: <code>Toggle</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_TOGGLE_BUTTON</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:switch</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXCheckBox</code></span><br>
-        <span class="property">AXSubrole: <code>AXSwitch</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-tab><code>tab</code></h4>
-<table aria-labelledby=role-map-tab>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#tab"><code>tab</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>tab</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_PAGETAB</code></span><br>
-        <span class="property">State: <code>STATE_SYSTEM_SELECTED</code> if focus is inside <a class="role-reference" href="#tabpanel"><code>tabpanel</code></a> associated with <a class="property-reference" href="#aria-labelledby"><code>aria-labelledby</code></a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>TabItem</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_PAGE_TAB</code></span><br>
-        <span class="property">State: <code>STATE_SELECTED</code> if focus is inside <a class="role-reference" href="#tabpanel"><code>tabpanel</code></a> associated with <a class="property-reference" href="#aria-labelledby"><code>aria-labelledby</code></a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXRadioButton</code></span><br>
-        <span class="property">AXSubrole: <code>AXTabButton</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-table><code>table</code></h4>
-<table aria-labelledby=role-map-table>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#table"><code>table</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>table</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_TABLE</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:table</code></span><br>
-        <span class="property">Interface: <code>IAccessibleTable2</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Table</code></span><br>
-        <span class="property">Control Pattern: <code>Grid</code></span><br>
-        <span class="property">Control Pattern: <code>Table</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_TABLE</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:table</code></span><br>
-        <span class="property">Interface: <code>Table</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXTable</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-        <span class="property">AXColumnHeaderUIElements: a list of pointers to the columnheader elements</span><br>
-        <span class="property">AXHeader: a pointer to the row or group containing those columnheader elements</span><br>
-        <span class="property">AXRowHeaderUIElements: a list of pointers to the rowheader elements</span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-tablist><code>tablist</code></h4>
-<table aria-labelledby=role-map-tablist>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#tablist"><code>tablist</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>tablist</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_PAGETABLIST</code></span><br>
-        <span class="method">Method: <code>IAccessible::accSelect()</code></span><br>
-        <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Tab</code></span><br>
-        <span class="property">Control Pattern: <code>Selection</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_PAGE_TAB_LIST</code></span><br>
-        <span class="property">Interface: <code>Selection</code></span>
-        <p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXTabGroup</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-tabpanel><code>tabpanel</code></h4>
-<table aria-labelledby=role-map-tabpanel>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#tabpanel"><code>tabpanel</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>tabpanel</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_PANE</code> or <code>ROLE_SYSTEM_PROPERTYPAGE</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Pane</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_SCROLL_PANE</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXTabPanel</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-term><code>term</code></h4>
-<table aria-labelledby=role-map-term>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#term"><code>term</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>term</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:term</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Text</code></span><br>
-        <span class="property">Localized Control Type: <code>term</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_DESCRIPTION_TERM</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXTerm</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-textbox><code>textbox</code> when <code>aria-multiline</code> is <code>false</code></h4>
-<table aria-labelledby=role-map-textbox>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#textbox"><code>textbox</code></a> when <code>aria-multiline</code> is <code>false</code>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>textbox</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span><br>
-        <span class="property">State: <code>IA2_STATE_SINGLE_LINE</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Edit</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_ENTRY</code></span><br>
-        <span class="property">State: <code>STATE_SINGLE_LINE</code></span><br>
-        <span class="property">Interface: <code>EditableText</code> if <a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a> is not <code>&quot;true&quot;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXTextField</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-textbox-multiline><code>textbox</code> when <code>aria-multiline</code> is <code>true</code></h4>
-<table aria-labelledby=role-map-textbox-multiline>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#textbox"><code>textbox</code></a> when <code>aria-multiline</code> is <code>true</code>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>textbox</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span><br>
-        <span class="property">State: <code>IA2_STATE_MULTI_LINE</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Edit</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_ENTRY</code></span><br>
-        <span class="property">State: <code>STATE_MULTI_LINE</code></span><br>
-        <span class="property">Interface: <code>EditableText</code> if <a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a> is not <code>&quot;true&quot;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXTextArea</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-time><code>time</code></h4>
-<table aria-labelledby=role-map-time>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#time"><code>time</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>time</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:time</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Text</code></span><br>
-        <span class="property">Localized Control Type: <code>time</code></span><br>
-        <span>Note: create a separate UIA Control of type Text. This is different from most UIA text mappings, which only create ranges in the page text pattern.</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_STATIC</code></span><br>
-        <span class="property">Object Attribute: <code>xml-roles:time</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXTimeGroup</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-timer><code>timer</code></h4>
-<table aria-labelledby=role-map-timer>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#timer"><code>timer</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>timer</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Object Attribute: <code>xml-roles:timer</code></span><br>
-        <span class="property">Object Attribute: <code>container-live:off</code></span><br>
-        <span class="property">Object Attribute: <code>live:off</code></span><br>
-        <span class="property">Object Attribute: <code>container-live-role:timer</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Group</code></span><br>
-        <span class="property">Localized Control Type: <code>timer</code></span><br>
-        <span class="property">LiveSetting: <code>Off (0)</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_TIMER</code></span><br>
-        <span class="property">Object Attribute: <code>container-live:off</code></span><br>
-        <span class="property">Object Attribute: <code>live:off</code></span><br>
-        <span class="property">Object Attribute: <code>container-live-role:timer</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXApplicationTimer</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-toolbar><code>toolbar</code></h4>
-<table aria-labelledby=role-map-toolbar>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#toolbar"><code>toolbar</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>toolbar</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_TOOLBAR</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>ToolBar</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_TOOL_BAR</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXToolbar</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-tooltip><code>tooltip</code></h4>
-<table aria-labelledby=role-map-tooltip>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#tooltip"><code>tooltip</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>tooltip</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_TOOLTIP</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>ToolTip</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_TOOL_TIP</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXGroup</code></span><br>
-        <span class="property">AXSubrole: <code>AXUserInterfaceTooltip</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-tree><code>tree</code></h4>
-<table aria-labelledby=role-map-tree>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#tree"><code>tree</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>tree</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_OUTLINE</code></span><br>
-        <span class="method">Method: <code>IAccessible::accSelect()</code></span><br>
-        <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>Tree</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_TREE</code></span><br>
-        <span class="property">Interface: <code>Selection</code></span>
-        <p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXOutline</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-treegrid><code>treegrid</code></h4>
-<table aria-labelledby=role-map-treegrid>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#treegrid"><code>treegrid</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>treegrid</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_OUTLINE</code></span><br>
-        <span class="property">Interface: <code>IAccessibleTable2</code></span><br>
-        <span class="method">Method: <code>IAccessible::accSelect()</code></span><br>
-        <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>DataGrid</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_TREE_TABLE</code></span><br>
-        <span class="property">Interface: <code>Table</code></span><br>
-        <span class="property">Interface: <code>Selection</code></span>
-        <p>Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXTable</code></span><br>
-        <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span><br>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-treeitem><code>treeitem</code></h4>
-<table aria-labelledby=role-map-treeitem>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="role-reference" href="#treeitem"><code>treeitem</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>Computed Role</th>
-      <td>
-        <p><code>treeitem</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2</th>
-      <td>
-        <span class="property">Role: <code>ROLE_SYSTEM_OUTLINEITEM</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Type: <code>TreeItem</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Role: <code>ROLE_TREE_ITEM</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
-      <td>
-        <span class="property">AXRole: <code>AXRow</code></span><br>
-        <span class="property">AXSubrole: <code>AXOutlineRow</code></span><br>
-        <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-          <div class="note" id="ftn.note1"><p>
-        	<sup>[Note 1]</sup>
-        	User agent should return a user-presentable, localized string value for the AXRoleDescription.</p>
-        </div>
+&lt;main role="html-video"&gt; &lt;!-- Author error. computedrole returns "main" --&gt;</pre
+            >
+          </aside>
+        </section>
+        <section id="mapping_role_table">
+          <h3>Role Mapping Tables</h3>
+          <h4 id="role-map-alert"><code>alert</code></h4>
+          <table aria-labelledby="role-map-alert">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#alert"><code>alert</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>alert</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_ALERT</code></span
+                  ><br />
+                  <span class="event"
+                    >Event: The user agent SHOULD fire <code>EVENT_SYSTEM_ALERT</code>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>alert</code></span
+                  ><br />
+                  <span class="property">LiveSetting: <code>Assertive (2)</code></span
+                  ><br />
+                  <span class="event"
+                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_NOTIFICATION</code></span
+                  ><br />
+                  <span class="event"
+                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXApplicationAlert</code></span
+                  ><br />
+                  <span class="event"
+                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span
+                  >
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-alertdialog"><code>alertdialog</code></h4>
+          <table aria-labelledby="role-map-alertdialog">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#alertdialog"><code>alertdialog</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>alertdialog</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_DIALOG</code></span
+                  ><br />
+                  <span class="event"
+                    >Event: The user agent SHOULD fire <code>EVENT_SYSTEM_ALERT</code>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Pane</code></span
+                  ><br />
+                  <span class="event"
+                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_ALERT</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Window</code></span
+                  ><br />
+                  <span class="event"
+                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXApplicationAlertDialog</code></span
+                  ><br />
+                  <span class="event"
+                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span
+                  >
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-application"><code>application</code></h4>
+          <table aria-labelledby="role-map-application">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#application"><code>application</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>application</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_APPLICATION</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Pane</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>application</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_EMBEDDED</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXWebApplication</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-article"><code>article</code></h4>
+          <table aria-labelledby="role-map-article">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#article"><code>article</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>article</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_DOCUMENT</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_SYSTEM_READONLY</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:article</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>article</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_ARTICLE</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:article</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXDocumentArticle</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-banner"><code>banner</code></h4>
+          <table aria-labelledby="role-map-banner">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#banner"><code>banner</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>banner</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:banner</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>banner</code></span
+                  ><br />
+                  <span class="property">Landmark Type: <code>Custom</code></span
+                  ><br />
+                  <span class="property">Localized Landmark Type: <code>banner</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_LANDMARK</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:banner</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXLandmarkBanner</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-blockquote"><code>blockquote</code></h4>
+          <table aria-labelledby="role-map-blockquote">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#blockquote"><code>blockquote</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>blockquote</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  ><br />
+                  <span class="property">Role: <code>IA2_ROLE_BLOCK_QUOTE</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>blockquote</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_BLOCK_QUOTE</code></span
+                  ><br />
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-button"><code>button</code> with default values for <code>aria-pressed</code> and <code>aria-haspopup</code></h4>
+          <table aria-labelledby="role-map-button">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#button"><code>button</code></a> with default values for <a class="property-reference" href="#aria-pressed"><code>aria-pressed</code></a> and
+                  <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>button</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_PUSHBUTTON</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Button</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_PUSH_BUTTON</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXButton</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-button-haspopup"><code>button</code> with non-<code>false</code> value for <code>aria-haspopup</code></h4>
+          <table aria-labelledby="role-map-button-haspopup">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#button"><code>button</code></a> with non-<code>false</code> value for <code>aria-haspopup</code>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>button</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_BUTTONMENU</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Button</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_PUSH_BUTTON</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXPopUpButton</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></h4>
+          <table aria-labelledby="role-map-button-pressed">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#button"><code>button</code></a> with defined value for <a class="property-reference" href="#aria-pressed"><code>aria-pressed</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>button</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_PUSHBUTTON</code></span
+                  ><br />
+                  <span class="property">Role: <code>IA2_ROLE_TOGGLE_BUTTON</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Button</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_TOGGLE_BUTTON</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXCheckBox</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXToggle</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-caption"><code>caption</code></h4>
+          <table aria-labelledby="role-map-caption">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#caption"><code>caption</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>caption</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  ><br />
+                  <span class="property">Role: <code>IA2_ROLE_CAPTION</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Text</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_CAPTION</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-cell"><code>cell</code></h4>
+          <table aria-labelledby="role-map-cell">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#cell"><code>cell</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>cell</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_CELL</code></span
+                  ><br />
+                  <span class="property">Interface: <code>IAccessibleTableCell</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>DataItem</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>item</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>GridItem</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>TableItem</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_TABLE_CELL</code></span
+                  ><br />
+                  <span class="property">Interface: <code>TableCell</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXCell</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-checkbox"><code>checkbox</code></h4>
+          <table aria-labelledby="role-map-checkbox">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#checkbox"><code>checkbox</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>checkbox</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_CHECKBUTTON</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Checkbox</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_CHECK_BOX</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXCheckBox</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-code"><code>code</code></h4>
+          <table aria-labelledby="role-map-code">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#code"><code>code</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>code</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:code</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Text</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>code</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_STATIC</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:code</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXCodeStyleGroup</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-columnheader"><code>columnheader</code></h4>
+          <table aria-labelledby="role-map-columnheader">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#columnheader"><code>columnheader</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>columnheader</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_COLUMNHEADER</code></span
+                  ><br />
+                  <span class="property">Interface: <code>IAccessibleTableCell</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>DataItem</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>column header</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>GridItem</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>TableItem</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_COLUMN_HEADER</code></span
+                  ><br />
+                  <span class="property">Interface: <code>TableCell</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXCell</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-combobox"><code>combobox</code></h4>
+          <table aria-labelledby="role-map-combobox">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#combobox"><code>combobox</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>combobox</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_COMBOBOX</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span
+                  ><br />
+                  <span class="property"
+                    >State: <code>STATE_SYSTEM_COLLAPSED</code> if <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a> is not <code>&quot;true&quot;</code></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Combobox</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_COMBO_BOX</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_EXPANDABLE</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_HAS_POPUP</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXComboBox</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-comment"><code>comment</code></h4>
+          <table aria-labelledby="role-map-comment">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#comment"><code>comment</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>comment</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>IA2_ROLE_COMMENT</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:comment</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>comment</code></span
+                  ><br />
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_COMMENT</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:comment</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-complementary"><code>complementary</code></h4>
+          <table aria-labelledby="role-map-complementary">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#complementary"><code>complementary</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>complementary</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:complementary</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>complementary</code></span
+                  ><br />
+                  <span class="property">Landmark Type: <code>Custom</code></span
+                  ><br />
+                  <span class="property">Localized Landmark Type: <code>complementary</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_LANDMARK</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:complementary</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXLandmarkComplementary</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-contentinfo"><code>contentinfo</code></h4>
+          <table aria-labelledby="role-map-contentinfo">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#contentinfo"><code>contentinfo</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>contentinfo</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:contentinfo</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>content information</code></span
+                  ><br />
+                  <span class="property">Landmark Type: <code>Custom</code></span
+                  ><br />
+                  <span class="property">Localized Landmark Type: <code>content information</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_LANDMARK</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:contentinfo</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXLandmarkContentInfo</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-definition"><code>definition</code></h4>
+          <table aria-labelledby="role-map-definition">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#definition"><code>definition</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>definition</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>xml-roles:definition</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>definition</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_DESCRIPTION_VALUE</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:definition</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXDefinition</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-deletion"><code>deletion</code></h4>
+          <table aria-labelledby="role-map-deletion">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#deletion"><code>deletion</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>deletion</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>IA2_ROLE_CONTENT_DELETION</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Text</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>deletion</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_CONTENT_DELETION</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:deletion</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXDeleteStyleGroup</code></span
+                  ><br />
+                  <span class="property">AXAttributedStringForTextMarkerRange: contains <code>AXIsSuggestedDeletion = 1;</code> for all text contained in a <code>deletion</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-dialog"><code>dialog</code></h4>
+          <table aria-labelledby="role-map-dialog">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#dialog"><code>dialog</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>dialog</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_DIALOG</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Pane</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_DIALOG</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Window</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXApplicationDialog</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-directory"><code>directory</code></h4>
+          <table aria-labelledby="role-map-directory">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#directory"><code>directory</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p>list</p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>List</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_LIST</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXList</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXContentList</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-document"><code>document</code></h4>
+          <table aria-labelledby="role-map-document">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#document"><code>document</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>document</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_DOCUMENT</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_SYSTEM_READONLY</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Document</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_DOCUMENT_FRAME</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXDocument</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-emphasis"><code>emphasis</code></h4>
+          <table aria-labelledby="role-map-emphasis">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#emphasis"><code>emphasis</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>emphasis</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:emphasis</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Text</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>emphasis</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_STATIC</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:emphasis</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXEmphasisStyleGroup</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-feed"><code>feed</code></h4>
+          <table aria-labelledby="role-map-feed">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#feed"><code>feed</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>feed</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:feed</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>feed</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_PANEL</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:feed</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXApplicationGroup</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-figure"><code>figure</code></h4>
+          <table aria-labelledby="role-map-figure">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#figure"><code>figure</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>figure</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:figure</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>figure</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_PANEL</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:figure</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-form"><code>form</code> with an accessible name</h4>
+          <table aria-labelledby="role-map-form">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#form"><code>form</code></a> with an accessible name
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>form</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>IA2_ROLE_FORM</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:form</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>form</code></span
+                  ><br />
+                  <span class="property">Landmark Type: <code>Form</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_LANDMARK</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:form</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXLandmarkForm</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-form-nameless"><code>form</code> without an accessible name</h4>
+          <table aria-labelledby="role-map-form-nameless">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#form"><code>form</code></a> without an accessible name
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>form</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-generic"><code>generic</code></h4>
+          <table aria-labelledby="role-map-generic">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#generic"><code>generic</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>generic</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  ><br />
+                  <span class="property">Role: <code>IA2_ROLE_SECTION</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SECTION</code></span
+                  ><br />
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-grid"><code>grid</code></h4>
+          <table aria-labelledby="role-map-grid">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#grid"><code>grid</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>grid</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_TABLE</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:grid</code></span
+                  ><br />
+                  <span class="property">Interface: <code>IAccessibleTable2</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible::accSelect()</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>DataGrid</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>Grid</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>Table</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>Selection</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_TABLE</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:grid</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Table</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Selection</code></span>
+                  <p>
+                    Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return
+                    <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXTable</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                  <span class="property">AXColumnHeaderUIElements: a list of pointers to the columnheader elements</span><br />
+                  <span class="property">AXHeader: a pointer to the row or group containing those columnheader elements</span><br />
+                  <span class="property">AXRowHeaderUIElements: a list of pointers to the rowheader elements</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-gridcell"><code>gridcell</code></h4>
+          <table aria-labelledby="role-map-gridcell">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#gridcell"><code>gridcell</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>gridcell</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_CELL</code></span
+                  ><br />
+                  <span class="property">Interface: <code>IAccessibleTableCell</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>DataItem</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>item</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>SelectionItem</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>GridItem</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>TableItem</code></span
+                  ><br />
+                  <span class="property">SelectionItem.SelectionContainer: the containing <code>grid</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_TABLE_CELL</code></span
+                  ><br />
+                  <span class="property">Interface: <code>TableCell</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXCell</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-group"><code>group</code></h4>
+          <table aria-labelledby="role-map-group">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#group"><code>group</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>group</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_PANEL</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXApplicationGroup</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-heading"><code>heading</code></h4>
+          <table aria-labelledby="role-map-heading">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#heading"><code>heading</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>heading</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>IA2_ROLE_HEADING</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:heading</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Text</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>heading</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_HEADING</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXHeading</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-image"><code>image</code></h4>
+          <table aria-labelledby="role-map-image">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#image"><code>image</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>image</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_GRAPHIC</code></span
+                  ><br />
+                  <span class="property">Interface: <code>IAccessibleImage</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Image</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_IMAGE</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Image</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXImage</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-img"><code>img</code></h4>
+          <table aria-labelledby="role-map-img">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#img"><code>img</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>image</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_GRAPHIC</code></span
+                  ><br />
+                  <span class="property">Interface: <code>IAccessibleImage</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Image</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_IMAGE</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Image</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXImage</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-insertion"><code>insertion</code></h4>
+          <table aria-labelledby="role-map-insertion">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#insertion"><code>insertion</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>insertion</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>IA2_ROLE_CONTENT_INSERTION</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Text</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>insertion</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_CONTENT_INSERTION</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:insertion</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXInsertStyleGroup</code></span
+                  ><br />
+                  <span class="property">AXAttributedStringForTextMarkerRange: contains <code>AXIsSuggestedInsertion = 1;</code> for all text contained in a <code>insertion</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-link"><code>link</code></h4>
+          <table aria-labelledby="role-map-link">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#link"><code>link</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>link</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_LINK</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_SYSTEM_LINKED</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_SYSTEM_LINKED</code></span> on its descendants<br />
+                  <span class="property">Interface: <code>IAccessibleHypertext</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>HyperLink</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>Value</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_LINK</code></span
+                  ><br />
+                  <span class="property">Interface: <code>HyperlinkImpl</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXLink</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-list"><code>list</code></h4>
+          <table aria-labelledby="role-map-list">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#list"><code>list</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>list</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_SYSTEM_READONLY</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>List</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_LIST</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXList</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXContentList</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-listbox"><code>listbox</code> without an accessibility parent of <code>combobox</code></h4>
+          <table aria-labelledby="role-map-listbox">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#listbox"><code>listbox</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>listbox</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible::accSelect()</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>List</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>Selection</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_LIST_BOX</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Selection</code></span>
+                  <p>
+                    Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return
+                    <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXList</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-listbox-in-combobox"><code>listbox</code> with an accessibility parent of <code>combobox</code></h4>
+          <table aria-labelledby="role-map-listbox-in-combobox">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#listbox"><code>listbox</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>listbox</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible::accSelect()</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>List</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>Selection</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_MENU</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Selection</code></span>
+                  <p>
+                    Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return
+                    <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXList</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-listitem"><code>listitem</code></h4>
+          <table aria-labelledby="role-map-listitem">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#listitem"><code>listitem</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>listitem</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_LISTITEM</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_SYSTEM_READONLY</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>ListItem</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>SelectionItem</code></span
+                  ><br />
+                  <span class="property">SelectionItem.SelectionContainer: the containing <code>list</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_LIST_ITEM</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-log"><code>log</code></h4>
+          <table aria-labelledby="role-map-log">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#log"><code>log</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>log</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>xml-roles:log</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live:polite</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>live:polite</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live-role:log</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>log</code></span
+                  ><br />
+                  <span class="property">LiveSetting: <code>Polite (1)</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_LOG</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:log</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live:polite</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>live:polite</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live-role:log</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXApplicationLog</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-main"><code>main</code></h4>
+          <table aria-labelledby="role-map-main">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#main"><code>main</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>main</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:main</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>main</code></span
+                  ><br />
+                  <span class="property">Landmark Type: <code>Main</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_LANDMARK</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:main</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXLandmarkMain</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-mark"><code>mark</code></h4>
+          <table aria-labelledby="role-map-mark">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#mark"><code>mark</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>mark</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  ><br />
+                  <span class="property">Role: <code>IA2_ROLE_MARK</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:mark</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_MARK</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:mark</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXRoleDescription: <code>highlight</code></span
+                  ><br />
+                  <span class="property">AXAttributedStringForTextMarkerRange: contains <code>AXHighlight = 1;</code> for all text contained in a <code>mark</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-marquee"><code>marquee</code></h4>
+          <table aria-labelledby="role-map-marquee">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#marquee"><code>marquee</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>marquee</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_ANIMATION</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:marquee</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live:off</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>live:off</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>marquee</code></span
+                  ><br />
+                  <span class="property">LiveSetting: <code>Off (0)</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_MARQUEE</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live:off</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>live:off</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXApplicationMarquee</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-math"><code>math</code></h4>
+          <table aria-labelledby="role-map-math">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#math"><code>math</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>math</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_EQUATION</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>math</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_MATH</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXDocumentMath</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-menu"><code>menu</code></h4>
+          <table aria-labelledby="role-map-menu">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#menu"><code>menu</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>menu</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_MENUPOPUP</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible::accSelect()</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Menu</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_MENU</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Selection</code></span>
+                  <p>
+                    Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return
+                    <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXMenu</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-menubar"><code>menubar</code></h4>
+          <table aria-labelledby="role-map-menubar">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#menubar"><code>menubar</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>menubar</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_MENUBAR</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible::accSelect()</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>MenuBar</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_MENU_BAR</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Selection</code></span>
+                  <p>
+                    Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return
+                    <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXMenuBar</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-menuitem"><code>menuitem</code></h4>
+          <table aria-labelledby="role-map-menuitem">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#menuitem"><code>menuitem</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>menuitem</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_MENUITEM</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>MenuItem</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_MENU_ITEM</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXMenuItem</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-menuitemcheckbox"><code>menuitemcheckbox</code></h4>
+          <table aria-labelledby="role-map-menuitemcheckbox">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#menuitemcheckbox"><code>menuitemcheckbox</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>menuitemcheckbox</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_CHECKBUTTON</code> or <code>ROLE_SYSTEM_MENUITEM</code></span
+                  ><br />
+                  <span class="property">Role: <code>IA2_ROLE_CHECK_MENU_ITEM</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>MenuItem</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>Toggle</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_CHECK_MENU_ITEM</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXMenuItem</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-menuitemradio"><code>menuitemradio</code></h4>
+          <table aria-labelledby="role-map-menuitemradio">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#menuitemradio"><code>menuitemradio</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>menuitemradio</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_RADIOBUTTON</code> or <code>ROLE_SYSTEM_MENUITEM</code></span
+                  ><br />
+                  <span class="property">Role: <code>IA2_ROLE_RADIO_MENU_ITEM</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>MenuItem</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>Toggle</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>SelectionItem</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_RADIO_MENU_ITEM</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXMenuItem</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-meter"><code>meter</code></h4>
+          <table aria-labelledby="role-map-meter">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#meter"><code>meter</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>meter</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>IA2_ROLE_LEVEL_BAR</code></span
+                  ><br />
+                  <span class="property">Interface: <code>IAccessibleValue</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>ProgressBar</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>meter</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>RangeValue</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_LEVEL_BAR</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Value</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXLevelIndicator</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXMeter</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-navigation"><code>navigation</code></h4>
+          <table aria-labelledby="role-map-navigation">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#navigation"><code>navigation</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>navigation</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:navigation</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>navigation</code></span
+                  ><br />
+                  <span class="property">Landmark Type: <code>Navigation</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_LANDMARK</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:navigation</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXLandmarkNavigation</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-none"><code>none</code></h4>
+          <table aria-labelledby="role-map-none">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#none"><code>none</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>none</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <p>
+                    For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the
+                    <a class="termref">accessibility tree</a>, expose it as <code>IA2_ROLE_TEXT_FRAME</code>. [=user agents=] SHOULD prune empty descendants from the
+                    <a class="termref">accessibility tree</a>.
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <p>
+                    For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the
+                    <a class="termref">accessibility tree</a>, expose it using the <code>text</code> pattern. [=user agents=] SHOULD prune empty descendants from the
+                    <a class="termref">accessibility tree</a>.
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <p>
+                    For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the
+                    <a class="termref">accessibility tree</a>, expose it as <code>ROLE_SECTION</code>. [=user agents=] SHOULD prune empty descendants from the
+                    <a class="termref">accessibility tree</a>.
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <p>
+                    For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the
+                    <a class="termref">accessibility tree</a>, expose it as <code>AXGroup</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.
+                  </p>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-note"><code>note</code></h4>
+          <table aria-labelledby="role-map-note">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#note"><code>note</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>note</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>IA2_ROLE_NOTE</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>note</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_COMMENT</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXDocumentNote</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-option"><code>option</code> not inside <code>combobox</code></h4>
+          <table aria-labelledby="role-map-option">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#option"><code>option</code></a> not inside <code>combobox</code>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>option</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_LISTITEM</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>ListItem</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>Invoke</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_LIST_ITEM</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a><br /></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXStaticText</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-option-in-combobox"><code>option</code> inside <code>combobox</code></h4>
+          <table aria-labelledby="role-map-option-in-combobox">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#option"><code>option</code></a> inside <code>combobox</code>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>option</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_LISTITEM</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>ListItem</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>Invoke</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_MENU_ITEM</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a><br /></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXStaticText</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-paragraph"><code>paragraph</code></h4>
+          <table aria-labelledby="role-map-paragraph">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#paragraph"><code>paragraph</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>paragraph</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  ><br />
+                  <span class="property">Role: <code>IA2_ROLE_PARAGRAPH</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Text</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_PARAGRAPH</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-presentation"><code>presentation</code></h4>
+          <table aria-labelledby="role-map-presentation">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#presentation"><code>presentation</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>none</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <p>
+                    For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the
+                    <a class="termref">accessibility tree</a>, expose it as <code>IA2_ROLE_TEXT_FRAME</code>. [=user agents=] SHOULD prune empty descendants from the
+                    <a class="termref">accessibility tree</a>.
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <p>
+                    For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the
+                    <a class="termref">accessibility tree</a>, expose it using the <code>text</code> pattern. [=user agents=] SHOULD prune empty descendants from the
+                    <a class="termref">accessibility tree</a>.
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <p>
+                    For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the
+                    <a class="termref">accessibility tree</a>, expose it as <code>ROLE_SECTION</code>. [=user agents=] SHOULD prune empty descendants from the
+                    <a class="termref">accessibility tree</a>.
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <p>
+                    For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the
+                    <a class="termref">accessibility tree</a>, expose it as <code>AXGroup</code>. [=user agents=] SHOULD prune empty descendants from the <a class="termref">accessibility tree</a>.
+                  </p>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-progressbar"><code>progressbar</code></h4>
+          <table aria-labelledby="role-map-progressbar">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#progressbar"><code>progressbar</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>progressbar</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_PROGRESSBAR</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_SYSTEM_READONLY</code></span
+                  ><br />
+                  <span class="property">Interface: <code>IAccessibleValue</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>ProgressBar</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>RangeValue</code> if <code>aria-valuenow</code>, <code>aria-valuemax</code>, or <code>aria-valuemin</code></span> is present
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_PROGRESS_BAR</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Value</code></span>
+                  <p>
+                    Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the value via the accessibility API, user agents MUST return
+                    <code>false</code> for all <code>Value</code> methods that provide a means to modify the value.
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXProgressIndicator</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-radio"><code>radio</code></h4>
+          <table aria-labelledby="role-map-radio">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#radio"><code>radio</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>radio</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_RADIOBUTTON</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>RadioButton</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>Toggle</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>SelectionItem</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_RADIO_BUTTON</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXRadioButton</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-radiogroup"><code>radiogroup</code></h4>
+          <table aria-labelledby="role-map-radiogroup">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#radiogroup"><code>radiogroup</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>radiogroup</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>List</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_PANEL</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXRadioGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-region"><code>region</code> with an accessible name</h4>
+          <table aria-labelledby="role-map-region">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#region"><code>region</code></a> with an accessible name
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>region</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:region</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>region</code></span
+                  ><br />
+                  <span class="property">Landmark Type: <code>Custom</code></span
+                  ><br />
+                  <span class="property">Localized Landmark Type: <code>region</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_LANDMARK</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:region</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXLandmarkRegion</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-region-nameless"><code>region</code> without an accessible name</h4>
+          <table aria-labelledby="role-map-region-nameless">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#region"><code>region</code></a> without an accessible name
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p>Use native host language role.</p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-row"><code>row</code> not inside <code>treegrid</code></h4>
+          <table aria-labelledby="role-map-row">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#row"><code>row</code></a> not inside <code>treegrid</code>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>row</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_ROW</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>DataItem</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>row</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>SelectionItem</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_TABLE_ROW</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXRow</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-row-in-treegrid"><code>row</code> inside <code>treegrid</code></h4>
+          <table aria-labelledby="role-map-row-in-treegrid">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#row"><code>row</code></a> inside <code>treegrid</code>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>row</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_OUTLINEITEM</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>DataItem</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>row</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>SelectionItem</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_TABLE_ROW</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXRow</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-rowgroup"><code>rowgroup</code></h4>
+          <table aria-labelledby="role-map-rowgroup">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#rowgroup"><code>rowgroup</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>rowgroup</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_PANEL</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-rowheader"><code>rowheader</code></h4>
+          <table aria-labelledby="role-map-rowheader">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#rowheader"><code>rowheader</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>rowheader</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_ROWHEADER</code></span
+                  ><br />
+                  <span class="property">Interface: <code>IAccessibleTableCell</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>HeaderItem</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_ROW_HEADER</code></span
+                  ><br />
+                  <span class="property">Interface: <code>TableCell</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXCell</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-scrollbar"><code>scrollbar</code></h4>
+          <table aria-labelledby="role-map-scrollbar">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#scrollbar"><code>scrollbar</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>scrollbar</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_SCROLLBAR</code></span
+                  ><br />
+                  <span class="property">Interface: <code>IAccessibleValue</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>ScrollBar</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>RangeValue</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SCROLL_BAR</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Value</code></span>
+                  <p>
+                    Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the value via the accessibility API, user agents MUST return
+                    <code>false</code> for all <code>Value</code> methods that provide a means to modify the value.
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXScrollBar</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-search"><code>search</code></h4>
+          <table aria-labelledby="role-map-search">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#search"><code>search</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>search</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:search</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>search</code></span
+                  ><br />
+                  <span class="property">Landmark Type: <code>Search</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_LANDMARK</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:search</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXLandmarkSearch</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-searchbox"><code>searchbox</code></h4>
+          <table aria-labelledby="role-map-searchbox">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#searchbox"><code>searchbox</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>searchbox</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>text-input-type:search</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Edit</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>search box</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_ENTRY</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:searchbox</code></span
+                  ><br />
+                  <span class="property"
+                    >Interface: <code>EditableText</code> if <a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a> is not <code>&quot;true&quot;</code></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXTextField</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXSearchField</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-separator"><code>separator</code> (non-focusable)</h4>
+          <table aria-labelledby="role-map-separator">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#separator"><code>separator</code></a> (non-focusable)
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>seperator</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_SEPARATOR</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Separator</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SEPARATOR</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXSplitter</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-separator-focusable"><code>separator</code> (focusable)</h4>
+          <table aria-labelledby="role-map-separator-focusable">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#separator"><code>separator</code></a> (focusable)
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>seperator</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_SEPARATOR</code></span
+                  ><br />
+                  <span class="property">Interface: <code>IAccessibleValue</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Thumb</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>RangeValue</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SEPARATOR</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Value</code></span>
+                  <p>
+                    Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the value via the accessibility API, user agents MUST return
+                    <code>false</code> for all <code>Value</code> methods that provide a means to modify the value.
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXSplitter</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-slider"><code>slider</code></h4>
+          <table aria-labelledby="role-map-slider">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#slider"><code>slider</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>slider</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_SLIDER</code></span
+                  ><br />
+                  <span class="property">Interface: <code>IAccessibleValue</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Slider</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>RangeValue</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SLIDER</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Value</code></span>
+                  <p>
+                    Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the value via the accessibility API, user agents MUST return
+                    <code>false</code> for all <code>Value</code> methods that provide a means to modify the value.
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXSlider</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-spinbutton"><code>spinbutton</code></h4>
+          <table aria-labelledby="role-map-spinbutton">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#spinbutton"><code>spinbutton</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>spinbutton</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_SPINBUTTON</code></span
+                  ><br />
+                  <span class="property">Interface: <code>IAccessibleValue</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Spinner</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>RangeValue</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SPIN_BUTTON</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Value</code></span>
+                  <p>
+                    Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the value via the accessibility API, user agents MUST return
+                    <code>false</code> for all <code>Value</code> methods that provide a means to modify the value.
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXIncrementor</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-status"><code>status</code></h4>
+          <table aria-labelledby="role-map-status">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#status"><code>status</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>status</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_STATUSBAR</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live:polite</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>live:polite</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live-role:status</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>status</code></span
+                  ><br />
+                  <span class="property">LiveSetting: <code>Polite (1)</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_STATUSBAR</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live:polite</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>live:polite</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live-role:status</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXApplicationStatus</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-strong"><code>strong</code></h4>
+          <table aria-labelledby="role-map-strong">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#strong"><code>strong</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>strong</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:strong</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Text</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>strong</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_STATIC</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:strong</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXStrongStyleGroup</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-subscript"><code>subscript</code></h4>
+          <table aria-labelledby="role-map-subscript">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#subscript"><code>subscript</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>subscript</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  ><br />
+                  <span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span
+                  ><br />
+                  <span class="property">Text Attribute: <code>text-position:sub</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Text</code></span
+                  ><br />
+                  <span class="property">Styles used are exposed by <code>IsSubscript</code> attribute of the <code>TextRange</code> Control Pattern implemented on the accessible object.</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SUBSCRIPT</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXSubscriptStyleGroup</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-suggestion"><code>suggestion</code></h4>
+          <table aria-labelledby="role-map-suggestion">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#suggestion"><code>suggestion</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>suggestion</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>IA2_ROLE_SUGGESTION</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:suggestion</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>suggestion</code></span
+                  ><br />
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SUGGESTION</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:suggestion</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXAttributedStringForTextMarkerRange: contains <code>AXIsSuggestion = 1;</code> for all text contained in a <code>suggestion</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-superscript"><code>superscript</code></h4>
+          <table aria-labelledby="role-map-superscript">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#superscript"><code>superscript</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>superscript</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  ><br />
+                  <span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span
+                  ><br />
+                  <span class="property">Text Attribute: <code>text-position:super</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Text</code></span
+                  ><br />
+                  <span class="property">Styles used are exposed by <code>IsSuperscript</code> attribute of the <code>TextRange</code> Control Pattern implemented on the accessible object.</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SUPERSCRIPT</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXSuperscriptStyleGroup</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-switch"><code>switch</code></h4>
+          <table aria-labelledby="role-map-switch">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#switch"><code>switch</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>switch</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_CHECKBUTTON</code></span
+                  ><br />
+                  <span class="property">Role: <code>IA2_ROLE_TOGGLE_BUTTON</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:switch</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Button</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>toggleswitch</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>Toggle</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_TOGGLE_BUTTON</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:switch</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXCheckBox</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXSwitch</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-tab"><code>tab</code></h4>
+          <table aria-labelledby="role-map-tab">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#tab"><code>tab</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>tab</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_PAGETAB</code></span
+                  ><br />
+                  <span class="property"
+                    >State: <code>STATE_SYSTEM_SELECTED</code> if focus is inside <a class="role-reference" href="#tabpanel"><code>tabpanel</code></a> associated with
+                    <a class="property-reference" href="#aria-labelledby"><code>aria-labelledby</code></a></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>TabItem</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_PAGE_TAB</code></span
+                  ><br />
+                  <span class="property"
+                    >State: <code>STATE_SELECTED</code> if focus is inside <a class="role-reference" href="#tabpanel"><code>tabpanel</code></a> associated with
+                    <a class="property-reference" href="#aria-labelledby"><code>aria-labelledby</code></a></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXRadioButton</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXTabButton</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-table"><code>table</code></h4>
+          <table aria-labelledby="role-map-table">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#table"><code>table</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>table</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_TABLE</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:table</code></span
+                  ><br />
+                  <span class="property">Interface: <code>IAccessibleTable2</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Table</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>Grid</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>Table</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_TABLE</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:table</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Table</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXTable</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                  <span class="property">AXColumnHeaderUIElements: a list of pointers to the columnheader elements</span><br />
+                  <span class="property">AXHeader: a pointer to the row or group containing those columnheader elements</span><br />
+                  <span class="property">AXRowHeaderUIElements: a list of pointers to the rowheader elements</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-tablist"><code>tablist</code></h4>
+          <table aria-labelledby="role-map-tablist">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#tablist"><code>tablist</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>tablist</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_PAGETABLIST</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible::accSelect()</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Tab</code></span
+                  ><br />
+                  <span class="property">Control Pattern: <code>Selection</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_PAGE_TAB_LIST</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Selection</code></span>
+                  <p>
+                    Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return
+                    <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXTabGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-tabpanel"><code>tabpanel</code></h4>
+          <table aria-labelledby="role-map-tabpanel">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#tabpanel"><code>tabpanel</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>tabpanel</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_PANE</code> or <code>ROLE_SYSTEM_PROPERTYPAGE</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Pane</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SCROLL_PANE</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXTabPanel</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-term"><code>term</code></h4>
+          <table aria-labelledby="role-map-term">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#term"><code>term</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>term</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:term</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Text</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>term</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_DESCRIPTION_TERM</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXTerm</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-textbox"><code>textbox</code> when <code>aria-multiline</code> is <code>false</code></h4>
+          <table aria-labelledby="role-map-textbox">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#textbox"><code>textbox</code></a> when <code>aria-multiline</code> is <code>false</code>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>textbox</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span
+                  ><br />
+                  <span class="property">State: <code>IA2_STATE_SINGLE_LINE</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Edit</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_ENTRY</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_SINGLE_LINE</code></span
+                  ><br />
+                  <span class="property"
+                    >Interface: <code>EditableText</code> if <a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a> is not <code>&quot;true&quot;</code></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXTextField</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-textbox-multiline"><code>textbox</code> when <code>aria-multiline</code> is <code>true</code></h4>
+          <table aria-labelledby="role-map-textbox-multiline">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#textbox"><code>textbox</code></a> when <code>aria-multiline</code> is <code>true</code>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>textbox</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span
+                  ><br />
+                  <span class="property">State: <code>IA2_STATE_MULTI_LINE</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Edit</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_ENTRY</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_MULTI_LINE</code></span
+                  ><br />
+                  <span class="property"
+                    >Interface: <code>EditableText</code> if <a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a> is not <code>&quot;true&quot;</code></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXTextArea</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-time"><code>time</code></h4>
+          <table aria-labelledby="role-map-time">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#time"><code>time</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>time</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:time</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Text</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>time</code></span
+                  ><br />
+                  <span>Note: create a separate UIA Control of type Text. This is different from most UIA text mappings, which only create ranges in the page text pattern.</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_STATIC</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>xml-roles:time</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXTimeGroup</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-timer"><code>timer</code></h4>
+          <table aria-labelledby="role-map-timer">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#timer"><code>timer</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>timer</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>xml-roles:timer</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live:off</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>live:off</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live-role:timer</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Group</code></span
+                  ><br />
+                  <span class="property">Localized Control Type: <code>timer</code></span
+                  ><br />
+                  <span class="property">LiveSetting: <code>Off (0)</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_TIMER</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live:off</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>live:off</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live-role:timer</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXApplicationTimer</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-toolbar"><code>toolbar</code></h4>
+          <table aria-labelledby="role-map-toolbar">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#toolbar"><code>toolbar</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>toolbar</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_TOOLBAR</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>ToolBar</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_TOOL_BAR</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXToolbar</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-tooltip"><code>tooltip</code></h4>
+          <table aria-labelledby="role-map-tooltip">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#tooltip"><code>tooltip</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>tooltip</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_TOOLTIP</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>ToolTip</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_TOOL_TIP</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXGroup</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXUserInterfaceTooltip</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-tree"><code>tree</code></h4>
+          <table aria-labelledby="role-map-tree">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#tree"><code>tree</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>tree</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_OUTLINE</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible::accSelect()</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>Tree</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_TREE</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Selection</code></span>
+                  <p>
+                    Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return
+                    <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXOutline</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-treegrid"><code>treegrid</code></h4>
+          <table aria-labelledby="role-map-treegrid">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#treegrid"><code>treegrid</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>treegrid</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_OUTLINE</code></span
+                  ><br />
+                  <span class="property">Interface: <code>IAccessibleTable2</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible::accSelect()</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>DataGrid</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_TREE_TABLE</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Table</code></span
+                  ><br />
+                  <span class="property">Interface: <code>Selection</code></span>
+                  <p>
+                    Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return
+                    <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXTable</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  ><br />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="role-map-treeitem"><code>treeitem</code></h4>
+          <table aria-labelledby="role-map-treeitem">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="role-reference" href="#treeitem"><code>treeitem</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>Computed Role</th>
+                <td>
+                  <p><code>treeitem</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Role: <code>ROLE_SYSTEM_OUTLINEITEM</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Type: <code>TreeItem</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Role: <code>ROLE_TREE_ITEM</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                </th>
+                <td>
+                  <span class="property">AXRole: <code>AXRow</code></span
+                  ><br />
+                  <span class="property">AXSubrole: <code>AXOutlineRow</code></span
+                  ><br />
+                  <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <div class="note" id="ftn.note1">
+            <p>
+              <sup>[Note 1]</sup>
+              User agent should return a user-presentable, localized string value for the AXRoleDescription.
+            </p>
+          </div>
           <div class="note" id="ftn.note2">
-          <p><sup>[Note 2]</sup> This specification does not currently contain guidance for when user agents should fire system alert events. Some guidance may be added to the specification at a later date but it will be a recommendation (SHOULD), not a requirement (MUST).</p>
-        </div>
+            <p>
+              <sup>[Note 2]</sup> This specification does not currently contain guidance for when user agents should fire system alert events. Some guidance may be added to the specification at a
+              later date but it will be a recommendation (SHOULD), not a requirement (MUST).
+            </p>
+          </div>
+        </section>
       </section>
-  </section>
 
-	<section id="mapping_state-property">
-		<h2>State and Property Mapping</h2>
-	  <p>This section describes how to expose <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a class="termref">states</a> and [=ARIA/properties=]. </p>
-	  <section id="statePropertyMappingGeneralRules">
-      <h2>General rules</h2>
-      <ol>
-        <li>[=User agents=]  MUST compute <a class="termref">managed states</a> <code>VISIBLE</code>/<code>INVISIBLE</code>, <code>SHOWING</code>/<code>OFFSCREEN</code>, etc. This typically is done in the same way as for ordinary <a class="termref">elements</a> that do not have <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> attributes present. The <code>FOCUSABLE</code>/<code>FOCUSED</code> states may be affected by <a class="property-reference" href="#aria-activedescendant"><code>aria-activedescendant</code></a>.</li>
-        <li>User agents MUST continue to expose native semantics in addition to <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> state and property semantics except where an explicit WAI-ARIA override is allowed by the host language. For example, an <abbr title="Hypertext Markup Language">HTML</abbr> checkbox may have an <a class="property-reference" href="#aria-labelledby"><code>aria-labelledby</code></a> attribute but the native <abbr title="Hypertext Markup Language">HTML</abbr> semantics must still be exposed. </li>
-        <li>User agents MUST expose additional states for certain <a class="termref">roles</a> as defined in the <a href="#mapping_role_table">Role Mapping Tables</a>.</li>
-        <li>User agents MUST compute states for the relevant <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref">attributes</a> and map to the <a class="termref">accessibility API</a> as specified in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a>. To determine the relevant <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> attributes, refer to the <cite><a href="#role_definitions" class="specref">Definition of Roles</a></cite> [[!WAI-ARIA-1.2]]]. Where the author has not provided values for required attributes, user agents SHOULD  process as if the default value was provided. </li>
-        <li>Some <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> properties are not global, and are only supported on  certain roles. If a non-global <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> state or property is used where it is not supported, user agents SHOULD NOT map the given <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> property to the platform accessibility <abbr title="application programming interface">API</abbr>.  For example, if <code>aria-checked=&quot;true&quot;</code> is specified on <code>&lt;div role=&quot;grid&quot;&gt;</code>, it should not be exposed in <abbr title="Microsoft Active Accessibility">MSAA</abbr> implementations as <code>STATE_SYSTEM_CHECKED</code>.</li>
-        <li>When an explicit or inherited role of <code>none</code> or <code>presentation</code> is applied to an element, the user agent MUST implement  the rules for the <a class="role-reference" href="#none"><code>none</code></a> or the <a class="role-reference" href="#presentation"><code>presentation</code></a> <a class="termref">role</a> defined in <cite><a class="specref" href="">Accessible Rich Internet Applications (WAI-ARIA) 1.2</a></cite> [[!WAI-ARIA-1.2]]].</li>
-      </ol>
-    </section>
-  <section id="mapping_state-property_table">
-    <h3>State and Property Mapping Tables</h3>
-    <section id="not_mapped">
-      <h4>Not Mapped</h4>
-      <p>There are a number of occurrences in the table where a given state or property is declared "Not mapped".  In some cases, this occurs for the default value of the state/property, and is equivalent to its absence.  User agents might find it quicker to map the value than check to see if it is the default. For computational efficiency, user agents MAY expose the state or property value if doing so is equivalent to not mapping it.  These cases are marked with an asterisk.  </p>
-      <p>In other cases, it is mandatory that the state/property not be mapped, since exposing it implies a related affordance.  An example is <a class="state-reference" href="#aria-grabbed"><code>aria-grabbed</code></a>.  Its absence not only indicates that the accessible object is not grabbed, but further defines it as not grab-able.  These cases are marked as "Not mapped" without an asterisk.  </p> 
-    </section>
-<h4 id=ariaActiveDescendant><code>aria-activedescendant</code></h4>
-<table aria-labelledby=ariaActiveDescendant>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-activedescendant"><code>aria-activedescendant</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        See <a href="#focus_state_event_table">Focus Changes</a>.
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        See <a href="#focus_state_event_table">Focus Changes</a>.
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        See <a href="#focus_state_event_table">Focus Changes</a>.
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        See <a href="#focus_state_event_table">Focus Changes</a>.<br>
-        <span class="property">Property: <code>AXSelectedRows</code>: pointer to active descendant node</span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaAtomicTrue><code>aria-atomic</code>=<code>true</code></h4>
-<table aria-labelledby=ariaAtomicTrue>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-atomic"><code>aria-atomic</code></a>=<code>true</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>atomic:true</code></span><br>
-        <span class="property">Object Attribute: <code>container-atomic:true</code></span><br>
-        <span class="property">Object Attribute: <code>container-atomic:true</code> on all descendants</span><br>
-        <span class="relation">Relation: <code>IA2_RELATION_MEMBER_OF</code> pointing to this element (the atomic root)</span><br>
-        <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.atomic</code>: <code>true</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>atomic:true</code></span><br>
-        <span class="property">Object Attribute: <code>container-atomic:true</code></span><br>
-        <span class="property">Object Attribute: <code>container-atomic:true</code> on all descendants</span><br>
-        <span class="relation">Relation: <code>RELATION_MEMBER_OF</code> pointing to this element (the atomic root)</span><br>
-        <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXARIAAtomic</code>: <code>YES</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaAtomicFalse><code>aria-atomic</code>=<code>false</code></h4>
-<table aria-labelledby=ariaAtomicFalse>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-atomic"><code>aria-atomic</code></a>=<code>false</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a>, but if mapped:</span><br>
-        <span class="property">Object Attribute: <code>atomic:false</code></span><br>
-        <span class="property">Object Attribute: <code>container-atomic:false</code></span><br>
-        <span class="property">Object Attribute: <code>container-atomic:false</code> on all descendants</span><br>
-        <span class="relation">Relation: <code>IA2_RELATION_MEMBER_OF</code> pointing to this element (the atomic root)</span><br>
-        <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.atomic</code>: <code>false</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a>, but if mapped:</span><br>
-        <span class="property">Object Attribute: <code>atomic:false</code></span><br>
-        <span class="property">Object Attribute: <code>container-atomic:false</code></span><br>
-        <span class="property">Object Attribute: <code>container-atomic:false</code> on all descendants</span><br>
-        <span class="relation">Relation: <code>RELATION_MEMBER_OF</code> pointing to this element (the atomic root)</span><br>
-        <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXARIAAtomic</code>: <code>NO</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaAutocompleteInlineListBoth><code>aria-autocomplete</code>=<code>inline</code>, <code>list</code>, or <code>both</code></h4>
-<table aria-labelledby=ariaAutocompleteInlineListBoth>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-autocomplete"><code>aria-autocomplete</code></a>=<code>inline</code>, <code>list</code>, or <code>both</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>autocomplete:&lt;value&gt;</code></span><br>
-        <span class="property">State: <code>IA2_STATE_SUPPORTS_AUTOCOMPLETION</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>autocomplete:&lt;value&gt;</code></span><br>
-        <span class="property">State: <code>STATE_SUPPORTS_AUTOCOMPLETION</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaAutocompleteNone><code>aria-autocomplete</code>=<code>none</code></h4>
-<table aria-labelledby=ariaAutocompleteNone>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-autocomplete"><code>aria-autocomplete</code></a>=<code>none</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaBraillelabel><code>aria-braillelabel</code></h4>
-<table aria-labelledby=ariaBraillelabel>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-braillelabel"><code>aria-braillelabel</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>braillelabel:&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.braillelabel</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>braillelabel:&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: AXBrailleLabel</span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaBrailleroledescription><code>aria-brailleroledescription</code></h4>
-<table aria-labelledby=ariaBrailleroledescription>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-brailleroledescription"><code>aria-brailleroledescription</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>brailleroledescription:&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.brailleroledescription</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>brailleroledescription:&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: AXBrailleRoleDescription</span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaBrailleroledescriptionUndefined><code>aria-brailleroledescription</code> is undefined or the empty string</h4>
-<table aria-labelledby=ariaBrailleroledescriptionUndefined>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-brailleroledescription"><code>aria-brailleroledescription</code></a> is undefined or the empty string
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaBusyTrue><code>aria-busy</code>=<code>true</code></h4>
-<table aria-labelledby=ariaBusyTrue>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-busy"><code>aria-busy</code></a>=<code>true</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_BUSY</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.busy</code>: <code>true</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_BUSY</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXElementBusy</code>: <code>YES</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaBusyFalse><code>aria-busy</code>=<code>false</code></h4>
-<table aria-labelledby=ariaBusyFalse>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-busy"><code>aria-busy</code></a>=<code>false</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_BUSY</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.busy</code>: <code>false</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_BUSY</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXElementBusy</code>: <code>NO</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaCheckedTrue><code>aria-checked</code>=<code>true</code></h4>
-<table aria-labelledby=ariaCheckedTrue>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-checked"><code>aria-checked</code></a>=<code>true</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_CHECKED</code></span><br>
-        <span class="property">Object Attribute: <code>checkable:true</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>Toggle.ToggleState</code>: <code>On (1)</code></span><br>
-        <span class="property">Property: <code>SelectionItem.IsSelected</code>: <code>True</code> for <code>radio</code> and <code>menuitemradio</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_CHECKABLE</code></span><br>
-        <span class="property">State: <code>STATE_CHECKED</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXValue</code>: <code>1</code></span><br>
-        <span class="property">Property: <code>AXMenuItemMarkChar</code>: <code>&#x2713;</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaCheckedFalse><code>aria-checked</code>=<code>false</code></h4>
-<table aria-labelledby=ariaCheckedFalse>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-checked"><code>aria-checked</code></a>=<code>false</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_CHECKED</code> not exposed</span><br>
-        <span class="property">Object Attribute: <code>checkable:true</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>Toggle.ToggleState</code>: <code>Off (0)</code></span><br>
-        <span class="property">Property: <code>SelectionItem.IsSelected</code>: <code>False</code> for <code>radio</code> and <code>menuitemradio</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_CHECKABLE</code></span><br>
-        <span class="property">State: <code>STATE_CHECKED</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXValue</code>: <code>0</code></span><br>
-        <span class="property">Property: <code>AXMenuItemMarkChar</code>: <code>&lt;nil&gt;</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaCheckedMixed><code>aria-checked</code>=<code>mixed</code></h4>
-<table aria-labelledby=ariaCheckedMixed>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-checked"><code>aria-checked</code></a>=<code>mixed</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_MIXED</code></span><br>
-        <span class="property">Object Attribute: <code>checkable:true</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>Toggle.ToggleState</code>: <code>Indeterminate (2)</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_INDETERMINATE</code></span><br>
-        <span class="property">State: <code>STATE_CHECKABLE</code></span><br>
-        <span class="property">State: <code>STATE_CHECKED</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXValue</code>: <code>2</code></span><br>
-        <span class="property">Property: <code>AXMenuItemMarkChar</code>: <code>&lt;nil&gt;</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaCheckedUndefined><code>aria-checked</code> is undefined</h4>
-<table aria-labelledby=ariaCheckedUndefined>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-checked"><code>aria-checked</code></a> is undefined
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaColCount><code>aria-colcount</code></h4>
-<table aria-labelledby=ariaColCount>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-colcount"><code>aria-colcount</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>colcount:&lt;value&gt;</code></span><br>
-        <span class="method">Method: <code>IAccessible2::groupPosition()</code>: <code>similarItemsInGroup=&lt;value&gt;</code> on cells and headers</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>Grid.ColumnCount</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>colcount</code> should contain the author-provided value.</span><br>
-        <span class="method">Method: <code>atk_table_get_n_columns()</code> should return the actual number of columns.</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXARIAColumnCount</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaColIndex><code>aria-colindex</code></h4>
-<table aria-labelledby=ariaColIndex>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-colindex"><code>aria-colindex</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>colindex:&lt;value&gt;</code></span><br>
-        <span class="method">Method: <code>IAccessible2::groupPosition()</code>: <code>positionInGroup=&lt;value&gt;</code> on cells and headers</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>GridItem.Column</code>: <code>&lt;value&gt;</code> (zero-based)</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>colindex</code> should contain the author-provided value.</span><br>
-        <span class="method">Method: <code>atk_table_cell_get_position()</code> should return the actual (zero-based) column index.</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXARIAColumnIndex</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaColIndexText><code>aria-colindextext</code></h4>
-<table aria-labelledby=ariaColIndexText>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-colindextext"><code>aria-colindextext</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>colindextext:&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.colindextext</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>colindextext:&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: TBD</span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaColSpan><code>aria-colspan</code></h4>
-<table aria-labelledby=ariaColSpan>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-colspan"><code>aria-colspan</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>colspan:&lt;value&gt;</code></span><br>
-        <span class="method">Method: <code>IAccessibleTableCell::columnExtent()</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>GridItem.ColumnSpan</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>colspan</code> should contain the author-provided value.</span><br>
-        <span class="method">Method: <code>atk_table_cell_get_row_column_span()</code> should return the actual column span.</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXColumnIndexRange.length</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaControls><code>aria-controls</code></h4>
-<table aria-labelledby=ariaControls>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-controls"><code>aria-controls</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="relation">Relation: <code>IA2_RELATION_CONTROLLER_FOR</code> points to accessible nodes matching IDREFs</span><br>
-        <span class="relation">Reverse Relation: <code>IA2_RELATION_CONTROLLED_BY</code> points to element</span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>ControllerFor</code>: pointers to accessible nodes matching IDREFs</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="relation">Relation: <code>RELATION_CONTROLLER_FOR</code> points to accessible nodes matching IDREFs</span><br>
-        <span class="relation">Reverse Relation: <code>RELATION_CONTROLLED_BY</code> points to element</span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXLinkedUIElements</code>: pointers to accessible nodes matching IDREFs</span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaCurrent><code>aria-current</code> with non-<code>false</code> allowed value</h4>
-<table aria-labelledby=ariaCurrent>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-current"><code>aria-current</code></a> with non-<code>false</code> allowed value
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>current:&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.current</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>current:&lt;value&gt;</code></span><br>
-        <span class="property">State: <code>STATE_ACTIVE</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXARIACurrent</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaCurrentUnrecognizedValue><code>aria-current</code> with unrecognized value</h4>
-<table aria-labelledby=ariaCurrentUnrecognizedValue>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-current"><code>aria-current</code></a> with unrecognized value
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>current:true</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.current</code>: <code>true</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>current:true</code></span><br>
-        <span class="property">State: <code>STATE_ACTIVE</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXARIACurrent</code>: <code>true</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaCurrentUndefined><code>aria-current</code> is <code>false</code> or undefined</h4>
-<table aria-labelledby=ariaCurrentUndefined>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-current"><code>aria-current</code></a> is <code>false</code> or undefined
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaDescribedBy><code>aria-describedby</code></h4>
-<table aria-labelledby=ariaDescribedBy>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-describedby"><code>aria-describedby</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Property: <code>accDescription</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="relation">Relation: <code>IA2_RELATION_DESCRIBED_BY</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
-        <span class="relation">Reverse Relation: <code>IA2_RELATION_DESCRIPTION_FOR</code> points to element</span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a> and <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>FullDescription</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Property: <code>Description</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="relation">Relation: <code>RELATION_DESCRIBED_BY</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
-        <span class="relation">Reverse Relation: <code>RELATION_DESCRIPTION_FOR</code> points to element</span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a> and <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="api">In the accessibilityCustomContent API, expose as an <code>AXCustomContent</code> object with <code>{ label: "description" }</code> and `<code>value</code>` set to the description string.</span><br>
-        - <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaDescription><code>aria-description</code></h4>
-<table aria-labelledby=ariaDescription>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-description"><code>aria-description</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Property: <code>accDescription</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>FullDescription</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Property: <code>Description</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="api">In the accessibilityCustomContent API, expose as an <code>AXCustomContent</code> object with <code>{ label: "description" }</code> and `<code>value</code>` set to the description string.</span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaDetails><code>aria-details</code></h4>
-<table aria-labelledby=ariaDetails>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-details"><code>aria-details</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="relation">Relation: <code>IA2_RELATION_DETAILS</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
-        <span class="relation">Reverse Relation: <code>IA2_RELATION_DETAILS_FOR</code> points to element</span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>DescribedBy</code>: points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="relation">Relation: <code>RELATION_DETAILS</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
-        <span class="relation">Reverse Relation: <code>RELATION_DETAILS_FOR</code> points to element</span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaDisabledTrue><code>aria-disabled</code>=<code>true</code></h4>
-<table aria-labelledby=ariaDisabledTrue>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-disabled"><code>aria-disabled</code></a>=<code>true</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_UNAVAILABLE</code></span><br>
-        <span class="property">State: <code>STATE_SYSTEM_UNAVAILABLE</code> on all descendants with <code>STATE_SYSTEM_FOCUSABLE</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>IsEnabled</code>: <code>false</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_ENABLED</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXEnabled</code>: <code>NO</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaDisabledFalse><code>aria-disabled</code>=<code>false</code></h4>
-<table aria-labelledby=ariaDisabledFalse>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-disabled"><code>aria-disabled</code></a>=<code>false</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_UNAVAILABLE</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>IsEnabled</code>: <code>true</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_ENABLED</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXEnabled</code>: <code>YES</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaDropeffectMoveLinkExecutePopup><code>aria-dropeffect</code>=<code>copy</code>, <code>move</code>, <code>link</code>, <code>execute</code>, or <code>popup</code></h4>
-<table aria-labelledby=ariaDropeffectMoveLinkExecutePopup>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-dropeffect"><code>aria-dropeffect</code></a>=<code>copy</code>, <code>move</code>, <code>link</code>, <code>execute</code>, or <code>popup</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>dropeffect:&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.dropeffect</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>dropeffect:&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <code>array AXDropEffects</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaDropeffectNone><code>aria-dropeffect</code>=<code>none</code></h4>
-<table aria-labelledby=ariaDropeffectNone>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-dropeffect"><code>aria-dropeffect</code></a>=<code>none</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>dropeffect:none</code> if there are no other valid tokens</span><br>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a> if not specified by the author</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>dropeffect:none</code> if there are no other valid tokens</span><br>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a> if not specified by the author</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaErrorMessage><code>aria-errormessage</code></h4>
-<table aria-labelledby=ariaErrorMessage>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-errormessage"><code>aria-errormessage</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="relation">Relation: <code>IA2_RELATION_ERROR</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
-        <span class="relation">Reverse Relation: <code>IA2_RELATION_ERROR_FOR</code> points to element</span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>ControllerFor</code>: pointer to the target accessible object</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="relation">Relation: <code>RELATION_ERROR_MESSAGE</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
-        <span class="relation">Reverse Relation: <code>RELATION_ERROR_FOR</code> points to element</span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXErrorMessageElements</code>: pointers to accessible nodes matching IDREFs</span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaExpandedTrue><code>aria-expanded</code>=<code>true</code></h4>
-<table aria-labelledby=ariaExpandedTrue>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a>=<code>true</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_EXPANDED</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>ExpandCollapse.ExpandCollapseState</code>: <code>Expanded</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_EXPANDABLE</code></span><br>
-        <span class="property">State: <code>STATE_EXPANDED</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXExpanded</code>: <code>YES</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaExpandedFalse><code>aria-expanded</code>=<code>false</code></h4>
-<table aria-labelledby=ariaExpandedFalse>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a>=<code>false</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_COLLAPSED</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>ExpandCollapse.ExpandCollapseState</code>: <code>Collapsed</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_EXPANDABLE</code></span><br>
-        <span class="property">State: <code>STATE_EXPANDED</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXExpanded</code>: <code>NO</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaExpandedUndefined><code>aria-expanded</code> is undefined</h4>
-<table aria-labelledby=ariaExpandedUndefined>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a> is undefined
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaFlowto><code>aria-flowto</code></h4>
-<table aria-labelledby=ariaFlowto>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-flowto"><code>aria-flowto</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="relation">Relation: <code>IA2_RELATION_FLOW_TO</code> points to accessible nodes matching IDREFs</span><br>
-        <span class="relation">Reverse Relation: <code>IA2_RELATION_FLOW_FROM</code> points to element</span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>FlowsTo</code>: pointers to accessible nodes matching IDREFs</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="relation">Relation: <code>RELATION_FLOWS_TO</code> points to accessible nodes matching IDREFs</span><br>
-        <span class="relation">Reverse Relation: <code>RELATION_FLOWS_FROM</code> points to element</span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXLinkedUIElements</code>: pointers to accessible nodes matching IDREFs</span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaGrabbedTrue><code>aria-grabbed</code>=<code>true</code></h4>
-<table aria-labelledby=ariaGrabbedTrue>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-grabbed"><code>aria-grabbed</code></a>=<code>true</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>grabbed:true</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.grabbed</code>: <code>true</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>grabbed:true</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXGrabbed</code>: <code>YES</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaGrabbedFalse><code>aria-grabbed</code>=<code>false</code></h4>
-<table aria-labelledby=ariaGrabbedFalse>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-grabbed"><code>aria-grabbed</code></a>=<code>false</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>grabbed:false</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.grabbed</code>: <code>false</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>grabbed:false</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXGrabbed</code>: <code>NO</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaGrabbedUndefined><code>aria-grabbed</code> is undefined</h4>
-<table aria-labelledby=ariaGrabbedUndefined>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-grabbed"><code>aria-grabbed</code></a> is undefined
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaHaspopupTrue><code>aria-haspopup</code>=<code>true</code></h4>
-<table aria-labelledby=ariaHaspopupTrue>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a>=<code>true</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br>
-        <span class="property">Object Attribute: <code>haspopup:menu</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Pattern: <code>ExpandCollapse</code></span>
-        <span class="seealso">See also: <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_HAS_POPUP</code></span><br>
-        <span class="property">Object Attribute: <code>haspopup:menu</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXPopupValue:menu</code></span><br>
-        <span class="property">Action: <code>AXShowMenu</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaHaspopupFalse><code>aria-haspopup</code>=<code>false</code></h4>
-<table aria-labelledby=ariaHaspopupFalse>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a>=<code>false</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code> not exposed</span><br>
-        <span class="property">Object Attribute: <code>haspopup:false</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaHaspopupDialog><code>aria-haspopup</code>=<code>dialog</code></h4>
-<table aria-labelledby=ariaHaspopupDialog>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a>=<code>dialog</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br>
-        <span class="property">Object Attribute: <code>haspopup:dialog</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Pattern: <code>ExpandCollapse</code></span><br>
-        <span class="seealso">See also: <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_HAS_POPUP</code></span><br>
-        <span class="property">Object Attribute: <code>haspopup:dialog</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXPopupValue:dialog</code></span><br>
-        <span class="action">Action: <code>AXShowMenu</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaHaspopupGrid><code>aria-haspopup</code>=<code>grid</code></h4>
-<table aria-labelledby=ariaHaspopupGrid>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a>=<code>grid</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br>
-        <span class="property">Object Attribute: <code>haspopup:grid</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Pattern: <code>ExpandCollapse</code></span><br>
-        <span class="seealso">See also: <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_HAS_POPUP</code></span><br>
-        <span class="property">Object Attribute: <code>haspopup:grid</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXPopupValue:grid</code></span><br>
-        <span class="action">Action: <code>AXShowMenu</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaHaspopupListbox><code>aria-haspopup</code>=<code>listbox</code></h4>
-<table aria-labelledby=ariaHaspopupListbox>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a>=<code>listbox</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br>
-        <span class="property">Object Attribute: <code>haspopup:listbox</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Pattern: <code>ExpandCollapse</code></span><br>
-        <span class="seealso">See also: <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_HAS_POPUP</code></span><br>
-        <span class="property">Object Attribute: <code>haspopup:listbox</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXPopupValue:listbox</code></span><br>
-        <span class="action">Action: <code>AXShowMenu</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaHaspopupMenu><code>aria-haspopup</code>=<code>menu</code></h4>
-<table aria-labelledby=ariaHaspopupMenu>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a>=<code>menu</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br>
-        <span class="property">Object Attribute: <code>haspopup:menu</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Pattern: <code>ExpandCollapse</code></span><br>
-        <span class="seealso">See also: <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_HAS_POPUP</code></span><br>
-        <span class="property">Object Attribute: <code>haspopup:menu</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXPopupValue:menu</code></span><br>
-        <span class="action">Action: <code>AXShowMenu</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaHaspopupTree><code>aria-haspopup</code>=<code>tree</code></h4>
-<table aria-labelledby=ariaHaspopupTree>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a>=<code>tree</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span><br>
-        <span class="property">Object Attribute: <code>haspopup:tree</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Control Pattern: <code>ExpandCollapse</code></span><br>
-        <span class="seealso">See also: <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_HAS_POPUP</code></span><br>
-        <span class="property">Object Attribute: <code>haspopup:tree</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXPopupValue:tree</code></span><br>
-        <span class="action">Action: <code>AXShowMenu</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaHiddenTrue><code>aria-hidden</code>=<code>true</code> on unfocused element</h4>
-<table aria-labelledby=ariaHiddenTrue>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-hidden"><code>aria-hidden</code></a>=<code>true</code> on unfocused element
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property not-in-tree">Element SHOULD NOT be exposed</span><br>
-        <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property not-in-tree">Element SHOULD NOT be exposed</span><br>
-        <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property not-in-tree">Element SHOULD NOT be exposed</span><br>
-        <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-in-tree">Element SHOULD NOT be exposed</span><br>
-        <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaHiddenTrueElementExposed><code>aria-hidden</code>=<code>true</code> when element is focused or fires an accessibility event</h4>
-<table aria-labelledby=ariaHiddenTrueElementExposed>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-hidden"><code>aria-hidden</code></a>=<code>true</code> when element is focused or fires an accessibility event
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>hidden:true</code></span><br>
-        <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.hidden</code>: <code>true</code></span><br>
-        <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>hidden:true</code></span><br>
-        <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span><br>
-        <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaHiddenFalse><code>aria-hidden</code>=<code>false</code></h4>
-<table aria-labelledby=ariaHiddenFalse>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-hidden"><code>aria-hidden</code></a>=<code>false</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaInvalidTrue><code>aria-invalid</code>=<code>true</code></h4>
-<table aria-labelledby=ariaInvalidTrue>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-invalid"><code>aria-invalid</code></a>=<code>true</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>IA2_STATE_INVALID_ENTRY</code></span><br>
-        <span class="property">Text Attribute: <code>invalid:true</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>IsDataValidForForm</code>: <code>false</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_INVALID_ENTRY</code></span><br>
-        <span class="property">Text Attribute: <code>invalid:true</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXInvalid</code>: <code>true</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaInvalidFalse><code>aria-invalid</code>=<code>false</code></h4>
-<table aria-labelledby=ariaInvalidFalse>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-invalid"><code>aria-invalid</code></a>=<code>false</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>IA2_STATE_INVALID_ENTRY</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>IsDataValidForForm</code>: <code>true</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_INVALID_ENTRY</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXInvalid</code>: <code>false</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaInvalidSpellingGrammar><code>aria-invalid</code>=<code>spelling</code> or <code>grammar</code></h4>
-<table aria-labelledby=ariaInvalidSpellingGrammar>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-invalid"><code>aria-invalid</code></a>=<code>spelling</code> or <code>grammar</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>IA2_STATE_INVALID_ENTRY</code></span><br>
-        <span class="property">Text Attribute: <code>invalid:&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>IsDataValidForForm</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_INVALID_ENTRY</code></span><br>
-        <span class="property">Text Attribute: <code>invalid:&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXInvalid</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaInvalidUnrecognizedValue><code>aria-invalid</code> with unrecognized value</h4>
-<table aria-labelledby=ariaInvalidUnrecognizedValue>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-invalid"><code>aria-invalid</code></a> with unrecognized value
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>IA2_STATE_INVALID_ENTRY</code></span><br>
-        <span class="property">Text Attribute: <code>invalid:true</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>IsDataValidForForm</code>: <code>false</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_INVALID_ENTRY</code></span><br>
-        <span class="property">Text Attribute: <code>invalid:true</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXInvalid</code>: <code>true</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaKeyshortcuts><code>aria-keyshortcuts</code></h4>
-<table aria-labelledby=ariaKeyshortcuts>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-keyshortcuts"><code>aria-keyshortcuts</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Property: <code>accKeyboardShortcut</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AcceleratorKey</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>keyshortcuts:&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXKeyShortcutsValue</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaLabel><code>aria-label</code></h4>
-<table aria-labelledby=ariaLabel>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-label"><code>aria-label</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Property: <code>accName</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>Name</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Property: <code>Name</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXDescription</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaLabelledBy><code>aria-labelledby</code></h4>
-<table aria-labelledby=ariaLabelledBy>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-labelledby"><code>aria-labelledby</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Property: <code>accName</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="relation">Relation: <code>IA2_RELATION_LABELLED_BY</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
-        <span class="relation">Reverse Relation: <code>IA2_RELATION_LABEL_FOR</code> points to element</span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a> and <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>Name</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="property">Property: <code>LabeledBy</code>: points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Property: <code>Name</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="relation">Relation: <code>RELATION_LABELLED_BY</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
-        <span class="relation">Reverse Relation: <code>RELATION_LABEL_FOR</code> points to element</span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a> and <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXDescription</code>: <code>&lt;value&gt;</code></span> if the value is not exposed visually<br>
-        <span class="property">Property: <code>AXTitle</code>: <code>&lt;value&gt;</code></span> if the value is exposed visually<br>
-        <span class="property">Property: <code>AXTitleUIElement</code> points to accessible node matching IDREF, if there is a single referenced element that is in the accessibility tree</span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaLevel><code>aria-level</code> on non-<code>heading</code></h4>
-<table aria-labelledby=ariaLevel>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-level"><code>aria-level</code></a> on non-<code>heading</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>level:&lt;value&gt;</code></span><br>
-        <span class="method">Method: <code>IAccessible2::groupPosition()</code>: <code>groupLevel=&lt;value&gt;</code> on roles that support <code>aria-posinset</code> and <code>aria-setsize</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_group_position"><code>groupPosition()</code></a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.level</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>level:&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXDisclosureLevel</code>: <code>&lt;value&gt;</code> (zero-based), when used on an outline row (like a <a class="role-reference" href="#treeitem"><code>treeitem</code></a> or <a class="role-reference" href="#group"><code>group</code></a>)</span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaLevelHeading><code>aria-level</code> on <code>heading</code></h4>
-<table aria-labelledby=ariaLevelHeading>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-level"><code>aria-level</code></a> on <code>heading</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>level:&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.level</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="property">Property: <code>StyleId_Heading</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>level:&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXValue</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaLiveAssertive><code>aria-live</code>=<code>assertive</code></h4>
-<table aria-labelledby=ariaLiveAssertive>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-live"><code>aria-live</code></a>=<code>assertive</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>live:assertive</code></span><br>
-        <span class="property">Object Attribute: <code>container-live:assertive</code></span><br>
-        <span class="property">Object Attribute: <code>container-live:assertive</code> on all descendants</span><br>
-        <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code><code>LiveSetting</code></code>: <code>&quot;assertive&quot;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>live:assertive</code></span><br>
-        <span class="property">Object Attribute: <code>container-live:assertive</code></span><br>
-        <span class="property">Object Attribute: <code>container-live:assertive</code> on all descendants</span><br>
-        <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXARIALive</code>: <code>&quot;assertive&quot;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaLivePolite><code>aria-live</code>=<code>polite</code></h4>
-<table aria-labelledby=ariaLivePolite>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-live"><code>aria-live</code></a>=<code>polite</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>live:polite</code></span><br>
-        <span class="property">Object Attribute: <code>container-live:polite</code></span><br>
-        <span class="property">Object Attribute: <code>container-live:polite</code> on all descendants</span><br>
-        <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code><code>LiveSetting</code></code>: <code>&quot;polite&quot;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>live:polite</code></span><br>
-        <span class="property">Object Attribute: <code>container-live:polite</code></span><br>
-        <span class="property">Object Attribute: <code>container-live:polite</code> on all descendants</span><br>
-        <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXARIALive</code>: <code>&quot;polite&quot;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaLiveOff><code>aria-live</code>=<code>off</code></h4>
-<table aria-labelledby=ariaLiveOff>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-live"><code>aria-live</code></a>=<code>off</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>live:off</code></span><br>
-        <span class="property">Object Attribute: <code>container-live:off</code></span><br>
-        <span class="property">Object Attribute: <code>container-live:off</code> on all descendants</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code><code>LiveSetting</code></code>: <code>&quot;off&quot;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>live:off</code></span><br>
-        <span class="property">Object Attribute: <code>container-live:off</code></span><br>
-        <span class="property">Object Attribute: <code>container-live:off</code> on all descendants</span><br>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXARIALive</code>: <code>&quot;off&quot;</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaModalTrue><code>aria-modal</code>=<code>true</code></h4>
-<table aria-labelledby=ariaModalTrue>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-modal"><code>aria-modal</code></a>=<code>true</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>IA2_STATE_MODAL</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>Window.IsModal</code>: <code>true</code></span><br>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_MODAL</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        Prune the accessibility tree such that the background content is no longer exposed. No specific property is set on the <a class="termref">accessible object</a> that corresponds to the <a class="termref">element</a> with <code>aria-modal="true"</code>. Only the tree whose root is that modal accessible object is exposed.
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaModalFalse><code>aria-modal</code>=<code>false</code></h4>
-<table aria-labelledby=ariaModalFalse>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-modal"><code>aria-modal</code></a>=<code>false</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>IA2_STATE_MODAL</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>Window.IsModal</code>: <code>false</code></span><br>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_MODAL</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        Grow the accessibility tree such that the background content is exposed. No specific property is set on the <a class="termref">accessible object</a> that corresponds to the <a class="termref">element</a> with <code>aria-modal="false"</code>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaMultilineTrue><code>aria-multiline</code>=<code>true</code></h4>
-<table aria-labelledby=ariaMultilineTrue>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-multiline"><code>aria-multiline</code></a>=<code>true</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>IA2_STATE_MULTI_LINE</code></span><br>
-        <span class="property">State: <code>IA2_STATE_SINGLE_LINE</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.multiline</code>: <code>true</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_MULTI_LINE</code></span><br>
-        <span class="property">State: <code>STATE_SINGLE_LINE</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span><br>
-        <span class="seealso">See also: <a href="#role-map-textbox"><code>textbox</code></a> in the Role Mapping Tables</span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaMultilineFalse><code>aria-multiline</code>=<code>false</code></h4>
-<table aria-labelledby=ariaMultilineFalse>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-multiline"><code>aria-multiline</code></a>=<code>false</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>IA2_STATE_SINGLE_LINE</code></span><br>
-        <span class="property">State: <code>IA2_STATE_MULTI_LINE</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_SINGLE_LINE</code></span><br>
-        <span class="property">State: <code>STATE_MULTI_LINE</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span><br>
-        <span class="seealso">See also: <a href="#role-map-textbox"><code>textbox</code></a> in the Role Mapping Tables</span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaMultiselectableTrue><code>aria-multiselectable</code>=<code>true</code></h4>
-<table aria-labelledby=ariaMultiselectableTrue>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-multiselectable"><code>aria-multiselectable</code></a>=<code>true</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_MULTISELECTABLE</code></span><br>
-        <span class="property">State: <code>STATE_SYSTEM_EXTSELECTABLE</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>Selection.CanSelectMultiple</code>: <code>true</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_MULTISELECTABLE</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span><br>
-        <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaMultiselectableFalse><code>aria-multiselectable</code>=<code>false</code></h4>
-<table aria-labelledby=ariaMultiselectableFalse>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-multiselectable"><code>aria-multiselectable</code></a>=<code>false</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_MULTISELECTABLE</code> not exposed</span><br>
-        <span class="property">State: <code>STATE_SYSTEM_EXTSELECTABLE</code> not exposed</span><br>
-        <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_MULTISELECTABLE</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaOrientationHorizontal><code>aria-orientation</code>=<code>horizontal</code></h4>
-<table aria-labelledby=ariaOrientationHorizontal>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-orientation"><code>aria-orientation</code></a>=<code>horizontal</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>IA2_STATE_HORIZONTAL</code></span><br>
-        <span class="property">State: <code>IA2_STATE_VERTICAL</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>Orientation</code>: <code>horizontal</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_HORIZONTAL</code></span><br>
-        <span class="property">State: <code>STATE_VERTICAL</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXOrientation</code>: <code>AXHorizontalOrientation</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaOrientationVertical><code>aria-orientation</code>=<code>vertical</code></h4>
-<table aria-labelledby=ariaOrientationVertical>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-orientation"><code>aria-orientation</code></a>=<code>vertical</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>IA2_STATE_VERTICAL</code></span><br>
-        <span class="property">State: <code>IA2_STATE_HORIZONTAL</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>Orientation</code>: <code>vertical</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_VERTICAL</code></span><br>
-        <span class="property">State: <code>STATE_HORIZONTAL</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXOrientation</code>: <code>AXVerticalOrientation</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaOrientationUndefined><code>aria-orientation</code> is undefined</h4>
-<table aria-labelledby=ariaOrientationUndefined>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-orientation"><code>aria-orientation</code></a> is undefined
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_VERTICAL</code> not exposed</span><br>
-        <span class="property">State: <code>STATE_HORIZONTAL</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXOrientation</code>: <code>AXUnknownOrientation</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaOwns><code>aria-owns</code></h4>
-<table aria-labelledby=ariaOwns>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <p>User agents MAY expose the elements that are referenced by this property as children of the current element. In which case, if multiple <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a> relationships are found, use only the first one. If the accessibility tree is not modified, expose as:</p>
-        <span class="relation">Relation: <code>IA2_RELATION_NODE_PARENT_OF</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
-        <span class="relation">Reverse Relation: <code>IA2_RELATION_NODE_CHILD_OF</code> points to element</span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        Expose the elements that are referenced by this property as children of the current element. If multiple <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a> relationships are found, use only the first one.
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <p>User agents MAY expose the elements that are referenced by this property as children of the current element. In which case, if multiple <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a> relationships are found, use only the first one. If the accessibility tree is not modified, expose as:</p>
-        <span class="relation">Relation: <code>RELATION_NODE_PARENT_OF</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br>
-        <span class="relation">Reverse Relation: <code>RELATION_NODE_CHILD_OF</code> points to element</span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXOwns</code>: pointers to accessible nodes matching IDREFs</span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaPlaceholder><code>aria-placeholder</code></h4>
-<table aria-labelledby=ariaPlaceholder>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-placeholder"><code>aria-placeholder</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>placeholder-text:&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>HelpText</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>placeholder-text:&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXPlaceholderValue</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaPosinset><code>aria-posinset</code></h4>
-<table aria-labelledby=ariaPosinset>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-posinset"><code>aria-posinset</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>posinset:&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.posinset</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>posinset:&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXARIAPosInSet</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaPressedTrue><code>aria-pressed</code>=<code>true</code></h4>
-<table aria-labelledby=ariaPressedTrue>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-pressed"><code>aria-pressed</code></a>=<code>true</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_PRESSED</code></span><br>
-        <span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>Toggle.ToggleState</code>: <code>On (1)</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_PRESSED</code></span><br>
-        <span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXValue</code>: <code>1</code></span><br>
-        <span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaPressedMixed><code>aria-pressed</code>=<code>mixed</code></h4>
-<table aria-labelledby=ariaPressedMixed>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-pressed"><code>aria-pressed</code></a>=<code>mixed</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_MIXED</code></span><br>
-        <span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>Toggle.ToggleState</code>: <code>Indeterminate (2)</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_INDETERMINATE</code></span><br>
-        <span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXValue</code>: <code>2</code></span><br>
-        <span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaPressedFalse><code>aria-pressed</code>=<code>false</code></h4>
-<table aria-labelledby=ariaPressedFalse>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-pressed"><code>aria-pressed</code></a>=<code>false</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_PRESSED</code> not exposed</span><br>
-        <span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>Toggle.ToggleState</code>: <code>Off (3)</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_PRESSED</code> not exposed</span><br>
-        <span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXValue</code>: <code>0</code></span><br>
-        <span class="seealso">See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaPressedUndefined><code>aria-pressed</code> is undefined</h4>
-<table aria-labelledby=ariaPressedUndefined>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-pressed"><code>aria-pressed</code></a> is undefined
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaReadonlyTrue><code>aria-readonly</code>=<code>true</code></h4>
-<table aria-labelledby=ariaReadonlyTrue>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a>=<code>true</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_READONLY</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>Value.IsReadOnly</code>: <code>true</code>, if the element implements <a href="https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.ivalueprovider"><code>IValueProvider</code></a>.</span><br>
-        <span class="property">Property: <code>RangeValue.IsReadOnly</code>: <code>true</code>, if the element implements <a href="https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.irangevalueprovider"><code>IRangeValueProvider</code></a>.</span><br>
-        <span class="property">Property: <code>AriaProperties.readonly</code>: <code>true</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_READ_ONLY</code></span><br>
-        <span class="property">State: <code>STATE_EDITABLE</code> not exposed on text input roles</span><br>
-        <span class="property">State: <code>STATE_CHECKABLE</code> not exposed on roles supporting <a class="state-reference" href="#aria-checked"><code>aria-checked</code></a></span><br>
-        <span class="property">State: <code>STATE_CHECKABLE</code> not exposed on <a class="role-reference" href="#radio">radio</a> descendants when used on a <code>radiogroup</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="method">Method: <code>AXUIElementIsAttributeSettable(AXValue)</code>: <code>NO</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaReadonlyFalse><code>aria-readonly</code>=<code>false</code></h4>
-<table aria-labelledby=ariaReadonlyFalse>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a>=<code>false</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_READONLY</code> not exposed</span><br>
-        <span class="property">State: <code>IA2_STATE_EDITABLE</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>Value.IsReadOnly</code>: <code>false</code>, if the element implements <a href="https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.ivalueprovider"><code>IValueProvider</code></a>.</span><br>
-        <span class="property">Property: <code>RangeValue.IsReadOnly</code>: <code>false</code>, if the element implements <a href="https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.irangevalueprovider"><code>IRangeValueProvider</code></a>.</span><br>
-        <span class="property">Property: <code>AriaProperties.readonly</code>: <code>false</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_READ_ONLY</code> not exposed</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="method">Method: <code>AXUIElementIsAttributeSettable(AXValue)</code>: <code>YES</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaReadonlyUnspecifiedOnGridcell><code>aria-readonly</code> is unspecified on <code>gridcell</code></h4>
-<table aria-labelledby=ariaReadonlyUnspecifiedOnGridcell>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a> is unspecified on <code>gridcell</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a>.
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a>.
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a>.
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaRelevant><code>aria-relevant</code></h4>
-<table aria-labelledby=ariaRelevant>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-relevant"><code>aria-relevant</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>relevant:&lt;value&gt;</code></span><br>
-        <span class="property">Object Attribute: <code>container-relevant:&lt;value&gt;</code></span><br>
-        <span class="property">Object Attribute: <code>container-relevant:&lt;value&gt;</code> on all descendants</span><br>
-        <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.relevant</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>relevant:&lt;value&gt;</code></span><br>
-        <span class="property">Object Attribute: <code>container-relevant:&lt;value&gt;</code></span><br>
-        <span class="property">Object Attribute: <code>container-relevant:&lt;value&gt;</code> on all descendants</span><br>
-        <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXARIARelevant</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaRequiredTrue><code>aria-required</code>=<code>true</code></h4>
-<table aria-labelledby=ariaRequiredTrue>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-required"><code>aria-required</code></a>=<code>true</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>IA2_STATE_REQUIRED</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>IsRequiredForForm</code>: <code>true</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_REQUIRED</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXRequired</code>: <code>YES</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaRequiredFalse><code>aria-required</code>=<code>false</code></h4>
-<table aria-labelledby=ariaRequiredFalse>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-required"><code>aria-required</code></a>=<code>false</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaRoleDescription><code>aria-roledescription</code></h4>
-<table aria-labelledby=ariaRoleDescription>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-roledescription"><code>aria-roledescription</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="method">Method: <code>localizedExtendedRole()</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Localized Control Type: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>roledescription:&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXRoleDescription</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaRoleDescriptionEmptyString><code>aria-roledescription</code> is undefined or the empty string</h4>
-<table aria-labelledby=ariaRoleDescriptionEmptyString>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-roledescription"><code>aria-roledescription</code></a> is undefined or the empty string
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Localized Control Type is defined as that specified for the role of the element: based on the explicit role if the role attribute is provided; otherwise, based on the implicit role for the host language.</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">AXRoleDescription is defined as that specified for the role of the element: based on the explicit role if the role attribute is provided; otherwise, based on the implicit role for the host language.</span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaRowCount><code>aria-rowcount</code></h4>
-<table aria-labelledby=ariaRowCount>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-rowcount"><code>aria-rowcount</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>rowcount:&lt;value&gt;</code></span><br>
-        <span class="method">Method: <code>IAccessible2::groupPosition()</code>: <code>similarItemsInGroup=&lt;value&gt;</code> on rows</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>Grid.RowCount</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>rowcount</code> should contain the author-provided value.</span><br>
-        <span class="method">Method: <code>atk_table_get_n_rows()</code> should return the actual number of rows.</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXARIARowCount</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaRowIndex><code>aria-rowindex</code></h4>
-<table aria-labelledby=ariaRowIndex>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-rowindex"><code>aria-rowindex</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>rowindex:&lt;value&gt;</code></span><br>
-        <span class="method">Method: <code>IAccessible2::groupPosition()</code>: <code>positionInGroup=&lt;value&gt;</code> on rows</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>GridItem.Row</code>: <code>&lt;value&gt;</code> (zero-based)</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>rowindex</code> should contain the author-provided value.</span><br>
-        <span class="method">Method: <code>atk_table_cell_get_position()</code> should return the actual (zero-based) row index.</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXARIARowIndex</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaRowIndexText><code>aria-rowindextext</code></h4>
-<table aria-labelledby=ariaRowIndexText>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-rowindextext"><code>aria-rowindextext</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>rowindextext:&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.rowindextext</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>rowindextext:&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: TBD</span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaRowSpan><code>aria-rowspan</code></h4>
-<table aria-labelledby=ariaRowSpan>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-rowspan"><code>aria-rowspan</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>rowspan:&lt;value&gt;</code></span><br>
-        <span class="method">Method: <code>IAccessibleTableCell::rowExtent()</code>: <code>column=&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>GridItem.RowSpan</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>rowspan</code> should contain the author-provided value.</span><br>
-        <span class="method">Method: <code>atk_table_cell_get_row_column_span()</code> should return the actual row span.</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXRowIndexRange.length</code>: <code>&lt;value&gt;</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaSelectedTrue><code>aria-selected</code>=<code>true</code></h4>
-<table aria-labelledby=ariaSelectedTrue>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-selected"><code>aria-selected</code></a>=<code>true</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_SELECTABLE</code></span><br>
-        <span class="property">State: <code>STATE_SYSTEM_SELECTED</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>SelectionItem.IsSelected</code>: <code>true</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_SELECTABLE</code></span><br>
-        <span class="property">State: <code>STATE_SELECTED</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXSelected</code>: <code>YES</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaSelectedFalse><code>aria-selected</code>=<code>false</code></h4>
-<table aria-labelledby=ariaSelectedFalse>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-selected"><code>aria-selected</code></a>=<code>false</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">State: <code>STATE_SYSTEM_SELECTABLE</code></span><br>
-        <span class="property">State: <code>STATE_SYSTEM_SELECTED</code> not exposed</span><br>
-        <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>SelectionItem.IsSelected</code>: <code>false</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">State: <code>STATE_SELECTABLE</code></span><br>
-        <span class="property">State: <code>STATE_SELECTED</code> not exposed</span><br>
-        <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXSelected</code>: <code>NO</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaSelectedUndefined><code>aria-selected</code> is undefined</h4>
-<table aria-labelledby=ariaSelectedUndefined>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-selected"><code>aria-selected</code></a> is undefined
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaSetsize><code>aria-setsize</code></h4>
-<table aria-labelledby=ariaSetsize>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-setsize"><code>aria-setsize</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>setsize:&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.setsize</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <p>If the author-provided value of <code>aria-setsize</code> is <code>-1</code>, the exposed value should be based on the number of objects in the <abbr title="Document Object Model">DOM</abbr>.</p>
-        <span class="property">Object Attribute: <code>setsize:&lt;value&gt;</code></span><br>
-        <span class="property">State: <code>STATE_INDETERMINATE</code> if the author-provided value is <code>-1</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXARIASetSize</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaSortAscending><code>aria-sort</code>=<code>ascending</code></h4>
-<table aria-labelledby=ariaSortAscending>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-sort"><code>aria-sort</code></a>=<code>ascending</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>sort:ascending</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.sort</code>: <code>ascending</code></span><br>
-        <span class="property">Property: <code>ItemStatus</code>: <code>ascending</code> if the element maps to <a href="https://msdn.microsoft.com/en-us/library/windows/apps/ee671630.aspx"><code>HeaderItem</code></a> Control Type</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>sort:ascending</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXSortDirection</code>: <code>AXAscendingSortDirection</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaSortDescending><code>aria-sort</code>=<code>descending</code></h4>
-<table aria-labelledby=ariaSortDescending>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-sort"><code>aria-sort</code></a>=<code>descending</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>sort:descending</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.sort</code>: <code>descending</code></span><br>
-        <span class="property">Property: <code>ItemStatus</code>: <code>descending</code> if the element maps to <a href="https://msdn.microsoft.com/en-us/library/windows/apps/ee671630.aspx"><code>HeaderItem</code></a> Control Type</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>sort:descending</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXSortDirection</code>: <code>AXDescendingSortDirection</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaSortOther><code>aria-sort</code>=<code>other</code></h4>
-<table aria-labelledby=ariaSortOther>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-sort"><code>aria-sort</code></a>=<code>other</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>sort:other</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>AriaProperties.sort</code>: <code>other</code></span><br>
-        <span class="property">Property: <code>ItemStatus</code>: <code>other</code> if the element maps to <a href="https://msdn.microsoft.com/en-us/library/windows/apps/ee671630.aspx"><code>HeaderItem</code></a> Control Type</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>sort:other</code></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXSortDirection</code>: <code>AXUnknownSortDirection</code></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaSortNone><code>aria-sort</code>=<code>none</code></h4>
-<table aria-labelledby=ariaSortNone>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-sort"><code>aria-sort</code></a>=<code>none</code>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="property">Object Attribute: <code>sort:none</code>, if the value is not unspecified</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>sort:none</code>, if the value is not unspecified</span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaValueMax><code>aria-valuemax</code></h4>
-<table aria-labelledby=ariaValueMax>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-valuemax"><code>aria-valuemax</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="method">Method: <code>IAccessibleValue::maximumValue()</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>RangeValue.Maximum</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="method">Method: <code>atk_value_get_maximum_value()</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXMaxValue</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaValueMin><code>aria-valuemin</code></h4>
-<table aria-labelledby=ariaValueMin>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-valuemin"><code>aria-valuemin</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="method">Method: <code>IAccessibleValue::minimumValue()</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>RangeValue.Minimum</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="method">Method: <code>atk_value_get_minimum_value()</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXMinValue</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaValueNow><code>aria-valuenow</code></h4>
-<table aria-labelledby=ariaValueNow>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-valuenow"><code>aria-valuenow</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="method">Method: <code>IAccessibleValue::currentValue()</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="method">Method: <code>IAccessible::get_accValue()</code>: <code>&lt;value&gt;</code> if <code>aria-valuetext</code> is not defined</span><br>
-        <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>RangeValue.Value</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="method">Method: <code>atk_value_get_current_value()</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXValue</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=ariaValueText><code>aria-valuetext</code></h4>
-<table aria-labelledby=ariaValueText>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-valuetext"><code>aria-valuetext</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 </th>
-      <td>
-        <span class="method">Method: <code>IAccessible::get_accValue()</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="property">Object Attribute: <code>valuetext:&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr></th>
-      <td>
-        <span class="property">Property: <code>Value.Value</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-      <td>
-        <span class="property">Object Attribute: <code>valuetext:&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-      <td>
-        <span class="property">Property: <code>AXValueDescription</code>: <code>&lt;value&gt;</code></span><br>
-        <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
-      </td>
-    </tr>
-  </tbody>
-</table>
-  </section>
-	</section>
-	<section id="mapping_additional">
-		<h2>Special Processing Requiring Additional Computation</h2>
-		<section id="mapping_additional_nd">
-			<h3>Name and Description</h3>
-				<p>For information on how to compute an <a class="termref" data-cite="accname-1.2#dfn-accessible-name">accessible name</a> or <a class="termref" data-cite="accname-1.2#dfn-accessible-description">accessible description</a>, see the section titled <a class="accname" href="#mapping_additional_nd_te">Accessible Name and Description Computation</a> of the <a class="accname" href="">Accessible Name and Description Computation</a> specification.</p>
-		</section>
-		<section id="mapping_additional_relations">
-		    <h3>Relations</h3>
-	      <p>Often in a <abbr title="Graphical User Interface">GUI</abbr>, there are <a class="termref">relationships</a> between the <a class="termref">widgets</a> that can be exposed programmatically to <a class="termref">assistive technology</a>. <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> provides several relationship [=ARIA/properties=] which are globally applicable to any <a class="termref">element</a>: <a class="property-reference" href="#aria-controls"><code>aria-controls</code></a>, <a class="property-reference" href="#aria-describedby"><code>aria-describedby</code></a>, <a class="property-reference" href="#aria-flowto"><code>aria-flowto</code></a>, <a class="property-reference" href="#aria-labelledby"><code>aria-labelledby</code></a>, <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a>, <a class="property-reference" href="#aria-posinset"><code>aria-posinset</code></a>, and <a class="property-reference" href="#aria-setsize"><code>aria-setsize</code></a>. Therefore, it is not important to check the <a class="termref">role</a> before computing them. [=User agents=]  can simply map these relations to <a class="termref">accessibility APIs</a> as defined in the section titled <a href="#mapping_state-property">State and Property Mapping</a>. </p>
-	        <section id="mapping_additional_relations_reverse_relations">
-	        <h4>Reverse Relations</h4>
-		      <p>A reverse relation exists when an element's ID is referenced by a [=ARIA/property=] in another <a class="termref">element</a>. For <abbr title="Application Programming Interfaces">APIs</abbr> that support reverse relations, [=user agents=]  MUST use the mapping defined in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a> when an element's ID is referenced by a relation property of another element and the referenced element is in the accessibility tree. All WAI-ARIA references must point to an element that is exposed as an accessible object in the accessibility tree. When the referenced object is not exposed in the accessibility tree (e.g. because it is [=element/hidden=]), the reference is null. <code>aria-labelledby</code> and <code>aria-describedby</code> have an additional feature, which allows them to pull a flattened string from the referenced element to populate the name or description fields of the accessibility API. This feature is described in the <a href="#mapping_additional_nd">Name and Description</a> section.</p>
-            <p>Special case: If both <a class="property-reference" href="#aria-labelledby"><code>aria-labelledby</code></a> and <abbr title="Hypertext Markup Language">HTML</abbr> <code>&lt;label for= &#8230; &gt;</code> are used, the user agent MUST use the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> relation and MUST ignore the <abbr title="Hypertext Markup Language">HTML</abbr> label relation.</p>
-            <p>Note that <a class="property-reference" href="#aria-describedby"><code>aria-describedby</code></a> may reference structured or interactive information where users would want to be able to navigate to different sections of content. User agents MAY provide a way for the user to navigate to structured information referenced by <a class="property-reference" href="#aria-describedby"><code>aria-describedby</code></a> and <a class="termref">assistive technology</a> SHOULD provide such a method.</p>
+      <section id="mapping_state-property">
+        <h2>State and Property Mapping</h2>
+        <p>This section describes how to expose <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a class="termref">states</a> and [=ARIA/properties=].</p>
+        <section id="statePropertyMappingGeneralRules">
+          <h2>General rules</h2>
+          <ol>
+            <li>
+              [=User agents=] MUST compute <a class="termref">managed states</a> <code>VISIBLE</code>/<code>INVISIBLE</code>, <code>SHOWING</code>/<code>OFFSCREEN</code>, etc. This typically is done
+              in the same way as for ordinary <a class="termref">elements</a> that do not have <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> attributes present. The
+              <code>FOCUSABLE</code>/<code>FOCUSED</code> states may be affected by <a class="property-reference" href="#aria-activedescendant"><code>aria-activedescendant</code></a
+              >.
+            </li>
+            <li>
+              User agents MUST continue to expose native semantics in addition to <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> state and property semantics except where an
+              explicit WAI-ARIA override is allowed by the host language. For example, an <abbr title="Hypertext Markup Language">HTML</abbr> checkbox may have an
+              <a class="property-reference" href="#aria-labelledby"><code>aria-labelledby</code></a> attribute but the native <abbr title="Hypertext Markup Language">HTML</abbr> semantics must still
+              be exposed.
+            </li>
+            <li>User agents MUST expose additional states for certain <a class="termref">roles</a> as defined in the <a href="#mapping_role_table">Role Mapping Tables</a>.</li>
+            <li>
+              User agents MUST compute states for the relevant <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref">attributes</a> and map to the
+              <a class="termref">accessibility API</a> as specified in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a>. To determine the relevant
+              <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> attributes, refer to the
+              <cite><a href="#role_definitions" class="specref">Definition of Roles</a></cite> [[!WAI-ARIA-1.2]]]. Where the author has not provided values for required attributes, user agents SHOULD
+              process as if the default value was provided.
+            </li>
+            <li>
+              Some <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> properties are not global, and are only supported on certain roles. If a non-global
+              <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> state or property is used where it is not supported, user agents SHOULD NOT map the given
+              <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> property to the platform accessibility <abbr title="application programming interface">API</abbr>. For example, if
+              <code>aria-checked=&quot;true&quot;</code> is specified on <code>&lt;div role=&quot;grid&quot;&gt;</code>, it should not be exposed in
+              <abbr title="Microsoft Active Accessibility">MSAA</abbr> implementations as <code>STATE_SYSTEM_CHECKED</code>.
+            </li>
+            <li>
+              When an explicit or inherited role of <code>none</code> or <code>presentation</code> is applied to an element, the user agent MUST implement the rules for the
+              <a class="role-reference" href="#none"><code>none</code></a> or the <a class="role-reference" href="#presentation"><code>presentation</code></a> <a class="termref">role</a> defined in
+              <cite><a class="specref" href="">Accessible Rich Internet Applications (WAI-ARIA) 1.2</a></cite> [[!WAI-ARIA-1.2]]].
+            </li>
+          </ol>
         </section>
-        <section id="mapping_additional_relations_implied">
-          <h4>Implied reverse relations</h4>
-			    <p>In addition to the explicit relations defined by <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> [=ARIA/properties=], reverse relations are implied in two other situations: <a class="termref">elements</a> with <code>role=&quot;treeitem&quot;</code> where the ancestor does not have an <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a> property and descendants of elements with <a class="property-reference" href="#aria-atomic"><code>aria-atomic</code></a> property.</p>  
-          <p>In the case of <code>role=&quot;<a class="role-reference" href="#treeitem">treeitem</a>&quot;</code>, when <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a> is not used, [=user agents=]  SHOULD do the following where reverse relations are supported by the <abbr title="application programming interface">API</abbr>:</p>
-          <ul>
-				    <li>If the current <a class="role-reference" href="#treeitem"><code>treeitem</code></a> uses <a class="property-reference" href="#aria-level"><code>aria-level</code></a>, then walk backwards in the tree until a <a class="role-reference" href="#treeitem"><code>treeitem</code></a> is found with a lower <a class="property-reference" href="#aria-level"><code>aria-level</code></a>, then set <code>RELATION_NODE_CHILD_OF</code> to that element. If the top of the tree is reached, then set <code>RELATION_NODE_CHILD_OF</code> to the tree element itself.</li>
-				    <li>If the parent of the <a class="role-reference" href="#treeitem"><code>treeitem</code></a> has a <a class="termref">role</a> of <a class="role-reference" href="#group"><code>group</code></a>, then walk backwards from the <a class="role-reference" href="#group"><code>group</code></a> until an element with a role of  <a class="role-reference" href="#treeitem"><code>treeitem</code></a> is found, then set <code>RELATION_NODE_CHILD_OF</code> to that element.</li>
-			    </ul>
-          <p>In the case of <a class="property-reference" href="#aria-atomic"><code>aria-atomic</code></a>, where reverse relations are supported by the <abbr title="application programming interface">API</abbr>:</p> 
-          <ul>
-            <li>User agents SHOULD check the chain of ancestor elements for <a class="property-reference" href="#aria-atomic"><code>aria-atomic</code></a><code>=&quot;true&quot;</code>. If found, user agents SHOULD set the <code>RELATION_MEMBER_OF</code> relation to point to the ancestor that sets  <a class="property-reference" href="#aria-atomic"><code>aria-atomic</code></a><code>=&quot;true&quot;</code>.</li>
-			    </ul>
+        <section id="mapping_state-property_table">
+          <h3>State and Property Mapping Tables</h3>
+          <section id="not_mapped">
+            <h4>Not Mapped</h4>
+            <p>
+              There are a number of occurrences in the table where a given state or property is declared "Not mapped". In some cases, this occurs for the default value of the state/property, and is
+              equivalent to its absence. User agents might find it quicker to map the value than check to see if it is the default. For computational efficiency, user agents MAY expose the state or
+              property value if doing so is equivalent to not mapping it. These cases are marked with an asterisk.
+            </p>
+            <p>
+              In other cases, it is mandatory that the state/property not be mapped, since exposing it implies a related affordance. An example is
+              <a class="state-reference" href="#aria-grabbed"><code>aria-grabbed</code></a
+              >. Its absence not only indicates that the accessible object is not grabbed, but further defines it as not grab-able. These cases are marked as "Not mapped" without an asterisk.
+            </p>
+          </section>
+          <h4 id="ariaActiveDescendant"><code>aria-activedescendant</code></h4>
+          <table aria-labelledby="ariaActiveDescendant">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-activedescendant"><code>aria-activedescendant</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>See <a href="#focus_state_event_table">Focus Changes</a>.</td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>See <a href="#focus_state_event_table">Focus Changes</a>.</td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>See <a href="#focus_state_event_table">Focus Changes</a>.</td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  See <a href="#focus_state_event_table">Focus Changes</a>.<br />
+                  <span class="property">Property: <code>AXSelectedRows</code>: pointer to active descendant node</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaAtomicTrue"><code>aria-atomic</code>=<code>true</code></h4>
+          <table aria-labelledby="ariaAtomicTrue">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-atomic"><code>aria-atomic</code></a
+                  >=<code>true</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>atomic:true</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-atomic:true</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-atomic:true</code> on all descendants</span><br />
+                  <span class="relation">Relation: <code>IA2_RELATION_MEMBER_OF</code> pointing to this element (the atomic root)</span><br />
+                  <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.atomic</code>: <code>true</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>atomic:true</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-atomic:true</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-atomic:true</code> on all descendants</span><br />
+                  <span class="relation">Relation: <code>RELATION_MEMBER_OF</code> pointing to this element (the atomic root)</span><br />
+                  <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXARIAAtomic</code>: <code>YES</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaAtomicFalse"><code>aria-atomic</code>=<code>false</code></h4>
+          <table aria-labelledby="ariaAtomicFalse">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-atomic"><code>aria-atomic</code></a
+                  >=<code>false</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a>, but if mapped:</span><br />
+                  <span class="property">Object Attribute: <code>atomic:false</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-atomic:false</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-atomic:false</code> on all descendants</span><br />
+                  <span class="relation">Relation: <code>IA2_RELATION_MEMBER_OF</code> pointing to this element (the atomic root)</span><br />
+                  <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.atomic</code>: <code>false</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a>, but if mapped:</span><br />
+                  <span class="property">Object Attribute: <code>atomic:false</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-atomic:false</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-atomic:false</code> on all descendants</span><br />
+                  <span class="relation">Relation: <code>RELATION_MEMBER_OF</code> pointing to this element (the atomic root)</span><br />
+                  <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXARIAAtomic</code>: <code>NO</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaAutocompleteInlineListBoth"><code>aria-autocomplete</code>=<code>inline</code>, <code>list</code>, or <code>both</code></h4>
+          <table aria-labelledby="ariaAutocompleteInlineListBoth">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-autocomplete"><code>aria-autocomplete</code></a
+                  >=<code>inline</code>, <code>list</code>, or <code>both</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>autocomplete:&lt;value&gt;</code></span
+                  ><br />
+                  <span class="property">State: <code>IA2_STATE_SUPPORTS_AUTOCOMPLETION</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>autocomplete:&lt;value&gt;</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_SUPPORTS_AUTOCOMPLETION</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaAutocompleteNone"><code>aria-autocomplete</code>=<code>none</code></h4>
+          <table aria-labelledby="ariaAutocompleteNone">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-autocomplete"><code>aria-autocomplete</code></a
+                  >=<code>none</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaBraillelabel"><code>aria-braillelabel</code></h4>
+          <table aria-labelledby="ariaBraillelabel">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-braillelabel"><code>aria-braillelabel</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>braillelabel:&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.braillelabel</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>braillelabel:&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: AXBrailleLabel</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaBrailleroledescription"><code>aria-brailleroledescription</code></h4>
+          <table aria-labelledby="ariaBrailleroledescription">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-brailleroledescription"><code>aria-brailleroledescription</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>brailleroledescription:&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.brailleroledescription</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>brailleroledescription:&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: AXBrailleRoleDescription</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaBrailleroledescriptionUndefined"><code>aria-brailleroledescription</code> is undefined or the empty string</h4>
+          <table aria-labelledby="ariaBrailleroledescriptionUndefined">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-brailleroledescription"><code>aria-brailleroledescription</code></a> is undefined or the empty string
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaBusyTrue"><code>aria-busy</code>=<code>true</code></h4>
+          <table aria-labelledby="ariaBusyTrue">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-busy"><code>aria-busy</code></a
+                  >=<code>true</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_BUSY</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.busy</code>: <code>true</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_BUSY</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXElementBusy</code>: <code>YES</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaBusyFalse"><code>aria-busy</code>=<code>false</code></h4>
+          <table aria-labelledby="ariaBusyFalse">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-busy"><code>aria-busy</code></a
+                  >=<code>false</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_BUSY</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.busy</code>: <code>false</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_BUSY</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXElementBusy</code>: <code>NO</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaCheckedTrue"><code>aria-checked</code>=<code>true</code></h4>
+          <table aria-labelledby="ariaCheckedTrue">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-checked"><code>aria-checked</code></a
+                  >=<code>true</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_CHECKED</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>checkable:true</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>Toggle.ToggleState</code>: <code>On (1)</code></span
+                  ><br />
+                  <span class="property">Property: <code>SelectionItem.IsSelected</code>: <code>True</code> for <code>radio</code> and <code>menuitemradio</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_CHECKABLE</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_CHECKED</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXValue</code>: <code>1</code></span
+                  ><br />
+                  <span class="property">Property: <code>AXMenuItemMarkChar</code>: <code>&#x2713;</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaCheckedFalse"><code>aria-checked</code>=<code>false</code></h4>
+          <table aria-labelledby="ariaCheckedFalse">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-checked"><code>aria-checked</code></a
+                  >=<code>false</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_CHECKED</code> not exposed</span><br />
+                  <span class="property">Object Attribute: <code>checkable:true</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>Toggle.ToggleState</code>: <code>Off (0)</code></span
+                  ><br />
+                  <span class="property">Property: <code>SelectionItem.IsSelected</code>: <code>False</code> for <code>radio</code> and <code>menuitemradio</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_CHECKABLE</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_CHECKED</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXValue</code>: <code>0</code></span
+                  ><br />
+                  <span class="property">Property: <code>AXMenuItemMarkChar</code>: <code>&lt;nil&gt;</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaCheckedMixed"><code>aria-checked</code>=<code>mixed</code></h4>
+          <table aria-labelledby="ariaCheckedMixed">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-checked"><code>aria-checked</code></a
+                  >=<code>mixed</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_MIXED</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>checkable:true</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>Toggle.ToggleState</code>: <code>Indeterminate (2)</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_INDETERMINATE</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_CHECKABLE</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_CHECKED</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXValue</code>: <code>2</code></span
+                  ><br />
+                  <span class="property">Property: <code>AXMenuItemMarkChar</code>: <code>&lt;nil&gt;</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaCheckedUndefined"><code>aria-checked</code> is undefined</h4>
+          <table aria-labelledby="ariaCheckedUndefined">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-checked"><code>aria-checked</code></a> is undefined
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaColCount"><code>aria-colcount</code></h4>
+          <table aria-labelledby="ariaColCount">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-colcount"><code>aria-colcount</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>colcount:&lt;value&gt;</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible2::groupPosition()</code>: <code>similarItemsInGroup=&lt;value&gt;</code> on cells and headers</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>Grid.ColumnCount</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>colcount</code> should contain the author-provided value.</span><br />
+                  <span class="method">Method: <code>atk_table_get_n_columns()</code> should return the actual number of columns.</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXARIAColumnCount</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaColIndex"><code>aria-colindex</code></h4>
+          <table aria-labelledby="ariaColIndex">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-colindex"><code>aria-colindex</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>colindex:&lt;value&gt;</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible2::groupPosition()</code>: <code>positionInGroup=&lt;value&gt;</code> on cells and headers</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>GridItem.Column</code>: <code>&lt;value&gt;</code> (zero-based)</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>colindex</code> should contain the author-provided value.</span><br />
+                  <span class="method">Method: <code>atk_table_cell_get_position()</code> should return the actual (zero-based) column index.</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXARIAColumnIndex</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaColIndexText"><code>aria-colindextext</code></h4>
+          <table aria-labelledby="ariaColIndexText">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-colindextext"><code>aria-colindextext</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>colindextext:&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.colindextext</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>colindextext:&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: TBD</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaColSpan"><code>aria-colspan</code></h4>
+          <table aria-labelledby="ariaColSpan">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-colspan"><code>aria-colspan</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>colspan:&lt;value&gt;</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessibleTableCell::columnExtent()</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>GridItem.ColumnSpan</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>colspan</code> should contain the author-provided value.</span><br />
+                  <span class="method">Method: <code>atk_table_cell_get_row_column_span()</code> should return the actual column span.</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXColumnIndexRange.length</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaControls"><code>aria-controls</code></h4>
+          <table aria-labelledby="ariaControls">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-controls"><code>aria-controls</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="relation">Relation: <code>IA2_RELATION_CONTROLLER_FOR</code> points to accessible nodes matching IDREFs</span><br />
+                  <span class="relation">Reverse Relation: <code>IA2_RELATION_CONTROLLED_BY</code> points to element</span><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>ControllerFor</code>: pointers to accessible nodes matching IDREFs</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="relation">Relation: <code>RELATION_CONTROLLER_FOR</code> points to accessible nodes matching IDREFs</span><br />
+                  <span class="relation">Reverse Relation: <code>RELATION_CONTROLLED_BY</code> points to element</span><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXLinkedUIElements</code>: pointers to accessible nodes matching IDREFs</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaCurrent"><code>aria-current</code> with non-<code>false</code> allowed value</h4>
+          <table aria-labelledby="ariaCurrent">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-current"><code>aria-current</code></a> with non-<code>false</code> allowed value
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>current:&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.current</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>current:&lt;value&gt;</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_ACTIVE</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXARIACurrent</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaCurrentUnrecognizedValue"><code>aria-current</code> with unrecognized value</h4>
+          <table aria-labelledby="ariaCurrentUnrecognizedValue">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-current"><code>aria-current</code></a> with unrecognized value
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>current:true</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.current</code>: <code>true</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>current:true</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_ACTIVE</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXARIACurrent</code>: <code>true</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaCurrentUndefined"><code>aria-current</code> is <code>false</code> or undefined</h4>
+          <table aria-labelledby="ariaCurrentUndefined">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-current"><code>aria-current</code></a> is <code>false</code> or undefined
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaDescribedBy"><code>aria-describedby</code></h4>
+          <table aria-labelledby="ariaDescribedBy">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-describedby"><code>aria-describedby</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Property: <code>accDescription</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="relation">Relation: <code>IA2_RELATION_DESCRIBED_BY</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span
+                  ><br />
+                  <span class="relation">Reverse Relation: <code>IA2_RELATION_DESCRIPTION_FOR</code> points to element</span><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a> and <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>FullDescription</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Property: <code>Description</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="relation">Relation: <code>RELATION_DESCRIBED_BY</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
+                  <span class="relation">Reverse Relation: <code>RELATION_DESCRIPTION_FOR</code> points to element</span><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a> and <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="api"
+                    >In the accessibilityCustomContent API, expose as an <code>AXCustomContent</code> object with <code>{ label: "description" }</code> and `<code>value</code>` set to the description
+                    string.</span
+                  ><br />
+                  - <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaDescription"><code>aria-description</code></h4>
+          <table aria-labelledby="ariaDescription">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-description"><code>aria-description</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Property: <code>accDescription</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>FullDescription</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Property: <code>Description</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="api"
+                    >In the accessibilityCustomContent API, expose as an <code>AXCustomContent</code> object with <code>{ label: "description" }</code> and `<code>value</code>` set to the description
+                    string.</span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaDetails"><code>aria-details</code></h4>
+          <table aria-labelledby="ariaDetails">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-details"><code>aria-details</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="relation">Relation: <code>IA2_RELATION_DETAILS</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
+                  <span class="relation">Reverse Relation: <code>IA2_RELATION_DETAILS_FOR</code> points to element</span><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>DescribedBy</code>: points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="relation">Relation: <code>RELATION_DETAILS</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
+                  <span class="relation">Reverse Relation: <code>RELATION_DETAILS_FOR</code> points to element</span><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaDisabledTrue"><code>aria-disabled</code>=<code>true</code></h4>
+          <table aria-labelledby="ariaDisabledTrue">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-disabled"><code>aria-disabled</code></a
+                  >=<code>true</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_UNAVAILABLE</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_SYSTEM_UNAVAILABLE</code> on all descendants with <code>STATE_SYSTEM_FOCUSABLE</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>IsEnabled</code>: <code>false</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_ENABLED</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXEnabled</code>: <code>NO</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaDisabledFalse"><code>aria-disabled</code>=<code>false</code></h4>
+          <table aria-labelledby="ariaDisabledFalse">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-disabled"><code>aria-disabled</code></a
+                  >=<code>false</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_UNAVAILABLE</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>IsEnabled</code>: <code>true</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_ENABLED</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXEnabled</code>: <code>YES</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaDropeffectMoveLinkExecutePopup"><code>aria-dropeffect</code>=<code>copy</code>, <code>move</code>, <code>link</code>, <code>execute</code>, or <code>popup</code></h4>
+          <table aria-labelledby="ariaDropeffectMoveLinkExecutePopup">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-dropeffect"><code>aria-dropeffect</code></a
+                  >=<code>copy</code>, <code>move</code>, <code>link</code>, <code>execute</code>, or <code>popup</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>dropeffect:&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.dropeffect</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>dropeffect:&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <code>array AXDropEffects</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaDropeffectNone"><code>aria-dropeffect</code>=<code>none</code></h4>
+          <table aria-labelledby="ariaDropeffectNone">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-dropeffect"><code>aria-dropeffect</code></a
+                  >=<code>none</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>dropeffect:none</code> if there are no other valid tokens</span><br />
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a> if not specified by the author</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>dropeffect:none</code> if there are no other valid tokens</span><br />
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a> if not specified by the author</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaErrorMessage"><code>aria-errormessage</code></h4>
+          <table aria-labelledby="ariaErrorMessage">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-errormessage"><code>aria-errormessage</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="relation">Relation: <code>IA2_RELATION_ERROR</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
+                  <span class="relation">Reverse Relation: <code>IA2_RELATION_ERROR_FOR</code> points to element</span><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>ControllerFor</code>: pointer to the target accessible object</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="relation">Relation: <code>RELATION_ERROR_MESSAGE</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
+                  <span class="relation">Reverse Relation: <code>RELATION_ERROR_FOR</code> points to element</span><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXErrorMessageElements</code>: pointers to accessible nodes matching IDREFs</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaExpandedTrue"><code>aria-expanded</code>=<code>true</code></h4>
+          <table aria-labelledby="ariaExpandedTrue">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a
+                  >=<code>true</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_EXPANDED</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>ExpandCollapse.ExpandCollapseState</code>: <code>Expanded</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_EXPANDABLE</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_EXPANDED</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXExpanded</code>: <code>YES</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaExpandedFalse"><code>aria-expanded</code>=<code>false</code></h4>
+          <table aria-labelledby="ariaExpandedFalse">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a
+                  >=<code>false</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_COLLAPSED</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>ExpandCollapse.ExpandCollapseState</code>: <code>Collapsed</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_EXPANDABLE</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_EXPANDED</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXExpanded</code>: <code>NO</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaExpandedUndefined"><code>aria-expanded</code> is undefined</h4>
+          <table aria-labelledby="ariaExpandedUndefined">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a> is undefined
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaFlowto"><code>aria-flowto</code></h4>
+          <table aria-labelledby="ariaFlowto">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-flowto"><code>aria-flowto</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="relation">Relation: <code>IA2_RELATION_FLOW_TO</code> points to accessible nodes matching IDREFs</span><br />
+                  <span class="relation">Reverse Relation: <code>IA2_RELATION_FLOW_FROM</code> points to element</span><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>FlowsTo</code>: pointers to accessible nodes matching IDREFs</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="relation">Relation: <code>RELATION_FLOWS_TO</code> points to accessible nodes matching IDREFs</span><br />
+                  <span class="relation">Reverse Relation: <code>RELATION_FLOWS_FROM</code> points to element</span><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXLinkedUIElements</code>: pointers to accessible nodes matching IDREFs</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaGrabbedTrue"><code>aria-grabbed</code>=<code>true</code></h4>
+          <table aria-labelledby="ariaGrabbedTrue">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-grabbed"><code>aria-grabbed</code></a
+                  >=<code>true</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>grabbed:true</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.grabbed</code>: <code>true</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>grabbed:true</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXGrabbed</code>: <code>YES</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaGrabbedFalse"><code>aria-grabbed</code>=<code>false</code></h4>
+          <table aria-labelledby="ariaGrabbedFalse">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-grabbed"><code>aria-grabbed</code></a
+                  >=<code>false</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>grabbed:false</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.grabbed</code>: <code>false</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>grabbed:false</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXGrabbed</code>: <code>NO</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaGrabbedUndefined"><code>aria-grabbed</code> is undefined</h4>
+          <table aria-labelledby="ariaGrabbedUndefined">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-grabbed"><code>aria-grabbed</code></a> is undefined
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaHaspopupTrue"><code>aria-haspopup</code>=<code>true</code></h4>
+          <table aria-labelledby="ariaHaspopupTrue">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a
+                  >=<code>true</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>haspopup:menu</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Pattern: <code>ExpandCollapse</code></span>
+                  <span class="seealso"
+                    >See also: <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_HAS_POPUP</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>haspopup:menu</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXPopupValue:menu</code></span
+                  ><br />
+                  <span class="property">Action: <code>AXShowMenu</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaHaspopupFalse"><code>aria-haspopup</code>=<code>false</code></h4>
+          <table aria-labelledby="ariaHaspopupFalse">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a
+                  >=<code>false</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code> not exposed</span><br />
+                  <span class="property">Object Attribute: <code>haspopup:false</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaHaspopupDialog"><code>aria-haspopup</code>=<code>dialog</code></h4>
+          <table aria-labelledby="ariaHaspopupDialog">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a
+                  >=<code>dialog</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>haspopup:dialog</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Pattern: <code>ExpandCollapse</code></span
+                  ><br />
+                  <span class="seealso"
+                    >See also: <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_HAS_POPUP</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>haspopup:dialog</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXPopupValue:dialog</code></span
+                  ><br />
+                  <span class="action">Action: <code>AXShowMenu</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaHaspopupGrid"><code>aria-haspopup</code>=<code>grid</code></h4>
+          <table aria-labelledby="ariaHaspopupGrid">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a
+                  >=<code>grid</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>haspopup:grid</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Pattern: <code>ExpandCollapse</code></span
+                  ><br />
+                  <span class="seealso"
+                    >See also: <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_HAS_POPUP</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>haspopup:grid</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXPopupValue:grid</code></span
+                  ><br />
+                  <span class="action">Action: <code>AXShowMenu</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaHaspopupListbox"><code>aria-haspopup</code>=<code>listbox</code></h4>
+          <table aria-labelledby="ariaHaspopupListbox">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a
+                  >=<code>listbox</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>haspopup:listbox</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Pattern: <code>ExpandCollapse</code></span
+                  ><br />
+                  <span class="seealso"
+                    >See also: <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_HAS_POPUP</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>haspopup:listbox</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXPopupValue:listbox</code></span
+                  ><br />
+                  <span class="action">Action: <code>AXShowMenu</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaHaspopupMenu"><code>aria-haspopup</code>=<code>menu</code></h4>
+          <table aria-labelledby="ariaHaspopupMenu">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a
+                  >=<code>menu</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>haspopup:menu</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Pattern: <code>ExpandCollapse</code></span
+                  ><br />
+                  <span class="seealso"
+                    >See also: <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_HAS_POPUP</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>haspopup:menu</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXPopupValue:menu</code></span
+                  ><br />
+                  <span class="action">Action: <code>AXShowMenu</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaHaspopupTree"><code>aria-haspopup</code>=<code>tree</code></h4>
+          <table aria-labelledby="ariaHaspopupTree">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-haspopup"><code>aria-haspopup</code></a
+                  >=<code>tree</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>haspopup:tree</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Control Pattern: <code>ExpandCollapse</code></span
+                  ><br />
+                  <span class="seealso"
+                    >See also: <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_HAS_POPUP</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>haspopup:tree</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXPopupValue:tree</code></span
+                  ><br />
+                  <span class="action">Action: <code>AXShowMenu</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaHiddenTrue"><code>aria-hidden</code>=<code>true</code> on unfocused element</h4>
+          <table aria-labelledby="ariaHiddenTrue">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-hidden"><code>aria-hidden</code></a
+                  >=<code>true</code> on unfocused element
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property not-in-tree">Element SHOULD NOT be exposed</span><br />
+                  <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property not-in-tree">Element SHOULD NOT be exposed</span><br />
+                  <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property not-in-tree">Element SHOULD NOT be exposed</span><br />
+                  <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-in-tree">Element SHOULD NOT be exposed</span><br />
+                  <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaHiddenTrueElementExposed"><code>aria-hidden</code>=<code>true</code> when element is focused or fires an accessibility event</h4>
+          <table aria-labelledby="ariaHiddenTrueElementExposed">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-hidden"><code>aria-hidden</code></a
+                  >=<code>true</code> when element is focused or fires an accessibility event
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>hidden:true</code></span
+                  ><br />
+                  <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.hidden</code>: <code>true</code></span
+                  ><br />
+                  <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>hidden:true</code></span
+                  ><br />
+                  <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span
+                  ><br />
+                  <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaHiddenFalse"><code>aria-hidden</code>=<code>false</code></h4>
+          <table aria-labelledby="ariaHiddenFalse">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-hidden"><code>aria-hidden</code></a
+                  >=<code>false</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaInvalidTrue"><code>aria-invalid</code>=<code>true</code></h4>
+          <table aria-labelledby="ariaInvalidTrue">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-invalid"><code>aria-invalid</code></a
+                  >=<code>true</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>IA2_STATE_INVALID_ENTRY</code></span
+                  ><br />
+                  <span class="property">Text Attribute: <code>invalid:true</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>IsDataValidForForm</code>: <code>false</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_INVALID_ENTRY</code></span
+                  ><br />
+                  <span class="property">Text Attribute: <code>invalid:true</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXInvalid</code>: <code>true</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaInvalidFalse"><code>aria-invalid</code>=<code>false</code></h4>
+          <table aria-labelledby="ariaInvalidFalse">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-invalid"><code>aria-invalid</code></a
+                  >=<code>false</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>IA2_STATE_INVALID_ENTRY</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>IsDataValidForForm</code>: <code>true</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_INVALID_ENTRY</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXInvalid</code>: <code>false</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaInvalidSpellingGrammar"><code>aria-invalid</code>=<code>spelling</code> or <code>grammar</code></h4>
+          <table aria-labelledby="ariaInvalidSpellingGrammar">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-invalid"><code>aria-invalid</code></a
+                  >=<code>spelling</code> or <code>grammar</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>IA2_STATE_INVALID_ENTRY</code></span
+                  ><br />
+                  <span class="property">Text Attribute: <code>invalid:&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>IsDataValidForForm</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_INVALID_ENTRY</code></span
+                  ><br />
+                  <span class="property">Text Attribute: <code>invalid:&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXInvalid</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaInvalidUnrecognizedValue"><code>aria-invalid</code> with unrecognized value</h4>
+          <table aria-labelledby="ariaInvalidUnrecognizedValue">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-invalid"><code>aria-invalid</code></a> with unrecognized value
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>IA2_STATE_INVALID_ENTRY</code></span
+                  ><br />
+                  <span class="property">Text Attribute: <code>invalid:true</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>IsDataValidForForm</code>: <code>false</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_INVALID_ENTRY</code></span
+                  ><br />
+                  <span class="property">Text Attribute: <code>invalid:true</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXInvalid</code>: <code>true</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaKeyshortcuts"><code>aria-keyshortcuts</code></h4>
+          <table aria-labelledby="ariaKeyshortcuts">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-keyshortcuts"><code>aria-keyshortcuts</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Property: <code>accKeyboardShortcut</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AcceleratorKey</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>keyshortcuts:&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXKeyShortcutsValue</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaLabel"><code>aria-label</code></h4>
+          <table aria-labelledby="ariaLabel">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-label"><code>aria-label</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Property: <code>accName</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>Name</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Property: <code>Name</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXDescription</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaLabelledBy"><code>aria-labelledby</code></h4>
+          <table aria-labelledby="ariaLabelledBy">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-labelledby"><code>aria-labelledby</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Property: <code>accName</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="relation">Relation: <code>IA2_RELATION_LABELLED_BY</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span
+                  ><br />
+                  <span class="relation">Reverse Relation: <code>IA2_RELATION_LABEL_FOR</code> points to element</span><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a> and <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>Name</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="property">Property: <code>LabeledBy</code>: points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Property: <code>Name</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="relation">Relation: <code>RELATION_LABELLED_BY</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
+                  <span class="relation">Reverse Relation: <code>RELATION_LABEL_FOR</code> points to element</span><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a> and <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXDescription</code>: <code>&lt;value&gt;</code></span> if the value is not exposed visually<br />
+                  <span class="property">Property: <code>AXTitle</code>: <code>&lt;value&gt;</code></span> if the value is exposed visually<br />
+                  <span class="property"
+                    >Property: <code>AXTitleUIElement</code> points to accessible node matching IDREF, if there is a single referenced element that is in the accessibility tree</span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaLevel"><code>aria-level</code> on non-<code>heading</code></h4>
+          <table aria-labelledby="ariaLevel">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-level"><code>aria-level</code></a> on non-<code>heading</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>level:&lt;value&gt;</code></span
+                  ><br />
+                  <span class="method"
+                    >Method: <code>IAccessible2::groupPosition()</code>: <code>groupLevel=&lt;value&gt;</code> on roles that support <code>aria-posinset</code> and <code>aria-setsize</code></span
+                  ><br />
+                  <span class="seealso"
+                    >See also: <a href="#mapping_group_position"><code>groupPosition()</code></a></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.level</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>level:&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property"
+                    >Property: <code>AXDisclosureLevel</code>: <code>&lt;value&gt;</code> (zero-based), when used on an outline row (like a
+                    <a class="role-reference" href="#treeitem"><code>treeitem</code></a> or <a class="role-reference" href="#group"><code>group</code></a
+                    >)</span
+                  >
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaLevelHeading"><code>aria-level</code> on <code>heading</code></h4>
+          <table aria-labelledby="ariaLevelHeading">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-level"><code>aria-level</code></a> on <code>heading</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>level:&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.level</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="property">Property: <code>StyleId_Heading</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>level:&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXValue</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaLiveAssertive"><code>aria-live</code>=<code>assertive</code></h4>
+          <table aria-labelledby="ariaLiveAssertive">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-live"><code>aria-live</code></a
+                  >=<code>assertive</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>live:assertive</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live:assertive</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live:assertive</code> on all descendants</span><br />
+                  <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property"
+                    >Property: <code><code>LiveSetting</code></code
+                    >: <code>&quot;assertive&quot;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>live:assertive</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live:assertive</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live:assertive</code> on all descendants</span><br />
+                  <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXARIALive</code>: <code>&quot;assertive&quot;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaLivePolite"><code>aria-live</code>=<code>polite</code></h4>
+          <table aria-labelledby="ariaLivePolite">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-live"><code>aria-live</code></a
+                  >=<code>polite</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>live:polite</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live:polite</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live:polite</code> on all descendants</span><br />
+                  <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property"
+                    >Property: <code><code>LiveSetting</code></code
+                    >: <code>&quot;polite&quot;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>live:polite</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live:polite</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live:polite</code> on all descendants</span><br />
+                  <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXARIALive</code>: <code>&quot;polite&quot;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaLiveOff"><code>aria-live</code>=<code>off</code></h4>
+          <table aria-labelledby="ariaLiveOff">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-live"><code>aria-live</code></a
+                  >=<code>off</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>live:off</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live:off</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live:off</code> on all descendants</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property"
+                    >Property: <code><code>LiveSetting</code></code
+                    >: <code>&quot;off&quot;</code></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>live:off</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live:off</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-live:off</code> on all descendants</span><br />
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXARIALive</code>: <code>&quot;off&quot;</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaModalTrue"><code>aria-modal</code>=<code>true</code></h4>
+          <table aria-labelledby="ariaModalTrue">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-modal"><code>aria-modal</code></a
+                  >=<code>true</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>IA2_STATE_MODAL</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>Window.IsModal</code>: <code>true</code></span
+                  ><br />
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_MODAL</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  Prune the accessibility tree such that the background content is no longer exposed. No specific property is set on the <a class="termref">accessible object</a> that corresponds to
+                  the <a class="termref">element</a> with <code>aria-modal="true"</code>. Only the tree whose root is that modal accessible object is exposed.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaModalFalse"><code>aria-modal</code>=<code>false</code></h4>
+          <table aria-labelledby="ariaModalFalse">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-modal"><code>aria-modal</code></a
+                  >=<code>false</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>IA2_STATE_MODAL</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>Window.IsModal</code>: <code>false</code></span
+                  ><br />
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_MODAL</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  Grow the accessibility tree such that the background content is exposed. No specific property is set on the <a class="termref">accessible object</a> that corresponds to the
+                  <a class="termref">element</a> with <code>aria-modal="false"</code>.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaMultilineTrue"><code>aria-multiline</code>=<code>true</code></h4>
+          <table aria-labelledby="ariaMultilineTrue">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-multiline"><code>aria-multiline</code></a
+                  >=<code>true</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>IA2_STATE_MULTI_LINE</code></span
+                  ><br />
+                  <span class="property">State: <code>IA2_STATE_SINGLE_LINE</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.multiline</code>: <code>true</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_MULTI_LINE</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_SINGLE_LINE</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span
+                  ><br />
+                  <span class="seealso"
+                    >See also: <a href="#role-map-textbox"><code>textbox</code></a> in the Role Mapping Tables</span
+                  >
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaMultilineFalse"><code>aria-multiline</code>=<code>false</code></h4>
+          <table aria-labelledby="ariaMultilineFalse">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-multiline"><code>aria-multiline</code></a
+                  >=<code>false</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>IA2_STATE_SINGLE_LINE</code></span
+                  ><br />
+                  <span class="property">State: <code>IA2_STATE_MULTI_LINE</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_SINGLE_LINE</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_MULTI_LINE</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span
+                  ><br />
+                  <span class="seealso"
+                    >See also: <a href="#role-map-textbox"><code>textbox</code></a> in the Role Mapping Tables</span
+                  >
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaMultiselectableTrue"><code>aria-multiselectable</code>=<code>true</code></h4>
+          <table aria-labelledby="ariaMultiselectableTrue">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-multiselectable"><code>aria-multiselectable</code></a
+                  >=<code>true</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_MULTISELECTABLE</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_SYSTEM_EXTSELECTABLE</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>Selection.CanSelectMultiple</code>: <code>true</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_MULTISELECTABLE</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaMultiselectableFalse"><code>aria-multiselectable</code>=<code>false</code></h4>
+          <table aria-labelledby="ariaMultiselectableFalse">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-multiselectable"><code>aria-multiselectable</code></a
+                  >=<code>false</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_MULTISELECTABLE</code> not exposed</span><br />
+                  <span class="property">State: <code>STATE_SYSTEM_EXTSELECTABLE</code> not exposed</span><br />
+                  <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_MULTISELECTABLE</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaOrientationHorizontal"><code>aria-orientation</code>=<code>horizontal</code></h4>
+          <table aria-labelledby="ariaOrientationHorizontal">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-orientation"><code>aria-orientation</code></a
+                  >=<code>horizontal</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>IA2_STATE_HORIZONTAL</code></span
+                  ><br />
+                  <span class="property">State: <code>IA2_STATE_VERTICAL</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>Orientation</code>: <code>horizontal</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_HORIZONTAL</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_VERTICAL</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXOrientation</code>: <code>AXHorizontalOrientation</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaOrientationVertical"><code>aria-orientation</code>=<code>vertical</code></h4>
+          <table aria-labelledby="ariaOrientationVertical">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-orientation"><code>aria-orientation</code></a
+                  >=<code>vertical</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>IA2_STATE_VERTICAL</code></span
+                  ><br />
+                  <span class="property">State: <code>IA2_STATE_HORIZONTAL</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>Orientation</code>: <code>vertical</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_VERTICAL</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_HORIZONTAL</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXOrientation</code>: <code>AXVerticalOrientation</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaOrientationUndefined"><code>aria-orientation</code> is undefined</h4>
+          <table aria-labelledby="ariaOrientationUndefined">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-orientation"><code>aria-orientation</code></a> is undefined
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_VERTICAL</code> not exposed</span><br />
+                  <span class="property">State: <code>STATE_HORIZONTAL</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXOrientation</code>: <code>AXUnknownOrientation</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaOwns"><code>aria-owns</code></h4>
+          <table aria-labelledby="ariaOwns">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <p>
+                    User agents MAY expose the elements that are referenced by this property as children of the current element. In which case, if multiple
+                    <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a> relationships are found, use only the first one. If the accessibility tree is not modified, expose as:
+                  </p>
+                  <span class="relation">Relation: <code>IA2_RELATION_NODE_PARENT_OF</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span
+                  ><br />
+                  <span class="relation">Reverse Relation: <code>IA2_RELATION_NODE_CHILD_OF</code> points to element</span><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  Expose the elements that are referenced by this property as children of the current element. If multiple
+                  <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a> relationships are found, use only the first one.
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <p>
+                    User agents MAY expose the elements that are referenced by this property as children of the current element. In which case, if multiple
+                    <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a> relationships are found, use only the first one. If the accessibility tree is not modified, expose as:
+                  </p>
+                  <span class="relation">Relation: <code>RELATION_NODE_PARENT_OF</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
+                  <span class="relation">Reverse Relation: <code>RELATION_NODE_CHILD_OF</code> points to element</span><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXOwns</code>: pointers to accessible nodes matching IDREFs</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaPlaceholder"><code>aria-placeholder</code></h4>
+          <table aria-labelledby="ariaPlaceholder">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-placeholder"><code>aria-placeholder</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>placeholder-text:&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>HelpText</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>placeholder-text:&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXPlaceholderValue</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaPosinset"><code>aria-posinset</code></h4>
+          <table aria-labelledby="ariaPosinset">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-posinset"><code>aria-posinset</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>posinset:&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.posinset</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>posinset:&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXARIAPosInSet</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaPressedTrue"><code>aria-pressed</code>=<code>true</code></h4>
+          <table aria-labelledby="ariaPressedTrue">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-pressed"><code>aria-pressed</code></a
+                  >=<code>true</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_PRESSED</code></span
+                  ><br />
+                  <span class="seealso"
+                    >See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>Toggle.ToggleState</code>: <code>On (1)</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_PRESSED</code></span
+                  ><br />
+                  <span class="seealso"
+                    >See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXValue</code>: <code>1</code></span
+                  ><br />
+                  <span class="seealso"
+                    >See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span
+                  >
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaPressedMixed"><code>aria-pressed</code>=<code>mixed</code></h4>
+          <table aria-labelledby="ariaPressedMixed">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-pressed"><code>aria-pressed</code></a
+                  >=<code>mixed</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_MIXED</code></span
+                  ><br />
+                  <span class="seealso"
+                    >See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>Toggle.ToggleState</code>: <code>Indeterminate (2)</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_INDETERMINATE</code></span
+                  ><br />
+                  <span class="seealso"
+                    >See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXValue</code>: <code>2</code></span
+                  ><br />
+                  <span class="seealso"
+                    >See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span
+                  >
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaPressedFalse"><code>aria-pressed</code>=<code>false</code></h4>
+          <table aria-labelledby="ariaPressedFalse">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-pressed"><code>aria-pressed</code></a
+                  >=<code>false</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_PRESSED</code> not exposed</span><br />
+                  <span class="seealso"
+                    >See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>Toggle.ToggleState</code>: <code>Off (3)</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_PRESSED</code> not exposed</span><br />
+                  <span class="seealso"
+                    >See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXValue</code>: <code>0</code></span
+                  ><br />
+                  <span class="seealso"
+                    >See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span
+                  >
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaPressedUndefined"><code>aria-pressed</code> is undefined</h4>
+          <table aria-labelledby="ariaPressedUndefined">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-pressed"><code>aria-pressed</code></a> is undefined
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaReadonlyTrue"><code>aria-readonly</code>=<code>true</code></h4>
+          <table aria-labelledby="ariaReadonlyTrue">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a
+                  >=<code>true</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_READONLY</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property"
+                    >Property: <code>Value.IsReadOnly</code>: <code>true</code>, if the element implements
+                    <a href="https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.ivalueprovider"><code>IValueProvider</code></a
+                    >.</span
+                  ><br />
+                  <span class="property"
+                    >Property: <code>RangeValue.IsReadOnly</code>: <code>true</code>, if the element implements
+                    <a href="https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.irangevalueprovider"><code>IRangeValueProvider</code></a
+                    >.</span
+                  ><br />
+                  <span class="property">Property: <code>AriaProperties.readonly</code>: <code>true</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_READ_ONLY</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_EDITABLE</code> not exposed on text input roles</span><br />
+                  <span class="property"
+                    >State: <code>STATE_CHECKABLE</code> not exposed on roles supporting <a class="state-reference" href="#aria-checked"><code>aria-checked</code></a></span
+                  ><br />
+                  <span class="property">State: <code>STATE_CHECKABLE</code> not exposed on <a class="role-reference" href="#radio">radio</a> descendants when used on a <code>radiogroup</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="method">Method: <code>AXUIElementIsAttributeSettable(AXValue)</code>: <code>NO</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaReadonlyFalse"><code>aria-readonly</code>=<code>false</code></h4>
+          <table aria-labelledby="ariaReadonlyFalse">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a
+                  >=<code>false</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_READONLY</code> not exposed</span><br />
+                  <span class="property">State: <code>IA2_STATE_EDITABLE</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property"
+                    >Property: <code>Value.IsReadOnly</code>: <code>false</code>, if the element implements
+                    <a href="https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.ivalueprovider"><code>IValueProvider</code></a
+                    >.</span
+                  ><br />
+                  <span class="property"
+                    >Property: <code>RangeValue.IsReadOnly</code>: <code>false</code>, if the element implements
+                    <a href="https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.irangevalueprovider"><code>IRangeValueProvider</code></a
+                    >.</span
+                  ><br />
+                  <span class="property">Property: <code>AriaProperties.readonly</code>: <code>false</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_READ_ONLY</code> not exposed</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="method">Method: <code>AXUIElementIsAttributeSettable(AXValue)</code>: <code>YES</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaReadonlyUnspecifiedOnGridcell"><code>aria-readonly</code> is unspecified on <code>gridcell</code></h4>
+          <table aria-labelledby="ariaReadonlyUnspecifiedOnGridcell">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a> is unspecified on <code>gridcell</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited
+                  value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and
+                  <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a
+                  >.
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited
+                  value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and
+                  <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a
+                  >.
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited
+                  value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and
+                  <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a
+                  >.
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited
+                  value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and
+                  <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a
+                  >.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaRelevant"><code>aria-relevant</code></h4>
+          <table aria-labelledby="ariaRelevant">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-relevant"><code>aria-relevant</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>relevant:&lt;value&gt;</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-relevant:&lt;value&gt;</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-relevant:&lt;value&gt;</code> on all descendants</span><br />
+                  <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.relevant</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>relevant:&lt;value&gt;</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-relevant:&lt;value&gt;</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>container-relevant:&lt;value&gt;</code> on all descendants</span><br />
+                  <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXARIARelevant</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaRequiredTrue"><code>aria-required</code>=<code>true</code></h4>
+          <table aria-labelledby="ariaRequiredTrue">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-required"><code>aria-required</code></a
+                  >=<code>true</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>IA2_STATE_REQUIRED</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>IsRequiredForForm</code>: <code>true</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_REQUIRED</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXRequired</code>: <code>YES</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaRequiredFalse"><code>aria-required</code>=<code>false</code></h4>
+          <table aria-labelledby="ariaRequiredFalse">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-required"><code>aria-required</code></a
+                  >=<code>false</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaRoleDescription"><code>aria-roledescription</code></h4>
+          <table aria-labelledby="ariaRoleDescription">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-roledescription"><code>aria-roledescription</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="method">Method: <code>localizedExtendedRole()</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Localized Control Type: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>roledescription:&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXRoleDescription</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaRoleDescriptionEmptyString"><code>aria-roledescription</code> is undefined or the empty string</h4>
+          <table aria-labelledby="ariaRoleDescriptionEmptyString">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-roledescription"><code>aria-roledescription</code></a> is undefined or the empty string
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property"
+                    >Localized Control Type is defined as that specified for the role of the element: based on the explicit role if the role attribute is provided; otherwise, based on the implicit
+                    role for the host language.</span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property"
+                    >AXRoleDescription is defined as that specified for the role of the element: based on the explicit role if the role attribute is provided; otherwise, based on the implicit role for
+                    the host language.</span
+                  >
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaRowCount"><code>aria-rowcount</code></h4>
+          <table aria-labelledby="ariaRowCount">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-rowcount"><code>aria-rowcount</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>rowcount:&lt;value&gt;</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible2::groupPosition()</code>: <code>similarItemsInGroup=&lt;value&gt;</code> on rows</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>Grid.RowCount</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>rowcount</code> should contain the author-provided value.</span><br />
+                  <span class="method">Method: <code>atk_table_get_n_rows()</code> should return the actual number of rows.</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXARIARowCount</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaRowIndex"><code>aria-rowindex</code></h4>
+          <table aria-labelledby="ariaRowIndex">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-rowindex"><code>aria-rowindex</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>rowindex:&lt;value&gt;</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible2::groupPosition()</code>: <code>positionInGroup=&lt;value&gt;</code> on rows</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>GridItem.Row</code>: <code>&lt;value&gt;</code> (zero-based)</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>rowindex</code> should contain the author-provided value.</span><br />
+                  <span class="method">Method: <code>atk_table_cell_get_position()</code> should return the actual (zero-based) row index.</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXARIARowIndex</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaRowIndexText"><code>aria-rowindextext</code></h4>
+          <table aria-labelledby="ariaRowIndexText">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-rowindextext"><code>aria-rowindextext</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>rowindextext:&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.rowindextext</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>rowindextext:&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: TBD</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaRowSpan"><code>aria-rowspan</code></h4>
+          <table aria-labelledby="ariaRowSpan">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-rowspan"><code>aria-rowspan</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>rowspan:&lt;value&gt;</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessibleTableCell::rowExtent()</code>: <code>column=&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>GridItem.RowSpan</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>rowspan</code> should contain the author-provided value.</span><br />
+                  <span class="method">Method: <code>atk_table_cell_get_row_column_span()</code> should return the actual row span.</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXRowIndexRange.length</code>: <code>&lt;value&gt;</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaSelectedTrue"><code>aria-selected</code>=<code>true</code></h4>
+          <table aria-labelledby="ariaSelectedTrue">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-selected"><code>aria-selected</code></a
+                  >=<code>true</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_SELECTABLE</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_SYSTEM_SELECTED</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>SelectionItem.IsSelected</code>: <code>true</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_SELECTABLE</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_SELECTED</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXSelected</code>: <code>YES</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaSelectedFalse"><code>aria-selected</code>=<code>false</code></h4>
+          <table aria-labelledby="ariaSelectedFalse">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-selected"><code>aria-selected</code></a
+                  >=<code>false</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">State: <code>STATE_SYSTEM_SELECTABLE</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_SYSTEM_SELECTED</code> not exposed</span><br />
+                  <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>SelectionItem.IsSelected</code>: <code>false</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">State: <code>STATE_SELECTABLE</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_SELECTED</code> not exposed</span><br />
+                  <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXSelected</code>: <code>NO</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaSelectedUndefined"><code>aria-selected</code> is undefined</h4>
+          <table aria-labelledby="ariaSelectedUndefined">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-selected"><code>aria-selected</code></a> is undefined
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaSetsize"><code>aria-setsize</code></h4>
+          <table aria-labelledby="ariaSetsize">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-setsize"><code>aria-setsize</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>setsize:&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.setsize</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <p>
+                    If the author-provided value of <code>aria-setsize</code> is <code>-1</code>, the exposed value should be based on the number of objects in the
+                    <abbr title="Document Object Model">DOM</abbr>.
+                  </p>
+                  <span class="property">Object Attribute: <code>setsize:&lt;value&gt;</code></span
+                  ><br />
+                  <span class="property">State: <code>STATE_INDETERMINATE</code> if the author-provided value is <code>-1</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXARIASetSize</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaSortAscending"><code>aria-sort</code>=<code>ascending</code></h4>
+          <table aria-labelledby="ariaSortAscending">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-sort"><code>aria-sort</code></a
+                  >=<code>ascending</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>sort:ascending</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.sort</code>: <code>ascending</code></span
+                  ><br />
+                  <span class="property"
+                    >Property: <code>ItemStatus</code>: <code>ascending</code> if the element maps to
+                    <a href="https://msdn.microsoft.com/en-us/library/windows/apps/ee671630.aspx"><code>HeaderItem</code></a> Control Type</span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>sort:ascending</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXSortDirection</code>: <code>AXAscendingSortDirection</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaSortDescending"><code>aria-sort</code>=<code>descending</code></h4>
+          <table aria-labelledby="ariaSortDescending">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-sort"><code>aria-sort</code></a
+                  >=<code>descending</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>sort:descending</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.sort</code>: <code>descending</code></span
+                  ><br />
+                  <span class="property"
+                    >Property: <code>ItemStatus</code>: <code>descending</code> if the element maps to
+                    <a href="https://msdn.microsoft.com/en-us/library/windows/apps/ee671630.aspx"><code>HeaderItem</code></a> Control Type</span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>sort:descending</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXSortDirection</code>: <code>AXDescendingSortDirection</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaSortOther"><code>aria-sort</code>=<code>other</code></h4>
+          <table aria-labelledby="ariaSortOther">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-sort"><code>aria-sort</code></a
+                  >=<code>other</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>sort:other</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AriaProperties.sort</code>: <code>other</code></span
+                  ><br />
+                  <span class="property"
+                    >Property: <code>ItemStatus</code>: <code>other</code> if the element maps to
+                    <a href="https://msdn.microsoft.com/en-us/library/windows/apps/ee671630.aspx"><code>HeaderItem</code></a> Control Type</span
+                  >
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>sort:other</code></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXSortDirection</code>: <code>AXUnknownSortDirection</code></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaSortNone"><code>aria-sort</code>=<code>none</code></h4>
+          <table aria-labelledby="ariaSortNone">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-sort"><code>aria-sort</code></a
+                  >=<code>none</code>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="property">Object Attribute: <code>sort:none</code>, if the value is not unspecified</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>sort:none</code>, if the value is not unspecified</span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaValueMax"><code>aria-valuemax</code></h4>
+          <table aria-labelledby="ariaValueMax">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-valuemax"><code>aria-valuemax</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="method">Method: <code>IAccessibleValue::maximumValue()</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>RangeValue.Maximum</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="method">Method: <code>atk_value_get_maximum_value()</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXMaxValue</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaValueMin"><code>aria-valuemin</code></h4>
+          <table aria-labelledby="ariaValueMin">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-valuemin"><code>aria-valuemin</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="method">Method: <code>IAccessibleValue::minimumValue()</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>RangeValue.Minimum</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="method">Method: <code>atk_value_get_minimum_value()</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXMinValue</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaValueNow"><code>aria-valuenow</code></h4>
+          <table aria-labelledby="ariaValueNow">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-valuenow"><code>aria-valuenow</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="method">Method: <code>IAccessibleValue::currentValue()</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="method">Method: <code>IAccessible::get_accValue()</code>: <code>&lt;value&gt;</code> if <code>aria-valuetext</code> is not defined</span><br />
+                  <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>RangeValue.Value</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="method">Method: <code>atk_value_get_current_value()</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXValue</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="ariaValueText"><code>aria-valuetext</code></h4>
+          <table aria-labelledby="ariaValueText">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-valuetext"><code>aria-valuetext</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>
+                  <span class="method">Method: <code>IAccessible::get_accValue()</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="property">Object Attribute: <code>valuetext:&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>
+                  <span class="property">Property: <code>Value.Value</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <span class="property">Object Attribute: <code>valuetext:&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                  <span class="property">Property: <code>AXValueDescription</code>: <code>&lt;value&gt;</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </section>
-	  </section>
-	  <section id="mapping_additional_position">
-			<h3>Group Position</h3>
-      <p><a class="property-reference" href="#aria-level"><code>aria-level</code></a>, <a class="property-reference" href="#aria-posinset"><code>aria-posinset</code></a>, and <a class="property-reference" href="#aria-setsize"><code>aria-setsize</code></a> are all 1-based. When the [=ARIA/property=] is not present or is &quot;0&quot;, it indicates the property is not computed or not supported. If any of these properties are specified by the author as either &quot;0&quot; or a negative number, [=user agents=]  SHOULD use &quot;1&quot; instead. </p>
-			<p>If <a class="property-reference" href="#aria-level"><code>aria-level</code></a> is not provided or inherited for an element of <a class="termref">role</a> <a class="role-reference" href="#treeitem"><code>treeitem</code></a> or <a class="role-reference" href="#comment"><code>comment</code></a>, user agents implementing IAccessible2 or <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> MUST compute it by following the explicit or computed <code>RELATION_NODE_CHILD_OF</code> relations.</p>
-	  <p>If <a class="property-reference" href="#aria-posinset"><code>aria-posinset</code></a> and <a class="property-reference" href="#aria-setsize"><code>aria-setsize</code></a> are not provided, user agents MUST compute them as follows:</p>
-		  <ul>
-				<li>for <code>role=&quot;<a class="role-reference" href="#treeitem">treeitem</a>&quot;</code> and <code>role=&quot;<a class="role-reference" href="#comment">comment</a>&quot;</code>, walk the tree backward and forward until the explicit or computed level becomes less than the current item's level. Count items only if they are at the same level as the current item.</li>
-			  <li>Otherwise, if the role supports <a class="property-reference" href="#aria-posinset"><code>aria-posinset</code></a> and <a class="property-reference" href="#aria-setsize"><code>aria-setsize</code></a>, process the parent (<abbr title="Document Object Model">DOM</abbr> parent or parent defined by <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a>), counting items that have the same role.</li>
-			  <li>Because these value are 1-based, include the current item  in the computation. For <a class="property-reference" href="#aria-posinset"><code>aria-posinset</code></a>, include the current item and other group items if they are before the current item in the DOM. For <a class="property-reference" href="#aria-setsize"><code>aria-setsize</code></a>, add to that the number of items in the same group after the current item in the <abbr title="Document Object Model">DOM</abbr>.</li>
-		  </ul>
-      <p>If the author provides one or more of <code>aria-setsize</code> and <code>aria-posinset</code>, it is the author's responsibility to supply them for all elements in the set.  [=User agent=]  correction of missing values in this case is not defined.</p>
-		  <p id="mapping_group_position">MSAA/IAccessible2 API mappings involve an additional function, <code>groupPosition()</code> [[IAccessible2]], when <a class="property-reference" href="#aria-level"><code>aria-level</code></a>, <a class="property-reference" href="#aria-posinset"><code>aria-posinset</code></a>, and/or <a class="property-reference" href="#aria-setsize"><code>aria-setsize</code></a> are present on an element, or are computed by the user agent. When this occurs: </p>
-		  <ul>
-		    <li><a class="property-reference" href="#aria-level"><code>aria-level</code></a> is exposed in the <code>groupLevel</code> parameter of <code>groupPosition()</code>,</li>
-		    <li><a class="property-reference" href="#aria-setsize"><code>aria-setsize</code></a>  is exposed in the <code>similarItemsInGroup</code> parameter, and</li>
-		    <li><a class="property-reference" href="#aria-posinset"><code>aria-posinset</code></a>  is exposed in the <code>positionInGroup</code> parameter.</li>
-		  </ul>
-    </section>
-	</section>
-  <section id="mapping_actions">
-		<h2>Actions</h2>
-    	<p>As part of mapping roles to accessible objects as defined in <a href="#mapping_role">Role Mapping</a>, users  agents expose a default action on the object.</p>
-		  <ul>
-            <li>MSAA: If an <abbr title="Assistive Technology">AT</abbr> calls <code>DoDefaultAction</code> on an accessible object, the  user agent SHOULD simulate a click on the <abbr title="Document Object Model">DOM</abbr> element which is mapped to that  accessible object.</li>
-            <li>IAccessible2: If an <abbr title="Assistive Technology">AT</abbr> calls the <code>IAccessibleAction</code> on an accessible object, the  user agent SHOULD simulate a click on the <abbr title="Document Object Model">DOM</abbr> element which is mapped to that  accessible object.</li>
-            <li>UIA Automation: If an <abbr title="Assistive Technology">AT</abbr> calls any <abbr title="User Interface Automation">UIA</abbr> pattern method on an accessible object, the  user agent SHOULD simulate a click on the <abbr title="Document Object Model">DOM</abbr> element which is mapped to that  accessible object.</li>
-            <li><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr>: If an <abbr title="Assistive Technology">AT</abbr> calls an action on an accessible object, the user agent SHOULD simulate a click on the <abbr title="Document Object Model">DOM</abbr> element which is mapped to  that accessible object.</li>
-            <li><abbr title="macOS Accessibility Protocol">AX API</abbr>: If an <abbr title="Assistive Technology">AT</abbr> triggers an <code>AXPress</code> action on an accessible object, the user   agent SHOULD simulate a click on the <abbr title="Document Object Model">DOM</abbr> element which is mapped to that   accessible object.</li>
+      </section>
+      <section id="mapping_additional">
+        <h2>Special Processing Requiring Additional Computation</h2>
+        <section id="mapping_additional_nd">
+          <h3>Name and Description</h3>
+          <p>
+            For information on how to compute an <a class="termref" data-cite="accname-1.2#dfn-accessible-name">accessible name</a> or
+            <a class="termref" data-cite="accname-1.2#dfn-accessible-description">accessible description</a>, see the section titled
+            <a class="accname" href="#mapping_additional_nd_te">Accessible Name and Description Computation</a> of the
+            <a class="accname" href="">Accessible Name and Description Computation</a> specification.
+          </p>
+        </section>
+        <section id="mapping_additional_relations">
+          <h3>Relations</h3>
+          <p>
+            Often in a <abbr title="Graphical User Interface">GUI</abbr>, there are <a class="termref">relationships</a> between the <a class="termref">widgets</a> that can be exposed programmatically
+            to <a class="termref">assistive technology</a>. <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> provides several relationship [=ARIA/properties=] which are globally
+            applicable to any <a class="termref">element</a>: <a class="property-reference" href="#aria-controls"><code>aria-controls</code></a
+            >, <a class="property-reference" href="#aria-describedby"><code>aria-describedby</code></a
+            >, <a class="property-reference" href="#aria-flowto"><code>aria-flowto</code></a
+            >, <a class="property-reference" href="#aria-labelledby"><code>aria-labelledby</code></a
+            >, <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a
+            >, <a class="property-reference" href="#aria-posinset"><code>aria-posinset</code></a
+            >, and <a class="property-reference" href="#aria-setsize"><code>aria-setsize</code></a
+            >. Therefore, it is not important to check the <a class="termref">role</a> before computing them. [=User agents=] can simply map these relations to
+            <a class="termref">accessibility APIs</a> as defined in the section titled <a href="#mapping_state-property">State and Property Mapping</a>.
+          </p>
+          <section id="mapping_additional_relations_reverse_relations">
+            <h4>Reverse Relations</h4>
+            <p>
+              A reverse relation exists when an element's ID is referenced by a [=ARIA/property=] in another <a class="termref">element</a>. For
+              <abbr title="Application Programming Interfaces">APIs</abbr> that support reverse relations, [=user agents=] MUST use the mapping defined in the
+              <a href="#mapping_state-property_table">State and Property Mapping Tables</a> when an element's ID is referenced by a relation property of another element and the referenced element is
+              in the accessibility tree. All WAI-ARIA references must point to an element that is exposed as an accessible object in the accessibility tree. When the referenced object is not exposed
+              in the accessibility tree (e.g. because it is [=element/hidden=]), the reference is null. <code>aria-labelledby</code> and <code>aria-describedby</code> have an additional feature, which
+              allows them to pull a flattened string from the referenced element to populate the name or description fields of the accessibility API. This feature is described in the
+              <a href="#mapping_additional_nd">Name and Description</a> section.
+            </p>
+            <p>
+              Special case: If both <a class="property-reference" href="#aria-labelledby"><code>aria-labelledby</code></a> and <abbr title="Hypertext Markup Language">HTML</abbr>
+              <code>&lt;label for= &#8230; &gt;</code> are used, the user agent MUST use the <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> relation and MUST ignore the
+              <abbr title="Hypertext Markup Language">HTML</abbr> label relation.
+            </p>
+            <p>
+              Note that <a class="property-reference" href="#aria-describedby"><code>aria-describedby</code></a> may reference structured or interactive information where users would want to be able
+              to navigate to different sections of content. User agents MAY provide a way for the user to navigate to structured information referenced by
+              <a class="property-reference" href="#aria-describedby"><code>aria-describedby</code></a> and <a class="termref">assistive technology</a> SHOULD provide such a method.
+            </p>
+          </section>
+          <section id="mapping_additional_relations_implied">
+            <h4>Implied reverse relations</h4>
+            <p>
+              In addition to the explicit relations defined by <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> [=ARIA/properties=], reverse relations are implied in two other
+              situations: <a class="termref">elements</a> with <code>role=&quot;treeitem&quot;</code> where the ancestor does not have an
+              <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a> property and descendants of elements with
+              <a class="property-reference" href="#aria-atomic"><code>aria-atomic</code></a> property.
+            </p>
+            <p>
+              In the case of <code>role=&quot;<a class="role-reference" href="#treeitem">treeitem</a>&quot;</code>, when <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a> is
+              not used, [=user agents=] SHOULD do the following where reverse relations are supported by the <abbr title="application programming interface">API</abbr>:
+            </p>
+            <ul>
+              <li>
+                If the current <a class="role-reference" href="#treeitem"><code>treeitem</code></a> uses <a class="property-reference" href="#aria-level"><code>aria-level</code></a
+                >, then walk backwards in the tree until a <a class="role-reference" href="#treeitem"><code>treeitem</code></a> is found with a lower
+                <a class="property-reference" href="#aria-level"><code>aria-level</code></a
+                >, then set <code>RELATION_NODE_CHILD_OF</code> to that element. If the top of the tree is reached, then set <code>RELATION_NODE_CHILD_OF</code> to the tree element itself.
+              </li>
+              <li>
+                If the parent of the <a class="role-reference" href="#treeitem"><code>treeitem</code></a> has a <a class="termref">role</a> of
+                <a class="role-reference" href="#group"><code>group</code></a
+                >, then walk backwards from the <a class="role-reference" href="#group"><code>group</code></a> until an element with a role of
+                <a class="role-reference" href="#treeitem"><code>treeitem</code></a> is found, then set <code>RELATION_NODE_CHILD_OF</code> to that element.
+              </li>
+            </ul>
+            <p>
+              In the case of <a class="property-reference" href="#aria-atomic"><code>aria-atomic</code></a
+              >, where reverse relations are supported by the <abbr title="application programming interface">API</abbr>:
+            </p>
+            <ul>
+              <li>
+                User agents SHOULD check the chain of ancestor elements for <a class="property-reference" href="#aria-atomic"><code>aria-atomic</code></a
+                ><code>=&quot;true&quot;</code>. If found, user agents SHOULD set the <code>RELATION_MEMBER_OF</code> relation to point to the ancestor that sets
+                <a class="property-reference" href="#aria-atomic"><code>aria-atomic</code></a
+                ><code>=&quot;true&quot;</code>.
+              </li>
+            </ul>
+          </section>
+        </section>
+        <section id="mapping_additional_position">
+          <h3>Group Position</h3>
+          <p>
+            <a class="property-reference" href="#aria-level"><code>aria-level</code></a
+            >, <a class="property-reference" href="#aria-posinset"><code>aria-posinset</code></a
+            >, and <a class="property-reference" href="#aria-setsize"><code>aria-setsize</code></a> are all 1-based. When the [=ARIA/property=] is not present or is &quot;0&quot;, it indicates the
+            property is not computed or not supported. If any of these properties are specified by the author as either &quot;0&quot; or a negative number, [=user agents=] SHOULD use &quot;1&quot;
+            instead.
+          </p>
+          <p>
+            If <a class="property-reference" href="#aria-level"><code>aria-level</code></a> is not provided or inherited for an element of <a class="termref">role</a>
+            <a class="role-reference" href="#treeitem"><code>treeitem</code></a> or <a class="role-reference" href="#comment"><code>comment</code></a
+            >, user agents implementing IAccessible2 or <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> MUST compute it by
+            following the explicit or computed <code>RELATION_NODE_CHILD_OF</code> relations.
+          </p>
+          <p>
+            If <a class="property-reference" href="#aria-posinset"><code>aria-posinset</code></a> and <a class="property-reference" href="#aria-setsize"><code>aria-setsize</code></a> are not provided,
+            user agents MUST compute them as follows:
+          </p>
+          <ul>
+            <li>
+              for <code>role=&quot;<a class="role-reference" href="#treeitem">treeitem</a>&quot;</code> and <code>role=&quot;<a class="role-reference" href="#comment">comment</a>&quot;</code>, walk
+              the tree backward and forward until the explicit or computed level becomes less than the current item's level. Count items only if they are at the same level as the current item.
+            </li>
+            <li>
+              Otherwise, if the role supports <a class="property-reference" href="#aria-posinset"><code>aria-posinset</code></a> and
+              <a class="property-reference" href="#aria-setsize"><code>aria-setsize</code></a
+              >, process the parent (<abbr title="Document Object Model">DOM</abbr> parent or parent defined by <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a
+              >), counting items that have the same role.
+            </li>
+            <li>
+              Because these value are 1-based, include the current item in the computation. For <a class="property-reference" href="#aria-posinset"><code>aria-posinset</code></a
+              >, include the current item and other group items if they are before the current item in the DOM. For <a class="property-reference" href="#aria-setsize"><code>aria-setsize</code></a
+              >, add to that the number of items in the same group after the current item in the <abbr title="Document Object Model">DOM</abbr>.
+            </li>
           </ul>
-      <p class="note">Authors will need to create handlers for those click events that update  <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties in the <abbr title="Document Object Model">DOM</abbr> accordingly, so that those updated states  can be populated by the user agent in the Accessibility <abbr title="Application Programming Interface">API</abbr>.</p>
-  </section>
-  <section id="mapping_events">
-		<h2>Events</h2>
-    <p>[=User agents=]  fire <a class="termref">events</a> for user actions, <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref">state</a> changes, changes to document content or node visibility, changes in selection and operation of menus as defined in the following sections. </p>
-    <section id="mapping_events_state-change">
-		  <h3>State and Property Change Events</h3>   
-        <p>[=User agents=]  MUST notify <a class="termref">assistive technology</a> of <a class="termref">state</a> changes as defined in the table below, SHOULD notify assistive technology of [=ARIA/property=] changes if the <a class="termref">accessibility API</a> defines a change <a class="termref">event</a> for the property, and SHOULD NOT notify assistive technology of property changes if the accessibility <abbr title="application programming interface">API</abbr> does not define a change event for the property. For example, IAccessible2 defines an event to be used when <a class="property-reference" href="#aria-activedescendant"><code>aria-activedescendant</code></a> changes. <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> properties that are expected to change include <a class="property-reference" href="#aria-activedescendant"><code>aria-activedescendant</code></a>, <a class="property-reference" href="#aria-valuenow"><code>aria-valuenow</code></a>, and <a class="property-reference" href="#aria-valuetext"><code>aria-valuetext</code></a>.</p>
-        <p class="note">In some <abbr title="Application Programming Interfaces">APIs</abbr>, AT will only be notified of events to which it has  subscribed.</p>
-        <p>For simplicity and  performance the user agent MAY trim out change events for state or property changes that <a class="termref">assistive technologies</a> typically ignore, such as events that are happening in a window that does not currently have focus.        </p>
-        <p class="note">Translators: For label text associated with the following table and its toggle buttons, see the <code>mappingTableLabels</code> object in the <code>&lt;head&gt;</code> section of this document.</p>
-<h4 id=event-aria-activedescendant><code>aria-activedescendant</code></h4>
-<table aria-labelledby=event-aria-activedescendant>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-activedescendant"><code>aria-activedescendant</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 event </th>
-      <td>
-        See <a href="#focus_state_event_table">Focus Changes</a>.
-        <p>In addition: </p>
-        <p><code>IA2_EVENT_ACTIVE_DESCENDANT_CHANGED</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr> event</th>
-      <td>
-        See <a href="#focus_state_event_table">Focus Changes</a>.
-        <p>In addition:</p>
-        <p><code>PropertyChangedEvent</code></p>
-        <p>Property: <code>AriaProperties</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
-      <td>
-        See <a href="#focus_state_event_table">Focus Changes</a>.
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
-      <td>
-        See <a href="#focus_state_event_table">Focus Changes</a>.
-        <p>In addition: <code>AXSelectedChildrenChanged</code></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=event-aria-busy><code>aria-busy</code> (state)</h4>
-<table aria-labelledby=event-aria-busy>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-busy"><code>aria-busy</code></a> (state)
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 event </th>
-      <td>
-        <code>EVENT_OBJECT_STATECHANGE</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr> event</th>
-      <td>
-        <code>PropertyChangedEvent</code>
-        <p>Property: <code>AriaProperties</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
-      <td>
-        <code>object:state-changed:busy</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
-      <td>
-        <code>AXElementBusyChanged</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=event-aria-checked><code>aria-checked</code> (state)</h4>
-<table aria-labelledby=event-aria-checked>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-checked"><code>aria-checked</code></a> (state)
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 event </th>
-      <td>
-        <code>EVENT_OBJECT_STATECHANGE</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr> event</th>
-      <td>
-        <code>PropertyChangedEvent</code>
-        <p>Properties: <code>AriaProperties</code>, <code>ToggleState</code> as part of <code>toggle</code> pattern</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
-      <td>
-        <code>object:state-changed:checked</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
-      <td>
-        <code>AXValueChanged</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=event-aria-current><code>aria-current</code> (state)</h4>
-<table aria-labelledby=event-aria-current>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-current"><code>aria-current</code></a> (state)
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 event </th>
-      <td>
-        <code>IA2_EVENT_OBJECT_ATTRIBUTE_CHANGED</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr> event</th>
-      <td>
-        <code>PropertyChangedEvent</code>
-        <p>Property: <code>AriaProperties</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
-      <td>
-        <code>object:state-changed:active</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
-      <td>
-        <code>AXCurrentStateChanged</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=event-aria-disabled><code>aria-disabled</code> (state)</h4>
-<table aria-labelledby=event-aria-disabled>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-disabled"><code>aria-disabled</code></a> (state)
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 event </th>
-      <td>
-        <code>EVENT_OBJECT_STATECHANGE</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr> event</th>
-      <td>
-        <code>PropertyChangedEvent</code>
-        <p>Properties: <code>AriaProperties</code>, <code>IsEnabled</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
-      <td>
-        <code>object:state-changed:enabled</code> and <code>object:state-changed:sensitive</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
-      <td>
-        <code>AXDisabledStateChanged</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=event-aria-describedby><code>aria-describedby</code></h4>
-<table aria-labelledby=event-aria-describedby>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-describedby"><code>aria-describedby</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 event </th>
-      <td>
-        <code>EVENT_OBJECT_DESCRIPTIONCHANGE</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr> event</th>
-      <td>
-        <code>PropertyChangedEvent</code>
-        <p>Properties: <code>DescribedBy</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
-      <td>
-        <code>object:property-change:accessible-description</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
-      <td>
-        <code>AXDescribedByChanged</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=event-aria-dropeffect><code>aria-dropeffect</code> (property, deprecated)</h4>
-<table aria-labelledby=event-aria-dropeffect>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-dropeffect"><code>aria-dropeffect</code></a> (property, deprecated)
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 event </th>
-      <td>
-        <code>IA2_EVENT_OBJECT_ATTRIBUTE_CHANGED</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr> event</th>
-      <td>
-        <code>PropertyChangedEvent</code>
-        <p>Property: <code>AriaProperties</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
-      <td>
-        <code>object:property-change</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
-      <td>
-        <code>AXDropEffectChanged</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=event-aria-expanded><code>aria-expanded</code> (state)</h4>
-<table aria-labelledby=event-aria-expanded>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a> (state)
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 event </th>
-      <td>
-        <code>EVENT_OBJECT_STATECHANGE</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr> event</th>
-      <td>
-        <code>PropertyChangedEvent</code>
-        <p>Properties: <code>AriaProperties</code>, <code>ExpandCollapseState</code> as part of the <code>ExpandCollapse</code> pattern</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
-      <td>
-        <code>object:state-changed:expanded</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
-      <td>
-        <code>AXRowExpanded</code>,<br>
-        <code>AXRowCollapsed</code>,<br>
-        <code>AXRowCountChanged</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=event-aria-grabbed><code>aria-grabbed</code> (state, deprecated)</h4>
-<table aria-labelledby=event-aria-grabbed>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-grabbed"><code>aria-grabbed</code></a> (state, deprecated)
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 event </th>
-      <td>
-        <p><code>EVENT_OBJECT_SELECTION</code></p>
-        <p><code>IA2_EVENT_OBJECT_ATTRIBUTE_CHANGED</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr> event</th>
-      <td>
-        <code>PropertyChangedEvent</code>
-        <p>Property: <code>AriaProperties</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
-      <td>
-        <code>object:property-change</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
-      <td>
-        <code>AXGrabbedStateChanged</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=event-aria-hidden><code>aria-hidden</code> (state)</h4>
-<table aria-labelledby=event-aria-hidden>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-hidden"><code>aria-hidden</code></a> (state)
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 event </th>
-      <td>
-        <code> IA2_EVENT_OBJECT_ATTRIBUTE_CHANGED</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr> event</th>
-      <td>
-        <code>StructureChangedEvent</code>
-        <p><code>PropertyChangedEvent</code></p>
-        <p>Property: <code>AriaProperties</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
-      <td>
-        <code>object:property-change</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
-      <td>
-        <code>AXUIElementDestroyed</code>,<br>
-        <code>AXUIElementCreated</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=event-aria-invalid><code>aria-invalid</code> (state)</h4>
-<table aria-labelledby=event-aria-invalid>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-invalid"><code>aria-invalid</code></a> (state)
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 event </th>
-      <td>
-        <code>EVENT_OBJECT_STATECHANGE</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr> event</th>
-      <td>
-        <code>PropertyChangedEvent</code>
-        <p>Properties: <code>AriaProperties</code>, <code>IsDataValidForForm</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
-      <td>
-        <code>object:state-changed:invalid_entry</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
-      <td>
-        <code>AXInvalidStatusChanged</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=event-aria-label><code>aria-label</code> and <code>aria-labelledby</code></h4>
-<table aria-labelledby=event-aria-label>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-label"><code>aria-label</code></a> and <a class="property-reference" href="#aria-labelledby"><code>aria-labelledby</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 event </th>
-      <td>
-        <code>EVENT_OBJECT_NAMECHANGE</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr> event</th>
-      <td>
-        <code>PropertyChangedEvent</code>
-        <p>Property for <code>aria-label</code>: <code>AriaProperties</code></p>
-        <p>Property for <code>aria-labelledby</code>: <code>LabeledBy</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
-      <td>
-        <code>object:property-change:accessible-name</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
-      <td>
-        <code>AXLabelCreated</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=event-aria-pressed><code>aria-pressed</code> (state)</h4>
-<table aria-labelledby=event-aria-pressed>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="state-reference" href="#aria-pressed"><code>aria-pressed</code></a> (state)
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 event </th>
-      <td>
-        <code>EVENT_OBJECT_STATECHANGE</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr> event</th>
-      <td>
-        <code>PropertyChangedEvent</code>
-        <p>Properties: <code>AriaProperties</code>, <code>ToggleState</code> as part of <code>toggle</code> pattern</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
-      <td>
-        <code>object:state-changed:pressed</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
-      <td>
-        <code>AXPressedStateChanged</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=event-aria-readonly><code>aria-readonly</code></h4>
-<table aria-labelledby=event-aria-readonly>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 event </th>
-      <td>
-        <code>EVENT_OBJECT_STATECHANGE</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr> event</th>
-      <td>
-        <code>PropertyChangedEvent</code>
-        <p>Property: <code>AriaProperties</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
-      <td>
-        <code>object:state-changed:readonly</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
-      <td>
-        <code>AXReadOnlyStatusChanged</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=event-aria-required><code>aria-required</code></h4>
-<table aria-labelledby=event-aria-required>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-required"><code>aria-required</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 event </th>
-      <td>
-        <code>EVENT_OBJECT_STATECHANGE</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr> event</th>
-      <td>
-        <code>PropertyChangedEvent</code>
-        <p>Properties: <code>AriaProperties</code>, <code>IsRequiredForForm</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
-      <td>
-        <code>object:state-changed:required</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
-      <td>
-        <code>AXRequiredStatusChanged</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=event-aria-selected><code>aria-selected</code> (state)</h4>
-<table aria-labelledby=event-aria-selected>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-selected"><code>aria-selected</code></a> (state)
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 event </th>
-      <td>
-        See section <a href="#mapping_events_selection">Selection</a> for details.
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr> event</th>
-      <td>
-        See section <a href="#mapping_events_selection">Selection</a> for details.
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
-      <td>
-        See section <a href="#mapping_events_selection">Selection</a> for details.
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
-      <td>
-        See section <a href="#mapping_events_selection">Selection</a> for details.
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=event-aria-valuenow><code>aria-valuenow</code></h4>
-<table aria-labelledby=event-aria-valuenow>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-valuenow"><code>aria-valuenow</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 event </th>
-      <td>
-        <code>EVENT_OBJECT_VALUECHANGE</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr> event</th>
-      <td>
-        <code>PropertyChangedEvent</code>
-        <p>Properties: <code>AriaProperties</code>, also <code>RangeValueValue</code> if element is mapped with <code>RangeValue</code> Control Pattern</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
-      <td>
-        <code>object:property-change:accessible-value</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
-      <td>
-        <code>AXValueChanged</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=event-aria-valuetext><code>aria-valuetext</code></h4>
-<table aria-labelledby=event-aria-valuetext>
-  <tbody>
-    <tr>
-      <th>ARIA Specification</th>
-      <td>
-        <a class="property-reference" href="#aria-valuetext"><code>aria-valuetext</code></a>
-      </td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 event </th>
-      <td>
-        <code>EVENT_OBJECT_VALUECHANGE</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr> event</th>
-      <td>
-        <code>PropertyChangedEvent</code>
-        <p>Property: <code>AriaProperties</code></p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
-      <td>
-        <code>object:property-change:accessible-value</code>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
-      <td>
-        <code>AXValueChanged</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
+          <p>
+            If the author provides one or more of <code>aria-setsize</code> and <code>aria-posinset</code>, it is the author's responsibility to supply them for all elements in the set. [=User agent=]
+            correction of missing values in this case is not defined.
+          </p>
+          <p id="mapping_group_position">
+            MSAA/IAccessible2 API mappings involve an additional function, <code>groupPosition()</code> [[IAccessible2]], when
+            <a class="property-reference" href="#aria-level"><code>aria-level</code></a
+            >, <a class="property-reference" href="#aria-posinset"><code>aria-posinset</code></a
+            >, and/or <a class="property-reference" href="#aria-setsize"><code>aria-setsize</code></a> are present on an element, or are computed by the user agent. When this occurs:
+          </p>
+          <ul>
+            <li>
+              <a class="property-reference" href="#aria-level"><code>aria-level</code></a> is exposed in the <code>groupLevel</code> parameter of <code>groupPosition()</code>,
+            </li>
+            <li>
+              <a class="property-reference" href="#aria-setsize"><code>aria-setsize</code></a> is exposed in the <code>similarItemsInGroup</code> parameter, and
+            </li>
+            <li>
+              <a class="property-reference" href="#aria-posinset"><code>aria-posinset</code></a> is exposed in the <code>positionInGroup</code> parameter.
+            </li>
+          </ul>
         </section>
-    <section id="mapping_events_visibility">
-		  <h3>Changes to document content or node visibility</h3>
-		  <p>Processing document changes is important regardless of <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr>. The events described in the table below are used by user agents to inform <abbr title="assistive technology">AT</abbr> of changes to the <abbr title="Document Object Model">DOM</abbr> via the accessibility tree. For the purposes of conformance with this standard, [=user agents=]  MUST implement the behavior described in this section whenever <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> attributes are applied to dynamic content on a Web page.        </p>
-		  <table>
-          <caption>Table of document change scenarios and events to be fired in each <abbr title="application programming interface">API</abbr></caption>
-          <tbody>
+      </section>
+      <section id="mapping_actions">
+        <h2>Actions</h2>
+        <p>As part of mapping roles to accessible objects as defined in <a href="#mapping_role">Role Mapping</a>, users agents expose a default action on the object.</p>
+        <ul>
+          <li>
+            MSAA: If an <abbr title="Assistive Technology">AT</abbr> calls <code>DoDefaultAction</code> on an accessible object, the user agent SHOULD simulate a click on the
+            <abbr title="Document Object Model">DOM</abbr> element which is mapped to that accessible object.
+          </li>
+          <li>
+            IAccessible2: If an <abbr title="Assistive Technology">AT</abbr> calls the <code>IAccessibleAction</code> on an accessible object, the user agent SHOULD simulate a click on the
+            <abbr title="Document Object Model">DOM</abbr> element which is mapped to that accessible object.
+          </li>
+          <li>
+            UIA Automation: If an <abbr title="Assistive Technology">AT</abbr> calls any <abbr title="User Interface Automation">UIA</abbr> pattern method on an accessible object, the user agent
+            SHOULD simulate a click on the <abbr title="Document Object Model">DOM</abbr> element which is mapped to that accessible object.
+          </li>
+          <li>
+            <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr>: If an <abbr title="Assistive Technology">AT</abbr> calls an
+            action on an accessible object, the user agent SHOULD simulate a click on the <abbr title="Document Object Model">DOM</abbr> element which is mapped to that accessible object.
+          </li>
+          <li>
+            <abbr title="macOS Accessibility Protocol">AX API</abbr>: If an <abbr title="Assistive Technology">AT</abbr> triggers an <code>AXPress</code> action on an accessible object, the user agent
+            SHOULD simulate a click on the <abbr title="Document Object Model">DOM</abbr> element which is mapped to that accessible object.
+          </li>
+        </ul>
+        <p class="note">
+          Authors will need to create handlers for those click events that update <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties in the
+          <abbr title="Document Object Model">DOM</abbr> accordingly, so that those updated states can be populated by the user agent in the Accessibility
+          <abbr title="Application Programming Interface">API</abbr>.
+        </p>
+      </section>
+      <section id="mapping_events">
+        <h2>Events</h2>
+        <p>
+          [=User agents=] fire <a class="termref">events</a> for user actions, <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref">state</a> changes, changes to
+          document content or node visibility, changes in selection and operation of menus as defined in the following sections.
+        </p>
+        <section id="mapping_events_state-change">
+          <h3>State and Property Change Events</h3>
+          <p>
+            [=User agents=] MUST notify <a class="termref">assistive technology</a> of <a class="termref">state</a> changes as defined in the table below, SHOULD notify assistive technology of
+            [=ARIA/property=] changes if the <a class="termref">accessibility API</a> defines a change <a class="termref">event</a> for the property, and SHOULD NOT notify assistive technology of
+            property changes if the accessibility <abbr title="application programming interface">API</abbr> does not define a change event for the property. For example, IAccessible2 defines an event
+            to be used when <a class="property-reference" href="#aria-activedescendant"><code>aria-activedescendant</code></a> changes.
+            <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> properties that are expected to change include
+            <a class="property-reference" href="#aria-activedescendant"><code>aria-activedescendant</code></a
+            >, <a class="property-reference" href="#aria-valuenow"><code>aria-valuenow</code></a
+            >, and <a class="property-reference" href="#aria-valuetext"><code>aria-valuetext</code></a
+            >.
+          </p>
+          <p class="note">In some <abbr title="Application Programming Interfaces">APIs</abbr>, AT will only be notified of events to which it has subscribed.</p>
+          <p>
+            For simplicity and performance the user agent MAY trim out change events for state or property changes that <a class="termref">assistive technologies</a> typically ignore, such as events
+            that are happening in a window that does not currently have focus.
+          </p>
+          <p class="note">
+            Translators: For label text associated with the following table and its toggle buttons, see the <code>mappingTableLabels</code> object in the <code>&lt;head&gt;</code> section of this
+            document.
+          </p>
+          <h4 id="event-aria-activedescendant"><code>aria-activedescendant</code></h4>
+          <table aria-labelledby="event-aria-activedescendant">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-activedescendant"><code>aria-activedescendant</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2 event</th>
+                <td>
+                  See <a href="#focus_state_event_table">Focus Changes</a>.
+                  <p>In addition:</p>
+                  <p><code>IA2_EVENT_ACTIVE_DESCENDANT_CHANGED</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+                <td>
+                  See <a href="#focus_state_event_table">Focus Changes</a>.
+                  <p>In addition:</p>
+                  <p><code>PropertyChangedEvent</code></p>
+                  <p>Property: <code>AriaProperties</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+                <td>See <a href="#focus_state_event_table">Focus Changes</a>.</td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+                <td>
+                  See <a href="#focus_state_event_table">Focus Changes</a>.
+                  <p>In addition: <code>AXSelectedChildrenChanged</code></p>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="event-aria-busy"><code>aria-busy</code> (state)</h4>
+          <table aria-labelledby="event-aria-busy">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-busy"><code>aria-busy</code></a> (state)
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2 event</th>
+                <td>
+                  <code>EVENT_OBJECT_STATECHANGE</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+                <td>
+                  <code>PropertyChangedEvent</code>
+                  <p>Property: <code>AriaProperties</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+                <td>
+                  <code>object:state-changed:busy</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+                <td>
+                  <code>AXElementBusyChanged</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="event-aria-checked"><code>aria-checked</code> (state)</h4>
+          <table aria-labelledby="event-aria-checked">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-checked"><code>aria-checked</code></a> (state)
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2 event</th>
+                <td>
+                  <code>EVENT_OBJECT_STATECHANGE</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+                <td>
+                  <code>PropertyChangedEvent</code>
+                  <p>Properties: <code>AriaProperties</code>, <code>ToggleState</code> as part of <code>toggle</code> pattern</p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+                <td>
+                  <code>object:state-changed:checked</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+                <td>
+                  <code>AXValueChanged</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="event-aria-current"><code>aria-current</code> (state)</h4>
+          <table aria-labelledby="event-aria-current">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-current"><code>aria-current</code></a> (state)
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2 event</th>
+                <td>
+                  <code>IA2_EVENT_OBJECT_ATTRIBUTE_CHANGED</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+                <td>
+                  <code>PropertyChangedEvent</code>
+                  <p>Property: <code>AriaProperties</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+                <td>
+                  <code>object:state-changed:active</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+                <td>
+                  <code>AXCurrentStateChanged</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="event-aria-disabled"><code>aria-disabled</code> (state)</h4>
+          <table aria-labelledby="event-aria-disabled">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-disabled"><code>aria-disabled</code></a> (state)
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2 event</th>
+                <td>
+                  <code>EVENT_OBJECT_STATECHANGE</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+                <td>
+                  <code>PropertyChangedEvent</code>
+                  <p>Properties: <code>AriaProperties</code>, <code>IsEnabled</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+                <td><code>object:state-changed:enabled</code> and <code>object:state-changed:sensitive</code></td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+                <td>
+                  <code>AXDisabledStateChanged</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="event-aria-describedby"><code>aria-describedby</code></h4>
+          <table aria-labelledby="event-aria-describedby">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-describedby"><code>aria-describedby</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2 event</th>
+                <td>
+                  <code>EVENT_OBJECT_DESCRIPTIONCHANGE</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+                <td>
+                  <code>PropertyChangedEvent</code>
+                  <p>Properties: <code>DescribedBy</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+                <td>
+                  <code>object:property-change:accessible-description</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+                <td>
+                  <code>AXDescribedByChanged</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="event-aria-dropeffect"><code>aria-dropeffect</code> (property, deprecated)</h4>
+          <table aria-labelledby="event-aria-dropeffect">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-dropeffect"><code>aria-dropeffect</code></a> (property, deprecated)
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2 event</th>
+                <td>
+                  <code>IA2_EVENT_OBJECT_ATTRIBUTE_CHANGED</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+                <td>
+                  <code>PropertyChangedEvent</code>
+                  <p>Property: <code>AriaProperties</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+                <td>
+                  <code>object:property-change</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+                <td>
+                  <code>AXDropEffectChanged</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="event-aria-expanded"><code>aria-expanded</code> (state)</h4>
+          <table aria-labelledby="event-aria-expanded">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a> (state)
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2 event</th>
+                <td>
+                  <code>EVENT_OBJECT_STATECHANGE</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+                <td>
+                  <code>PropertyChangedEvent</code>
+                  <p>Properties: <code>AriaProperties</code>, <code>ExpandCollapseState</code> as part of the <code>ExpandCollapse</code> pattern</p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+                <td>
+                  <code>object:state-changed:expanded</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+                <td>
+                  <code>AXRowExpanded</code>,<br />
+                  <code>AXRowCollapsed</code>,<br />
+                  <code>AXRowCountChanged</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="event-aria-grabbed"><code>aria-grabbed</code> (state, deprecated)</h4>
+          <table aria-labelledby="event-aria-grabbed">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-grabbed"><code>aria-grabbed</code></a> (state, deprecated)
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2 event</th>
+                <td>
+                  <p><code>EVENT_OBJECT_SELECTION</code></p>
+                  <p><code>IA2_EVENT_OBJECT_ATTRIBUTE_CHANGED</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+                <td>
+                  <code>PropertyChangedEvent</code>
+                  <p>Property: <code>AriaProperties</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+                <td>
+                  <code>object:property-change</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+                <td>
+                  <code>AXGrabbedStateChanged</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="event-aria-hidden"><code>aria-hidden</code> (state)</h4>
+          <table aria-labelledby="event-aria-hidden">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-hidden"><code>aria-hidden</code></a> (state)
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2 event</th>
+                <td>
+                  <code> IA2_EVENT_OBJECT_ATTRIBUTE_CHANGED</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+                <td>
+                  <code>StructureChangedEvent</code>
+                  <p><code>PropertyChangedEvent</code></p>
+                  <p>Property: <code>AriaProperties</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+                <td>
+                  <code>object:property-change</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+                <td>
+                  <code>AXUIElementDestroyed</code>,<br />
+                  <code>AXUIElementCreated</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="event-aria-invalid"><code>aria-invalid</code> (state)</h4>
+          <table aria-labelledby="event-aria-invalid">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-invalid"><code>aria-invalid</code></a> (state)
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2 event</th>
+                <td>
+                  <code>EVENT_OBJECT_STATECHANGE</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+                <td>
+                  <code>PropertyChangedEvent</code>
+                  <p>Properties: <code>AriaProperties</code>, <code>IsDataValidForForm</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+                <td>
+                  <code>object:state-changed:invalid_entry</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+                <td>
+                  <code>AXInvalidStatusChanged</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="event-aria-label"><code>aria-label</code> and <code>aria-labelledby</code></h4>
+          <table aria-labelledby="event-aria-label">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-label"><code>aria-label</code></a> and <a class="property-reference" href="#aria-labelledby"><code>aria-labelledby</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2 event</th>
+                <td>
+                  <code>EVENT_OBJECT_NAMECHANGE</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+                <td>
+                  <code>PropertyChangedEvent</code>
+                  <p>Property for <code>aria-label</code>: <code>AriaProperties</code></p>
+                  <p>Property for <code>aria-labelledby</code>: <code>LabeledBy</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+                <td>
+                  <code>object:property-change:accessible-name</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+                <td>
+                  <code>AXLabelCreated</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="event-aria-pressed"><code>aria-pressed</code> (state)</h4>
+          <table aria-labelledby="event-aria-pressed">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="state-reference" href="#aria-pressed"><code>aria-pressed</code></a> (state)
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2 event</th>
+                <td>
+                  <code>EVENT_OBJECT_STATECHANGE</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+                <td>
+                  <code>PropertyChangedEvent</code>
+                  <p>Properties: <code>AriaProperties</code>, <code>ToggleState</code> as part of <code>toggle</code> pattern</p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+                <td>
+                  <code>object:state-changed:pressed</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+                <td>
+                  <code>AXPressedStateChanged</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="event-aria-readonly"><code>aria-readonly</code></h4>
+          <table aria-labelledby="event-aria-readonly">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2 event</th>
+                <td>
+                  <code>EVENT_OBJECT_STATECHANGE</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+                <td>
+                  <code>PropertyChangedEvent</code>
+                  <p>Property: <code>AriaProperties</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+                <td>
+                  <code>object:state-changed:readonly</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+                <td>
+                  <code>AXReadOnlyStatusChanged</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="event-aria-required"><code>aria-required</code></h4>
+          <table aria-labelledby="event-aria-required">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-required"><code>aria-required</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2 event</th>
+                <td>
+                  <code>EVENT_OBJECT_STATECHANGE</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+                <td>
+                  <code>PropertyChangedEvent</code>
+                  <p>Properties: <code>AriaProperties</code>, <code>IsRequiredForForm</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+                <td>
+                  <code>object:state-changed:required</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+                <td>
+                  <code>AXRequiredStatusChanged</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="event-aria-selected"><code>aria-selected</code> (state)</h4>
+          <table aria-labelledby="event-aria-selected">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-selected"><code>aria-selected</code></a> (state)
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2 event</th>
+                <td>See section <a href="#mapping_events_selection">Selection</a> for details.</td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+                <td>See section <a href="#mapping_events_selection">Selection</a> for details.</td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+                <td>See section <a href="#mapping_events_selection">Selection</a> for details.</td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+                <td>See section <a href="#mapping_events_selection">Selection</a> for details.</td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="event-aria-valuenow"><code>aria-valuenow</code></h4>
+          <table aria-labelledby="event-aria-valuenow">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-valuenow"><code>aria-valuenow</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2 event</th>
+                <td>
+                  <code>EVENT_OBJECT_VALUECHANGE</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+                <td>
+                  <code>PropertyChangedEvent</code>
+                  <p>Properties: <code>AriaProperties</code>, also <code>RangeValueValue</code> if element is mapped with <code>RangeValue</code> Control Pattern</p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+                <td>
+                  <code>object:property-change:accessible-value</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+                <td>
+                  <code>AXValueChanged</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h4 id="event-aria-valuetext"><code>aria-valuetext</code></h4>
+          <table aria-labelledby="event-aria-valuetext">
+            <tbody>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>
+                  <a class="property-reference" href="#aria-valuetext"><code>aria-valuetext</code></a>
+                </td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2 event</th>
+                <td>
+                  <code>EVENT_OBJECT_VALUECHANGE</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+                <td>
+                  <code>PropertyChangedEvent</code>
+                  <p>Property: <code>AriaProperties</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+                <td>
+                  <code>object:property-change:accessible-value</code>
+                </td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+                <td>
+                  <code>AXValueChanged</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+        <section id="mapping_events_visibility">
+          <h3>Changes to document content or node visibility</h3>
+          <p>
+            Processing document changes is important regardless of <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr>. The events described in the table below are used by user agents
+            to inform <abbr title="assistive technology">AT</abbr> of changes to the <abbr title="Document Object Model">DOM</abbr> via the accessibility tree. For the purposes of conformance with
+            this standard, [=user agents=] MUST implement the behavior described in this section whenever <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> attributes are applied to
+            dynamic content on a Web page.
+          </p>
+          <table>
+            <caption>
+              Table of document change scenarios and events to be fired in each
+              <abbr title="application programming interface">API</abbr>
+            </caption>
+            <tbody>
+              <tr>
+                <th>Scenario</th>
+                <th>MSAA + IAccessible2 event</th>
+                <th><abbr title="User Interface Automation">UIA</abbr> event</th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+              </tr>
+              <tr>
+                <th>When text is removed</th>
+                <td><code>IA2_EVENT_TEXT_REMOVED</code></td>
+                <td><code>EVENT_OBJECT_LIVEREGIONCHANGED</code></td>
+                <td><code>text_changed::delete</code></td>
+                <td>If in a <a class="termref">live region</a>, <code>AXLiveRegionChanged</code>.<br />If in <code>aria-errormessage</code>, <code>AXValidationErrorChanged</code>.</td>
+              </tr>
+              <tr>
+                <th>When text is inserted</th>
+                <td><code>IA2_EVENT_TEXT_INSERTED</code></td>
+                <td><code>EVENT_OBJECT_LIVEREGIONCHANGED</code></td>
+                <td><code>text_changed::insert</code></td>
+                <td>If in a <a class="termref">live region</a>, <code>AXLiveRegionChanged</code>.<br />If in <code>aria-errormessage</code>, <code>AXValidationErrorChanged</code>.</td>
+              </tr>
+              <tr>
+                <th>When text is changed</th>
+                <td><code>IA2_EVENT_TEXT_REMOVE</code> and <code>IA2_EVENT_TEXT_INSERTED</code></td>
+                <td><code>EVENT_OBJECT_LIVEREGIONCHANGED</code></td>
+                <td><code>text_changed::delete</code> and <code>text_changed::insert</code></td>
+                <td>If in a <a class="termref">live region</a>, <code>AXLiveRegionChanged</code>.<br />If in <code>aria-errormessage</code>, <code>AXValidationErrorChanged</code>.</td>
+              </tr>
+            </tbody>
+          </table>
+          <p>Fire these events for node changes where the node in question is an element and has an <a class="termref">accessible object</a>:</p>
+          <table>
+            <caption>
+              Table of document change scenarios and events to be fired in each
+              <abbr title="application programming interface">API</abbr>
+            </caption>
+            <tbody>
+              <tr>
+                <th>Scenario</th>
+                <th><abbr title="Microsoft Active Accessibility">MSAA</abbr></th>
+                <th>Microsoft <abbr title="User Interface Automation">UIA</abbr> event</th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+              </tr>
+              <tr>
+                <th>When an <a class="termref">accessibility subtree</a> is [=element/hidden=]</th>
+                <td>
+                  <code>EVENT_OBJECT_HIDE</code><br />
+                  The <abbr title="Microsoft Active Accessibility">MSAA</abbr> event called <code>EVENT_OBJECT_DESTROY</code> is not used because this has a history of stability issues and assistive
+                  technology avoids it. In any case, from the user's point of view, there is no difference between something that is hidden or destroyed.
+                </td>
+                <td><code>AutomationElement..::.StructureChangedEvent</code></td>
+                <td><code>children_changed::remove</code></td>
+                <td>
+                  <p><code>AXUIElementDestroyed</code></p>
+                  <p>If in a live region, <code>AXLiveRegionChanged</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>When an accessibility subtree is removed</th>
+                <td>
+                  <code>EVENT_OBJECT_REORDER</code><br />
+                  The <abbr title="Microsoft Active Accessibility">MSAA</abbr> event called <code>EVENT_OBJECT_DESTROY</code> is not used because this has a history of stability issues and assistive
+                  technology avoids it. In any case, from the user's point of view, there is no difference between something that is hidden or destroyed.
+                </td>
+                <td><code>AutomationElement..::.StructureChangedEvent</code></td>
+                <td><code>children_changed::remove</code></td>
+                <td>
+                  <p><code>AXUIElementDestroyed</code></p>
+                  <p>If in a live region, <code>AXLiveRegionChanged</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>When an accessibility subtree is shown</th>
+                <td><code>EVENT_OBJECT_SHOW</code></td>
+                <td>&#160;</td>
+                <td><code>children_changed::add</code></td>
+                <td>
+                  <p><code>AXUIElementCreated</code></p>
+                  <p>If in a live region, <code>AXLiveRegionChanged</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>When an accessibility subtree is inserted</th>
+                <td><code>EVENT_OBJECT_REORDER</code></td>
+                <td>&#160;</td>
+                <td><code>children_changed::add</code></td>
+                <td>
+                  <p><code>AXUIElementCreated</code></p>
+                  <p>If in a live region, <code>AXLiveRegionChanged</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>When an accessibility subtree is moved</th>
+                <td>Treat it as a removal from one place and insertion in another</td>
+                <td>Treat it as a removal from one place and insertion in another</td>
+                <td>Treat it as a removal from one place and insertion in another</td>
+                <td>
+                  <p><code>AXUIElementDestroyed</code>/ <code>AXUIElementCreated</code></p>
+                  <p>If in a live region, <code>AXLiveRegionChanged</code></p>
+                </td>
+              </tr>
+              <tr>
+                <th>When an accessibility subtree is changed (e.g. replaceNode)</th>
+                <td>Treat it as a removal and insertion</td>
+                <td>Treat it as a removal and insertion</td>
+                <td>Treat it as a removal and insertion</td>
+                <td>
+                  <p><code>AXUIElementDestroyed</code>/ <code>AXUIElementCreated</code></p>
+                  <p>If in a live region, <code>AXLiveRegionChanged</code></p>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            In some cases, node changes may occur where the node is not an element or has no accessible object. For example, a numbered list bullet ("12.") may have a node in the accessibility tree
+            but not in the <abbr title="Document Object Model">DOM</abbr> tree. For text within a paragraph marked in <abbr title="Hypertext Markup Language">HTML</abbr> as
+            <code>&lt;strong&gt;</code>, the <code>&lt;strong&gt;</code> element has a node in the <abbr title="Document Object Model">DOM</abbr> tree but may not have one in the accessibility tree.
+            The text itself will of course be in the accessibility tree along with the identification of the range of text that is formatted as strong. If any of the changes described in the table
+            above occur on such a node, user agents SHOULD compute and fire relevant text change events as described above.
+          </p>
+          <p>
+            User agents SHOULD ensure that an assistive technology, running in process can receive notification of a node being removed prior to removal. This allows an assistive technology, such as a
+            screen reader, to refer back to the corresponding <abbr title="Document Object Model">DOM</abbr> node being deleted. This is important for <a class="termref">live regions</a> where
+            removals are important. For example, a screen reader would want to notify a user that another user has left a chat room. The event in
+            <abbr title="Microsoft Active Accessibility">MSAA</abbr> would be<code> EVENT_OBJECT_HIDE</code>. For <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr
+              title="Assistive Technology - Service Provider Interface"
+              >AT-SPI</abbr
+            >
+            this would be <code>children_changed::remove</code>. And in macOS, the event is <code>AXLiveRegionChanged</code>. This also requires the user agent to provide a unique ID in the
+            <a class="termref">accessibility API</a> notification identifying the unique node being removed.
+          </p>
+          <p>
+            When firing any of the above-mentioned change events, it is very useful to provide information about whether the change was caused by user input (as opposed to a timeout initiated from the
+            page load, etc.). This allows the assistive technology to have different rules for presenting changes from the real world as opposed to from user action. Mouse hovers are not considered
+            explicit user input because they can occur from accidental bumps of the mouse.
+          </p>
+          <p>To expose whether a change occurred from user input:</p>
+          <ul>
+            <li>
+              In <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr> this can be provided by appending the string
+              &quot;:system&quot; to the event name when the user did not cause the change.
+            </li>
+            <li>
+              In IAccessible2, which screen readers typically access in process on the same thread, the best practice is to expose the object attribute <code>event-from-user-input:true</code> on the
+              accessible object for the event, if the user caused the change.
+            </li>
+          </ul>
+          <p>Exposing additional useful information about the context of the change:</p>
+          <ul>
+            <li>
+              In <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr> and IAccessible2, the
+              <code>RELATION_MEMBER_OF</code> relation on the accessible event's target accessible object SHOULD point to any ancestor with
+              <a class="property-reference" href="#aria-atomic"><code>aria-atomic</code></a
+              ><code>=&quot;true&quot;</code> (if any).
+            </li>
+            <li>
+              In <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr> and IAccessible2, the <code>container-live</code>,
+              <code>container-relevant</code>, <code>container-busy</code>, <code>container-atomic</code> object attributes SHOULD be exposed on the accessible event object, providing the computed
+              value for the related <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> properties. The computed value is the value of the closest ancestor. It is recommended to not
+              expose the object attribute if the default value is used.
+            </li>
+          </ul>
+          <p>Additional <abbr title="Microsoft Active Accessibility">MSAA</abbr> events may be necessary:</p>
+          <ul>
+            <li>
+              If something changes in an ancestor with a mapped <abbr title="Microsoft Active Accessibility">MSAA</abbr> role of <code>ROLE_SYSTEM_ALERT</code>, then an
+              <code>EVENT_SYSTEM_ALERT</code> event SHOULD be fired for the alert. The alert role has an implied value of &quot;assertive&quot; for the
+              <a class="property-reference" href="#aria-live"><code>aria-live</code></a> property.
+            </li>
+            <li>Menu events may need to be fired. See <a href="#mapping_events_menus">Special Events for Menus</a>.</li>
+          </ul>
+        </section>
+        <section id="focus_state_event_table">
+          <h3>Focus Changes</h3>
+          <p>The following table defines the accessibility <abbr title="Application Programming Interface">API</abbr> keyboard focus states and events.</p>
+          <table>
+            <caption>
+              Table of
+              <a class="termref">accessibility <abbr title="application programming interface">APIs</abbr></a>
+              for focus states and
+              <a class="termref">events</a>
+            </caption>
             <tr>
-              <th>Scenario</th>
-              <th>MSAA + IAccessible2 event </th>
-              <th><abbr title="User Interface Automation">UIA</abbr> event</th>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
-              <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
-            </tr>
-            <tr>
-              <th>When text is removed</th>
-              <td><code>IA2_EVENT_TEXT_REMOVED</code></td>
-              <td><code>EVENT_OBJECT_LIVEREGIONCHANGED</code></td>
-              <td><code>text_changed::delete</code></td>
-              <td>If in a <a class="termref">live region</a>, <code>AXLiveRegionChanged</code>.<br />If in <code>aria-errormessage</code>, <code>AXValidationErrorChanged</code>.</td>
-            </tr>
-            <tr>
-              <th>When text is inserted</th>
-              <td><code>IA2_EVENT_TEXT_INSERTED</code></td>
-              <td><code>EVENT_OBJECT_LIVEREGIONCHANGED</code></td>
-              <td><code>text_changed::insert</code></td>
-              <td>If in a <a class="termref">live region</a>, <code>AXLiveRegionChanged</code>.<br />If in <code>aria-errormessage</code>, <code>AXValidationErrorChanged</code>.</td>
-            </tr>
-            <tr>
-              <th>When text is changed</th>
-              <td><code>IA2_EVENT_TEXT_REMOVE</code> and <code>IA2_EVENT_TEXT_INSERTED</code></td>
-              <td><code>EVENT_OBJECT_LIVEREGIONCHANGED</code></td>
-              <td><code>text_changed::delete</code> and <code>text_changed::insert</code></td>
-              <td>If in a <a class="termref">live region</a>, <code>AXLiveRegionChanged</code>.<br />If in <code>aria-errormessage</code>, <code>AXValidationErrorChanged</code>.</td>
-            </tr>
-          </tbody>
-        </table>
-		<p>Fire these events for node changes where the node in question is an element and has an <a class="termref">accessible object</a>:</p>
-        <table>
-          <caption>Table of document change scenarios and events to be fired in each <abbr title="application programming interface">API</abbr></caption>
-          <tbody>
-            <tr>
-              <th>Scenario</th>
+              <th>&#160;</th>
               <th><abbr title="Microsoft Active Accessibility">MSAA</abbr></th>
-              <th>Microsoft <abbr title="User Interface Automation">UIA</abbr> event</th>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr> event</th>
-              <th><abbr title="macOS Accessibility Protocol">AX API</abbr> Notification</th>
+              <th>Microsoft <abbr title="User Interface Automation">UIA</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+              <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
             </tr>
             <tr>
-              <th>When an <a class="termref">accessibility subtree</a> is [=element/hidden=]</th>
-              <td><code>EVENT_OBJECT_HIDE</code><br />
-                  The <abbr title="Microsoft Active Accessibility">MSAA</abbr> event called <code>EVENT_OBJECT_DESTROY</code> is not used because this has a history of  stability issues and assistive technology avoids it. In any case, from the user's point  of view, there is no difference between something that is hidden or  destroyed.
+              <th>Focusable state</th>
+              <td><code>STATE_SYSTEM_FOCUSABLE</code></td>
+              <td>
+                Current state reflected in <code>IUIAutomationElement::CurrentIsKeyboardFocusable</code>, can be retrieved with <code>IUIAutomationElement::GetCurrentPropertyValue</code> method using
+                <code>UIA_IsKeyboardFocusablePropertyId</code> property identifier.
               </td>
-              <td><code>AutomationElement..::.StructureChangedEvent</code></td>
-              <td><code>children_changed::remove</code></td>
-              <td><p><code>AXUIElementDestroyed</code></p>
-                    <p>If in a live region, <code>AXLiveRegionChanged</code></p></td>
+              <td><code>STATE_FOCUSABLE</code></td>
+              <td><code>boolean AXFocused</code>: the <code>AXUIElementIsAttributeSettable</code> method returns <code>YES</code>.</td>
             </tr>
             <tr>
-              <th>When an accessibility subtree is removed</th>
-              <td><code>EVENT_OBJECT_REORDER</code><br />
-                  The <abbr title="Microsoft Active Accessibility">MSAA</abbr> event called <code>EVENT_OBJECT_DESTROY</code> is not used because this has a history of  stability issues and assistive technology avoids it. In any case, from the user's point  of view, there is no difference between something that is hidden or  destroyed.
+              <th>Focused state</th>
+              <td><code>STATE_SYSTEM_FOCUSED</code></td>
+              <td>
+                Current state reflected in <code>IUIAutomationElement::CurrentHasKeyboardFocus</code>, can be retrieved with <code>IUIAutomationElement::GetCurrentPropertyValue</code> method using
+                <code>UIA_HasKeyboardFocusPropertyId</code> property identifier.
               </td>
-              <td><code>AutomationElement..::.StructureChangedEvent</code></td>
-              <td><code>children_changed::remove</code></td>
-              <td><p><code>AXUIElementDestroyed</code></p>
-                  <p>If in a live region, <code>AXLiveRegionChanged</code></p></td>
+              <td><code>STATE_FOCUSED</code></td>
+              <td><code>boolean AXFocused</code></td>
             </tr>
             <tr>
-              <th>When an accessibility subtree is shown</th>
-              <td><code>EVENT_OBJECT_SHOW</code></td>
-              <td>&#160;</td>
-              <td><code>children_changed::add</code></td>
-              <td><p><code>AXUIElementCreated</code></p>
-                  <p>If in a live region, <code>AXLiveRegionChanged</code></p></td>
+              <th>Focus event</th>
+              <td><code>EVENT_OBJECT_FOCUS</code></td>
+              <td>Clients can subscribe with <code>IUIAutomation::AddFocusChangedEventHandler</code> using callback interface is <code>IUIAutomationFocusChangedEventHandler</code></td>
+              <td>
+                <code>object:state-changed:focused</code> and:
+                <ul>
+                  <li><code>detail1 = 1</code> for the <a class="termref">accessible object</a> which just gained focus.</li>
+                  <li><code>detail1 = 0</code> for the <a class="termref">accessible object</a> which just lost focus.</li>
+                </ul>
+              </td>
+              <td><code>AXFocusedUIElementChanged</code></td>
             </tr>
-            <tr>
-              <th>When an accessibility subtree is inserted</th>
-              <td><code>EVENT_OBJECT_REORDER</code></td>
-              <td>&#160;</td>
-              <td><code>children_changed::add</code></td>
-              <td><p><code>AXUIElementCreated</code></p>
-                  <p>If in a live region, <code>AXLiveRegionChanged</code></p></td>
-            </tr>
-            <tr>
-              <th>When an accessibility subtree is moved</th>
-              <td>Treat it as a removal from one place and insertion in another</td>
-              <td>Treat it as a removal from one place and insertion in another</td>
-              <td>Treat it as a removal from one place and insertion in another</td>
-              <td><p><code>AXUIElementDestroyed</code>/ <code>AXUIElementCreated</code></p>
-                  <p>If in a live region, <code>AXLiveRegionChanged</code></p></td>
-            </tr>
-            <tr>
-              <th>When an accessibility subtree is changed (e.g. replaceNode)</th>
-              <td>Treat it as a removal and insertion</td>
-              <td>Treat it as a removal and insertion</td>
-              <td>Treat it as a removal and insertion</td>
-              <td><p><code>AXUIElementDestroyed</code>/ <code>AXUIElementCreated</code></p>
-                  <p>If in a live region, <code>AXLiveRegionChanged</code></p></td>
-            </tr>
-          </tbody>
-        </table>
-	  <p>In some cases, node changes may occur where the node is not an element or has no accessible object. For example, a numbered list bullet ("12.") may have a node in the accessibility tree but not in the <abbr title="Document Object Model">DOM</abbr> tree. For text within a paragraph marked in <abbr title="Hypertext Markup Language">HTML</abbr> as <code>&lt;strong&gt;</code>, the  <code>&lt;strong&gt;</code> element has a node in the  <abbr title="Document Object Model">DOM</abbr> tree but may not have one in the accessibility tree. The text itself will of course be in the accessibility tree along with the identification of the range of text that is formatted as strong. If any of the changes described in the table above occur on such a node, user agents SHOULD compute and fire relevant text change events as described above. </p>
-    <p>User agents SHOULD ensure that an assistive technology, running in process can receive notification of a node being removed prior to removal. This allows an assistive technology, such as a screen reader, to refer back to the corresponding <abbr title="Document Object Model">DOM</abbr> node being deleted. This is important for <a class="termref">live regions</a> where removals are important. For example, a screen reader would want to notify a user that another user has left a chat room. The event in <abbr title="Microsoft Active Accessibility">MSAA</abbr> would be<code> EVENT_OBJECT_HIDE</code>. For <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr> this would be <code>children_changed::remove</code>. And in macOS, the event is <code>AXLiveRegionChanged</code>. This also requires the user agent to provide a unique ID in the <a class="termref">accessibility API</a> notification identifying the unique node being removed.</p>
-		<p>When firing any of the above-mentioned change events, it is very  useful to provide information about whether the change was caused by  user input (as opposed to a timeout initiated from the page load,  etc.). This allows the assistive technology to have different rules for presenting  changes from the real world as opposed to from user action. Mouse  hovers are not considered explicit user input because they can occur  from accidental bumps of the mouse.</p>
-	  <p>To expose whether a change occurred from user input:</p>
-		<ul>
-			<li>In <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr> this can be provided by appending the string &quot;:system&quot; to the event name when the user did not cause the change.</li>
-			<li>In  IAccessible2, which screen readers typically access in process on the same  thread, the best practice is to expose the object attribute <code>event-from-user-input:true</code> on the accessible object for the event, if  the user caused the change.</li>
-		</ul>
-		<p>Exposing additional useful information about the context of the change:</p>
-		<ul>
-			<li>In <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr> and IAccessible2, the <code>RELATION_MEMBER_OF</code> relation on the accessible event's target accessible object SHOULD point to any ancestor with <a class="property-reference" href="#aria-atomic"><code>aria-atomic</code></a><code>=&quot;true&quot;</code> (if any).</li>
-			<li>In <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr> and IAccessible2, the  <code>container-live</code>, <code>container-relevant</code>, <code>container-busy</code>,  <code>container-atomic</code> object attributes SHOULD be exposed on the accessible  event object, providing the computed value for the related <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr>  properties. The computed value is the value of the closest ancestor. It  is recommended to not expose the object attribute if the default value  is used.</li>
-		</ul>
-    <p>Additional <abbr title="Microsoft Active Accessibility">MSAA</abbr> events may be necessary:</p>
-		<ul>
-			<li>If something changes in an ancestor with a mapped <abbr title="Microsoft Active Accessibility">MSAA</abbr> role of <code>ROLE_SYSTEM_ALERT</code>, then an <code>EVENT_SYSTEM_ALERT</code> event SHOULD be fired for  the alert. The alert role has an implied value of &quot;assertive&quot; for the <a class="property-reference" href="#aria-live"><code>aria-live</code></a> property.</li>
-			<li>Menu events may need to be fired. See <a href="#mapping_events_menus">Special Events for Menus</a>.</li>
-		</ul>
+          </table>
+        </section>
+        <section id="mapping_events_selection">
+          <h3>Selection</h3>
+          <p>There are two cases for selection:</p>
+          <ul>
+            <li>Single selection</li>
+            <li>Multiple selection</li>
+          </ul>
+          <p>
+            In the single selection case, selection follows focus (see the section "<a href="#focus_state_event_table">Focus States and Events Table</a>" for information about focus events). User
+            agents MUST fire the following events when <a class="state-reference" href="#aria-selected"><code>aria-selected</code></a> changes:
+          </p>
+          <table>
+            <caption>
+              Single selection events
+            </caption>
+            <tbody>
+              <tr>
+                <th>Scenario</th>
+                <th><abbr title="Microsoft Active Accessibility">MSAA</abbr></th>
+                <th>Microsoft <abbr title="User Interface Automation">UIA</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+              </tr>
+              <tr>
+                <th>Focus change</th>
+                <td><code>EVENT_OBJECT_SELECTION</code> and <code>EVENT_OBJECT_STATECHANGE</code> on newly focused item.</td>
+                <td>
+                  <code>UIA_SelectionItem_ElementSelectedEventId</code> on the newly focused element.
+                  <p>If on a <code>gridcell</code>, <code>row</code>, <code>option</code>, or <code>tab</code>, fire <code>UIA_SelectionItem_ElementSelectedEventId</code>.</p>
+                </td>
+                <td>
+                  <ul>
+                    <li><code>object:selection-changed</code> on the current container,</li>
+                    <li>
+                      <code>object:state-changed:selected</code> on the descendant <a class="termref">accessible object</a> whose selection has changed:
+                      <ul>
+                        <li><code>detail1 = 1</code> for the descendant which just became selected.</li>
+                        <li><code>detail1 = 0</code> for the descendant which just became unselected.</li>
+                      </ul>
+                    </li>
+                  </ul>
+                </td>
+                <td><code>AXSelectedChildrenChanged</code></td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            The multiple selection case occurs when <a class="property-reference" href="#aria-multiselectable"><code>aria-multiselectable</code></a
+            ><code>=&quot;true&quot;</code> on an <a class="termref">element</a> with a <a class="termref">role</a> that supports that [=ARIA/property=]. User agents MUST fire the following events
+            when <a class="state-reference" href="#aria-selected"><code>aria-selected</code></a> changes on a descendant, as follows:
+          </p>
+          <p>
+            The multiple selection case occurs when <a class="property-reference" href="#aria-multiselectable"><code>aria-multiselectable</code></a
+            ><code>=&quot;true&quot;</code> on an <a class="termref">element</a> with a <a class="termref">role</a> that supports that [=ARIA/property=]. There are several important aspects:
+          </p>
+          <ol>
+            <li>
+              In Microsoft <abbr title="User Interface Automation">UIA</abbr>, the <code>Selection</code> and <code>SelectionItem</code> Control Patterns expose the selection availability, state, and
+              methods.
+            </li>
+            <li>
+              User agents MUST fire the following events when <a class="state-reference" href="#aria-selected"><code>aria-selected</code></a> changes on a descendant, as follows:
+            </li>
+          </ol>
+          <table>
+            <caption>
+              Multiple selection events
+            </caption>
+            <tbody>
+              <tr>
+                <th>Scenario</th>
+                <th><abbr title="Microsoft Active Accessibility">MSAA</abbr></th>
+                <th>Microsoft <abbr title="User Interface Automation">UIA</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+              </tr>
+              <tr>
+                <th>
+                  Toggle <a class="state-reference" href="#aria-selected"><code>aria-selected</code></a>
+                </th>
+                <td><code>EVENT_OBJECT_SELECTIONADD</code>/<code>EVENT_OBJECT_SELECTIONREMOVE</code> on the item.</td>
+                <td>
+                  <code>SelectionItem Control Pattern</code>:<code>UIA_SelectionItem_ElementAddedToSelectionEventId</code> or <code>UIA_SelectionItem_ElementRemovedFromSelectionEventId</code> on the
+                  item.
+                </td>
+                <td>
+                  <ul>
+                    <li><code>object:selection-changed</code> on the current container,</li>
+                    <li>
+                      <code>object:state-changed:selected</code> on any descendant <a class="termref">accessible object</a> whose selection has changed:
+                      <ul>
+                        <li><code>detail1 = 1</code> for any descendant which just became selected.</li>
+                        <li><code>detail1 = 0</code> for any descendant which just became unselected.</li>
+                      </ul>
+                    </li>
+                  </ul>
+                </td>
+                <td><code>AXSelectedChildrenChanged</code></td>
+              </tr>
+              <tr>
+                <th>Selection follows focus</th>
+                <td><code>EVENT_OBJECT_SELECTION</code> and <code>EVENT_OBJECT_STATECHANGE</code> on newly focused item.</td>
+                <td><code>FocusChangedEvent</code> should be fired but individual selection event may not happen, to avoid redundancy.</td>
+                <td>
+                  <ul>
+                    <li><code>object:selection-changed</code> on the current container,</li>
+                    <li>
+                      <code>object:state-changed:selected</code> on any descendant <a class="termref">accessible object</a> whose selection has changed:
+                      <ul>
+                        <li><code>detail1 = 1</code> for any <a class="termref">accessible object</a> which just became selected.</li>
+                        <li><code>detail1 = 0</code> for any <a class="termref">accessible object</a> which just became unselected.</li>
+                      </ul>
+                    </li>
+                  </ul>
+                </td>
+                <td><code>AXSelectedChildrenChanged</code></td>
+              </tr>
+              <tr>
+                <th>Select or deselect many items at once</th>
+                <td>User agent MAY fire an <code>EVENT_OBJECT_SELECTIONWITHIN</code>. If this event is fired the other events noted above MAY be trimmed out for performance.</td>
+                <td>
+                  For each element selected or deselected, fire <code>SelectionItem</code> Control Pattern: <code>UIA_SelectionItem_ElementAddedToSelectionEventId</code> or
+                  <code>UIA_SelectionItem_ElementRemovedFromSelectionEventId</code> on the current container. User agents MAY choose to fire the Selection Control Pattern Invalidated event, which
+                  indicates that the selection in a container has changed significantly and requires sending more addition and removal events than the <code>InvalidateLimit</code> constant permits.
+                </td>
+                <td>
+                  <ul>
+                    <li>the user agent MAY fire a single <code>object:selection-changed</code> event on the container, vs. multiple events, for performance,</li>
+                    <li>
+                      <code>object:state-changed:selected</code> on any descendant <a class="termref">accessible object</a> whose selection has changed:
+                      <ul>
+                        <li><code>detail1 = 1</code> for any <a class="termref">accessible object</a> which just became selected.</li>
+                        <li><code>detail1 = 0</code> for any <a class="termref">accessible object</a> which just became unselected.</li>
+                      </ul>
+                    </li>
+                  </ul>
+                </td>
+                <td><code>AXSelectedChildrenChanged</code></td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+        <section id="mapping_events_menus">
+          <h3>Special Events for Menus</h3>
+          <p>
+            Some <abbr title="Application Programming Interfaces">APIs</abbr>, provide special <a class="termref">events</a> whenever a menu is opened or closed. [=User agents=] SHOULD provide the
+            events as described in the table below. If provided, because menus can be made visible or [=element/hidden=] using a variety of techniques, a [=user agent=] MUST ensure that the events are
+            nested and symmetrical.
+          </p>
+          <p>
+            Frequently, a <a class="role-reference" href="#menubar"><code>menubar</code></a> is used to organize a hierarchy of menus. In those cases, the menubar MUST be a
+            <abbr title="Document Object Model">DOM</abbr> parent of the associated <a class="role-reference" href="#menuitem"><code>menuitem</code></a
+            >s, or one defined by <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a
+            >. In other cases, no menubar is involved; for example, when the <a class="role-reference" href="#menu"><code>menu</code></a> is associated with a toolbar button, or is a context menu.
+            Nonetheless the relevant menu events are provided as described in the following table.
+          </p>
+          <table>
+            <caption>
+              Menu events
+            </caption>
+            <tbody>
+              <tr>
+                <th>Scenario</th>
+                <th><abbr title="Microsoft Active Accessibility">MSAA</abbr></th>
+                <th>Microsoft <abbr title="User Interface Automation">UIA</abbr></th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+              </tr>
+              <tr>
+                <td><p>Menubar is currently not active, and user moves focus to the menubar from elsewhere thereby activating it. As a result, a menuitem in the menubar is focused.</p></td>
+                <td>Activate the menubar and fire <code>EVENT_SYSTEM_MENUSTART</code> on the accessible object for the menubar.</td>
+                <td><code>MenuModeStartEvent</code> on the accessible object for the menu.</td>
+                <td><code>AXMenuOpenedNotification</code></td>
+              </tr>
+              <tr>
+                <td><p>Focus a menuitem while menubar is activated, or focus a menuitem in a menu.</p></td>
+                <td><code>EVENT_OBJECT_FOCUS</code></td>
+                <td><code>AutomationFocusChangedEvent</code></td>
+                <td><code>AXMenuItemSelectedNotification</code></td>
+              </tr>
+              <tr>
+                <td>
+                  <p>Menu popup made visible (menu is opened).</p>
+                  <p>Should only be fired once until the menu is closed and opened again.</p>
+                </td>
+                <td><code>EVENT_SYSTEM_MENUPOPUPSTART</code></td>
+                <td><code>MenuOpenedEvent</code>, then a <code>focus</code> event on a menuitem.</td>
+                <td><code>AXMenuOpenedNotification</code></td>
+              </tr>
+              <tr>
+                <td>Menu popup hidden (menu is closed).</td>
+                <td><code>EVENT_SYSTEM_MENUPOPUPEND</code> once only for accessible menu object and only if <code>EVENT_SYSTEM_MENUPOPUPSTART</code> was fired for it.</td>
+                <td><code>MenuClosedEvent</code></td>
+                <td><code>AXMenuClosedNotification</code></td>
+              </tr>
+              <tr>
+                <td>Any open menus are closed including sub-menus, and user moves focus away from the menubar; menubar is deactivated.</td>
+                <td><code>EVENT_SYSTEM_MENUEND</code> on the menubar and deactivate the menubar.</td>
+                <td><code>MenuClosedEvent</code>, then <code>MenuModeEndEvent</code></td>
+                <td><code>AXMenuClosedNotification</code></td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+      </section>
     </section>
-    <section id="focus_state_event_table">
-      <h3>Focus Changes</h3>
-      <p>The following table defines the accessibility <abbr title="Application Programming Interface">API</abbr> keyboard focus states and events.</p>
-      <table>
-	<caption>Table of <a class="termref">accessibility <abbr title="application programming interface">APIs</abbr></a> for focus states and <a class="termref">events</a></caption>
-	<tr>
-	  <th>&#160;</th>
-	  <th><abbr title="Microsoft Active Accessibility">MSAA</abbr></th>
-	  <th>Microsoft <abbr title="User Interface Automation">UIA</abbr></th>
-	  <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-	  <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-	</tr>
-	<tr>
-	  <th>Focusable state</th>
-	  <td><code>STATE_SYSTEM_FOCUSABLE</code></td>
-	  <td>Current state reflected in <code>IUIAutomationElement::CurrentIsKeyboardFocusable</code>, can be retrieved with <code>IUIAutomationElement::GetCurrentPropertyValue</code> method using <code>UIA_IsKeyboardFocusablePropertyId</code> property identifier.</td>
-	  <td><code>STATE_FOCUSABLE</code></td>
-	  <td><code>boolean AXFocused</code>: the <code>AXUIElementIsAttributeSettable</code> method returns <code>YES</code>.</td>
-	</tr>
-	<tr>
-	  <th>Focused state</th>
-	  <td><code>STATE_SYSTEM_FOCUSED</code></td>
-	  <td>Current state reflected in <code>IUIAutomationElement::CurrentHasKeyboardFocus</code>, can be retrieved with <code>IUIAutomationElement::GetCurrentPropertyValue</code> method using <code>UIA_HasKeyboardFocusPropertyId</code> property identifier.</td>
-	  <td><code>STATE_FOCUSED</code></td>
-	  <td><code>boolean AXFocused</code></td>
-	</tr>
-	<tr>
-	  <th>Focus event</th>
-	  <td><code>EVENT_OBJECT_FOCUS</code></td>
-	  <td>Clients can subscribe with <code>IUIAutomation::AddFocusChangedEventHandler</code> using callback interface is <code>IUIAutomationFocusChangedEventHandler</code></td>
-	  <td><code>object:state-changed:focused</code> and:
-	    <ul>
-	      <li><code>detail1 = 1</code> for the <a class="termref">accessible object</a> which just gained focus.</li>
-	      <li><code>detail1 = 0</code> for the <a class="termref">accessible object</a> which just lost focus.</li>
-	    </ul>
-	  </td>
-	  <td><code>AXFocusedUIElementChanged</code></td>
-	</tr>
-      </table>
-    </section>
-    <section id="mapping_events_selection">
-		  <h3>Selection</h3>
-		  <p>There are two cases for selection:</p>
-		  <ul>
-			  <li>Single selection</li>
-			  <li>Multiple selection</li>
-		  </ul>
-      <p>In the single selection case, selection follows focus (see the section "<a href="#focus_state_event_table">Focus States and Events Table</a>" for information about focus events). User agents MUST fire the following events when <a class="state-reference" href="#aria-selected"><code>aria-selected</code></a> changes:</p>
-      <table>
-        <caption>Single selection events</caption>
-	      <tbody>
-				<tr>
-					<th>Scenario</th>
-					<th><abbr title="Microsoft Active Accessibility">MSAA</abbr></th>
-					<th>Microsoft <abbr title="User Interface Automation">UIA</abbr></th>
-					<th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-					<th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-				</tr>
-				<tr>
-					<th>Focus change</th>
-					<td><code>EVENT_OBJECT_SELECTION</code> and <code>EVENT_OBJECT_STATECHANGE</code> on newly focused item.</td>
-					<td><code>UIA_SelectionItem_ElementSelectedEventId</code> on the newly focused element.
-					    <p>If on a <code>gridcell</code>, <code>row</code>, <code>option</code>, or <code>tab</code>, fire <code>UIA_SelectionItem_ElementSelectedEventId</code>.</p></td>
-					<td>
-					  <ul>
-					    <li><code>object:selection-changed</code> on the current container,</li>
-					    <li><code>object:state-changed:selected</code> on the descendant <a class="termref">accessible object</a> whose selection has changed:
-					      <ul>
-					        <li><code>detail1 = 1</code> for the descendant which just became selected.</li>
-					        <li><code>detail1 = 0</code> for the descendant which just became unselected.</li>
-					      </ul>
-					    </li>
-					  </ul>
-					</td>
-					<td><code>AXSelectedChildrenChanged</code></td>
-				</tr>
-        </tbody>
-      </table>
-    <p>The multiple selection case occurs when <a class="property-reference" href="#aria-multiselectable"><code>aria-multiselectable</code></a><code>=&quot;true&quot;</code>  on an <a class="termref">element</a> with a <a class="termref">role</a> that supports that [=ARIA/property=].  User agents MUST fire the following events when <a class="state-reference" href="#aria-selected"><code>aria-selected</code></a> changes on a descendant, as follows:</p>
-    <p>The multiple selection case occurs when <a class="property-reference" href="#aria-multiselectable"><code>aria-multiselectable</code></a><code>=&quot;true&quot;</code>  on an <a class="termref">element</a> with a <a class="termref">role</a> that supports that [=ARIA/property=]. There are  several important aspects:</p>
-		<ol>
-			<li>In Microsoft <abbr title="User Interface Automation">UIA</abbr>, the <code>Selection</code> and <code>SelectionItem</code> Control Patterns expose the selection availability, state, and methods.</li>
-			<li>User agents MUST fire the following events when <a class="state-reference" href="#aria-selected"><code>aria-selected</code></a> changes on a descendant, as follows:</li>
-		</ol>
-		<table>
-		  <caption>Multiple selection events</caption>
-      <tbody>
-				<tr>
-					<th>Scenario</th>
-					<th><abbr title="Microsoft Active Accessibility">MSAA</abbr></th>
-					<th>Microsoft <abbr title="User Interface Automation">UIA</abbr></th>
-					<th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-					<th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-				</tr>
-				<tr>
-					<th>Toggle <a class="state-reference" href="#aria-selected"><code>aria-selected</code></a></th>
-					<td><code>EVENT_OBJECT_SELECTIONADD</code>/<code>EVENT_OBJECT_SELECTIONREMOVE</code> on the item.</td>
-					<td><code>SelectionItem Control Pattern</code>:<code>UIA_SelectionItem_ElementAddedToSelectionEventId</code> or <code>UIA_SelectionItem_ElementRemovedFromSelectionEventId</code> on the item.</td>
-					<td>
-					    <ul>
-					      <li><code>object:selection-changed</code> on the current container,</li>
-					      <li><code>object:state-changed:selected</code> on any descendant <a class="termref">accessible object</a> whose selection has changed:
-						    <ul>
-					          <li><code>detail1 = 1</code> for any descendant which just became selected.</li>
-					          <li><code>detail1 = 0</code> for any descendant which just became unselected.</li>
-					        </ul>
-					      </li>
-					    </ul>
-					</td>
-					<td><code>AXSelectedChildrenChanged</code></td>
-				</tr>
-				<tr>
-					<th>Selection follows focus</th>
-					<td><code>EVENT_OBJECT_SELECTION</code> and <code>EVENT_OBJECT_STATECHANGE</code> on newly focused item.</td>
-					<td><code>FocusChangedEvent</code> should be fired but individual selection event may not happen, to avoid redundancy.</td>
-					<td>
-					    <ul>
-					      <li><code>object:selection-changed</code> on the current container,</li>
-					      <li><code>object:state-changed:selected</code> on any descendant <a class="termref">accessible object</a> whose selection has changed:
-						    <ul>
-					          <li><code>detail1 = 1</code> for any <a class="termref">accessible object</a> which just became selected.</li>
-					          <li><code>detail1 = 0</code> for any <a class="termref">accessible object</a> which just became unselected.</li>
-					        </ul>
-					      </li>
-					    </ul>
-					</td>
-					<td><code>AXSelectedChildrenChanged</code></td>
-				</tr>
-				<tr>
-					<th>Select or deselect many items at once</th>
-					<td>User agent MAY fire an <code>EVENT_OBJECT_SELECTIONWITHIN</code>. If this event is fired the other events noted above MAY be trimmed out for performance.</td>
-					<td>For each element selected or deselected, fire <code>SelectionItem</code> Control   Pattern: <code>UIA_SelectionItem_ElementAddedToSelectionEventId</code> or   <code>UIA_SelectionItem_ElementRemovedFromSelectionEventId</code> on the current   container.  User agents MAY choose to fire the Selection Control Pattern   Invalidated event, which indicates that the selection in a container   has changed significantly and requires sending more addition and removal   events than the <code>InvalidateLimit</code> constant permits.</td>
-					<td>
-					    <ul>
-					      <li>the user agent MAY fire a single <code>object:selection-changed</code> event on the container, vs. multiple events, for performance,</li>
-					      <li><code>object:state-changed:selected</code> on any descendant <a class="termref">accessible object</a> whose selection has changed:
-					        <ul>
-					          <li><code>detail1 = 1</code> for any <a class="termref">accessible object</a> which just became selected.</li>
-					          <li><code>detail1 = 0</code> for any <a class="termref">accessible object</a> which just became unselected.</li>
-					        </ul>
-					      </li>
-					    </ul>
-					</td>
-					<td><code>AXSelectedChildrenChanged</code></td>
-				</tr>
-			</tbody>
-		</table>
-	</section>
-	  <section id="mapping_events_menus">
-	    <h3>Special Events for Menus</h3>
-		  <p>Some <abbr title="Application Programming Interfaces">APIs</abbr>, provide special <a class="termref">events</a> whenever a menu is opened or closed.  [=User agents=]  SHOULD provide the events as described in the table below.  If provided, because menus can be made visible or [=element/hidden=] using a variety of techniques, a [=user agent=]  MUST ensure that the events are nested and symmetrical. </p>
-		  <p>Frequently, a <a class="role-reference" href="#menubar"><code>menubar</code></a> is used to organize a hierarchy of menus.  In those cases, the menubar MUST be a <abbr title="Document Object Model">DOM</abbr> parent of the associated <a class="role-reference" href="#menuitem"><code>menuitem</code></a>s, or one defined by <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a>.  In other cases, no menubar is involved; for example, when the <a class="role-reference" href="#menu"><code>menu</code></a> is associated with a toolbar button, or is a context menu. Nonetheless the relevant menu events are provided as described in the following table. </p>
-     <table>
-      <caption>Menu events</caption>
-			<tbody>
-				<tr>
-					<th>Scenario</th>
-					<th><abbr title="Microsoft Active Accessibility">MSAA</abbr></th>
-          <th>Microsoft <abbr title="User Interface Automation">UIA</abbr></th>
-          <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-        </tr>
-				<tr>
-					<td><p>Menubar is currently not active, and user moves focus to the menubar from elsewhere thereby activating it.  As a result, a menuitem in the menubar is focused.  </p></td>
-					<td>Activate the menubar and fire <code>EVENT_SYSTEM_MENUSTART</code> on the accessible object for the menubar.</td>
-					<td><code>MenuModeStartEvent</code> on the accessible object for the menu.</td>
-          <td><code>AXMenuOpenedNotification</code></td>
-        </tr>
-        <tr>
-          <td><p>Focus a menuitem while menubar is activated, or focus a menuitem in a menu.</p></td>
-          <td><code>EVENT_OBJECT_FOCUS</code></td>
-          <td><code>AutomationFocusChangedEvent</code></td>
-          <td><code>AXMenuItemSelectedNotification</code></td>
-        </tr>
-				<tr>
-				  <td><p>Menu popup made visible (menu is opened).</p>
-              <p>Should only be fired once until the menu is closed and opened again.</p> </td>
-				  <td><code>EVENT_SYSTEM_MENUPOPUPSTART</code></td>
-					<td><code>MenuOpenedEvent</code>, then a <code>focus</code> event on a menuitem.</td>
-          <td><code>AXMenuOpenedNotification</code></td>
-        </tr>
-				<tr>
-					<td>Menu popup hidden (menu is closed).</td>
-					<td><code>EVENT_SYSTEM_MENUPOPUPEND</code> once only for accessible menu object and only if <code>EVENT_SYSTEM_MENUPOPUPSTART</code> was fired for it.</td>
-					<td><code>MenuClosedEvent</code></td>
-          <td><code>AXMenuClosedNotification</code></td>
-        </tr>
-        <tr>
-          <td>Any open menus are closed including sub-menus, and user moves focus away from the menubar; menubar is deactivated.</td>
-          <td><code>EVENT_SYSTEM_MENUEND</code> on the menubar and deactivate the menubar.</td>
-          <td><code>MenuClosedEvent</code>, then <code>MenuModeEndEvent</code></td>
-          <td><code>AXMenuClosedNotification</code></td>
-        </tr>
-			</tbody>
-		</table>
-    </section>
-  </section>
-</section>
 
-	<section>
-		<h2>Privacy considerations</h2>
-		<p>In accordance with <a href="https://w3ctag.github.io/design-principles/#do-not-expose-use-of-assistive-tech">Web Platform Design Principles</a>, this specification provides no programmatic interface to determine if information is being used by Assistive Technologies. However, this specification does allow an author to present different information to users of Assistive Technologies from the information available to users who do not use Assistive Technologies. This is possible using many features of the ARIA and CORE-AAM specifications, just as this is possible using many other parts of the web technology stack. This content disparity could be abused to perform <a href="https://www.w3.org/TR/fingerprinting-guidance/#active-0">active fingerprinting</a> of users of Assistive Technologies.</p>
-	</section>
-	<section>
-		<h2>Security considerations</h2>
-		<p>This specification introduces no new security considerations.</p>
-	</section>
+    <section>
+      <h2>Privacy considerations</h2>
+      <p>
+        In accordance with <a href="https://w3ctag.github.io/design-principles/#do-not-expose-use-of-assistive-tech">Web Platform Design Principles</a>, this specification provides no programmatic
+        interface to determine if information is being used by Assistive Technologies. However, this specification does allow an author to present different information to users of Assistive
+        Technologies from the information available to users who do not use Assistive Technologies. This is possible using many features of the ARIA and CORE-AAM specifications, just as this is
+        possible using many other parts of the web technology stack. This content disparity could be abused to perform
+        <a href="https://www.w3.org/TR/fingerprinting-guidance/#active-0">active fingerprinting</a> of users of Assistive Technologies.
+      </p>
+    </section>
+    <section>
+      <h2>Security considerations</h2>
+      <p>This specification introduces no new security considerations.</p>
+    </section>
 
-	<section class="appendix" id="changelog">
-		<h2>Change Log</h2>
-		<section>
-		<h2>Substantive changes since the last public working draft</h2>
-		<ul>
-			<!-- EdNote: After each WD publish, move contents of this list into the next one below. -->
-			<li>12-Oct-2022: Remove mappings for <code>label</code> and <code>legend</code>.</li>
-			<li>05-Apr-2021: Update ATK mappings for <code>aria-colindex</code>, <code>aria-colspan</code>, <code>aria-colcount</code>, <code>aria-rowindex</code>, <code>aria-rowspan</code>, and <code>aria-rowcount</code>.</li>
-			<li>06-Apr-2020: Update ATK mappings for <code>alert</code> and <code>alertdialog</code>.</li>
-			<li>25-Feb-2020: Add mappings for <code>comment</code>, <code>mark</code>, and <code>suggestion</code> roles. Include <code>comment</code> in calculation for <code>aria-label</code> and group position.</li>
-			<li>25-Feb-2020: Add mappings for <code>aria-description</code>.</li>
-			<li>03-Nov-2019: Remove explicit AXRoleDescription values for AX API. User agents should follow the guidance described in the note.</li>
-			<li>22-Oct-2019: Add mappings for <code>strong</code> and <code>emphasis</code> roles for AX API.</li>
-			<li>22-Oct-2019: Add mappings for <code>code</code> role for AX API.</li>
-			<li>21-Oct-2019: Add mappings for <code>aria-colindextext</code> and <code>aria-rowindextext</code> roles for ATK, IA2, and UIA.</li>
-			<li>21-Oct-2019: Add mappings for <code>strong</code> and <code>emphasis</code> roles for ATK, IA2, and UIA.</li>
-			<li>21-Oct-2019: Add mappings for <code>code</code> role for ATK, IA2, and UIA.</li>
-			<li>18-Sep-2019: Update MSAA mappings for <code>subscript</code> and <code>superscript</code></li>
-			<li>10-Sep-2019: Add mappings for <code>generic</code> role.</li>
-			<li>09-Jul-2019: Add mappings for <code>insertion</code> and <code>deletion</code> roles.</li>
-			<li>14-May-2019: Add mappings for <code>legend</code> role.</li>
-			<li>14-May-2019: Add mappings for <code>label</code> role.</li>
-			<li>14-May-2019: Add mappings for <code>time</code> role.</li>
-			<li>25-Apr-2019: Add mappings for <code>subscript</code> and <code>superscript</code> roles.</li>
-			<li>25-Feb-2019: Add mappings for <code>meter</code> role.</li>
-		        <li>05-Feb-2019: Update UIA state and property change events.</li>
-			<li>06-Jun-2018: Update UIA mappings for <code>aria-placeholder</code>.</li>
-			<li>04-Jun-2018: Add mappings for <code>blockquote</code>, <code>caption</code>, and <code>paragraph</code> roles.</li>
-			<li>05-Mar-2018: Add mention of <code>AXTitle</code> for exposing rendered labels for AXAPI.</li>
-			<li>05-Mar-2018: Add events for <code>aria-label</code>, <code>aria-labelledby</code>, and <code>aria-describedby</code>.</li>
-		</ul>
-	</section>
-	<section>
-		<h2>Substantive changes since the <a href="https://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1 Recommendation</a></h2>
-		<ul>
-			<!-- EdNote: After each WD publish, move contents of the previous list into this one. -->
-		</ul>
-	</section>
-	</section>
-	<section class="appendix informative section" id="acknowledgements">
-		<h3>Acknowledgments</h3>
-		<p>The following people contributed to the development of this document.</p>
-		<ul id="gh-contributors">
-			<!-- list of contributors will appear here, along with link to their GitHub profiles -->
-		</ul>
-		<div data-include="../common/acknowledgements/aria-wg-active.html" data-include-replace="true"></div>
-		<div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>
-	</section>
-</body>
+    <section class="appendix" id="changelog">
+      <h2>Change Log</h2>
+      <section>
+        <h2>Substantive changes since the last public working draft</h2>
+        <ul>
+          <!-- EdNote: After each WD publish, move contents of this list into the next one below. -->
+          <li>12-Oct-2022: Remove mappings for <code>label</code> and <code>legend</code>.</li>
+          <li>
+            05-Apr-2021: Update ATK mappings for <code>aria-colindex</code>, <code>aria-colspan</code>, <code>aria-colcount</code>, <code>aria-rowindex</code>, <code>aria-rowspan</code>, and
+            <code>aria-rowcount</code>.
+          </li>
+          <li>06-Apr-2020: Update ATK mappings for <code>alert</code> and <code>alertdialog</code>.</li>
+          <li>
+            25-Feb-2020: Add mappings for <code>comment</code>, <code>mark</code>, and <code>suggestion</code> roles. Include <code>comment</code> in calculation for <code>aria-label</code> and group
+            position.
+          </li>
+          <li>25-Feb-2020: Add mappings for <code>aria-description</code>.</li>
+          <li>03-Nov-2019: Remove explicit AXRoleDescription values for AX API. User agents should follow the guidance described in the note.</li>
+          <li>22-Oct-2019: Add mappings for <code>strong</code> and <code>emphasis</code> roles for AX API.</li>
+          <li>22-Oct-2019: Add mappings for <code>code</code> role for AX API.</li>
+          <li>21-Oct-2019: Add mappings for <code>aria-colindextext</code> and <code>aria-rowindextext</code> roles for ATK, IA2, and UIA.</li>
+          <li>21-Oct-2019: Add mappings for <code>strong</code> and <code>emphasis</code> roles for ATK, IA2, and UIA.</li>
+          <li>21-Oct-2019: Add mappings for <code>code</code> role for ATK, IA2, and UIA.</li>
+          <li>18-Sep-2019: Update MSAA mappings for <code>subscript</code> and <code>superscript</code></li>
+          <li>10-Sep-2019: Add mappings for <code>generic</code> role.</li>
+          <li>09-Jul-2019: Add mappings for <code>insertion</code> and <code>deletion</code> roles.</li>
+          <li>14-May-2019: Add mappings for <code>legend</code> role.</li>
+          <li>14-May-2019: Add mappings for <code>label</code> role.</li>
+          <li>14-May-2019: Add mappings for <code>time</code> role.</li>
+          <li>25-Apr-2019: Add mappings for <code>subscript</code> and <code>superscript</code> roles.</li>
+          <li>25-Feb-2019: Add mappings for <code>meter</code> role.</li>
+          <li>05-Feb-2019: Update UIA state and property change events.</li>
+          <li>06-Jun-2018: Update UIA mappings for <code>aria-placeholder</code>.</li>
+          <li>04-Jun-2018: Add mappings for <code>blockquote</code>, <code>caption</code>, and <code>paragraph</code> roles.</li>
+          <li>05-Mar-2018: Add mention of <code>AXTitle</code> for exposing rendered labels for AXAPI.</li>
+          <li>05-Mar-2018: Add events for <code>aria-label</code>, <code>aria-labelledby</code>, and <code>aria-describedby</code>.</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Substantive changes since the <a href="https://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1 Recommendation</a></h2>
+        <ul>
+          <!-- EdNote: After each WD publish, move contents of the previous list into this one. -->
+        </ul>
+      </section>
+    </section>
+    <section class="appendix informative section" id="acknowledgements">
+      <h3>Acknowledgments</h3>
+      <p>The following people contributed to the development of this document.</p>
+      <ul id="gh-contributors">
+        <!-- list of contributors will appear here, along with link to their GitHub profiles -->
+      </ul>
+      <div data-include="../common/acknowledgements/aria-wg-active.html" data-include-replace="true"></div>
+      <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>
+    </section>
+  </body>
 </html>


### PR DESCRIPTION
Moved from https://github.com/w3c/core-aam/pull/228

# Original Description:

Part of the work on https://github.com/w3c/aria/issues/1440

This adds mappings for `aria-actions` that piggyback off `aria-details`. This should (in theory) allow actions to build off the work already done for `aria-details` while still making it possible for screen reader vendors to create different UX for actions.

Leaving this in draft for now to get feedback from SR and browser vendors before marking it ready for review.
