### PR TITLE
Editorial: Adds script to get ARIA participants and Respec gh-contributors functionality to the specs that did not have it

### DIFF
--- a/accname/index.html
+++ b/accname/index.html
@@ -8,6 +8,7 @@
     <script src="../common/script/resolveReferences.js" class="remove"></script>
     <script src="../common/script/utility.js" class="remove"></script>
     <script src="../common/biblio.js" class="remove" defer="defer"></script>
+    <script src="../common/script/participants.js" class="remove"></script>
     <script class="remove">
       var respecConfig = {
         github: "w3c/accname",
@@ -138,7 +139,7 @@
           REC: "https://www.w3.org/WAI/ARIA/apg/",
         },
 
-        preProcess: [linkCrossReferences],
+        preProcess: [linkCrossReferences, getParticipants],
         postProcess: [addPlatformMaintainers],
         //Pointing to the 1.2 versions but should remove the version in the publishing branch
         xref: ["dom", "core-aam-1.2", "wai-aria-1.2", "infra"],
@@ -791,9 +792,17 @@
       <section class="appendix informative section" id="acknowledgements">
         <h3>Acknowledgments</h3>
         <p>The following people contributed to the development of this document.</p>
-        <div data-include="../common/acknowledgements/aria-wg-active.html" data-include-replace="true"></div>
-        <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>
-      </section>
-    </section>
+        <ul id="gh-contributors">
+            <!-- GitHub contributors go here -->
+        </ul>
+		<section class="section" id="ack_group">
+			<h4>ARIA WG participants at the time of publication</h4>
+			<ul>
+				<!-- List of participants is injected here -->
+			</ul>
+		</section>
+  <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>
+</section>
+</section>
   </body>
 </html>

--- a/accname/index.html
+++ b/accname/index.html
@@ -793,16 +793,16 @@
         <h3>Acknowledgments</h3>
         <p>The following people contributed to the development of this document.</p>
         <ul id="gh-contributors">
-            <!-- GitHub contributors go here -->
+          <!-- GitHub contributors go here -->
         </ul>
-		<section class="section" id="ack_group">
-			<h4>ARIA WG participants at the time of publication</h4>
-			<ul>
-				<!-- List of participants is injected here -->
-			</ul>
-		</section>
-  <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>
-</section>
-</section>
+        <section class="section" id="ack_group">
+          <h4>ARIA WG participants at the time of publication</h4>
+          <ul>
+            <!-- List of participants is injected here -->
+          </ul>
+        </section>
+        <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>
+      </section>
+    </section>
   </body>
 </html>

--- a/common/script/participants.js
+++ b/common/script/participants.js
@@ -8,43 +8,19 @@ function getParticipants() {
     // Define the ID of the list element where the user information will be inserted
     const LIST_ID = "ack_group";
 
-    /**
-     * Fetches users and their affiliations from the API and returns an array of user information.
-     * Each element in the array is an object containing the user's title and affiliation.
-     *
-     * @async
-     * @function getUsersInfo
-     * @returns {Promise<Array<{title: string, affiliation: string}>>} - A promise that resolves to an array of user information.
-     */
     async function getUsersInfo() {
-        // Send a GET request to the users endpoint
         const response = await fetch(`${BASE_URL}/users`);
-        // Fetch the JSON data from the response
         const data = await response.json();
-        // Extract the list of users
         const users = data._links.users;
-
-        // Initialize an empty array to store user information
-        let usersInfo = [];
-        // Iterate over each user
-        for (const user of users) {
-            // Fetch the affiliation of the current user
+    
+        const usersInfo = await Promise.all(users.map(async (user) => {
             const affiliation = await getAffiliation(user);
-            // Push an object containing the user's title and affiliation to the usersInfo array
-            usersInfo.push({ title: user.title, affiliation: affiliation });
-        }
-        // Return the array containing information of all users
+            return { title: user.title, affiliation: affiliation };
+        }));
+    
         return usersInfo;
     }
-
-    /**
-     * Fetches the affiliation of a given user from the API.
-     *
-     * @async
-     * @function getAffiliation
-     * @param {Object} user - The user object.
-     * @returns {Promise<string>} - A promise that resolves to the title of the user's affiliation.
-     */
+    
     async function getAffiliation(user) {
         // Send a GET request to the affiliations endpoint of the user
         const response = await fetch(user.href + "/affiliations/");
@@ -58,23 +34,18 @@ function getParticipants() {
         // Return the title of the affiliation
         return affiliation;
     }
-
-    /**
-     * Fetches users and their affiliations, creates a list item for each user with their title and affiliation,
-     * and appends these list items to a specified list in the document.
-     *
-     * @async
-     * @function insertUsersInfoIntoDocument
-     */
     async function insertUsersInfoIntoDocument() {
         const usersInfo = await getUsersInfo();
         const usersList = document.querySelector(`#${LIST_ID} ul`);
-
-        for (const user of usersInfo) {
+        const fragment = document.createDocumentFragment();
+    
+        usersInfo.forEach(user => {
             const li = document.createElement("li");
             li.textContent = `${user.title} (${user.affiliation})`;
-            usersList.appendChild(li);
-        }
+            fragment.appendChild(li);
+        });
+    
+        usersList.appendChild(fragment);
     }
 
     insertUsersInfoIntoDocument();

--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -7,6 +7,7 @@
     <script src="../common/script/resolveReferences.js" class="remove"></script>
     <script src="../common/script/utility.js" class="remove"></script>
     <script src="../common/biblio.js" class="remove" defer></script>
+    <script src="../common/script/participants.js" class="remove"></script>
 
     <link href="../common/css/mapping-tables.css" rel="stylesheet" type="text/css" />
     <link href="../common/css/common.css" rel="stylesheet" type="text/css" />
@@ -130,7 +131,7 @@
           REC: "https://www.w3.org/TR/accname-1.2/",
         },
 
-        preProcess: [linkCrossReferences],
+        preProcess: [linkCrossReferences, getParticipants],
         postProcess: [addPlatformMaintainers],
         xref: ["dom", "accname", "wai-aria", "infra"],
       };
@@ -11122,8 +11123,13 @@
       <ul id="gh-contributors">
         <!-- list of contributors will appear here, along with link to their GitHub profiles -->
       </ul>
-      <div data-include="../common/acknowledgements/aria-wg-active.html" data-include-replace="true"></div>
-      <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>
+      <section class="section" id="ack_group">
+        <h4>ARIA WG participants at the time of publication</h4>
+        <ul>
+            <!-- List of participants is injected here -->
+        </ul>
+    </section>
+    <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>
     </section>
   </body>
 </html>

--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -11126,10 +11126,10 @@
       <section class="section" id="ack_group">
         <h4>ARIA WG participants at the time of publication</h4>
         <ul>
-            <!-- List of participants is injected here -->
+          <!-- List of participants is injected here -->
         </ul>
-    </section>
-    <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>
+      </section>
+      <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>
     </section>
   </body>
 </html>

--- a/dpub-aam/index.html
+++ b/dpub-aam/index.html
@@ -5,6 +5,7 @@
     <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script src="../common/script/resolveReferences.js" class="remove"></script>
+    <script src="../common/script/participants.js" class="remove"></script>
     <link href="../common/css/mapping-tables.css" rel="stylesheet" type="text/css" />
     <link href="../common/css/common.css" rel="stylesheet" type="text/css" />
     <script class="remove">
@@ -147,7 +148,7 @@
           CR: "https://www.w3.org/TR/accname-1.2/",
           REC: "https://www.w3.org/TR/accname-1.2/",
         },
-        preProcess: [linkCrossReferences],
+        preProcess: [linkCrossReferences, getParticipants],
         postProcess: [],
         xref: ["core-aam", "wai-aria", "dom", "infra", "accname"],
         lint: {
@@ -2679,25 +2680,15 @@
         <h3>Acknowledgments</h3>
 
         <p>The following people contributed to the development of this document:</p>
-
-        <ul>
-          <li>James Craig (Apple Inc.)</li>
-          <li>Romain Deltour (DAISY Consortium)</li>
-          <li>Joanmarie Diggs (Igalia)</li>
-          <li>Matt Garrish (DAISY Consortium)</li>
-          <li>George Kerscher (DAISY Consortium)</li>
-          <li>Peter Krautzberger (W3C Invited Experts)</li>
-          <li>Charles Lapierre (Benetech)</li>
-          <li>Aaron Leventhal (Google)</li>
-          <li>Daniel Montalvo (W3C Staff)</li>
-          <li>James Nurthen (Adobe)</li>
-          <li>Scott O'Hara (Microsoft Corporation)</li>
-          <li>Gregorio Pellegrino (Fondazione LIA)</li>
-          <li>Tzviya Siegman (Wiley)</li>
-          <li>Avneesh Singh (DAISY Consortium)</li>
-          <li>Valerie Young (Igalia)</li>
-        </ul>
-
+       <ul id="gh-contributors">
+        <!-- List of GitHub contributors goes here -->
+       </ul>
+		<section class="section" id="ack_group">
+			<h4>ARIA WG participants at the time of publication</h4>
+			<ul>
+				<!-- List of participants is injected here -->
+			</ul>
+		</section>
         <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>
       </section>
     </section>

--- a/dpub-aam/index.html
+++ b/dpub-aam/index.html
@@ -2680,15 +2680,15 @@
         <h3>Acknowledgments</h3>
 
         <p>The following people contributed to the development of this document:</p>
-       <ul id="gh-contributors">
-        <!-- List of GitHub contributors goes here -->
-       </ul>
-		<section class="section" id="ack_group">
-			<h4>ARIA WG participants at the time of publication</h4>
-			<ul>
-				<!-- List of participants is injected here -->
-			</ul>
-		</section>
+        <ul id="gh-contributors">
+          <!-- List of GitHub contributors goes here -->
+        </ul>
+        <section class="section" id="ack_group">
+          <h4>ARIA WG participants at the time of publication</h4>
+          <ul>
+            <!-- List of participants is injected here -->
+          </ul>
+        </section>
         <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>
       </section>
     </section>

--- a/dpub-aria/index.html
+++ b/dpub-aria/index.html
@@ -6,6 +6,7 @@
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script src="../common/script/resolveReferences.js" class="remove"></script>
     <script src="../common/biblio.js" class="remove" defer="defer"></script>
+    <script src="../common/script/participants.js" class="remove"></script>
     <link href="../common/css/common.css" rel="stylesheet" type="text/css" />
     <script class="remove" src="../common/script/ariaChild.js"></script>
     <script class="remove" src="../common/script/roleInfo.js"></script>
@@ -109,7 +110,7 @@
           CRD: "https://www.w3.org/TR/wai-aria-practices-1.2/",
           REC: "https://www.w3.org/TR/wai-aria-practices-1.2/",
         },
-        preProcess: [linkCrossReferences],
+        preProcess: [linkCrossReferences, getParticipants],
         postProcess: [ariaAttributeReferences],
         definitionMap: [],
         xref: ["core-aam", "accname", "wai-aria", "dom", "infra"],
@@ -4466,25 +4467,15 @@
       <h2>Acknowledgments</h2>
 
       <p>The following people contributed to the development of this document:</p>
-
-      <ul>
-        <li>James Craig (Apple Inc.)</li>
-        <li>Romain Deltour (DAISY Consortium)</li>
-        <li>Joanmarie Diggs (Igalia)</li>
-        <li>Matt Garrish (DAISY Consortium)</li>
-        <li>George Kerscher (DAISY Consortium)</li>
-        <li>Peter Krautzberger (W3C Invited Experts)</li>
-        <li>Charles Lapierre (Benetech)</li>
-        <li>Aaron Leventhal (Google)</li>
-        <li>Daniel Montalvo (W3C Staff)</li>
-        <li>James Nurthen (Adobe)</li>
-        <li>Scott O'Hara (Microsoft Corporation)</li>
-        <li>Gregorio Pellegrino (Fondazione LIA)</li>
-        <li>Tzviya Siegman (Wiley)</li>
-        <li>Avneesh Singh (DAISY Consortium)</li>
-        <li>Valerie Young (Igalia)</li>
+      <ul id="gh-contributors">
+        <!-- list goes here -->
       </ul>
-
+      <section class="section" id="ack_group">
+        <h4>ARIA WG participants at the time of publication</h4>
+        <ul>
+            <!-- List of participants is injected here -->
+        </ul>
+    </section>
       <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>
     </section>
   </body>

--- a/dpub-aria/index.html
+++ b/dpub-aria/index.html
@@ -4473,9 +4473,9 @@
       <section class="section" id="ack_group">
         <h4>ARIA WG participants at the time of publication</h4>
         <ul>
-            <!-- List of participants is injected here -->
+          <!-- List of participants is injected here -->
         </ul>
-    </section>
+      </section>
       <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>
     </section>
   </body>

--- a/graphics-aam/index.html
+++ b/graphics-aam/index.html
@@ -6,6 +6,7 @@
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
     <script src="../common/script/resolveReferences.js" class="remove"></script>
     <script src="../common/biblio.js" class="remove" defer="defer"></script>
+    <script src="../common/script/participants.js" class="remove"></script>
     <link href="../common/css/mapping-tables.css" rel="stylesheet" type="text/css" />
     <link href="../common/css/common.css" rel="stylesheet" type="text/css" />
     <!--<link href="css/dpub-aam.css" rel="stylesheet" type="text/css"/>-->
@@ -172,7 +173,7 @@
           PR: "https://www.w3.org/TR/graphics-aam-1.0/",
           REC: "https://www.w3.org/TR/graphics-aam-1.0/",
         },
-        preProcess: [linkCrossReferences],
+        preProcess: [linkCrossReferences, getParticipants],
         postProcess: [],
         definitionMap: [],
         xref: ["core-aam", "accname", "wai-aria", "dom", "infra"],
@@ -502,23 +503,7 @@
       <section class="section" id="ack_group">
         <h4>Participants active in the ARIA WG at the time of publication</h4>
         <ul>
-          <li>David Bolter (Mozilla Foundation)</li>
-          <li>Michael Cooper (W3C/MIT)</li>
-          <li>James Craig (Apple Inc.)</li>
-          <li>Joanmarie Diggs (Igalia)</li>
-          <li>John Foliot (Invited Expert)</li>
-          <li>Christopher Gallelo (Microsoft Corporation)</li>
-          <li>Bryan Garaventa (SSB BART Group)</li>
-          <li>Jon Gunderson (University of Illinois at Urbana-Champaign)</li>
-          <li>Matthew King (IBM Corporation)</li>
-          <li>Dominic Mazzoni (Google, Inc.)</li>
-          <li>Shane McCarron (Invited Expert, Aptest)</li>
-          <li>James Nurthen (Oracle Corporation)</li>
-          <li>Janina Sajka (Invited Expert, The Linux Foundation)</li>
-          <li>Stefan Schnabel (SAP AG)</li>
-          <li>Lisa Seeman (Invited Expert)</li>
-          <li>Alexander Surkov (Mozilla Foundation)</li>
-          <li>Jason White (Educational Testing Service)</li>
+            <!-- List goes here -->
         </ul>
       </section>
       <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>

--- a/graphics-aam/index.html
+++ b/graphics-aam/index.html
@@ -503,7 +503,7 @@
       <section class="section" id="ack_group">
         <h4>Participants active in the ARIA WG at the time of publication</h4>
         <ul>
-            <!-- List goes here -->
+          <!-- List goes here -->
         </ul>
       </section>
       <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>

--- a/graphics-aria/index.html
+++ b/graphics-aria/index.html
@@ -1187,7 +1187,7 @@ OK to omit the second example?
       <section class="section" id="ack_group">
         <h4>Participants active in the ARIA WG at the time of publication</h4>
         <ul>
-            <!-- List goes here -->
+          <!-- List goes here -->
         </ul>
       </section>
       <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>

--- a/graphics-aria/index.html
+++ b/graphics-aria/index.html
@@ -7,6 +7,7 @@
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
     <script src="../common/script/resolveReferences.js" class="remove"></script>
     <script src="../common/biblio.js" class="remove" defer="defer"></script>
+    <script src="../common/script/participants.js" class="remove"></script>
     <link href="../common/css/common.css" rel="stylesheet" type="text/css" />
     <script class="remove" src="../common/script/ariaChild.js"></script>
     <script class="remove" src="../common/script/roleInfo.js"></script>
@@ -148,7 +149,7 @@
           REC: "https://www.w3.org/TR/wai-aria-1.1/",
         },
 
-        preProcess: [linkCrossReferences],
+        preProcess: [linkCrossReferences, getParticipants],
         postProcess: [ariaAttributeReferences],
         definitionMap: [],
         xref: ["core-aam", "accname", "wai-aria"],
@@ -1169,6 +1170,7 @@ OK to omit the second example?
     <section class="appendix informative section" id="acknowledgements">
       <h3>Acknowledgments</h3>
       <p>The following people contributed to the development of this document.</p>
+      <ul id="gh-contributors"></ul>
       <section class="section" id="ack_svga11y">
         <h4>Participants active in the SVG accessibility task force at the time of publication</h4>
         <ul>
@@ -1185,23 +1187,7 @@ OK to omit the second example?
       <section class="section" id="ack_group">
         <h4>Participants active in the ARIA WG at the time of publication</h4>
         <ul>
-          <li>David Bolter (Mozilla Foundation)</li>
-          <li>Michael Cooper (W3C/MIT)</li>
-          <li>James Craig (Apple Inc.)</li>
-          <li>Joanmarie Diggs (Igalia)</li>
-          <li>John Foliot (Invited Expert)</li>
-          <li>Christopher Gallelo (Microsoft Corporation)</li>
-          <li>Bryan Garaventa (SSB BART Group)</li>
-          <li>Jon Gunderson (University of Illinois at Urbana-Champaign)</li>
-          <li>Matthew King (IBM Corporation)</li>
-          <li>Dominic Mazzoni (Google, Inc.)</li>
-          <li>Shane McCarron (Invited Expert, Aptest)</li>
-          <li>James Nurthen (Oracle Corporation)</li>
-          <li>Janina Sajka (Invited Expert, The Linux Foundation)</li>
-          <li>Stefan Schnabel (SAP AG)</li>
-          <li>Lisa Seeman (Invited Expert)</li>
-          <li>Alexander Surkov (Mozilla Foundation)</li>
-          <li>Jason White (Educational Testing Service)</li>
+            <!-- List goes here -->
         </ul>
       </section>
       <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -16667,12 +16667,12 @@
         <h3>Acknowledgments</h3>
         <p>The following people contributed to the development of this document.</p>
         <ul id="gh-contributors"></ul>
-		<section class="section" id="ack_group">
-			<h4>ARIA WG participants at the time of publication</h4>
-			<ul>
-				<!-- List of participants is injected here -->
-			</ul>
-		</section>
+        <section class="section" id="ack_group">
+          <h4>ARIA WG participants at the time of publication</h4>
+          <ul>
+            <!-- List of participants is injected here -->
+          </ul>
+        </section>
         <!-- TODO:e Include people whose comments have added value to the specification -->
         <div data-include="../common//acknowledgements/funders.html" data-include-replace="true"></div>
       </section>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -7,7 +7,7 @@
     <script src="../common/script/resolveReferences.js" class="remove"></script>
     <script src="../common/script/utility.js" class="remove"></script>
     <script src="../common/biblio.js" class="remove" defer="defer"></script>
-
+    <script src="../common/script/participants.js" class="remove"></script>
     <link href="../common/css/mapping-tables.css" rel="stylesheet" type="text/css" />
     <link href="../common/css/common.css" rel="stylesheet" type="text/css" />
     <link href="css/html-aam.css" rel="stylesheet" />
@@ -72,7 +72,7 @@
         },
 
         xref: ["HTML", "core-aam", "accname", "wai-aria", "dom", "infra"],
-        preProcess: [linkCrossReferences],
+        preProcess: [linkCrossReferences, getParticipants],
         postProcess: [fixContributors],
         a11y: false,
       };
@@ -16666,17 +16666,15 @@
       <section class="appendix informative" id="acknowledgements">
         <h3>Acknowledgments</h3>
         <p>The following people contributed to the development of this document.</p>
-        <div class="section" id="ack_group">
-          <!-- left in place to ensure deep links to ID remain functional -->
-          <ul id="gh-contributors"></ul>
-          <!-- list of contributors will appear here,
-					 along with link to their GitHub profiles -->
-          <!--
-          TODO:
-          Add listing of individuals who have providing meaningful
-          contributions through commenting that have impacted the specification.
-        --></div>
-        <div data-include="https://rawgit.com/w3c/aria/master/../common/acknowledgements/funders.html" data-include-replace="true"></div>
+        <ul id="gh-contributors"></ul>
+		<section class="section" id="ack_group">
+			<h4>ARIA WG participants at the time of publication</h4>
+			<ul>
+				<!-- List of participants is injected here -->
+			</ul>
+		</section>
+        <!-- TODO:e Include people whose comments have added value to the specification -->
+        <div data-include="../common//acknowledgements/funders.html" data-include-replace="true"></div>
       </section>
     </section>
   </body>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 <link href="common/css/common.css" rel="stylesheet" type="text/css"/>
 <script class="remove" src="common/script/aria.js"></script>
 <script src="common/script/resolveReferences.js" class="remove"></script>
+<script src="common/script/participants.js" class="remove"></script>
 <script class="remove">
 	var respecConfig = {
 		github: "w3c/aria",
@@ -150,7 +151,7 @@
           "REC": "https://www.w3.org/WAI/ARIA/apg/"
         },
 
-	preProcess: [ linkCrossReferences ],
+	preProcess: [ linkCrossReferences, getParticipants ],
 	postProcess: [ ariaAttributeReferences ],
 	xref: ["dom", "accname-1.2", "core-aam-1.2", "infra", "HTML"],
 	definitionMap: []
@@ -14066,8 +14067,13 @@ el.getAttribute("aria-label"); // Returns "Publish"</pre>
 			<!-- list of contributors will appear here,
 					 along with link to their GitHub profiles -->
 		</ul>
-		<div data-include="common/acknowledgements/aria-wg-active.html" data-include-replace="true"></div>
-		<div data-include="common/acknowledgements/funders.html" data-include-replace="true"></div>
+		<section class="section" id="ack_group">
+			<h4>ARIA WG participants at the time of publication</h4>
+			<ul>
+				<!-- List of participants is injected here -->
+			</ul>
+		</section>
+  <div data-include="common/acknowledgements/funders.html" data-include-replace="true"></div>
 	</section>
 </body>
 </html>

--- a/mathml-aam/index.html
+++ b/mathml-aam/index.html
@@ -6,6 +6,7 @@
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
     <script src="../common/script/resolveReferences.js" class="remove"></script>
     <script src="../common/biblio.js" class="remove" defer="defer"></script>
+    <script src="../common/script/participants.js" class="remove"></script>
     <link href="../common/css/mapping-tables.css" rel="stylesheet" type="text/css" />
     <link href="../common/css/common.css" rel="stylesheet" type="text/css" />
     <script class="remove">
@@ -52,7 +53,7 @@
           REC: "https://www.w3.org/TR/wai-aria-implementation/",
         },
 
-        preProcess: [linkCrossReferences],
+        preProcess: [linkCrossReferences, getParticipants],
         postProcess: [],
         definitionMap: [],
         xref: ["dom", "core-aam", "accname", "wai-aria", "infra"],
@@ -1409,7 +1410,14 @@
     <section class="appendix informative section" id="acknowledgements">
       <h3>Acknowledgments</h3>
       <p>The following people contributed to the development of this document.</p>
-      <div data-include="../common/acknowledgements/aria-wg-active.html" data-include-replace="true"></div>
+      <ul id="gh-contributors"></ul>
+      <section class="section" id="ack_group">
+        <h4>ARIA WG participants at the time of publication</h4>
+        <ul>
+            <!-- List of participants is injected here -->
+        </ul>
+    </section>
+
       <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>
     </section>
   </body>

--- a/mathml-aam/index.html
+++ b/mathml-aam/index.html
@@ -1414,9 +1414,9 @@
       <section class="section" id="ack_group">
         <h4>ARIA WG participants at the time of publication</h4>
         <ul>
-            <!-- List of participants is injected here -->
+          <!-- List of participants is injected here -->
         </ul>
-    </section>
+      </section>
 
       <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>
     </section>

--- a/svg-aam/index.html
+++ b/svg-aam/index.html
@@ -3108,6 +3108,7 @@
           In addition to the credited authors and editors, the participants in the SVG Accessibility Task Force contributed to the development of this document. Appreciation also goes to Joanmarie
           Diggs and other implementers who have offered feedback on the drafts and helped with testing.
         </p>
+<<<<<<< HEAD
         <section class="section" id="ack_group">
 <<<<<<< HEAD
           <h4>ARIA WG Participants at the time of publication</h4>
@@ -3121,6 +3122,8 @@
             </ul>
 >>>>>>> a8f16056 (Fix typo)
         </section>
+=======
+>>>>>>> 77e4c701 (Flip around for consistency with graphics mainly)
         <section class="section" id="ack_taskforce">
           <h4>Past participants in the SVG Accessibility Task Force</h4>
           <ul>
@@ -3140,6 +3143,12 @@
             <li>Léonie Watson (The Paciello Group, LLC)</li>
             <li>Jason White (Educational Testing Service)</li>
           </ul>
+        </section>
+        <section class="section" id="ack_group">
+            <h4>ARIA WG Participants at the time of publication</h4>
+            <ul>
+                <!-- List is injected here -->
+            </ul>
         </section>
         <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>
       </section>

--- a/svg-aam/index.html
+++ b/svg-aam/index.html
@@ -3109,10 +3109,17 @@
           Diggs and other implementers who have offered feedback on the drafts and helped with testing.
         </p>
         <section class="section" id="ack_group">
+<<<<<<< HEAD
           <h4>ARIA WG Participants at the time of publication</h4>
           <ul>
             <!-- List in injected here -->
           </ul>
+=======
+            <h4>ARIA WG Participants at the time of publication</h4>
+            <ul>
+                <!-- List is injected here -->
+            </ul>
+>>>>>>> a8f16056 (Fix typo)
         </section>
         <section class="section" id="ack_taskforce">
           <h4>Past participants in the SVG Accessibility Task Force</h4>

--- a/svg-aam/index.html
+++ b/svg-aam/index.html
@@ -5,7 +5,7 @@
     <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer="defer"></script>
     <script src="../common/script/resolveReferences.js" class="remove"></script>
     <script src="../common/biblio.js" class="remove" defer="defer"></script>
-
+    <script src="../common/script/participants.js" class="remove"></script>
     <link href="../common/css/mapping-tables.css" rel="stylesheet" type="text/css" />
     <link href="../common/css/common.css" rel="stylesheet" type="text/css" />
     <!--<link href="css/svg-aam.css" rel="stylesheet" type="text/css"/>-->
@@ -132,7 +132,7 @@
           REC: "https://www.w3.org/TR/graphics-aam/",
         },
 
-        preProcess: [linkCrossReferences],
+        preProcess: [linkCrossReferences, getParticipants],
       };
     </script>
   </head>
@@ -3109,6 +3109,12 @@
           Diggs and other implementers who have offered feedback on the drafts and helped with testing.
         </p>
         <section class="section" id="ack_group">
+            <h4>ARIA WG Participants at the time of publication</h4>
+            <ul>
+                <!-- List in injected here -->
+            </ul>
+        </section>
+        <section class="section" id="ack_taskforce">
           <h4>Past participants in the SVG Accessibility Task Force</h4>
           <ul>
             <li>Amelia Bellamy-Royds</li>

--- a/svg-aam/index.html
+++ b/svg-aam/index.html
@@ -3109,10 +3109,10 @@
           Diggs and other implementers who have offered feedback on the drafts and helped with testing.
         </p>
         <section class="section" id="ack_group">
-            <h4>ARIA WG Participants at the time of publication</h4>
-            <ul>
-                <!-- List is injected here -->
-            </ul>
+          <h4>ARIA WG Participants at the time of publication</h4>
+          <ul>
+            <!-- List is injected here -->
+          </ul>
         </section>
         <section class="section" id="ack_taskforce">
           <h4>Past participants in the SVG Accessibility Task Force</h4>
@@ -3135,10 +3135,10 @@
           </ul>
         </section>
         <section class="section" id="ack_group">
-            <h4>ARIA WG Participants at the time of publication</h4>
-            <ul>
-                <!-- List is injected here -->
-            </ul>
+          <h4>ARIA WG Participants at the time of publication</h4>
+          <ul>
+            <!-- List is injected here -->
+          </ul>
         </section>
         <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>
       </section>

--- a/svg-aam/index.html
+++ b/svg-aam/index.html
@@ -3109,10 +3109,10 @@
           Diggs and other implementers who have offered feedback on the drafts and helped with testing.
         </p>
         <section class="section" id="ack_group">
-            <h4>ARIA WG Participants at the time of publication</h4>
-            <ul>
-                <!-- List in injected here -->
-            </ul>
+          <h4>ARIA WG Participants at the time of publication</h4>
+          <ul>
+            <!-- List in injected here -->
+          </ul>
         </section>
         <section class="section" id="ack_taskforce">
           <h4>Past participants in the SVG Accessibility Task Force</h4>

--- a/svg-aam/index.html
+++ b/svg-aam/index.html
@@ -3108,22 +3108,12 @@
           In addition to the credited authors and editors, the participants in the SVG Accessibility Task Force contributed to the development of this document. Appreciation also goes to Joanmarie
           Diggs and other implementers who have offered feedback on the drafts and helped with testing.
         </p>
-<<<<<<< HEAD
         <section class="section" id="ack_group">
-<<<<<<< HEAD
-          <h4>ARIA WG Participants at the time of publication</h4>
-          <ul>
-            <!-- List in injected here -->
-          </ul>
-=======
             <h4>ARIA WG Participants at the time of publication</h4>
             <ul>
                 <!-- List is injected here -->
             </ul>
->>>>>>> a8f16056 (Fix typo)
         </section>
-=======
->>>>>>> 77e4c701 (Flip around for consistency with graphics mainly)
         <section class="section" id="ack_taskforce">
           <h4>Past participants in the SVG Accessibility Task Force</h4>
           <ul>


### PR DESCRIPTION
Closes w3c/aria-common#109

See [All previews](https://github.com/w3c/aria/pull/2288/checks?check_run_id=27663152252)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2288.html" title="Last updated on Aug 21, 2024, 11:51 AM UTC (83e555d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2288/1d0b8b9...83e555d.html" title="Last updated on Aug 21, 2024, 11:51 AM UTC (83e555d)">Diff</a>