### PR TITLE
Editorial: Changed prior employer to current status.

### DIFF
--- a/accname/index.html
+++ b/accname/index.html
@@ -43,7 +43,7 @@
         // editors, add as many as you like
         // only "name" is required
         editors: [
-          { name: "Bryan Garaventa", company: "Level Access", companyURL: "https://www.levelaccess.com/", w3cid: 67215 },
+          { name: "Bryan Garaventa", company: "Invited Expert", companyURL: "https://github.com/whatsock", w3cid: 67215 },
           { name: "Melanie Sumner", company: "Invited Expert", companyURL: "https://github.com/melsumner", w3cid: 125865 },
         ],
         formerEditors: [


### PR DESCRIPTION
This change got dropped during the monorepo move.