### PR TITLE
update ia2/atk mappings for maxlength attr

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -12044,9 +12044,7 @@
                 <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
               </th>
               <td>
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span> `maxlength: &lt;value&gt;`
-                </div>
+                <div class="objattrs"><span class="type">Object attributes:</span> `maxlength: &lt;value&gt;`</div>
               </td>
             </tr>
             <tr>
@@ -12058,9 +12056,7 @@
             <tr>
               <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
               <td>
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span> `maxlength: &lt;value&gt;`
-                </div>
+                <div class="objattrs"><span class="type">Object attributes:</span> `maxlength: &lt;value&gt;`</div>
               </td>
             </tr>
             <tr>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -12044,7 +12044,9 @@
                 <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
               </th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="objattrs">
+                  <span class="type">Object attributes:</span> `maxlength: &lt;value&gt;`
+                </div>
               </td>
             </tr>
             <tr>
@@ -12056,7 +12058,9 @@
             <tr>
               <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="objattrs">
+                  <span class="type">Object attributes:</span> `maxlength: &lt;value&gt;`
+                </div>
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
Supersedes [HTML AAM PR 522](https://github.com/w3c/html-aam/pull/522)

Co-authored by: @smhigley

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [X] "author MUST" tests: n/a
* [X] "user agent MUST" tests: n/a
* [ ] Browser implementations (link to issue or commit):
   * WebKit:
   * Gecko:
   * Blink:
* [X] ACT review? n/a
* [X] Does this need AT implementations? n/a
* [X] Related APG Issue/PR: n/a
* [X] MDN Issue/PR: n/a