### PR TITLE
[accname] Update text node definition

### DIFF
--- a/accname/index.html
+++ b/accname/index.html
@@ -285,7 +285,7 @@
         </dd>
         <dt>contents</dt>
         <dd>
-          name is generated from the Text [=nodes=] associated with the [=element=]. Although this may be allowed in addition to "author" in some <a class="termref">roles</a>, "content" is used only
+          name is generated from the [=Text=] node associated with the [=element=]. Although this may be allowed in addition to "author" in some <a class="termref">roles</a>, "content" is used only
           if higher priority "author" features are not provided. Priority is defined by the <a href="#mapping_additional_nd_te">text equivalent computation</a> algorithm.
         </dd>
         <dt>prohibited</dt>
@@ -706,7 +706,7 @@
                   </div>
                 </li>
                 <li id="comp_text_node">
-                  <span id="step2G"><!-- Don't link to this legacy numbered ID. --></span><em>Text Node:</em> Otherwise, if the <code>current node</code> is a Text [=Node=], return its textual
+                  <span id="step2G"><!-- Don't link to this legacy numbered ID. --></span><em>Text Node:</em> Otherwise, if the <code>current node</code> is a [=Text=] node, return its textual
                   contents.
                 </li>
                 <li id="comp_recursive_name_from_content">


### PR DESCRIPTION
Closes [accname #212](https://github.com/w3c/accname/issues/212)

Update text node definition using the [DOM text interface](https://dom.spec.whatwg.org/#interface-text) definition.
