### PR TITLE
Editorial: Add Editor's Draft reference URLs for ARIA and Accname

### DIFF
--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -118,12 +118,14 @@
 
         // Spec URLs
         ariaSpecURLs: {
+          ED: "../index.html",
           CR: "https://w3c.github.io/aria/",
           CRD: "https://w3c.github.io/aria/",
           PR: "https://www.w3.org/TR/wai-aria/",
           REC: "https://www.w3.org/TR/wai-aria/",
         },
         accNameURLs: {
+          ED: "../accname/index.html",
           CR: "https://w3c.github.io/accname/",
           CRD: "https://w3c.github.io/accname/",
           PR: "https://www.w3.org/TR/accname-1.2/",

--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -118,14 +118,14 @@
 
         // Spec URLs
         ariaSpecURLs: {
-          ED: "../index.html",
+          ED: "https://w3c.github.io/aria/",
           CR: "https://w3c.github.io/aria/",
           CRD: "https://w3c.github.io/aria/",
           PR: "https://www.w3.org/TR/wai-aria/",
           REC: "https://www.w3.org/TR/wai-aria/",
         },
         accNameURLs: {
-          ED: "../accname/index.html",
+          ED: "https://w3c.github.io/accname/",
           CR: "https://w3c.github.io/accname/",
           CRD: "https://w3c.github.io/accname/",
           PR: "https://www.w3.org/TR/accname-1.2/",


### PR DESCRIPTION
This works, as you can even see in the preview -- see "definition of roles" link: https://deploy-preview-2298--wai-aria.netlify.app/core-aam/#mapping_state-property
