### PR TITLE
Editorial - Fixed wrong closing `</p>` tag on line 6265 that is causing the "Prettier / prettier (pull_request)" check to fail.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6258,11 +6258,10 @@
 				<p>An <a>element</a> that displays the progress status for tasks that take a long time.</p>
 				<p>A progressbar indicates that the user's request has been received and the application is making progress toward completing the requested action.</p>
 				<p>Authors MAY set <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> to indicate the minimum and maximum progress indicator values. Otherwise, their implicit values follow the same rules as <code>&lt;input type="[^input/type/range^]"&gt;</code> in HTML:</p>
-					<ul>
-						<li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero).</li>
-						<li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100.</li>
-					</ul>
-				</p>
+				<ul>
+					<li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero).</li>
+					<li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100.</li>
+				</ul>
 				<p>The author SHOULD supply a <span>value</span> for <pref>aria-valuenow</pref> unless the value is indeterminate, in which case the author SHOULD omit the <pref>aria-valuenow</pref> attribute.
 				Authors SHOULD update this value when the visual progress indicator is updated. If the <code>progressbar</code> is describing the loading progress of a particular region of a page, authors SHOULD both use <pref>aria-describedby</pref> to reference the progressbar status, and set the <sref>aria-busy</sref> attribute to <code>true</code> on the region until it is finished loading. It is not possible for the user to alter the value of a <code>progressbar</code> because it is always read-only.</p>
 				<p class="note">Assistive technologies generally will render the value of <pref>aria-valuenow</pref> as a percent of a range between the value of <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref>, unless <pref>aria-valuetext</pref> is specified.</p>


### PR DESCRIPTION
Closes #2243

Fixed wrong closing `</p>` tag on line 6265 that is causing the "Prettier / prettier (pull_request)" check to fail.

Editorial


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2244.html" title="Last updated on Jun 13, 2024, 6:56 PM UTC (9798e2c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2244/2dfbe1d...9798e2c.html" title="Last updated on Jun 13, 2024, 6:56 PM UTC (9798e2c)">Diff</a>