### PR TITLE
HTML AAM: Clarification for popovertargetaction

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -13450,7 +13450,7 @@
                 <ul>
                   <li>The element's `popovertargetaction` attribute value is "`hide`"</li>
                   <li>The associated popover element is the next immediate accessibility sibling to the invoking element,</li>
-                  <li>The element's `popovertargetaction` attribute is the "`auto`" state and the element is a descendant of the `popover` it is associated with.</li>
+                  <li>The element's implicit or explicit `popovertargetaction` is the "`auto`" state and the element is a descendant of the `popover` it is associated with.</li>
                   <!-- accessibility sibling will be defined in the ARIA specification -->
                 </ul>
               </td>


### PR DESCRIPTION
this line was meant to mean that whether someone explicitly defines the popovertargetaction=auto or if an author leaves off this attribute, making it an implicit popovertargetaction.

changing this to hopefully be clearer about this, and not have people think it only applied to if someone explicitly declared that attribute/value.