### PR TITLE
[html-aam] fix ax iframe mapping

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -3019,9 +3019,7 @@
             <tr>
               <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
               <td>
-                <div class="role"><span class="type">AXRole:</span> `AXWebArea`</div>
-                <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
-                <div class="roledesc"><span class="type">AXRoleDescription:</span> `"html content"`</div>
+                <div class="general">Not mapped</div>
               </td>
             </tr>
             <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->


### PR DESCRIPTION
closes [html aam 130](https://github.com/w3c/html-aam/issues/130)

the iframe mapping for the ax api listed `AXWebArea` as the platform role, but this is incorrect / is the role of the child web area, not the iframe itself.

speaking with @minorninth (who opened the original issue), 'not mapped' seems most appropriate at this time.
