### PR TITLE
[html-aam] - browser repair for a no href

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -581,7 +581,7 @@
             <tr>
               <th>Comments</th>
               <td>
-                User agents MAY still expose an `a` element lacking a `href` attribute with a `link` role in the event an author specifies interactive behavior for the element. E.g., by using an
+                User agents MAY still expose an `a` element lacking the `href` attribute with a `link` role in the event an author specifies interactive behavior for the element. For example, if using an
                 `onclick` attribute.
               </td>
             </tr>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -582,7 +582,7 @@
               <th>Comments</th>
               <td>
                 User agents MAY still expose an `a` element lacking the `href` attribute with a `link` role in the event an author specifies interactive behavior for the element. For example, if using
-                an <a data-cite="html/#event-handler-content-attributes">event handler attribute</a>.
+                an <a data-cite="html/webappapis.html#event-handler-content-attributes">event handler attribute</a>.
               </td>
             </tr>
           </tbody>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -582,7 +582,7 @@
               <th>Comments</th>
               <td>
                 User agents MAY still expose an `a` element lacking the `href` attribute with a `link` role in the event an author specifies interactive behavior for the element. For example, if using
-                an `onclick` attribute.
+                an <a data-cite="html/#event-handler-content-attributes">event handler attribute</a>.
               </td>
             </tr>
           </tbody>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -580,7 +580,7 @@
             </tr>
             <tr>
               <th>Comments</th>
-              <td></td>
+              <td>User agents MAY still expose an `a` element lacking a `href` attribute with a `link` role in the event an author specifies interactive behavior for the element. E.g., by using an `onclick` attribute.</td>
             </tr>
           </tbody>
         </table>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -581,8 +581,8 @@
             <tr>
               <th>Comments</th>
               <td>
-                User agents MAY still expose an `a` element lacking the `href` attribute with a `link` role in the event an author specifies interactive behavior for the element. For example, if using an
-                `onclick` attribute.
+                User agents MAY still expose an `a` element lacking the `href` attribute with a `link` role in the event an author specifies interactive behavior for the element. For example, if using
+                an `onclick` attribute.
               </td>
             </tr>
           </tbody>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -580,7 +580,10 @@
             </tr>
             <tr>
               <th>Comments</th>
-              <td>User agents MAY still expose an `a` element lacking a `href` attribute with a `link` role in the event an author specifies interactive behavior for the element. E.g., by using an `onclick` attribute.</td>
+              <td>
+                User agents MAY still expose an `a` element lacking a `href` attribute with a `link` role in the event an author specifies interactive behavior for the element. E.g., by using an
+                `onclick` attribute.
+              </td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
This comment acknowledges that some browsers will attempt to mitigate for potential author error for `<a onclick...>` by exposing the placeholder link with a `role=link` instead of as a `generic`.
