### PR TITLE
[html-aam PR 540] Clarify li element role mapping

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -5104,7 +5104,7 @@
     <tr>
       <th>Comments</th>
       <td>
-        If `li` element is not a child of <a data-cite="html">`ol`</a> , <a data-cite="html">`menu`</a> or <a data-cite="html">`ul`</a>, or if the containing
+        If `li` element is not an accessibility child of an <a data-cite="html">`ol`</a> , <a data-cite="html">`menu`</a> or <a data-cite="html">`ul`</a>, or if the containing
         list element is no longer exposed with a `list` role, then expose the `li` element with a `generic` role.
       </td>
     </tr>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -5104,7 +5104,7 @@
     <tr>
       <th>Comments</th>
       <td>
-        If `li` element is not an accessibility child of an <a data-cite="html">`ol`</a> , <a data-cite="html">`menu`</a> or <a data-cite="html">`ul`</a>, or if the containing
+        If `li` element is not an [=accessibility child=] of an <a data-cite="html">`ol`</a> , <a data-cite="html">`menu`</a> or <a data-cite="html">`ul`</a>, or if the containing
         list element is no longer exposed with a `list` role, then expose the `li` element with a `generic` role.
       </td>
     </tr>


### PR DESCRIPTION
Moved from https://github.com/w3c/html-aam/pull/540/

edit:
closes https://github.com/w3c/aria/issues/2173
approving reviewers from migrated HTML AAM PR: @smhigley, @cookiecrook, @spectranaut 


edit again:
pointing back to the original HTML AAM PR that this is one is clarifying - https://github.com/w3c/html-aam/pull/476

* [X] "author MUST" tests: n/a
* [X] "user agent MUST" tests: https://github.com/web-platform-tests/wpt/pull/49643
* [ ] Browser implementations (link to issue or commit):
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=315766
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2043336
   * Blink: https://issues.chromium.org/issues/517413737
* [X] Does this need AT implementations? no
* [X] Related APG Issue/PR: n/a
* [X] MDN Issue/PR: n/a