### PR TITLE
[Monorepo] [accname PR 229] Add `nameFrom: heading` to AccName text alt algorithm 

### DIFF
--- a/accname/index.html
+++ b/accname/index.html
@@ -629,6 +629,10 @@
                     </p>
                   </div>
                 </li>
+                <li id="comp_name_from_heading">
+                  <em>Name From Heading:</em> Otherwise, if the <code>current node</code> has a role that supports <a href="https://w3c.github.io/aria/#namefromheading">nameFrom: heading</a>, return
+                  the text alternative of the first descendant <a>element</a> node matching the role of <code>heading</code> in an <em>iterative deepening depth-first search.</em>
+                </li>
                 <li id="comp_name_from_content">
                   <span id="step2F"><!-- Don't link to this legacy numbered ID. --></span><em>Name From Content:</em> Otherwise, if the <code>current node's</code> <a class="termref">role</a> allows
                   <a class="specref" href="#namefromcontent">name from content</a>, or if the <code>current node</code> is referenced by <code>aria-labelledby</code>, <code>aria-describedby</code>, or


### PR DESCRIPTION
Moved from https://github.com/w3c/accname/pull/229/