### PR TITLE
Add `class` and `id` mappings

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -9010,25 +9010,25 @@
                 <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
               </th>
               <td>
-                <div class="objattrs"><span class="type">Object attributes:</span> <code>class: &lt;value&gt;</code></div>
+                <div class="objattrs"><span class="type">Object attributes:</span> `class: &lt;value&gt;`</div>
               </td>
             </tr>
             <tr>
               <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
               <td>
-                <div class="property"><span class="type">Property:</span> <code>UIA_ClassNamePropertyId</code></div>
+                <div class="property"><span class="type">Property:</span> `UIA_ClassNamePropertyId`</div>
               </td>
             </tr>
             <tr>
               <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
               <td>
-                <div class="objattrs"><span class="type">Object attributes:</span> <code>class: &lt;value&gt;</code></div>
+                <div class="objattrs"><span class="type">Object attributes:</span> `class: &lt;value&gt;`</div>
               </td>
             </tr>
             <tr>
               <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
               <td>
-                <div class="property"><span class="type">Property:</span> <code>AXDOMClassList</code></div>
+                <div class="property"><span class="type">Property:</span> `AXDOMClassList`</div>
               </td>
             </tr>
             <tr>
@@ -11207,25 +11207,25 @@
                 <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
               </th>
               <td>
-                <div class="objattrs"><span class="type">Object attributes:</span> <code>id: &lt;value&gt;</code></div>
+                <div class="objattrs"><span class="type">Object attributes:</span> `id: &lt;value&gt;`</div>
               </td>
             </tr>
             <tr>
               <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
               <td>
-                <div class="property"><span class="type">Property:</span> <code>UIA_AutomationIdPropertyId</code></div>
+                <div class="property"><span class="type">Property:</span> `UIA_AutomationIdPropertyId`</div>
               </td>
             </tr>
             <tr>
               <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
               <td>
-                <div class="objattrs"><span class="type">Object attributes:</span> <code>id: &lt;value&gt;</code></div>
+                <div class="objattrs"><span class="type">Object attributes:</span> `id: &lt;value&gt;`</div>
               </td>
             </tr>
             <tr>
               <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
               <td>
-                <div class="property"><span class="type">Property:</span> <code>AXDOMIdentifier</code></div>
+                <div class="property"><span class="type">Property:</span> `AXDOMIdentifier`</div>
               </td>
             </tr>
             <tr>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -9010,25 +9010,25 @@
                 <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
               </th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="objattrs"><span class="type">Object attributes:</span> <code>class</code></div>
               </td>
             </tr>
             <tr>
               <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="property"><span class="type">Property:</span> <code>UIA_ClassNamePropertyId</code></div>
               </td>
             </tr>
             <tr>
               <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="objattrs"><span class="type">Object attributes:</span> <code>class</code></div>
               </td>
             </tr>
             <tr>
               <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="property"><span class="type">Property:</span> <code>AXDOMClassList</code></div>
               </td>
             </tr>
             <tr>
@@ -11207,25 +11207,25 @@
                 <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
               </th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="objattrs"><span class="type">Object attributes:</span> <code>id</code></div>
               </td>
             </tr>
             <tr>
               <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="property"><span class="type">Property:</span> <code>UIA_AutomationIdPropertyId</code></div>
               </td>
             </tr>
             <tr>
               <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="objattrs"><span class="type">Object attributes:</span> <code>id</code></div>
               </td>
             </tr>
             <tr>
               <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="property"><span class="type">Property:</span> <code>AXDOMIdentifier</code></div>
               </td>
             </tr>
             <tr>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -9010,7 +9010,7 @@
                 <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
               </th>
               <td>
-                <div class="objattrs"><span class="type">Object attributes:</span> <code>class</code></div>
+                <div class="objattrs"><span class="type">Object attributes:</span> <code>class: &lt;value&gt;</code></div>
               </td>
             </tr>
             <tr>
@@ -9022,7 +9022,7 @@
             <tr>
               <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
               <td>
-                <div class="objattrs"><span class="type">Object attributes:</span> <code>class</code></div>
+                <div class="objattrs"><span class="type">Object attributes:</span> <code>class: &lt;value&gt;</code></div>
               </td>
             </tr>
             <tr>
@@ -11207,7 +11207,7 @@
                 <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
               </th>
               <td>
-                <div class="objattrs"><span class="type">Object attributes:</span> <code>id</code></div>
+                <div class="objattrs"><span class="type">Object attributes:</span> <code>id: &lt;value&gt;</code></div>
               </td>
             </tr>
             <tr>
@@ -11219,7 +11219,7 @@
             <tr>
               <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
               <td>
-                <div class="objattrs"><span class="type">Object attributes:</span> <code>id</code></div>
+                <div class="objattrs"><span class="type">Object attributes:</span> <code>id: &lt;value&gt;</code></div>
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
Closes https://github.com/w3c/html-aam/issues/553

Initially filed as https://github.com/w3c/html-aam/pull/559

@aleventhal provided mappings in https://github.com/w3c/html-aam/issues/553. I verified they match up with Chromium’s mappings:

**`id`**
- `kHtmlId` maps to `id` in [ax_platform_node_base.cc;l=1506-1509](https://source.chromium.org/chromium/chromium/src/+/main:ui/accessibility/platform/ax_platform_node_base.cc;l=1506-1509?q=kHtmlId&ss=chromium%2Fchromium%2Fsrc:ui%2Faccessibility%2Fplatform%2F)
- `kHtmlId` maps to `UIA_AutomationIdPropertyId` in [ax_platform_node_win.cc;l=5254-5264](https://source.chromium.org/chromium/chromium/src/+/main:ui/accessibility/platform/ax_platform_node_win.cc;l=5254-5264?q=UIA_AutomationIdPropertyId&start=11) (via [`GetAuthorUniqueId()`](https://source.chromium.org/chromium/chromium/src/+/main:ui/accessibility/platform/ax_platform_node_delegate.cc;l=583-587;drc=5203366d4cf174b9331ee33563e0520f10b60828))
- `kHtmlId` maps to `AXDOMIdentifier` in [ax_platform_node_cocoa.mm;l=1594-1601](https://source.chromium.org/chromium/chromium/src/+/main:ui/accessibility/platform/ax_platform_node_cocoa.mm;l=1594-1601?q=AXDOMIdentifier)

**`class`**
- `kClassName` maps to `class` in [ax_platform_node_base.cc;l=1492-1497](https://source.chromium.org/chromium/chromium/src/+/main:ui/accessibility/platform/ax_platform_node_base.cc;l=1492-1497?q=kClassName&ss=chromium%2Fchromium%2Fsrc:ui%2Faccessibility%2Fplatform%2F)
- `kClassName` maps to `UIA_ClassNamePropertyId` in [ax_platform_node_win.cc;l=5265-5269](https://source.chromium.org/chromium/chromium/src/+/main:ui/accessibility/platform/ax_platform_node_win.cc;l=5265-5269?q=UIA_ClassNamePropertyId)
- `kClassName` maps to `AXDOMClassList` in [ax_platform_node_cocoa.mm;l=1577-1592](https://source.chromium.org/chromium/chromium/src/+/main:ui/accessibility/platform/ax_platform_node_cocoa.mm;l=1577-1592?q=AXDOMClassList)

**Reviewers:** Please also check the formatting. I’ve attempted to match existing styles, but those are inconsistent, e.g. “Object attributes” is bold in [datetime](https://w3c.github.io/html-aam/#att-datetime-time) (but not in [draggable](https://w3c.github.io/html-aam/#att-draggable)); it uses `<code>` in [src](https://w3c.github.io/html-aam/#att-src-media) (but not in [abbr](https://w3c.github.io/html-aam/#el-abbr)).

**Previews**
- [`class`](https://deploy-preview-2308--wai-aria.netlify.app/html-aam/#att-class)
- [`id`](https://deploy-preview-2308--wai-aria.netlify.app/html-aam/#att-id)

❧

<!--- IF EDITORIAL or CHORE, delete the rest of this template -->

<details>
<summary>Test, Documentation and Implementation tracking</summary>
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests:
* [ ] Browser implementations (link to issue or commit):
   * WebKit:
   * Gecko: [Bug for AXDOMClassList on Webkit](https://bugzilla.mozilla.org/show_bug.cgi?id=1912836)
   * Blink: current implementation
* [ ] Does this need AT implementations?
* [ ] Related APG Issue/PR:
* [ ] MDN Issue/PR:
</details>