### PR TITLE
Make aria-relevant and ariaRelevant reflect

### DIFF
--- a/index.html
+++ b/index.html
@@ -13581,7 +13581,7 @@ button.ariaPressed; // null</pre>
 				[CEReactions] attribute DOMString? ariaPosInSet;
 				[CEReactions] attribute DOMString? ariaPressed;
 				[CEReactions] attribute DOMString? ariaReadOnly;
-				<!-- [CEReactions] attribute DOMString? ariaRelevant; -->
+				[CEReactions] attribute DOMString? ariaRelevant;
 				[CEReactions] attribute DOMString? ariaRequired;
 				[CEReactions] attribute DOMString? ariaRoleDescription;
 				[CEReactions] attribute DOMString? ariaRowCount;
@@ -13654,7 +13654,7 @@ button.ariaPressed; // null</pre>
 			<tr><td><dfn>ariaPosInSet</dfn></td><td><pref>aria-posinset</pref></td></tr>
 			<tr><td><dfn>ariaPressed</dfn></td><td><sref>aria-pressed</sref></td></tr>
 			<tr><td><dfn>ariaReadOnly</dfn></td><td><pref>aria-readonly</pref></td></tr>
-			<!-- <tr><td><dfn>ariaRelevant</dfn></td><td><pref>aria-relevant</pref></td></tr> -->
+                        <tr><td><dfn>ariaRelevant</dfn></td><td><pref>aria-relevant</pref></td></tr>
 			<tr><td><dfn>ariaRequired</dfn></td><td><pref>aria-required</pref></td></tr>
 			<tr><td><dfn>ariaRoleDescription</dfn></td><td><pref>aria-roledescription</pref></td></tr>
 			<tr><td><dfn>ariaRowCount</dfn></td><td><pref>aria-rowcount</pref></td></tr>


### PR DESCRIPTION
The `ariaRelevant` IDL attribute seems to have been intentionally commented out from the `ARIAMixin` interface in https://github.com/w3c/aria/commit/646f093848a1943c8343f34ad80f72dbd78f54e6 — without any explanation that I could find, including not in the related issue at https://github.com/w3c/aria/issues/1058.

But since at https://w3c.github.io/aria/#idl-reflection-attribute-values the spec says:

> _All ARIA attributes reflect in IDL as nullable DOMString attributes._

…and since there’s a test case included in http://wpt.live/html/dom/aria-attribute-reflection.html, and WebKit, Gecko, and Blink all pass that test — then it seems `ariaRelevant` needs to be included in `ARIAMixin` in the spec.

* [x] "author MUST" tests: N/A
* [x] "user agent MUST" tests: http://wpt.live/html/dom/aria-attribute-reflection.html
* [x] Browser implementations (link to issue or commit):
   * WebKit: Already implemented to reflect
   * Gecko: Already implemented to reflect
   * Blink: Already implemented to reflect
* [ ] Does this need AT implementations?
* [ ] Related APG Issue/PR:
* [ ] MDN Issue/PR:


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2326.html" title="Last updated on Nov 29, 2024, 6:27 AM UTC (5b9e38d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2326/1d0b8b9...5b9e38d.html" title="Last updated on Nov 29, 2024, 6:27 AM UTC (5b9e38d)">Diff</a>