### PR TITLE
Editorial: Update computation step "comp_embedded_control" (formerly step 2c) text for clarity

### DIFF
--- a/accname/index.html
+++ b/accname/index.html
@@ -554,7 +554,8 @@
                   </div>
                 </li>
                 <li id="comp_embedded_control">
-                  <span id="step2C"><!-- Don't link to this legacy numbered ID. --></span><em>Embedded Control:</em> Otherwise, if the <code>current node</code> is a user-adjustable control embedded within the label, and the control is not the element being named or described, then return the embedded control's value as part of the text alternative in the following manner:
+                  <span id="step2C"><!-- Don't link to this legacy numbered ID. --></span><em>Embedded Control:</em> Otherwise, if the <code>current node</code> is a user-adjustable control embedded
+                  within the label, and the control is not the element being named or described, then return the embedded control's value as part of the text alternative in the following manner:
                   <ol>
                     <li id="comp_embedded_control_textbox"><em>Textbox:</em> If the embedded control has role <a class="role-reference" href="#textbox">textbox</a>, return its value.</li>
                     <li id="comp_embedded_control_combobox_or_listbox">

--- a/accname/index.html
+++ b/accname/index.html
@@ -554,7 +554,7 @@
                   </div>
                 </li>
                 <li id="comp_embedded_control">
-                  <span id="step2C"><!-- Don't link to this legacy numbered ID. --></span><em>Embedded Control:</em> Otherwise, if the <code>current node</code> is a user-adjustable control embedded
+                  <span id="step2C"><!-- Don't link to this legacy numbered ID. --></span><em>Embedded Control:</em> Otherwise, if the <code>current node</code> is a user-perceivable control embedded
                   within the label, and the control is not the element being named or described, then return the embedded control's value as part of the text alternative in the following manner:
                   <ol>
                     <li id="comp_embedded_control_textbox"><em>Textbox:</em> If the embedded control has role <a class="role-reference" href="#textbox">textbox</a>, return its value.</li>

--- a/accname/index.html
+++ b/accname/index.html
@@ -554,9 +554,7 @@
                   </div>
                 </li>
                 <li id="comp_embedded_control">
-                  <span id="step2C"><!-- Don't link to this legacy numbered ID. --></span><em>Embedded Control:</em> Otherwise, if the <code>current node</code> is a control embedded within the label
-                  (e.g. any element directly referenced by <code>aria-labelledby</code>) for another <a class="termref">widget</a>, where the user can adjust the embedded control's value, then return
-                  the embedded control as part of the text alternative in the following manner:
+                  <span id="step2C"><!-- Don't link to this legacy numbered ID. --></span><em>Embedded Control:</em> Otherwise, if the <code>current node</code> is a user-adjustable control embedded within the label, and the control is not the element being named or described, then return the embedded control's value as part of the text alternative in the following manner:
                   <ol>
                     <li id="comp_embedded_control_textbox"><em>Textbox:</em> If the embedded control has role <a class="role-reference" href="#textbox">textbox</a>, return its value.</li>
                     <li id="comp_embedded_control_combobox_or_listbox">


### PR DESCRIPTION
Closes [accname issue 244](https://github.com/w3c/accname/issues/244)

If merged, this PR updates step "comp_embedded_control" (formerly step 2c) to be the agreed upon text per this issue: https://github.com/w3c/accname/issues/244


