### PR TITLE
[Monorepo] [accname PR 235] feat: update step 2F to exclude nodes referenced by aria-actions

### DIFF
--- a/accname/index.html
+++ b/accname/index.html
@@ -671,6 +671,13 @@
                       <span id="step2F.iii"><!-- Don't link to this legacy numbered ID. --></span><em>Name From Each Child:</em> For each <code>rendered child node</code> of the
                       <code>current node</code>:
                       <ol>
+                        <li id="comp_name_from_content_find_child_actions">
+                          If the <code>current node</code> has an <code>aria-actions</code> [=attribute=] with an IDREF matching the rendered child node, skip steps b-d for this child node.
+                        </li>
+                        <li>
+                          If the <code>current node</code> has an <code>aria-actions</code> [=attribute=] with at least one valid IDREF matching any of the descendents of the rendered child node,
+                          exclude the referenced descendants from the name from content of the <code>current node</code>.
+                        </li>
                         <li id="comp_name_from_content_for_each_child_set_current">
                           <span id="step2F.iii.a"><!-- Don't link to this legacy numbered ID. --></span>Set the <code>current node</code> to the <code>rendered child node</code>.
                         </li>


### PR DESCRIPTION
Moved from https://github.com/w3c/accname/pull/235/