### PR TITLE
[html-aam] - UIA input mappings cleanup

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -3203,7 +3203,8 @@
               <td>
                 <a data-cite="html">`input`</a>
                 <span class="el-context"
-                  >(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a data-cite="html/input.html#checkbox-state-(type=checkbox)">Checkbox</a> state)</span>
+                  >(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a data-cite="html/input.html#checkbox-state-(type=checkbox)">Checkbox</a> state)</span
+                >
               </td>
             </tr>
             <tr>
@@ -15493,10 +15494,9 @@
               </th>
               <td>
                 <div class="general">
-                  Defines the accessible role, states and other properties, refer to 
-                  <code>type="<a href="#el-input-text">text</a>"</code>, 
-                  <code>type="<a href="#el-input-password">password</a>"</code>, 
-                  <code>type="<a href="#el-input-button">`button`</a>"</code>, etc.
+                  Defines the accessible role, states and other properties, refer to
+                  <code>type="<a href="#el-input-text">text</a>"</code>, <code>type="<a href="#el-input-password">password</a>"</code>, <code>type="<a href="#el-input-button">`button`</a>"</code>,
+                  etc.
                 </div>
               </td>
             </tr>
@@ -15504,10 +15504,9 @@
               <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
               <td>
                 <div class="general">
-                  Defines the accessible role, states and other properties, refer to 
-                  <code>type="<a href="#el-input-text">text</a>"</code>, 
-                  <code>type="<a href="#el-input-password">password</a>"</code>, 
-                  <code>type="<a href="#el-input-button">`button`</a>"</code>, etc.
+                  Defines the accessible role, states and other properties, refer to
+                  <code>type="<a href="#el-input-text">text</a>"</code>, <code>type="<a href="#el-input-password">password</a>"</code>, <code>type="<a href="#el-input-button">`button`</a>"</code>,
+                  etc.
                 </div>
               </td>
             </tr>
@@ -15515,10 +15514,9 @@
               <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
               <td>
                 <div class="general">
-                  Defines the accessible role, states and other properties, refer to 
-                  <code>type="<a href="#el-input-text">text</a>"</code>, 
-                  <code>type="<a href="#el-input-password">password</a>"</code>, 
-                  <code>type="<a href="#el-input-button">`button`</a>"</code>, etc.
+                  Defines the accessible role, states and other properties, refer to
+                  <code>type="<a href="#el-input-text">text</a>"</code>, <code>type="<a href="#el-input-password">password</a>"</code>, <code>type="<a href="#el-input-button">`button`</a>"</code>,
+                  etc.
                 </div>
               </td>
             </tr>
@@ -15526,10 +15524,9 @@
               <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
               <td>
                 <div class="general">
-                  Defines the accessible role, states and other properties, refer to 
-                  <code>type="<a href="#el-input-text">text</a>"</code>, 
-                  <code>type="<a href="#el-input-password">password</a>"</code>, 
-                  <code>type="<a href="#el-input-button">`button`</a>"</code>, etc.
+                  Defines the accessible role, states and other properties, refer to
+                  <code>type="<a href="#el-input-text">text</a>"</code>, <code>type="<a href="#el-input-password">password</a>"</code>, <code>type="<a href="#el-input-button">`button`</a>"</code>,
+                  etc.
                 </div>
               </td>
             </tr>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -3203,8 +3203,7 @@
               <td>
                 <a data-cite="html">`input`</a>
                 <span class="el-context"
-                  >(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a data-cite="html/input.html#checkbox-state-(type=checkbox)">Checkbox</a> state)</span
-                >
+                  >(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a data-cite="html/input.html#checkbox-state-(type=checkbox)">Checkbox</a> state)</span>
               </td>
             </tr>
             <tr>
@@ -3471,7 +3470,6 @@
               <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
-                <div class="ctrltype"><span class="type">Localized Control Type:</span> `"email"`</div>
               </td>
             </tr>
             <tr>
@@ -3753,10 +3751,7 @@
             <tr>
               <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
               <td>
-                <div class="general">If implemented as a spin button, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-spinbutton">`spinbutton`</a>.</div>
-                <div class="general">If implemented as a text input:</div>
-                <div class="ctrltype"><span class="type">Control Type:</span> `Edit`</div>
-                <div class="ctrltype"><span class="type">Localized Control Type:</span> `"number"`</div>
+                <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
             <tr>
@@ -3813,8 +3808,7 @@
               <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
               <td>
                 <div class="ctrltype"><span class="type">Control Type:</span> `Edit`</div>
-                <div class="properties"><span class="type">Localized Control Type:</span> `"password"`</div>
-                <div class="properties"><span class="type">Other properties: </span>Set `isPassword` to `true`</div>
+                <div class="properties"><span class="type">Other properties:</span> `isPassword=true`</div>
               </td>
             </tr>
             <tr>
@@ -4144,7 +4138,6 @@
               <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
-                <div class="ctrltype"><span class="type">Localized Control Type:</span> `"telephone"`</div>
               </td>
             </tr>
             <tr>
@@ -4378,7 +4371,6 @@
               <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
-                <div class="ctrltype"><span class="type">Localized Control Type:</span> `"url"`</div>
               </td>
             </tr>
             <tr>
@@ -15501,10 +15493,10 @@
               </th>
               <td>
                 <div class="general">
-                  Defines the accessible role, states and other properties, refer to type="<a href="#el-input-text">`text`</a>", type="<a href="#el-input-password">`password`</a>", type="<a
-                    href="#el-input-button"
-                    >`button`</a
-                  >", etc
+                  Defines the accessible role, states and other properties, refer to 
+                  <code>type="<a href="#el-input-text">text</a>"</code>, 
+                  <code>type="<a href="#el-input-password">password</a>"</code>, 
+                  <code>type="<a href="#el-input-button">`button`</a>"</code>, etc.
                 </div>
               </td>
             </tr>
@@ -15512,10 +15504,10 @@
               <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
               <td>
                 <div class="general">
-                  Defines the accessible role, states and other properties, refer to type="<a href="#el-input-text">`text`</a>", type="<a href="#el-input-password">`password`</a>", type="<a
-                    href="#el-input-button"
-                    >`button`</a
-                  >", etc
+                  Defines the accessible role, states and other properties, refer to 
+                  <code>type="<a href="#el-input-text">text</a>"</code>, 
+                  <code>type="<a href="#el-input-password">password</a>"</code>, 
+                  <code>type="<a href="#el-input-button">`button`</a>"</code>, etc.
                 </div>
               </td>
             </tr>
@@ -15523,10 +15515,10 @@
               <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
               <td>
                 <div class="general">
-                  Defines the accessible role, states and other properties, refer to type="<a href="#el-input-text">`text`</a>", type="<a href="#el-input-password">`password`</a>", type="<a
-                    href="#el-input-button"
-                    >`button`</a
-                  >", etc
+                  Defines the accessible role, states and other properties, refer to 
+                  <code>type="<a href="#el-input-text">text</a>"</code>, 
+                  <code>type="<a href="#el-input-password">password</a>"</code>, 
+                  <code>type="<a href="#el-input-button">`button`</a>"</code>, etc.
                 </div>
               </td>
             </tr>
@@ -15534,10 +15526,10 @@
               <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
               <td>
                 <div class="general">
-                  Defines the accessible role, states and other properties, refer to type="<a href="#el-input-text">`text`</a>", type="<a href="#el-input-password">`password`</a>", type="<a
-                    href="#el-input-button"
-                    >`button`</a
-                  >", etc
+                  Defines the accessible role, states and other properties, refer to 
+                  <code>type="<a href="#el-input-text">text</a>"</code>, 
+                  <code>type="<a href="#el-input-password">password</a>"</code>, 
+                  <code>type="<a href="#el-input-button">`button`</a>"</code>, etc.
                 </div>
               </td>
             </tr>


### PR DESCRIPTION
closes [#173](https://github.com/w3c/html-aam/issues/173)

the localized control types for the UIA mappings for various input elements is not how these controls are actually reflected... nor, per the issue filed, how they likely should be.

being 'edit' fields with accNames that will more than likely convey their purpose is likely enough, and the localized control types don't need to reflect the type attribute value.

This is not a normative change, since this updates the spec to reflect the current implementation.

Additional inputs may need to be reviewed / changed, but those can be updated in a separate PR.
