### PR TITLE
[html-aam] Update ATK URL

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -309,7 +309,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -359,7 +359,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -412,7 +412,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> `ATK_ROLE_STATIC`</div>
                 <div class="objattrs">
@@ -467,7 +467,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -517,7 +517,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -567,7 +567,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -616,7 +616,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -663,7 +663,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -716,7 +716,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -776,7 +776,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role: </span> `ATK_ROLE_AUDIO`</div>
               </td>
@@ -833,7 +833,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -883,7 +883,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -933,7 +933,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -983,7 +983,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -1033,7 +1033,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -1083,7 +1083,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -1133,7 +1133,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -1183,7 +1183,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -1233,7 +1233,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -1287,7 +1287,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> `ATK_ROLE_CANVAS`</div>
               </td>
@@ -1346,7 +1346,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
                 <div class="relations">
@@ -1404,7 +1404,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">No accessible object. Styles used are mapped into text attributes on its text container.</div>
               </td>
@@ -1456,7 +1456,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -1506,7 +1506,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -1559,7 +1559,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -1609,7 +1609,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -1663,7 +1663,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -1716,7 +1716,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -1766,7 +1766,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -1819,7 +1819,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
                 <div class="ctrltype">
@@ -1872,7 +1872,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -1922,7 +1922,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -1972,7 +1972,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -2026,7 +2026,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> `ATK_ROLE_DESCRIPTION_LIST`</div>
               </td>
@@ -2081,7 +2081,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -2131,7 +2131,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -2182,7 +2182,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> `ATK_ROLE_EMBEDDED`</div>
               </td>
@@ -2233,7 +2233,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> Use WAI-ARIA mapping</div>
                 <div class="relations"><span class="type">Relations:</span> `ATK_RELATION_LABELLED_BY` with child <a href="#el-legend">`legend`</a> element</div>
@@ -2289,7 +2289,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> `ATK_ROLE_CAPTION`</div>
                 <div class="relations">
@@ -2349,7 +2349,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> Use WAI-ARIA mapping</div>
                 <div class="name"><span class="type">Name:</span> related <a href="#el-figcaption">`figcaption`</a> content</div>
@@ -2399,7 +2399,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -2451,7 +2451,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> `ATK_ROLE_FOOTER`</div>
               </td>
@@ -2501,7 +2501,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
                 <div>If a `form` has no <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>:</div>
@@ -2553,7 +2553,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -2606,7 +2606,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -2656,7 +2656,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -2704,7 +2704,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -2756,7 +2756,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> `ATK_ROLE_HEADER`</div>
               </td>
@@ -2806,7 +2806,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -2859,7 +2859,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -2911,7 +2911,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -2961,7 +2961,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -3011,7 +3011,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> `ATK_ROLE_INTERNAL_FRAME`</div>
               </td>
@@ -3066,7 +3066,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -3126,7 +3126,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -3177,7 +3177,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -3234,7 +3234,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -3293,7 +3293,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">If implemented as a button, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-button">`button`</a>.</div>
                 <div class="general">If implemented as a textbox, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-textbox">`textbox`</a>.</div>
@@ -3361,7 +3361,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role: </span> `ATK_ROLE_CALENDAR`</div>
               </td>
@@ -3417,7 +3417,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> `ATK_ROLE_CALENDAR`</div>
               </td>
@@ -3475,7 +3475,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -3535,7 +3535,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> `ATK_ROLE_STATIC`</div>
                 <div class="children">
@@ -3592,7 +3592,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -3645,7 +3645,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -3696,7 +3696,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> `ATK_ROLE_DATE_EDITOR`</div>
               </td>
@@ -3760,7 +3760,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">If implemented as a spin button, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-spinbutton">`spinbutton`</a>.</div>
                 <div class="general">If implemented as a text input, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-textbox">`textbox`</a>.</div>
@@ -3818,7 +3818,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> `ATK_ROLE_PASSWORD_TEXT`</div>
                 <div class="states"><span class="type">States:</span> `ATK_STATE_SINGLE_LINE`; `ATK_STATE_READ_ONLY` if readonly, otherwise `ATK_STATE_EDITABLE`</div>
@@ -3881,7 +3881,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -3932,7 +3932,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -3985,7 +3985,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -4039,7 +4039,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -4092,7 +4092,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -4148,7 +4148,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -4202,7 +4202,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -4263,7 +4263,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -4318,7 +4318,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role">
                   <p>
@@ -4382,7 +4382,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -4434,7 +4434,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> `ATK_ROLE_CALENDAR`</div>
               </td>
@@ -4486,7 +4486,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -4537,7 +4537,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">No accessible object. Mapped into "font-family:monospace" text attribute on its text container.</div>
               </td>
@@ -4605,7 +4605,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> `ATK_ROLE_LABEL`</div>
                 <div class="relations">
@@ -4668,7 +4668,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> `ATK_ROLE_LABEL`</div>
                 <div class="relations">
@@ -4728,7 +4728,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -4781,7 +4781,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -4831,7 +4831,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -4882,7 +4882,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped if used as an image map, otherwise:</div>
                 <div class="role"><span class="type">Role:</span> `ATK_ROLE_STATIC`</div>
@@ -4937,7 +4937,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -4983,7 +4983,7 @@
               <td>See comments</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>See comments</td>
             </tr>
             <tr>
@@ -5029,7 +5029,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -5087,7 +5087,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -5137,7 +5137,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -5187,7 +5187,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -5237,7 +5237,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -5292,7 +5292,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Depends on format of data file. If contains a plugin then</div>
                 <div class="role">
@@ -5344,7 +5344,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -5394,7 +5394,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -5450,7 +5450,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -5501,7 +5501,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
                 <div class="relations"><span class="type">Relations:</span> `ATK_RELATION_LABELLED_BY` with associated `label` element</div>
@@ -5556,7 +5556,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -5606,7 +5606,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -5656,7 +5656,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -5706,7 +5706,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -5761,7 +5761,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -5811,7 +5811,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -5864,7 +5864,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">No accessible object. No child elements are exposed if <a href="#el-ruby">`ruby`</a> is supported by the browser.</div>
               </td>
@@ -5915,7 +5915,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">No accessible object.</div>
               </td>
@@ -5968,7 +5968,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> `ATK_ROLE_STATIC`</div>
               </td>
@@ -6020,7 +6020,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -6070,7 +6070,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -6120,7 +6120,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -6170,7 +6170,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -6223,7 +6223,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -6277,7 +6277,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -6331,7 +6331,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -6381,7 +6381,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -6431,7 +6431,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -6481,7 +6481,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -6531,7 +6531,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -6581,7 +6581,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -6631,7 +6631,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -6686,7 +6686,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -6750,7 +6750,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> `ROLE_TOGGLE_BUTTON`</div>
                 <div class="relations"><span class="type">Relations:</span> `ATK_RELATION_DETAILS`</div>
@@ -6806,7 +6806,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -6852,7 +6852,7 @@
               <td>See comments</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>See comments</td>
             </tr>
             <tr>
@@ -6894,7 +6894,7 @@
               <td>Use WAI-ARIA mapping</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>Use WAI-ARIA mapping</td>
             </tr>
             <tr>
@@ -6936,7 +6936,7 @@
               <td>Use WAI-ARIA mapping</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>Use WAI-ARIA mapping</td>
             </tr>
             <tr>
@@ -6983,7 +6983,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -7034,7 +7034,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -7084,7 +7084,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -7134,7 +7134,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -7184,7 +7184,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -7239,7 +7239,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -7298,7 +7298,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -7349,7 +7349,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -7400,7 +7400,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -7450,7 +7450,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -7500,7 +7500,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -7550,7 +7550,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -7600,7 +7600,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -7650,7 +7650,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -7700,7 +7700,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -7750,7 +7750,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -7800,7 +7800,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">No accessible object. Styles used are mapped to text attributes on its text container.</div>
               </td>
@@ -7862,7 +7862,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> `ATK_ROLE_VIDEO`</div>
               </td>
@@ -7919,7 +7919,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">A line break if added is exposed via Text interface on its text container</div>
               </td>
@@ -7995,7 +7995,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="objattrs">
                   <span class="type">Object attributes:</span>
@@ -8047,7 +8047,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8098,7 +8098,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8153,7 +8153,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">`atk_action_get_keybinding`</div>
               </td>
@@ -8202,7 +8202,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8253,7 +8253,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8304,7 +8304,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8360,7 +8360,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Used for <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>, exposed via `atk_object_get_name`</div>
               </td>
@@ -8409,7 +8409,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8460,7 +8460,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8511,7 +8511,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8566,7 +8566,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="states">
                   <span class="type">States:</span>
@@ -8624,7 +8624,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="states"><span class="type">States:</span> `ATK_STATE_SUPPORTS_AUTOCOMPLETION`</div>
               </td>
@@ -8673,7 +8673,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8724,7 +8724,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8776,7 +8776,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8827,7 +8827,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8872,7 +8872,7 @@
               <td>Property: `Toggle.ToggleState: On (1)`</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -8918,7 +8918,7 @@
               <td>Property: `Toggle.ToggleState: Off (0)`</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -8971,7 +8971,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9020,7 +9020,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9071,7 +9071,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9122,7 +9122,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9173,7 +9173,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -9224,7 +9224,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9293,7 +9293,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <p>
                   If the element is in the editable state, the following mappings apply to the element and every nested accessible object with the exception of those which have been specified in the
@@ -9356,7 +9356,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9405,7 +9405,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Defines an accessible object's dimensions, exposed via `atk_component_get_position` and `atk_component_get_size`</div>
               </td>
@@ -9458,7 +9458,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9509,7 +9509,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9560,7 +9560,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="objattrs"><span class="type">Object attributes:</span> `datetime: &lt;value&gt;`</div>
               </td>
@@ -9609,7 +9609,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="objattrs"><span class="type">Object attributes:</span> `datetime: &lt;value&gt;`</div>
               </td>
@@ -9658,7 +9658,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9709,7 +9709,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9760,7 +9760,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9811,7 +9811,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Exposed as "writing-mode" text attribute on the text container.</div>
               </td>
@@ -9862,7 +9862,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Exposed as "writing-mode" text attribute on the text container.</div>
               </td>
@@ -9913,7 +9913,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9967,7 +9967,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -10018,7 +10018,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -10066,7 +10066,7 @@
               <td>Not mapped</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>Not mapped</td>
             </tr>
             <tr>
@@ -10113,7 +10113,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10164,7 +10164,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="objattrs"><span class="objattrs">Object attributes:</span> draggable:true</div>
               </td>
@@ -10215,7 +10215,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10266,7 +10266,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10321,7 +10321,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10381,7 +10381,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="name">Used for <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a></div>
                 <div class="relations">
@@ -10440,7 +10440,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="relations">
                   <span class="type">Relations: </span>
@@ -10498,7 +10498,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10550,7 +10550,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10602,7 +10602,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10654,7 +10654,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10706,7 +10706,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10755,7 +10755,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10807,7 +10807,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">
                   Links the cell to its row and <a data-cite="HTML/tables.html#column-header">column header</a> cells (note, only one row and one column header cells can be exposed because of API
@@ -10863,7 +10863,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Defines an accessible object's height (`atk_component_get_size`)</div>
               </td>
@@ -10913,7 +10913,7 @@
               <td>Use WAI-ARIA mapping</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>Use WAI-ARIA mapping</td>
             </tr>
             <tr>
@@ -10956,7 +10956,7 @@
               <td>`RangeValue.Maximum`</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11011,7 +11011,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">
                   Creates a link accessible object. For details, refer to
@@ -11063,7 +11063,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11115,7 +11115,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11166,7 +11166,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11217,7 +11217,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11262,7 +11262,7 @@
               <td>See comments</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>See comments</td>
             </tr>
             <tr>
@@ -11311,7 +11311,7 @@
               <td>Use WAI-ARIA mapping</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>Use WAI-ARIA mapping</td>
             </tr>
             <tr>
@@ -11358,7 +11358,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11409,7 +11409,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11460,7 +11460,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11511,7 +11511,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11562,7 +11562,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11613,7 +11613,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11658,7 +11658,7 @@
               <td>Not mapped</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>Not mapped</td>
             </tr>
             <tr>
@@ -11707,7 +11707,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="name">Associates the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a></div>
               </td>
@@ -11759,7 +11759,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="textattrs">Exposed as "language" text attribute on the text container</div>
               </td>
@@ -11808,7 +11808,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="relations">`ATK_RELATION_CONTROLLER_FOR` point to the `datalist` element referred to by the IDREF value of the `list` attribute.</div>
               </td>
@@ -11860,7 +11860,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11909,7 +11909,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11958,7 +11958,7 @@
               <td>`RangeValue.Maximum`</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Exposed as `atk_value_get_maximum_value` if the element implements the `AtkValue` interface</div>
               </td>
@@ -12006,7 +12006,7 @@
               <td>`RangeValue.Maximum`</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Exposed as `atk_value_get_maximum_value` if the element implements the `AtkValue` interface</div>
               </td>
@@ -12054,7 +12054,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12107,7 +12107,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12158,7 +12158,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12207,7 +12207,7 @@
               <td>`RangeValue.Minimum`</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Exposed as `atk_value_get_minimum_value` if the element implements the `AtkValue` interface</div>
               </td>
@@ -12254,7 +12254,7 @@
               <td>`RangeValue.Minimum`</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Exposed as `atk_value_get_minimum_value` if the element implements the `AtkValue` interface</div>
               </td>
@@ -12310,7 +12310,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="states">
                   <span class="type">States:</span>
@@ -12367,7 +12367,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12418,7 +12418,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -12470,7 +12470,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12524,7 +12524,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12575,7 +12575,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12627,7 +12627,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12678,7 +12678,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12729,7 +12729,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12780,7 +12780,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12831,7 +12831,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12882,7 +12882,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12933,7 +12933,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12980,7 +12980,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="states">
                   <span class="type">States: </span>
@@ -13035,7 +13035,7 @@
               <td>Use WAI-ARIA mapping</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>Use WAI-ARIA mapping</td>
             </tr>
             <tr>
@@ -13088,7 +13088,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -13138,7 +13138,7 @@
               <td>Use WAI-ARIA mapping</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>Use WAI-ARIA mapping</td>
             </tr>
             <tr>
@@ -13185,7 +13185,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -13237,7 +13237,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -13293,7 +13293,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -13349,7 +13349,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <p><span class="type">Relations:</span> `RELATION_DETAILS_FOR` points to invoking element. <a href="#att-popover-comments">See Comments</a>.</p>
                 <div class="objattrs">
@@ -13428,7 +13428,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
                 <div class="general"><span class="type">Object attributes:</span> `details-roles:popover`</div>
@@ -13493,7 +13493,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -13544,7 +13544,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -13595,7 +13595,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -13647,7 +13647,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -13701,7 +13701,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -13753,7 +13753,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -13805,7 +13805,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -13867,7 +13867,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Reverses the numerical or alphabetical order of the child list item markers.</div>
               </td>
@@ -13916,7 +13916,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -13968,7 +13968,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -14019,7 +14019,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -14071,7 +14071,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -14122,7 +14122,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -14173,7 +14173,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -14228,7 +14228,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped for `input` elements.</div>
                 <div class="general">For `select` element use WAI-ARIA mapping.</div>
@@ -14284,7 +14284,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -14336,7 +14336,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -14387,7 +14387,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -14437,7 +14437,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Exposed via `atk_table_get_column_extent_at`</div>
               </td>
@@ -14488,7 +14488,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -14546,7 +14546,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="objattrs">
                   <span class="type">Object attributes:</span>
@@ -14598,7 +14598,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -14649,7 +14649,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -14701,7 +14701,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -14752,7 +14752,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Changes the first number of the child list item accessible objects to match the `start` attribute's value.</div>
               </td>
@@ -14801,7 +14801,7 @@
               <td>If the `input` is in the <a href="#el-input-range">`Range`</a> state, set both `RangeValue.SmallChange` and `RangeValue.LargeChange` to the value of `step`.</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Exposed as `atk_value_get_minimum_increment` if the element implements the `AtkValue` interface.</div>
               </td>
@@ -14850,7 +14850,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -14901,7 +14901,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -14956,7 +14956,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -15007,7 +15007,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -15058,7 +15058,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -15112,7 +15112,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -15169,7 +15169,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="name">Associates the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a></div>
               </td>
@@ -15212,7 +15212,7 @@
               <td>Not mapped</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>Not mapped</td>
             </tr>
             <tr>
@@ -15257,7 +15257,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -15308,7 +15308,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -15360,7 +15360,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -15409,7 +15409,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general"><a href="#el-input-submit">`submit`</a> type may be a default button in the form.</div>
               </td>
@@ -15462,7 +15462,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -15521,7 +15521,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">
                   Defines the accessible role, states and other properties, refer to type="<a href="#el-input-text">`text`</a>", type="<a href="#el-input-password">`password`</a>", type="<a
@@ -15586,7 +15586,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">
                   Defines the list item marker, which has no <a class="termref">accessible object</a>, but is exposed as content in the accessible text of the associated list item.
@@ -15650,7 +15650,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Responsible for image map creation.</div>
               </td>
@@ -15702,7 +15702,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -15753,7 +15753,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -15806,7 +15806,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="name">
                   Associates the accessible value for entry type input elements and <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> for button type input elements
@@ -15860,7 +15860,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Exposed as first text node of `li`'s accessible object.</div>
               </td>
@@ -15915,7 +15915,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Exposed as `atk_value_get_current_value`</div>
               </td>
@@ -15970,7 +15970,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Defines an accessible object's width (`atk_component_get_size`)</div>
               </td>
@@ -16021,7 +16021,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>


### PR DESCRIPTION
Initially filed as https://github.com/w3c/html-aam/pull/560

https://gnome.pages.gitlab.gnome.org/atk/ (the URL currently referenced throughout [html-aam](https://w3c.github.io/html-aam)) 404s, even after logging in to the GNOME GitLab instance[^1].

https://docs.gtk.org/atk/ (this PR’s replacement URL) seems to be the new location. [GTK’s “API Docs” page](https://www.gtk.org/docs/apis/) links to this URL.

[^1]: That said, [GNOME’s “Technologies” page](https://www.gnome.org/technologies/) still links to this URL. 🤷

❧

<!--- IF EDITORIAL or CHORE, delete the rest of this template -->

<details>
<summary>Test, Documentation and Implementation tracking</summary>
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests:
* [ ] Browser implementations (link to issue or commit):
   * WebKit:
   * Gecko:
   * Blink:
* [ ] Does this need AT implementations?
* [ ] Related APG Issue/PR:
* [ ] MDN Issue/PR:
</details>