### PR TITLE
Remove Core-AAM UA requirement to disallow orphaned role context.

### DIFF
--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -548,18 +548,13 @@
 &lt;a href="#" role="button"&gt; &lt;!-- computedrole returns "button" --&gt;</pre
             >
           </aside>
-          <p>
-            When an element has a role but is not contained in the required context (for example, an orphaned `listitem` without the required accessible parent of role `list`), User Agents MUST ignore
-            the role token, and return the `computedrole` as if the ignored role token had not been included.
+          <p class="note">
+            When an element has a role but is not contained in the required context (for example, an orphaned `listitem` without the required accessible parent of role `list`), this is an authoring error, but the user agent behavior is not specified as a single rule. For most roles, user agents can either recover the error by ignoring the role, or respect the author's intended role in scenarios deemed by the implementation to be harmless. This unspecified permissiveness in how engines treat author role usage errors is occasionally overridden for a specific role in other specs such as [[HTML-AAM]].
           </p>
           <aside class="example">
             <!-- ReSpec needs these examples to be unindented. -->
             <pre>
-&lt;div role="listitem"&gt; &lt;!-- Author error: orphaned listitem. computedrole returns "generic" --&gt;
-
-&lt;div role="list"&gt; &lt;!-- computedrole returns "list" --&gt;
-  &lt;div role="listitem"&gt; &lt;!-- computedrole returns "listitem" in the required context. --&gt;</pre
-            >
+&lt;div role="listitem"&gt; &lt;!-- Author error: orphaned listitem. computedrole is unspecified. --&gt;</pre>
           </aside>
           <p>
             When host language elements do not have an exact or equivalent mapping to a valid, non-abstract role, the related Accessibilty API Mapping extension specification MAY specify a unique


### PR DESCRIPTION
Remove Core-AAM UA requirement to disallow orphaned role context.

Closes https://github.com/w3c/aria/issues/2166

