### PR TITLE
Empty or non-matching values for ID reference and ID reference list - Clarification on author responsibilities

### DIFF
--- a/index.html
+++ b/index.html
@@ -10013,7 +10013,7 @@
 				<dt id="valuetype_true-false-undefined">true/false/undefined</dt>
 				<dd>Value representing <code>true</code>, <code>false</code>, or <code>undefined</code> (not applicable). The default value for this value type is <code>undefined</code> unless otherwise specified. For example, an element with <sref>aria-expanded</sref> set to <code>false</code> is not currently expanded; an element with <sref>aria-expanded</sref> set to <code>undefined</code> is not expandable.</dd>
 				<dt id="valuetype_idref">ID reference</dt>
-				<dd>Reference to the ID of another <a>element</a> in the same document</dd>
+				<dd>Reference to the ID of another <a>element</a> in the same document.</dd>
 				<dt id="valuetype_idref_list">ID reference list</dt>
 				<dd>A list of one or more ID references.</dd>
 				<dt id="valuetype_integer">integer</dt>
@@ -13369,7 +13369,7 @@ button.ariaPressed; // null</pre>
 		<p>Sometimes states and properties are present in the DOM but have a zero-length string ("") as their value. Authors MAY specify a zero-length string ("") for any supported (but not required) state or property. User agents SHOULD treat state and property attributes with a value of "" the same as they treat an absent attribute.  For supported states and properties, this corresponds to the default value, but if it is a required attribute, it signals an author error and is processed as detailed at <a href="#document-handling_author-errors">Handling Author Errors</a>. </p>
 		<section id="mapping_additional_relations_error_processing">
 	        <h3>ID Reference Error Processing</h3>
-	        <p>[=user agents=] SHOULD ignore ID references that do not match the ID of another <a>element</a> in the same document.</p>
+	        <p>The author is allowed to set either an empty value or a value that does not match the ID of another <a>element</a> in the same document. This flexibility acknowledges the dynamic nature of modern websites, where the DOM can be populated accordingly when necessary. [=user agents=] SHOULD ignore ID references that do not match the ID of another <a>element</a> in the same document.</p>
 	        <p>It is the author's responsibility to ensure that IDs are unique. If more than one element has the same ID, the user agent SHOULD use the first element found with the given ID. The behavior will be the same as <code>getElementById</code>.</p>
 	        <p>If the same element is specified multiple times in a single <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> relation, user agents SHOULD return multiple pointers to the same <a>element</a>.</p>
 	        <p><pref>aria-activedescendant</pref> is defined as referencing only a single ID reference. Any <code>aria-activedescendant</code> value that does not match an existing ID reference exactly is an author error and will not match any element in the <abbr title="Document Object Model">DOM</abbr>.</p>


### PR DESCRIPTION
Closes: #2225

Clarification on author responsibilities concerning empty or invalid references for properties accepting ID reference (or ID reference list) as values. 

The intention is, considering the dynamic nature of contemporary websites, to allow authors to set empty or "invalid" values, acknowledging the DOM can be populated accordingly when necessary.