### PR TITLE
Editorial: adds link that was previously empty

### DIFF
--- a/accname/index.html
+++ b/accname/index.html
@@ -295,7 +295,7 @@
         </dd>
       </dl>
       <p>
-        The <cite><a class="specref" href="#">Accessible Rich Internet Applications (WAI-ARIA) 1.2</a></cite> [[!WAI-ARIA]] specification provides lists of
+        The <cite><a class="specref" href="https://www.w3.org/TR/wai-aria-1.2/">Accessible Rich Internet Applications (WAI-ARIA) 1.2</a></cite> [[!WAI-ARIA]] specification provides lists of
         <a class="specref" href="#namefromauthor">roles that support name from author</a>, <a class="specref" href="#namefromcontent">roles that support name from content</a> and
         <a class="specref" href="#namefromprohibited">roles that cannot be named</a>.
       </p>


### PR DESCRIPTION
Editorial. When reviewing the code, I found an empty link. 
