### PR TITLE
Add listview and listviewitem roles to support interactive lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,35 +120,35 @@
 		group: "aria",
 		maxTocLevel: 4,
 
-        // Spec URLs
-        ariaSpecURLs: {
-          "ED": "https://w3c.github.io/aria/",
-          "FPWD": "https://www.w3.org/TR/wai-aria-1.3/",
-          "WD": "https://www.w3.org/TR/wai-aria-1.3/",
-          "CR": "https://www.w3.org/TR/wai-aria-1.3/",
-          "REC": "https://www.w3.org/TR/wai-aria-1.3/",
-        },
-        accNameURLs: {
-          "ED": "https://w3c.github.io/accname/",
-          "WD" : "https://www.w3.org/TR/accname-1.2/",
-          "FPWD": "https://www.w3.org/TR/accname-1.2/",
-          "CR" : "https://www.w3.org/TR/accname-1.2/",
-          "REC": "https://www.w3.org/TR/accname-1.2/"
-        },
-        coreMappingURLs: {
-          "ED": "https://w3c.github.io/core-aam/",
-          "WD" : "https://www.w3.org/TR/core-aam-1.2/",
-          "FPWD": "https://www.w3.org/TR/core-aam-1.2/",
-          "CR": "https://www.w3.org/TR/core-aam-1.2/",
-          "REC": "https://www.w3.org/TR/core-aam-1.2/"
-        },
-        practicesURLs: {
-          "ED": "https://www.w3.org/WAI/ARIA/apg/",
-          "WD" : "https://www.w3.org/WAI/ARIA/apg/",
-          "FPWD": "https://www.w3.org/WAI/ARIA/apg/",
-          "CR": "https://www.w3.org/WAI/ARIA/apg/",
-          "REC": "https://www.w3.org/WAI/ARIA/apg/"
-        },
+				// Spec URLs
+				ariaSpecURLs: {
+					"ED": "https://w3c.github.io/aria/",
+					"FPWD": "https://www.w3.org/TR/wai-aria-1.3/",
+					"WD": "https://www.w3.org/TR/wai-aria-1.3/",
+					"CR": "https://www.w3.org/TR/wai-aria-1.3/",
+					"REC": "https://www.w3.org/TR/wai-aria-1.3/",
+				},
+				accNameURLs: {
+					"ED": "https://w3c.github.io/accname/",
+					"WD" : "https://www.w3.org/TR/accname-1.2/",
+					"FPWD": "https://www.w3.org/TR/accname-1.2/",
+					"CR" : "https://www.w3.org/TR/accname-1.2/",
+					"REC": "https://www.w3.org/TR/accname-1.2/"
+				},
+				coreMappingURLs: {
+					"ED": "https://w3c.github.io/core-aam/",
+					"WD" : "https://www.w3.org/TR/core-aam-1.2/",
+					"FPWD": "https://www.w3.org/TR/core-aam-1.2/",
+					"CR": "https://www.w3.org/TR/core-aam-1.2/",
+					"REC": "https://www.w3.org/TR/core-aam-1.2/"
+				},
+				practicesURLs: {
+					"ED": "https://www.w3.org/WAI/ARIA/apg/",
+					"WD" : "https://www.w3.org/WAI/ARIA/apg/",
+					"FPWD": "https://www.w3.org/WAI/ARIA/apg/",
+					"CR": "https://www.w3.org/WAI/ARIA/apg/",
+					"REC": "https://www.w3.org/WAI/ARIA/apg/"
+				},
 
 	preProcess: [ linkCrossReferences ],
 	postProcess: [ ariaAttributeReferences ],
@@ -274,12 +274,12 @@
 		<dl class="termlist">
 			<dt><dfn data-export="">Accessibility <abbr title="Application Programming Interface">API</abbr></dfn></dt>
 			<dd>
-			  <p>Operating systems and other platforms provide a set of interfaces that expose information about <a class="termref">objects</a> and <a class="termref">events</a> to <a>assistive technologies</a>. Assistive technologies use these interfaces to get information about and interact with those <a class="termref">widgets</a>. Examples of accessibility APIs are <a href="https://docs.microsoft.com/en-us/windows/win32/winauto/microsoft-active-accessibility">Microsoft Active Accessibility</a> [[MSAA]], <a href="https://learn.microsoft.com/en-us/windows/win32/winauto/entry-uiauto-win32">Microsoft User Interface Automation</a> [[UI-AUTOMATION]], <abbr title="Microsoft Active Accessibility">MSAA</abbr> with <cite><a href="https://learn.microsoft.com/en-us/windows/win32/winauto/iaccessibleex"><abbr title="User Interface Automation">UIA</abbr> Express</a></cite> [[UIA-EXPRESS]], the
-				  <a href="https://developer.apple.com/documentation/appkit/nsaccessibility">Mac <abbr title="OS Ten">OS X</abbr> Accessibility Protocol</a> [[AXAPI]], the <cite><a href="https://gnome.pages.gitlab.gnome.org/atk/">Linux/Unix Accessibility Toolkit</a></cite> [[ATK]] and <cite><a href="https://gnome.pages.gitlab.gnome.org/at-spi2-core/libatspi/">Assistive Technology Service Provider Interface</a></cite> [[AT-SPI]], and <a href="https://wiki.linuxfoundation.org/accessibility/iaccessible2/start">IAccessible2</a> [[IAccessible2]].</p>
+				<p>Operating systems and other platforms provide a set of interfaces that expose information about <a class="termref">objects</a> and <a class="termref">events</a> to <a>assistive technologies</a>. Assistive technologies use these interfaces to get information about and interact with those <a class="termref">widgets</a>. Examples of accessibility APIs are <a href="https://docs.microsoft.com/en-us/windows/win32/winauto/microsoft-active-accessibility">Microsoft Active Accessibility</a> [[MSAA]], <a href="https://learn.microsoft.com/en-us/windows/win32/winauto/entry-uiauto-win32">Microsoft User Interface Automation</a> [[UI-AUTOMATION]], <abbr title="Microsoft Active Accessibility">MSAA</abbr> with <cite><a href="https://learn.microsoft.com/en-us/windows/win32/winauto/iaccessibleex"><abbr title="User Interface Automation">UIA</abbr> Express</a></cite> [[UIA-EXPRESS]], the
+					<a href="https://developer.apple.com/documentation/appkit/nsaccessibility">Mac <abbr title="OS Ten">OS X</abbr> Accessibility Protocol</a> [[AXAPI]], the <cite><a href="https://gnome.pages.gitlab.gnome.org/atk/">Linux/Unix Accessibility Toolkit</a></cite> [[ATK]] and <cite><a href="https://gnome.pages.gitlab.gnome.org/at-spi2-core/libatspi/">Assistive Technology Service Provider Interface</a></cite> [[AT-SPI]], and <a href="https://wiki.linuxfoundation.org/accessibility/iaccessible2/start">IAccessible2</a> [[IAccessible2]].</p>
 			</dd>
 			<dt><dfn data-export="">Accessible object</dfn></dt>
 			<dd>
-			  <p>A [=nodes|node=] in the <a class="termref">accessibility tree</a> of a platform <a>accessibility <abbr title="application programming interface">API</abbr></a>. Accessible objects expose various <a class="termref">states</a>, [=ARIA/properties=], and <a class="termref">events</a> for use by <a>assistive technologies</a>.  In the context of markup languages (e.g., HTML and SVG) in general, and of WAI-ARIA in particular, markup [=elements=] and their [=attributes=] are represented as accessible objects.  </p>
+				<p>A [=nodes|node=] in the <a class="termref">accessibility tree</a> of a platform <a>accessibility <abbr title="application programming interface">API</abbr></a>. Accessible objects expose various <a class="termref">states</a>, [=ARIA/properties=], and <a class="termref">events</a> for use by <a>assistive technologies</a>.  In the context of markup languages (e.g., HTML and SVG) in general, and of WAI-ARIA in particular, markup [=elements=] and their [=attributes=] are represented as accessible objects.  </p>
 			</dd>
 			<dt><dfn data-export="">Assistive Technologies</dfn></dt>
 			<dd><p>Hardware and/or software that:</p>
@@ -288,61 +288,61 @@
 						<li>works with a user agent or web content itself through the use of APIs, and</li>
 						<li>provides services beyond those offered by the user agent to facilitate user interaction with web content by people with disabilities</li>
 					</ul>
-			  <p>This definition might differ from that used in other documents.</p>
+				<p>This definition might differ from that used in other documents.</p>
 			<p>Examples of assistive technologies that are important in the context
-			  of this document include the following:</p>
+				of this document include the following:</p>
 			<ul>
-			  <li>screen magnifiers, which are used to enlarge and improve the visual readability of rendered text and images;</li>
-			  <li>screen readers, which are most-often used to convey information through synthesized speech or a refreshable Braille display;</li>
-			  <li>text-to-speech software, which is used to convert text into synthetic speech;</li>
-			  <li>speech recognition software, which is used to allow spoken control and dictation;</li>
-			  <li>alternate input technologies (including head pointers, on-screen keyboards, single switches, and sip/puff devices), which are used to simulate the keyboard;</li>
-			  <li>alternate pointing devices, which are used to simulate mouse pointing and clicking.</li>
+				<li>screen magnifiers, which are used to enlarge and improve the visual readability of rendered text and images;</li>
+				<li>screen readers, which are most-often used to convey information through synthesized speech or a refreshable Braille display;</li>
+				<li>text-to-speech software, which is used to convert text into synthetic speech;</li>
+				<li>speech recognition software, which is used to allow spoken control and dictation;</li>
+				<li>alternate input technologies (including head pointers, on-screen keyboards, single switches, and sip/puff devices), which are used to simulate the keyboard;</li>
+				<li>alternate pointing devices, which are used to simulate mouse pointing and clicking.</li>
 			</ul>
 			</dd>
 			<dt><dfn data-local-lt="deprecate|deprecation">Deprecated</dfn></dt>
 			<dd>
-			  <p>A deprecated <a class="termref" href="#dfn-role">role</a>, <a class="termref" href="#dfn-state">state</a>, or <a class="termref" href="#dfn-property">property</a> is one which has been outdated by newer constructs or changed circumstances, and which might be removed in future versions of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> specification. [=user agents=] are encouraged to continue to support items identified as deprecated for backward compatibility. For more information, see <a href="#deprecated" class="specref">Deprecated Requirements</a> in the Conformance section.</p>
+				<p>A deprecated <a class="termref" href="#dfn-role">role</a>, <a class="termref" href="#dfn-state">state</a>, or <a class="termref" href="#dfn-property">property</a> is one which has been outdated by newer constructs or changed circumstances, and which might be removed in future versions of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> specification. [=user agents=] are encouraged to continue to support items identified as deprecated for backward compatibility. For more information, see <a href="#deprecated" class="specref">Deprecated Requirements</a> in the Conformance section.</p>
 			</dd>
 			<dt><dfn>Defines</dfn></dt>
 			<dd>
-			  <p>Used in an attribute description to denote that the value <a href="#propcharacteristic_value">type</a> is an <a href="#valuetype_integer">integer</a>, <a href="#valuetype_number">number</a>, or <a href="#valuetype_string">string</a>.</p>
-			  <p>Related Terms: <a>Identifies</a>, <a>Indicates</a></p>
+				<p>Used in an attribute description to denote that the value <a href="#propcharacteristic_value">type</a> is an <a href="#valuetype_integer">integer</a>, <a href="#valuetype_number">number</a>, or <a href="#valuetype_string">string</a>.</p>
+				<p>Related Terms: <a>Identifies</a>, <a>Indicates</a></p>
 			</dd>
 			<dt><dfn data-local-lt="desktop focus">Desktop focus event</dfn></dt>
 			<dd>
-			  <p>Event from/to the host operating system via the accessibility <abbr title="application programming interface">API</abbr>, notifying of a change of input focus.</p>
+				<p>Event from/to the host operating system via the accessibility <abbr title="application programming interface">API</abbr>, notifying of a change of input focus.</p>
 			</dd>
 			<dt><dfn>Event</dfn></dt>
 			<dd>
-			  <p>A programmatic message used to communicate discrete changes in the <a>state</a> of an <a>object</a> to other objects in a computational system. User input to a web page is commonly mediated through abstract events that describe the interaction and can provide notice of changes to the state of a document object. In some programming languages, events are more commonly known as notifications.</p>
+				<p>A programmatic message used to communicate discrete changes in the <a>state</a> of an <a>object</a> to other objects in a computational system. User input to a web page is commonly mediated through abstract events that describe the interaction and can provide notice of changes to the state of a document object. In some programming languages, events are more commonly known as notifications.</p>
 			</dd>
 			<dt><dfn>Expose</dfn></dt><!--Not used-->
 			<dd>
-			  <p>Translated to platform-specific <a class="termref">accessibility APIs</a> as defined in the <a href="" class="core-mapping">Core Accessibility API Mappings</a>.</p>
+				<p>Translated to platform-specific <a class="termref">accessibility APIs</a> as defined in the <a href="" class="core-mapping">Core Accessibility API Mappings</a>.</p>
 			</dd>
 			<dt><dfn>Graphical Document</dfn></dt>
 			<dd>
-			  <p>A document containing graphic representations with user-navigable parts. Charts, maps, diagrams, blueprints, and dashboards are examples of graphical documents. A graphical document is composed using any combination of symbols, images, text, and graphic primitives (shapes such as circles, points, lines, paths, rectangles, etc).</p>
+				<p>A document containing graphic representations with user-navigable parts. Charts, maps, diagrams, blueprints, and dashboards are examples of graphical documents. A graphical document is composed using any combination of symbols, images, text, and graphic primitives (shapes such as circles, points, lines, paths, rectangles, etc).</p>
 			</dd>
 			<dt><dfn data-dfn-for="element" data-export="">Hidden</dfn></dt>
 			<dd>
-			  <p>Indicates that the <a>element</a> is excluded from the accessibility tree and therefore not exposed to accessibility APIs.</p>
-			  <p>Related: <a href="#tree_exclusion">Excluding Elements in the Accessibility Tree</a>, [=element/hidden from all users=], <sref>aria-hidden</sref>.</p>
+				<p>Indicates that the <a>element</a> is excluded from the accessibility tree and therefore not exposed to accessibility APIs.</p>
+				<p>Related: <a href="#tree_exclusion">Excluding Elements in the Accessibility Tree</a>, [=element/hidden from all users=], <sref>aria-hidden</sref>.</p>
 			<dt><dfn data-dfn-for="element" data-lt="hide from all users" data-export="">Hidden From All Users</dfn></dt>
 			<dd>
-			  <p>Indicates that the <a>element</a> is not visible, <a>perceivable</a>, or interactive for <em>any</em> user. Note that an <a>element</a> can be [=element/hidden=] but not [=element/hidden from all users=] by using <code>aria-hidden</code>.</p>
-			  <p>Related: <a href="#tree_exclusion">Excluding Elements in the Accessibility Tree</a>, [=element/hidden=], <sref>aria-hidden</sref>.<p>
+				<p>Indicates that the <a>element</a> is not visible, <a>perceivable</a>, or interactive for <em>any</em> user. Note that an <a>element</a> can be [=element/hidden=] but not [=element/hidden from all users=] by using <code>aria-hidden</code>.</p>
+				<p>Related: <a href="#tree_exclusion">Excluding Elements in the Accessibility Tree</a>, [=element/hidden=], <sref>aria-hidden</sref>.<p>
 			</dd>
 			<dt><dfn>Identifies</dfn></dt>
 			<dd>
-			  <p>Used in an attribute description to denote that the value <a href="#propcharacteristic_value">type</a> is an <a href="#valuetype_idref">ID reference</a> (identifying a single element) or <a href="#valuetype_idref_list">ID reference list</a> (identifying one or more elements).</p>
-			  <p>Related Terms: <a>Defines</a>, <a>Indicates</a></p>
+				<p>Used in an attribute description to denote that the value <a href="#propcharacteristic_value">type</a> is an <a href="#valuetype_idref">ID reference</a> (identifying a single element) or <a href="#valuetype_idref_list">ID reference list</a> (identifying one or more elements).</p>
+				<p>Related Terms: <a>Defines</a>, <a>Indicates</a></p>
 			</dd>
 			<dt><dfn>Indicates</dfn></dt>
 			<dd>
-			  <p>Used in an attribute description to denote that the value <a href="#propcharacteristic_value">type</a> is a named token or otherwise token-like, including the Boolean-like <a href="#valuetype_true-false">true/false</a>, <a href="#valuetype_true-false-undefined">true/false/undefined</a>, <a href="#valuetype_tristate">tristate (true/false/mixed)</a>, a single named <a href="#valuetype_token">token</a>, or a <a href="#valuetype_token_list">token list</a>.</p>
-			  <p>Related Terms: <a>Defines</a>, <a>Identifies</a></p>
+				<p>Used in an attribute description to denote that the value <a href="#propcharacteristic_value">type</a> is a named token or otherwise token-like, including the Boolean-like <a href="#valuetype_true-false">true/false</a>, <a href="#valuetype_true-false-undefined">true/false/undefined</a>, <a href="#valuetype_tristate">tristate (true/false/mixed)</a>, a single named <a href="#valuetype_token">token</a>, or a <a href="#valuetype_token_list">token list</a>.</p>
+				<p>Related Terms: <a>Defines</a>, <a>Identifies</a></p>
 			</dd>
 			<dt><dfn>Keyboard Accessible</dfn></dt>
 			<dd>
@@ -350,15 +350,15 @@
 			</dd>
 			<dt><dfn>Landmark</dfn></dt>
 			<dd>
-			  <p>A type of region on a page to which the user might want quick access. Content in such a region is different from that of other regions on the page and relevant to a specific user purpose, such as navigating, searching, perusing the primary content, etc.</p>
+				<p>A type of region on a page to which the user might want quick access. Content in such a region is different from that of other regions on the page and relevant to a specific user purpose, such as navigating, searching, perusing the primary content, etc.</p>
 			</dd>
 			<dt><dfn data-export="">Live Region</dfn></dt>
 			<dd>
-			  <p>Live regions are perceivable regions of a web page that are typically updated as a result of an external event. These regions are not always updated as a result of a user interaction and can receive these updates even when they do not have focus. Examples of live regions include a chat log, stock ticker, or a sport scoring section that updates periodically to reflect game statistics. Since these asynchronous areas are expected to update outside the user's area of focus, assistive technologies such as screen readers have either been unaware of their existence or unable to process them for the user. WAI-ARIA has provided a collection of properties that allow the author to identify these live regions and process them: aria-live, aria-relevant, aria-atomic, and aria-busy.</p>
+				<p>Live regions are perceivable regions of a web page that are typically updated as a result of an external event. These regions are not always updated as a result of a user interaction and can receive these updates even when they do not have focus. Examples of live regions include a chat log, stock ticker, or a sport scoring section that updates periodically to reflect game statistics. Since these asynchronous areas are expected to update outside the user's area of focus, assistive technologies such as screen readers have either been unaware of their existence or unable to process them for the user. WAI-ARIA has provided a collection of properties that allow the author to identify these live regions and process them: aria-live, aria-relevant, aria-atomic, and aria-busy.</p>
 			</dd>
 			<dt><dfn data-export="">Managed State</dfn></dt>
 			<dd>
-			  <p><a>Accessibility API</a> <a>state</a> that is controlled by the user agent, such as focus and selection. These are contrasted with &quot;unmanaged states&quot; that are typically controlled by the author. Nevertheless, authors can override some managed states, such as aria-posinset and aria-setsize. Many managed states have corresponding CSS pseudo-classes, such as :focus, and pseudo-elements, such as ::selection, that are also updated by the user agent.</p>
+				<p><a>Accessibility API</a> <a>state</a> that is controlled by the user agent, such as focus and selection. These are contrasted with &quot;unmanaged states&quot; that are typically controlled by the author. Nevertheless, authors can override some managed states, such as aria-posinset and aria-setsize. Many managed states have corresponding CSS pseudo-classes, such as :focus, and pseudo-elements, such as ::selection, that are also updated by the user agent.</p>
 			</dd>
 			<dt><dfn>Nemeth Braille</dfn></dt>
 			<dd>
@@ -366,43 +366,43 @@
 			</dd>
 			<dt><dfn>Object</dfn></dt>
 			<dd>
-			  <p>In the context of user interfaces,  an item in the   perceptual user experience, represented in markup languages by one or   more [=elements=], and rendered by [=user agents=].</p>
+				<p>In the context of user interfaces,  an item in the   perceptual user experience, represented in markup languages by one or   more [=elements=], and rendered by [=user agents=].</p>
 			In the context of programming, the instantiation of one or more classes and interfaces which define the general characteristics of similar objects. An object in an <a>accessibility <abbr title="Application Programming Interfaces">API</abbr></a> can represent one or more DOM objects. <a class="termref">Accessibility APIs</a> have defined interfaces that are distinct from DOM interfaces.</dd>
 			<dt><dfn>Ontology</dfn></dt>
 			<dd>
-			  <p>A description of the characteristics of classes and how they relate to each other.</p>
+				<p>A description of the characteristics of classes and how they relate to each other.</p>
 			</dd>
 			<dt><dfn>Operable</dfn></dt>
 			<dd>
-			  <p>Usable by users in ways they can control. References in this document relate to <cite><a href="https://www.w3.org/TR/WCAG21/#operable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.1 Principle 2: Content must be operable</a></cite> [[WCAG21]]. See <a>Keyboard Accessible</a>.</p>
+				<p>Usable by users in ways they can control. References in this document relate to <cite><a href="https://www.w3.org/TR/WCAG21/#operable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.1 Principle 2: Content must be operable</a></cite> [[WCAG21]]. See <a>Keyboard Accessible</a>.</p>
 			</dd>
 			<dt><dfn data-export="">Perceivable</dfn></dt>
 			<dd>
-			  <p>Presentable to users in ways they can sense. References in this document relate to <cite><a href="https://www.w3.org/TR/WCAG21/#perceivable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.1 Principle 1: Content must be perceivable</a></cite> [[WCAG21]].</p>
+				<p>Presentable to users in ways they can sense. References in this document relate to <cite><a href="https://www.w3.org/TR/WCAG21/#perceivable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.1 Principle 1: Content must be perceivable</a></cite> [[WCAG21]].</p>
 			</dd>
 			<dt><dfn data-export="" data-dfn-for="ARIA">Property</dfn></dt>
 			<dd>
-			  <p>[=attributes=] that are essential to the nature of a given <a>object</a>, or that represent a data value associated with the object. A change of a property can significantly impact the meaning or presentation of an object. Certain properties (for example, <pref>aria-multiline</pref>) are less likely to change than <a class="termref" href="#dfn-state">states</a>, but note that the frequency of change difference is not a rule. A few properties, such as <pref>aria-activedescendant</pref>, <pref>aria-valuenow</pref>, and <pref>aria-valuetext</pref> are expected to change often. See <a class="specref" href="#statevsprop">clarification of states versus properties</a>.</p>
+				<p>[=attributes=] that are essential to the nature of a given <a>object</a>, or that represent a data value associated with the object. A change of a property can significantly impact the meaning or presentation of an object. Certain properties (for example, <pref>aria-multiline</pref>) are less likely to change than <a class="termref" href="#dfn-state">states</a>, but note that the frequency of change difference is not a rule. A few properties, such as <pref>aria-activedescendant</pref>, <pref>aria-valuenow</pref>, and <pref>aria-valuetext</pref> are expected to change often. See <a class="specref" href="#statevsprop">clarification of states versus properties</a>.</p>
 			</dd>
 			<dt><dfn data-export="">Relationship</dfn></dt>
 			<dd>
-			  <p>A connection between two distinct things. Relationships can be of various types to indicate which <a>object</a> labels another, controls another, etc.</p>
+				<p>A connection between two distinct things. Relationships can be of various types to indicate which <a>object</a> labels another, controls another, etc.</p>
 			</dd>
 			<dt><dfn data-export="">Role</dfn></dt>
 			<dd>
-			  <p>Main indicator of type. <!-- (removing, vague) The object's role is the class of <a class="termref">objects</a> of which it is a member. --> This <a class="termref" data-lt="semantics">semantic</a> association allows tools to present and support interaction with the object in a manner that is consistent with user expectations about other objects of that type.</p>
+				<p>Main indicator of type. <!-- (removing, vague) The object's role is the class of <a class="termref">objects</a> of which it is a member. --> This <a class="termref" data-lt="semantics">semantic</a> association allows tools to present and support interaction with the object in a manner that is consistent with user expectations about other objects of that type.</p>
 			</dd>
 			<dt><dfn data-export="" data-local-lt="semantically">Semantics</dfn></dt>
 			<dd>
-			  <p>The meaning of something as understood by a human, defined in a way that computers can process a representation of an <a>object</a>, such as [=elements=] and [=attributes=], and reliably represent the object in a way that various humans will achieve a mutually consistent understanding of the object.</p>
+				<p>The meaning of something as understood by a human, defined in a way that computers can process a representation of an <a>object</a>, such as [=elements=] and [=attributes=], and reliably represent the object in a way that various humans will achieve a mutually consistent understanding of the object.</p>
 			</dd>
 			<dt><dfn data-export="">State</dfn></dt>
 			<dd>
-			  <p>A state is a dynamic <a class="termref" href="#dfn-property">property</a> expressing characteristics of an <a>object</a> that can change in response to user action or automated processes. States do not affect the essential nature of the object, but represent data associated with the object or user interaction possibilities. See <a class="specref" href="#statevsprop">clarification of states versus properties</a>.</p>
+				<p>A state is a dynamic <a class="termref" href="#dfn-property">property</a> expressing characteristics of an <a>object</a> that can change in response to user action or automated processes. States do not affect the essential nature of the object, but represent data associated with the object or user interaction possibilities. See <a class="specref" href="#statevsprop">clarification of states versus properties</a>.</p>
 			</dd>
 			<dt><dfn>Target Element</dfn></dt>
 			<dd>
-			  <p>An element specified in a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> relation. For example, in <code> &lt;div aria-controls=”elem1”&gt;</code>, where <code>“elem1”</code> is the ID for the target element.</p>
+				<p>An element specified in a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> relation. For example, in <code> &lt;div aria-controls=”elem1”&gt;</code>, where <code>“elem1”</code> is the ID for the target element.</p>
 			</dd>
 			<dt><dfn data-lt="unicode braille">Unicode Braille Patterns</dfn></dt>
 			<dd>
@@ -410,7 +410,7 @@
 			</dd>
 			<dt><dfn data-export="">Widget</dfn></dt>
 			<dd>
-			  <p>Discrete user interface <a class="termref" href="#dfn-object">object</a> with which the user can interact. Widgets range from simple objects that have one value or operation (e.g., check boxes and menu items), to complex objects that contain many managed sub-objects (e.g., trees and grids).</p>
+				<p>Discrete user interface <a class="termref" href="#dfn-object">object</a> with which the user can interact. Widgets range from simple objects that have one value or operation (e.g., check boxes and menu items), to complex objects that contain many managed sub-objects (e.g., trees and grids).</p>
 			</dd>
 		</dl>
 	</div>
@@ -474,74 +474,74 @@
 [aria-checked=&quot;true&quot;]::before { background-image: url(checked.gif); }</pre>
 		<p>If CSS is not used to toggle the visual representation of the check mark, the author could include additional markup and scripts to manage an image that represents whether or not the <rref>menuitemcheckbox</rref> is checked.</p>
 		<pre class="example highlight">&lt;li role=&quot;menuitemcheckbox&quot; aria-checked=&quot;true&quot;&gt;
-  &lt;img src=&quot;checked.gif&quot; alt=&quot;&quot;&gt;
-  <span class="comment">&lt;!-- note: additional scripts required to toggle image source --&gt;</span>
-  Sort by Last Modified
+	&lt;img src=&quot;checked.gif&quot; alt=&quot;&quot;&gt;
+	<span class="comment">&lt;!-- note: additional scripts required to toggle image source --&gt;</span>
+	Sort by Last Modified
 &lt;/li&gt;</pre>
 	</section>
 	<section id="managingfocus" class="normative">
-	  <h2>Managing Focus and Supporting Keyboard Navigation</h2>
-	  <p>When using standard <abbr title="Hypertext Markup Language">HTML</abbr> interactive elements and simple <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>widgets</a>, application developers can manipulate the tab order or associate keyboard shortcuts with elements in the document.</p>
-	  <p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> includes a number of &quot;managing container&quot; widgets, also known as &quot;composite&quot; widgets. When appropriate, the container is responsible for tracking the last descendant that was active (the default is usually the first item in the container). It is essential that a container maintain a usable and consistent strategy when focus leaves a container and is then later refocused. While there can be exceptions, it is recommended that when a previously focused container is refocused, the active descendant be the same element as the active descendant when the container was last focused. Exceptions include cases where the contents of a container widget have changed, and widgets like a menubar where the user expects to always return to the first item when focus leaves the menu bar. For example, if the second item of a tree group was the active descendant when the user tabbed out of the tree group, then the second item of the tree group remains the active descendant when the tree group gets focus again. The user can also activate the container by clicking on one of the descendants within it. When the container or its active descendant has focus, the user can navigate through the container by pressing additional keys, such as the arrow keys, to change the currently active descendant. Any additional press of the main navigation key (generally the <kbd>TAB</kbd> key) will move out of the container to the next widget.</p>
-	  <p>Usable keyboard navigation in a rich internet application is different from the tabbing paradigm among interactive elements, such as links and form controls, in a static document. In rich internet applications, the user tabs to significantly complex <a class="termref">widgets</a>, such as a menu or spreadsheet, and uses the arrow keys to navigate within the widget. The changes that <abbr title="accessible rich internet applications">WAI-ARIA</abbr> introduces to keyboard navigation make this enhanced accessibility possible. In <abbr title="accessible rich internet applications">WAI-ARIA</abbr>, any element can be keyboard focusable. In addition to host language mechanisms such as <code>tabindex</code>, <pref>aria-activedescendant</pref> provides another mechanism for keyboard operation. Most other aspects of <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> widget development depend on keyboard navigation functioning properly.</p>
-          <p>
-            When implementing <pref>aria-activedescendant</pref> as described below, the user agent keeps the <abbr title="Document Object Model">DOM</abbr> focus on the container element or on an input element that controls the container element.
-            However, the user agent communicates <a>desktop focus events</a> and states to the assistive technology as if the element referenced by <pref>aria-activedescendant</pref> has focus.
-            User agents are not expected to validate that the active descendant is a descendant of the container element.
-            It is the responsibility of the user agent to ensure that keyboard events are processed at the <a>element</a> that has <abbr title="Document Object Model">DOM</abbr> focus.
-            Any keyboard events directed at the active descendant bubble up to the <abbr title="Document Object Model">DOM</abbr> element with focus for processing.
-          </p>
-	  <section id="managingfocus_authors">
-	    <h3>Information for Authors</h3>
-	    <p>If the author removes the element with focus, the author SHOULD move focus to a logical element. Similarly, authors SHOULD not scroll the element with focus off screen unless the user performed a scrolling action.</p>
-	    <p>Authors SHOULD ensure that all interactive [=elements=] are focusable and that all parts of composite widgets are either focusable or have a documented alternative method to achieve their function.</p>
-	    <p>Authors MUST manage focus on the following container roles:</p>
-	    <ul>
-	      <li><rref>grid</rref></li>
-	      <li><rref>listbox</rref></li>
-	      <li><rref>menu</rref></li>
-	      <li><rref>menubar</rref></li>
-	      <li><rref>radiogroup</rref></li>
-	      <li><rref>tree</rref></li>
-	      <li><rref>treegrid</rref></li>
-	      <li><rref>tablist</rref></li>
-	    </ul>
-	    <p>User agents that support <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> expand the usage of host language mechanisms such as <code>tabindex</code>, <code>focus</code>, and <code>blur</code> to allow them on all [=elements=]. Where the host language supports it, authors MAY add any element such as a <code>div</code>, <code>span</code>, or <code>img</code> to the default tab order by setting <code>tabindex=&quot;0&quot;</code>. In addition, any item with <code>tabindex</code> equal to a negative integer is focusable via script or a mouse click, but is not part of the default tab order. This is supported in both [[HTML]] and [[SVG2]].</p>
-	    <p>Authors MAY use <pref>aria-activedescendant</pref> to inform <a>assistive technologies</a> which descendant of a <rref>widget</rref> element is treated as having keyboard focus in the user interface if the role of the widget element supports <code>aria-activedescendant</code>.
-        This is often a more convenient way of providing keyboard navigation within widgets, such as a <rref>listbox</rref>, where the widget occupies only one stop in the page <kbd>Tab</kbd> sequence and other keys, typically arrow keys, are used to focus elements inside the widget.</p>
-	    <p>Typically, the author will use host language <a>semantics</a> to put the widget in the <kbd>Tab</kbd> sequence (e.g., <code>tabindex="0"</code> in HTML) and <code>aria-activedescendant</code> to point to the ID of the currently active descendant. The author, not the user agent, is responsible for styling the currently active descendant to show it has keyboard focus. The author cannot use <code>:<span class="css-selector">focus</span></code> to style the currently active descendant since the actual focus is on the container.</p>
-	    <p>More information on managing focus can be found in the <a href="practices/keyboard-interface" class="practices">Developing a Keyboard Interface</a> section of the <cite><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</cite>.</p>
-	  </section>
-	  <section id="managingfocus_useragents">
-	    <h3>Information for User Agents</h3>
-	    <p>The user agent MUST do the following to implement <pref>aria-activedescendant</pref>:</p>
-	    <ol>
-	      <li>Implement the host language method for keyboard navigation so that widgets that support <code>aria-activedescendant</code> can be included in the tab order.</li>
-	      <li>For platforms that expose <a>desktop focus</a> or <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> focus separately from <abbr title="Document Object Model">DOM</abbr> focus, do not expose the focused state in the accessibility <abbr title="application programming interface">API</abbr> for any element when it has <abbr title="Document Object Model">DOM</abbr> focus and also has <pref>aria-activedescendant</pref> which points to a valid <a href="#valuetype_idref">ID reference</a>.</li>
-	      <li>When the <pref>aria-activedescendant</pref> attribute changes on an element that currently has <abbr title="Document Object Model">DOM</abbr> focus, remove the focused state from the previously focused object and fire an accessibility <abbr title="application programming interface">API</abbr> <a>desktop focus event</a> on the new element referenced by <code>aria-activedescendant</code>. If <pref>aria-activedescendant</pref> is cleared or does not point to an element in the current document, fire a desktop focus event for the <a>object</a> that had the attribute change.</li>
-	      <li>Apply the following accessibility <abbr title="Application Programming Interface">API</abbr> states to any element with an ID attribute that can be referenced by an element with both an <pref>aria-activedescendant</pref> attribute and has <abbr title="Document Object Model">DOM</abbr> focus. There are two ways an element can be referenced by <pref>aria-activedescendant</pref>. One way is when it is an <a>accessibility descendant</a> of the element with <pref>aria-activedescendant</pref> and the other is when it is an <a>accessibility descendant</a> of an element that is controlled by an element with role of <rref>combobox</rref>, <rref>textbox</rref> or <rref>searchbox</rref> with an <pref>aria-activedescendant</pref> attribute:
+		<h2>Managing Focus and Supporting Keyboard Navigation</h2>
+		<p>When using standard <abbr title="Hypertext Markup Language">HTML</abbr> interactive elements and simple <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>widgets</a>, application developers can manipulate the tab order or associate keyboard shortcuts with elements in the document.</p>
+		<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> includes a number of &quot;managing container&quot; widgets, also known as &quot;composite&quot; widgets. When appropriate, the container is responsible for tracking the last descendant that was active (the default is usually the first item in the container). It is essential that a container maintain a usable and consistent strategy when focus leaves a container and is then later refocused. While there can be exceptions, it is recommended that when a previously focused container is refocused, the active descendant be the same element as the active descendant when the container was last focused. Exceptions include cases where the contents of a container widget have changed, and widgets like a menubar where the user expects to always return to the first item when focus leaves the menu bar. For example, if the second item of a tree group was the active descendant when the user tabbed out of the tree group, then the second item of the tree group remains the active descendant when the tree group gets focus again. The user can also activate the container by clicking on one of the descendants within it. When the container or its active descendant has focus, the user can navigate through the container by pressing additional keys, such as the arrow keys, to change the currently active descendant. Any additional press of the main navigation key (generally the <kbd>TAB</kbd> key) will move out of the container to the next widget.</p>
+		<p>Usable keyboard navigation in a rich internet application is different from the tabbing paradigm among interactive elements, such as links and form controls, in a static document. In rich internet applications, the user tabs to significantly complex <a class="termref">widgets</a>, such as a menu or spreadsheet, and uses the arrow keys to navigate within the widget. The changes that <abbr title="accessible rich internet applications">WAI-ARIA</abbr> introduces to keyboard navigation make this enhanced accessibility possible. In <abbr title="accessible rich internet applications">WAI-ARIA</abbr>, any element can be keyboard focusable. In addition to host language mechanisms such as <code>tabindex</code>, <pref>aria-activedescendant</pref> provides another mechanism for keyboard operation. Most other aspects of <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> widget development depend on keyboard navigation functioning properly.</p>
+					<p>
+						When implementing <pref>aria-activedescendant</pref> as described below, the user agent keeps the <abbr title="Document Object Model">DOM</abbr> focus on the container element or on an input element that controls the container element.
+						However, the user agent communicates <a>desktop focus events</a> and states to the assistive technology as if the element referenced by <pref>aria-activedescendant</pref> has focus.
+						User agents are not expected to validate that the active descendant is a descendant of the container element.
+						It is the responsibility of the user agent to ensure that keyboard events are processed at the <a>element</a> that has <abbr title="Document Object Model">DOM</abbr> focus.
+						Any keyboard events directed at the active descendant bubble up to the <abbr title="Document Object Model">DOM</abbr> element with focus for processing.
+					</p>
+		<section id="managingfocus_authors">
+			<h3>Information for Authors</h3>
+			<p>If the author removes the element with focus, the author SHOULD move focus to a logical element. Similarly, authors SHOULD not scroll the element with focus off screen unless the user performed a scrolling action.</p>
+			<p>Authors SHOULD ensure that all interactive [=elements=] are focusable and that all parts of composite widgets are either focusable or have a documented alternative method to achieve their function.</p>
+			<p>Authors MUST manage focus on the following container roles:</p>
+			<ul>
+				<li><rref>grid</rref></li>
+				<li><rref>listbox</rref></li>
+				<li><rref>menu</rref></li>
+				<li><rref>menubar</rref></li>
+				<li><rref>radiogroup</rref></li>
+				<li><rref>tree</rref></li>
+				<li><rref>treegrid</rref></li>
+				<li><rref>tablist</rref></li>
+			</ul>
+			<p>User agents that support <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> expand the usage of host language mechanisms such as <code>tabindex</code>, <code>focus</code>, and <code>blur</code> to allow them on all [=elements=]. Where the host language supports it, authors MAY add any element such as a <code>div</code>, <code>span</code>, or <code>img</code> to the default tab order by setting <code>tabindex=&quot;0&quot;</code>. In addition, any item with <code>tabindex</code> equal to a negative integer is focusable via script or a mouse click, but is not part of the default tab order. This is supported in both [[HTML]] and [[SVG2]].</p>
+			<p>Authors MAY use <pref>aria-activedescendant</pref> to inform <a>assistive technologies</a> which descendant of a <rref>widget</rref> element is treated as having keyboard focus in the user interface if the role of the widget element supports <code>aria-activedescendant</code>.
+				This is often a more convenient way of providing keyboard navigation within widgets, such as a <rref>listbox</rref>, where the widget occupies only one stop in the page <kbd>Tab</kbd> sequence and other keys, typically arrow keys, are used to focus elements inside the widget.</p>
+			<p>Typically, the author will use host language <a>semantics</a> to put the widget in the <kbd>Tab</kbd> sequence (e.g., <code>tabindex="0"</code> in HTML) and <code>aria-activedescendant</code> to point to the ID of the currently active descendant. The author, not the user agent, is responsible for styling the currently active descendant to show it has keyboard focus. The author cannot use <code>:<span class="css-selector">focus</span></code> to style the currently active descendant since the actual focus is on the container.</p>
+			<p>More information on managing focus can be found in the <a href="practices/keyboard-interface" class="practices">Developing a Keyboard Interface</a> section of the <cite><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</cite>.</p>
+		</section>
+		<section id="managingfocus_useragents">
+			<h3>Information for User Agents</h3>
+			<p>The user agent MUST do the following to implement <pref>aria-activedescendant</pref>:</p>
+			<ol>
+				<li>Implement the host language method for keyboard navigation so that widgets that support <code>aria-activedescendant</code> can be included in the tab order.</li>
+				<li>For platforms that expose <a>desktop focus</a> or <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> focus separately from <abbr title="Document Object Model">DOM</abbr> focus, do not expose the focused state in the accessibility <abbr title="application programming interface">API</abbr> for any element when it has <abbr title="Document Object Model">DOM</abbr> focus and also has <pref>aria-activedescendant</pref> which points to a valid <a href="#valuetype_idref">ID reference</a>.</li>
+				<li>When the <pref>aria-activedescendant</pref> attribute changes on an element that currently has <abbr title="Document Object Model">DOM</abbr> focus, remove the focused state from the previously focused object and fire an accessibility <abbr title="application programming interface">API</abbr> <a>desktop focus event</a> on the new element referenced by <code>aria-activedescendant</code>. If <pref>aria-activedescendant</pref> is cleared or does not point to an element in the current document, fire a desktop focus event for the <a>object</a> that had the attribute change.</li>
+				<li>Apply the following accessibility <abbr title="Application Programming Interface">API</abbr> states to any element with an ID attribute that can be referenced by an element with both an <pref>aria-activedescendant</pref> attribute and has <abbr title="Document Object Model">DOM</abbr> focus. There are two ways an element can be referenced by <pref>aria-activedescendant</pref>. One way is when it is an <a>accessibility descendant</a> of the element with <pref>aria-activedescendant</pref> and the other is when it is an <a>accessibility descendant</a> of an element that is controlled by an element with role of <rref>combobox</rref>, <rref>textbox</rref> or <rref>searchbox</rref> with an <pref>aria-activedescendant</pref> attribute:
 		<ol>
-		  <li>Focusable, if the element also has a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref">role</a>. The element needs to be focusable because it could be referenced by the <pref>aria-activedescendant</pref> attribute. Native elements that have no <a class="termref">role</a> attribute do not need to be checked; their native semantics determine the focusable state.</li>
-		  <li>Focused, whenever the element is the target of the <pref>aria-activedescendant</pref> attribute and the element with the <pref>aria-activedescendant</pref> attribute has <abbr title="Document Object Model">DOM</abbr> focus.</li>
+			<li>Focusable, if the element also has a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref">role</a>. The element needs to be focusable because it could be referenced by the <pref>aria-activedescendant</pref> attribute. Native elements that have no <a class="termref">role</a> attribute do not need to be checked; their native semantics determine the focusable state.</li>
+			<li>Focused, whenever the element is the target of the <pref>aria-activedescendant</pref> attribute and the element with the <pref>aria-activedescendant</pref> attribute has <abbr title="Document Object Model">DOM</abbr> focus.</li>
 		</ol>
-	      </li>
-	    </ol>
-	    <p>When an assistive technology uses its platform's accessibility <abbr title="Application Programming Interfaces">API</abbr> to request a change of focus, user agents MUST do the following:</p>
-	    <ol>
-	      <li>Remove the platform's focused state from the previously focused object.</li>
-	      <li>Set the <abbr title="Document Object Model">DOM</abbr> focus:
+				</li>
+			</ol>
+			<p>When an assistive technology uses its platform's accessibility <abbr title="Application Programming Interfaces">API</abbr> to request a change of focus, user agents MUST do the following:</p>
+			<ol>
+				<li>Remove the platform's focused state from the previously focused object.</li>
+				<li>Set the <abbr title="Document Object Model">DOM</abbr> focus:
 		<ol>
-		  <li>If the <a class="termref">element</a> can take <abbr title="Document Object Model">DOM</abbr> focus, the <a class="termref">user agent</a> MUST set the <abbr title="Document Object Model">DOM</abbr> focus to it.</li>
-		  <li>Otherwise, if the element being focused has an ID and the ID is referenced by the <pref>aria-activedescendant</pref> attribute of an element that is focusable, the user agent MUST set <abbr title="Document Object Model">DOM</abbr> focus to the element that has the <pref>aria-activedescendant</pref> attribute.
-		  	<p class="note">An element with an ID can be referenced when it is an <a>accessibility descendant</a> of a container element that has the <pref>aria-activedescendant</pref> attribute or by a container element that is controlled by an element that has the <pref>aria-activedescendant</pref> attribute  (e.g. see <rref>combobox</rref>).  Otherwise the <pref>aria-activedescendant</pref> attribute reference indicates an author error.</p>
-		    <p class="note">The inability to set <abbr title="Document Object Model">DOM</abbr> focus to the containing element indicates an author error.</p>
-		  </li>
-		  <li>Otherwise, the user agent MAY attempt to set <abbr title="Document Object Model">DOM</abbr> focus to the child element itself.</li>
+			<li>If the <a class="termref">element</a> can take <abbr title="Document Object Model">DOM</abbr> focus, the <a class="termref">user agent</a> MUST set the <abbr title="Document Object Model">DOM</abbr> focus to it.</li>
+			<li>Otherwise, if the element being focused has an ID and the ID is referenced by the <pref>aria-activedescendant</pref> attribute of an element that is focusable, the user agent MUST set <abbr title="Document Object Model">DOM</abbr> focus to the element that has the <pref>aria-activedescendant</pref> attribute.
+				<p class="note">An element with an ID can be referenced when it is an <a>accessibility descendant</a> of a container element that has the <pref>aria-activedescendant</pref> attribute or by a container element that is controlled by an element that has the <pref>aria-activedescendant</pref> attribute  (e.g. see <rref>combobox</rref>).  Otherwise the <pref>aria-activedescendant</pref> attribute reference indicates an author error.</p>
+				<p class="note">The inability to set <abbr title="Document Object Model">DOM</abbr> focus to the containing element indicates an author error.</p>
+			</li>
+			<li>Otherwise, the user agent MAY attempt to set <abbr title="Document Object Model">DOM</abbr> focus to the child element itself.</li>
 		</ol>
-	      </li>
-	      <li>If the element being focused has an ID and is an <a>accessibility descendant</a> of either a container element with both an <code>aria-activedescendant</code> attribute and has <abbr title="Document Object Model">DOM</abbr> focus, or by a container element that is controlled by an element with both an <pref>aria-activedescendant</pref> attribute and has <abbr title="Document Object Model">DOM</abbr> focus, the user agent MUST set the accessibility <abbr title="Application Programming Interface">API</abbr> focused state and fire an accessibility <abbr title="Application Programming Interface">API</abbr> focus <a>event</a> on the element identified  by the value of <code>aria-activedescendant</code>.</li>
-	    </ol>
-	  </section>
+				</li>
+				<li>If the element being focused has an ID and is an <a>accessibility descendant</a> of either a container element with both an <code>aria-activedescendant</code> attribute and has <abbr title="Document Object Model">DOM</abbr> focus, or by a container element that is controlled by an element with both an <pref>aria-activedescendant</pref> attribute and has <abbr title="Document Object Model">DOM</abbr> focus, the user agent MUST set the accessibility <abbr title="Application Programming Interface">API</abbr> focused state and fire an accessibility <abbr title="Application Programming Interface">API</abbr> focus <a>event</a> on the element identified  by the value of <code>aria-activedescendant</code>.</li>
+			</ol>
+		</section>
 	</section>
 </section>
 <section class="normative" id="roles">
@@ -663,7 +663,7 @@
 					<ol>
 						<li>author: name comes from values provided by the author in explicit markup features such as the <pref>aria-label</pref> attribute, the <pref>aria-labelledby</pref> attribute, or the host language labeling mechanism, such as the <code>alt</code> or <code>title</code> attributes in HTML, with HTML <code>title</code> attribute having the lowest precedence for specifying a text alternative.</li>
 						<li>contents: name comes from the text value of the <a>element</a> node. Although this might be allowed in addition to "author" in some <a>roles</a>, this is used in content only if higher priority "author" features are not provided. Priority is defined by the <a href="#mapping_additional_nd_te" class="accname">accessible name and description computation</a> algorithm [[ACCNAME-1.2]].</li>
-            <li>prohibited: the element does not support name from author. Authors MUST NOT use the <pref>aria-label</pref> or <pref>aria-labelledby</pref> attributes to name the element.</li>
+						<li>prohibited: the element does not support name from author. Authors MUST NOT use the <pref>aria-label</pref> or <pref>aria-labelledby</pref> attributes to name the element.</li>
 					</ol>
 				</dd>
 			</dl>
@@ -679,21 +679,21 @@
 				<h4>Accessible Name and Description Computation</h4>
 				<p><a href="#mapping_additional_nd_te" class="accname">Accessible Name and Description Computation</a> is defined in the Accessible Name and Description specification.</p>
 			</section>
-            <section id="namefromauthor">
-                <h4>Roles Supporting Name from Author</h4>
-                <div id="index_fromauthor">
-                </div>
+						<section id="namefromauthor">
+								<h4>Roles Supporting Name from Author</h4>
+								<div id="index_fromauthor">
+								</div>
 			</section>
-            <section id="namefromcontent">
-                <h4>Roles Supporting Name from Content</h4>
-                <div id="index_fromcontent">
-                </div>
+						<section id="namefromcontent">
+								<h4>Roles Supporting Name from Content</h4>
+								<div id="index_fromcontent">
+								</div>
 			</section>
 			<section id="namefromprohibited">
-                <h4>Roles which cannot be named (Name prohibited)</h4>
-                <div id="index_fromprohibited">
-                </div>
-            </section>
+								<h4>Roles which cannot be named (Name prohibited)</h4>
+								<div id="index_fromprohibited">
+								</div>
+						</section>
 		</section>
 		<section id="childrenArePresentational">
 			<h3>Presentational Children</h3>
@@ -756,8 +756,8 @@
 				<li><rref>menuitemradio</rref></li>
 				<li><rref>option</rref></li>
 <!-- FIXME: This is commented out because the ARIA Working Group agreed to move the password role to ARIA 2.0,
-     but we've not branched for 1.1 yet. Once we have branched, this section should be deleted from the 1.1
-     branch and uncommented for the master branch (pending discussion and consensus).
+		 but we've not branched for 1.1 yet. Once we have branched, this section should be deleted from the 1.1
+		 branch and uncommented for the master branch (pending discussion and consensus).
 				<li><rref>password</rref></li>
 -->
 				<li><rref>progressbar</rref></li>
@@ -832,8 +832,8 @@
 				<li><rref>time</rref></li>
 
 <!-- FIXME: This is commented out because the ARIA Working Group agreed to move the text role to ARIA 2.0,
-     but we've not branched for 1.1 yet. Once we have branched, this entire section should be deleted from
-     the 1.1 branch and uncommented for the master branch.
+		 but we've not branched for 1.1 yet. Once we have branched, this entire section should be deleted from
+		 the 1.1 branch and uncommented for the master branch.
 				<li><rref>text</rref></li>
 -->
 				<li><rref>toolbar</rref></li>
@@ -1238,8 +1238,8 @@
 				<p>A <rref>landmark</rref> that contains mostly site-oriented content, rather than page-specific content.</p>
 				<p>Site-oriented content typically includes things such as the logo or identity of the site sponsor, and a site-specific search tool. A banner usually appears at the top of the page and typically spans the full width.</p>
 				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>banner</code>.
-  				[=user agents=] SHOULD treat elements with role <code>banner</code> as navigational <a>landmarks</a>.
-  				[=user agents=] MAY enable users to quickly navigate to elements with role <code>banner</code>.</p>
+					[=user agents=] SHOULD treat elements with role <code>banner</code> as navigational <a>landmarks</a>.
+					[=user agents=] MAY enable users to quickly navigate to elements with role <code>banner</code>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #main and #contentinfo-->
 				<p>The author SHOULD mark no more than one <a>element</a> on a page with the <code>banner</code> <a>role</a>.</p>
 				<p class="note">Because <code>document</code> and <code>application</code> elements can be nested in the <abbr title="Document Object Model">DOM</abbr>, they can have multiple <code>banner</code> elements as <abbr title="Document Object Model">DOM</abbr> descendants, assuming each of those is associated with different document nodes, either by a DOM nesting (e.g., <rref>document</rref> within <rref>document</rref>) or by use of the <pref>aria-owns</pref> <a>attribute</a>.</p>
@@ -1428,7 +1428,7 @@
 					<tr>
 						<th class="role-related-head" scope="row">Related Concepts:</th>
 						<td class="role-related">
-						    <rref>link</rref>
+								<rref>link</rref>
 						</td>
 					</tr>
 					<tr>
@@ -1500,55 +1500,55 @@
 
 				<pre class="example highlight">
 					&lt;div role="radiogroup" aria-labelledby="cap"&gt;
-				    &lt;div role="caption" id="cap"&gt;
-				      Choose your favorite fruit
-				    &lt;/div&gt;
-				    &lt;!-- ... --&gt;
+						&lt;div role="caption" id="cap"&gt;
+							Choose your favorite fruit
+						&lt;/div&gt;
+						&lt;!-- ... --&gt;
 				</pre>
 
 				<p>If a <code>caption</code> contains content that serves as both a name and description for its containing element, authors MAY instead specify <pref>aria-labelledby</pref> to reference an element within the <code>caption</code> that represents the "name" of the containing element, and specify <pref>aria-describedby</pref> to reference an element within the <code>caption</code> that represents the descriptive content.</p>
 
 				<pre class="example highlight">
 					&lt;div role="table" aria-labelledby="name" aria-describedby="desc"&gt;
-				    &lt;div role="caption"&gt;
-				      &lt;div id="name"&gt;Contest Entrants&lt;/div&gt;
-				      &lt;div id="desc"&gt;
-				        This table shows the total number of entrants (500) the
-				        contest accepted over the past four weeks.
-				      &lt;/div&gt;
-				    &lt;/div&gt;
-				    &lt;!-- ... --&gt;
+						&lt;div role="caption"&gt;
+							&lt;div id="name"&gt;Contest Entrants&lt;/div&gt;
+							&lt;div id="desc"&gt;
+								This table shows the total number of entrants (500) the
+								contest accepted over the past four weeks.
+							&lt;/div&gt;
+						&lt;/div&gt;
+						&lt;!-- ... --&gt;
 				</pre>
 
 				<p>If the <code>caption</code> represents a long-form description, or if the description contains semantic elements which are important in understanding the description, authors MAY instead specify <pref>aria-labelledby</pref> to reference an element within the <code>caption</code> that represents the "name" of the containing element, and specify <pref>aria-details</pref> to reference an element within the <code>caption</code> that represents the descriptive content.</p>
 
 				<pre class="example highlight">
 					&lt;div role="figure" aria-labelledby="name" aria-details="details"&gt;
-					  &lt;!-- figure content here, such as a complex data viz SVG -->
-				    &lt;div role="caption"&gt;
-				      &lt;div id="name"&gt;Sales information for 20XX&lt;/div&gt;
-				      &lt;div id="details"&gt;
-				        This barchart represents the total amount of sales over the course
-				        of five years. &lt;a href="...">Sales information for last year&lt;/a> can
-				        be reviewed, or you can overlay &lt;button aria-pressed="false">previous year&lt;/button>
-				        information in this graphic.
-				      &lt;/div&gt;
-				    &lt;/div&gt;
-				    &lt;!-- ... --&gt;
+						&lt;!-- figure content here, such as a complex data viz SVG -->
+						&lt;div role="caption"&gt;
+							&lt;div id="name"&gt;Sales information for 20XX&lt;/div&gt;
+							&lt;div id="details"&gt;
+								This barchart represents the total amount of sales over the course
+								of five years. &lt;a href="...">Sales information for last year&lt;/a> can
+								be reviewed, or you can overlay &lt;button aria-pressed="false">previous year&lt;/button>
+								information in this graphic.
+							&lt;/div&gt;
+						&lt;/div&gt;
+						&lt;!-- ... --&gt;
 				</pre>
 
 				<p>If a <code>caption</code> contains only a description, without a suitable text string to serve as the accessible name for its containing element, then <pref>aria-label</pref> or <pref>aria-labelledby</pref> MAY be used to provide an accessible name, and the <code>caption</code> MAY be treated solely as descriptive content, referenced via <pref>aria-details</pref>.
 
 				<pre class="example highlight">
 					&lt;div role="figure" aria-label="Sales information" aria-details="details"&gt;
-					  &lt;!-- figure content here, such as a complex data viz SVG -->
-				    &lt;div role="caption" id="details"&gt;
-				      This barchart represents the total amount of sales over the course
-				      of five years. &lt;a href="...">Sales information for last year&lt;/a> can
-				      be reviewed, or you can overlay &lt;button aria-pressed="false">previous year&lt;/button>
-				      information in this graphic.
-				    &lt;/div&gt;
-				    &lt;!-- ... --&gt;
+						&lt;!-- figure content here, such as a complex data viz SVG -->
+						&lt;div role="caption" id="details"&gt;
+							This barchart represents the total amount of sales over the course
+							of five years. &lt;a href="...">Sales information for last year&lt;/a> can
+							be reviewed, or you can overlay &lt;button aria-pressed="false">previous year&lt;/button>
+							information in this graphic.
+						&lt;/div&gt;
+						&lt;!-- ... --&gt;
 				</pre>
 
 			</div>
@@ -1952,7 +1952,7 @@
 				<p>Applying the <sref>aria-selected</sref> state on a columnheader MUST not cause the user agent to automatically propagate the <sref>aria-selected</sref> state to all the cells in the corresponding column. An author MAY choose to propagate selection in this manner depending on the specific application.</p>
 				<p>While the <code>columnheader</code> role can be used in both interactive grids and non-interactive tables, the use of <pref>aria-readonly</pref> and <pref>aria-required</pref> is only applicable to interactive elements. Therefore, authors SHOULD NOT use <pref>aria-required</pref> or <pref>aria-readonly</pref> in a <code>columnheader</code> that descends from a <rref>table</rref>, and user agents SHOULD NOT expose either property to <a>assistive technologies</a> unless the <code>columnheader</code> descends from a <rref>grid</rref>.</p>
 				<p class="note">Because cells are organized into rows, there is not a single container element for the column. The column is the set of <rref>gridcell</rref> elements in a particular position within their respective <rref>row</rref> containers.</p>
-                <p class="note" title="Usage of aria-disabled">While <sref>aria-disabled</sref> is currently supported on <rref>columnheader</rref>, in a future version the working group plans to prohibit its use on elements with role <rref>columnheader</rref> except when the element is in the context of a <rref>grid</rref> or <rref>treegrid</rref>.</p>
+								<p class="note" title="Usage of aria-disabled">While <sref>aria-disabled</sref> is currently supported on <rref>columnheader</rref>, in a future version the working group plans to prohibit its use on elements with role <rref>columnheader</rref> except when the element is in the context of a <rref>grid</rref> or <rref>treegrid</rref>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -2044,7 +2044,7 @@
 				<p class="ednote" title="Major Changes to combobox role in ARIA 1.2">
 					The Guidance for <rref>combobox</rref> has changed significantly in ARIA 1.2 due to problems with implementation of the previous patterns.
 					Authors and developers of User Agents, Assistive Technologies, and Conformance Checkers are advised to review this section carefully to understand the changes.
-          			Explanation of the changes is available in the <a href="https://github.com/w3c/aria/wiki/Resolving-ARIA-1.1-Combobox-Issues">ARIA repository wiki</a>.
+								Explanation of the changes is available in the <a href="https://github.com/w3c/aria/wiki/Resolving-ARIA-1.1-Combobox-Issues">ARIA repository wiki</a>.
 				</p>
 				<p>
 				A <code>combobox</code> functionally combines a named input field with the ability to assist value selection via a supplementary popup element.
@@ -2076,15 +2076,15 @@
 					<li>Otherwise, the value of the <code>combobox</code> is represented by its descendant elements and can be determined using the same method used to compute the name of a <rref>button</rref> from its descendant content.</li>
 				</ul>
 				<pre class="example highlight">
-          &lt;label id="tag_label" for="tag_combo">Tag&lt;/label>
-		      &lt;input type="text" id="tag_combo"
-            role="combobox" aria-autocomplete="list"
-            aria-haspopup="listbox" aria-expanded="true"
-            aria-controls="popup_listbox" aria-activedescendant="selected_option"&gt;
-				  &lt;ul role="listbox" id="popup_listbox" aria-labelledby="tag_label"&gt;
-			      &lt;li role="option"&gt;Zebra&lt;/li&gt;
-			      &lt;li role="option" id="selected_option"&gt;Zoom&lt;/li&gt;
-				  &lt;/ul&gt;
+					&lt;label id="tag_label" for="tag_combo">Tag&lt;/label>
+					&lt;input type="text" id="tag_combo"
+						role="combobox" aria-autocomplete="list"
+						aria-haspopup="listbox" aria-expanded="true"
+						aria-controls="popup_listbox" aria-activedescendant="selected_option"&gt;
+					&lt;ul role="listbox" id="popup_listbox" aria-labelledby="tag_label"&gt;
+						&lt;li role="option"&gt;Zebra&lt;/li&gt;
+						&lt;li role="option" id="selected_option"&gt;Zoom&lt;/li&gt;
+					&lt;/ul&gt;
 				</pre>
 				<p class="ednote" title="Validity changes combobox for ARIA 1.2">
 					Please review the following carefully. As a result of these changes a combobox following the ARIA 1.1 combobox specification will no longer conform with the ARIA specification.
@@ -2146,7 +2146,7 @@
 						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
 						<td class="role-properties">
 							<ul>
-                <li><pref>aria-activedescendant</pref></li>
+								<li><pref>aria-activedescendant</pref></li>
 								<li><pref>aria-autocomplete</pref></li>
 								<li><pref>aria-controls</pref></li>
 								<li><pref>aria-errormessage</pref></li>
@@ -2375,8 +2375,8 @@
 				<p>A <rref>landmark</rref> that is designed to be complementary to the main content that it is a sibling to, or a direct descendant of. The contents of a complementary landmark would be expected to remain meaningful if it were to be separated from the main content it is relevant to.</p>
 				<p>There are various types of content that would appropriately have this <a>role</a>. For example, in the case of a portal, this can include but not be limited to show times, current weather, related articles, or stocks to watch. If the complementary content is completely separable from the main content, it might be appropriate to use a more general role.</p>
 				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>complementary</code>.
-  				[=user agents=] SHOULD treat elements with role <code>complementary</code> as navigational <a>landmarks</a>.
-  				[=user agents=] MAY enable users to quickly navigate to elements with role <code>complementary</code>.</p>
+					[=user agents=] SHOULD treat elements with role <code>complementary</code> as navigational <a>landmarks</a>.
+					[=user agents=] MAY enable users to quickly navigate to elements with role <code>complementary</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -2532,8 +2532,8 @@
 				<p>A <rref>landmark</rref> that contains information about the parent document.</p>
 				<p>Examples of information included in this region of the page are copyrights and links to privacy statements.</p>
 				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>contentinfo</code>.
-  				[=user agents=] SHOULD treat elements with role <code>contentinfo</code> as navigational <a>landmarks</a>.
-  				[=user agents=] MAY enable users to quickly navigate to elements with role <code>contentinfo</code>.</p>
+					[=user agents=] SHOULD treat elements with role <code>contentinfo</code> as navigational <a>landmarks</a>.
+					[=user agents=] MAY enable users to quickly navigate to elements with role <code>contentinfo</code>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #banner and #main -->
 				<p>The author SHOULD mark no more than one <a>element</a> on a page with the <code>contentinfo</code> role.</p>
 				<p class="note">Because <code>document</code> and <code>application</code> elements can be nested in the <abbr title="Document Object Model">DOM</abbr>, they can have multiple <code>contentinfo</code> elements as <abbr title="Document Object Model">DOM</abbr> descendants, assuming each of those is associated with different document nodes, either by a DOM nesting (e.g., <rref>document</rref> within <rref>document</rref>) or by use of the <pref>aria-owns</pref> attribute.</p>
@@ -2611,12 +2611,12 @@
 			</table>
 		</div>
 		<div class="role" id="definition">
-      		<rdef>definition</rdef>
-      		<div class="role-description">
-        		<p>A definition of a term or concept. See related <rref>term</rref>.</p>
-        		<p>Authors MUST identify the <a>element</a> being defined and assign that element a role of <rref>term</rref>.</p>
-        		<p>Authors SHOULD NOT use the <code>definition</code> role on interactive elements such as form controls because doing so could prevent users of assistive technologies from interacting with those elements.</p>
-      		</div>
+					<rdef>definition</rdef>
+					<div class="role-description">
+						<p>A definition of a term or concept. See related <rref>term</rref>.</p>
+						<p>Authors MUST identify the <a>element</a> being defined and assign that element a role of <rref>term</rref>.</p>
+						<p>Authors SHOULD NOT use the <code>definition</code> role on interactive elements such as form controls because doing so could prevent users of assistive technologies from interacting with those elements.</p>
+					</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
 				<thead>
@@ -4102,9 +4102,9 @@
 				<p>A perceivable <rref>section</rref> containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.</p>
 				<p><code>landmark</code> is an abstract role used for the ontology. Authors MUST NOT use <code>landmark</code> role in content.</p>
 				<p>Authors designate the purpose of the content by assigning a role that is a subclass of the landmark role and, when needed, by providing a brief, descriptive label.</p>
-        		<p>Elements with a role that is a subclass of the landmark role are known as <a>landmark</a> regions or navigational landmark regions.</p>
+						<p>Elements with a role that is a subclass of the landmark role are known as <a>landmark</a> regions or navigational landmark regions.</p>
 				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to landmark regions.
-  				[=user agents=] MAY enable users to quickly navigate to landmark regions.</p>
+					[=user agents=] MAY enable users to quickly navigate to landmark regions.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -4551,6 +4551,295 @@
 				</tbody>
 			</table>
 		</div>
+		<div class="role" id="listitem">
+			<rdef>listitem</rdef>
+			<div class="role-description">
+				<p>A single item in a list or directory.</p>
+				<p>Authors MUST ensure [=elements=] whose <a>role</a> is <code>listitem</code> are <a>accessibility children</a> of an <a>element</a> whose <a>role</a> is <rref>list</rref>.</p>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent"><rref>section</rref></td>
+					</tr>
+					<tr>
+						<th class="role-children-head" scope="row">Subclass Roles:</th>
+						<td class="role-children">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"><code>&lt;[^li^]&gt;</code> in HTML</td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"> </td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Accessibility Parent Roles:</th>
+						<td class="role-scope">
+							<ul>
+								<li><rref>directory</rref></li>
+								<li><rref>list</rref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Allowed Accessibility Child Roles:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties">
+							<ul>
+								<li><pref>aria-posinset</pref></li>
+								<li><pref>aria-setsize</pref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">author</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired"> </td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational"> </td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div class="role" id="listview">
+			<rdef>listview</rdef>
+			<div class="role-description">
+				<p>A composite <rref>widget</rref> containing a collection of interactive elements that may also contain interactive elements. See related <rref>grid</rref> and <rref>treegrid</rref></p>
+				<p>A <code>listview</code> contains <rref>listviewitem</rref> elements.</p>
+				<p>Authors may use a <code>listview</code> to make a collection navigable and interactive. Elements in A listview may also be selectable, but they are not selectable by default. Authors may specify either <sref>aria-selected</sref> or <sref>aria-checked</sref> for items in a listview to indicate selection (see <rref>listviewitem</rref>).</p>
+				<p>To be <a>keyboard accessible</a>, authors SHOULD manage focus of <rref>listviewitem</rref> descendants for all instances of this <a>role</a>, as described in <a href="#managingfocus">Managing Focus</a>.</p>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent">
+							<ul>
+								<li><rref>composite</rref></li>
+								<li><rref>list</rref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-children-head" scope="row">Subclass Roles:</th>
+						<td class="role-children">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"><code>&lt;[^ul^]&gt;</code> in HTML</td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"> </td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Accessibility Parent Roles:</th>
+						<td class="role-scope"></td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Allowed Accessibility Child Roles:</th>
+						<td class="role-mustcontain"><rref>listviewitem</rref></td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties"><pref>aria-multiselectable</pref></td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">author</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired">True</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational"> </td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<div class="role" id="listviewitem">
+			<rdef>listviewitem</rdef>
+			<div class="role-description">
+				<p>An item in a <rref>listview</rref>.</p>
+				<p>A <code>listviewitem</code> is focusable and can be selectable.</p>
+				<p>
+					A <code>listviewitem</code> <a>element</a> can contain a sub-level group of elements that can be expanded or collapsed.
+					An expandable collection of <code>listviewitem</code> elements are enclosed in an element with the <rref>group</rref> <a>role</a>.
+				</p>
+				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>listviewitem</code> are <a>accessibility children</a> of an element with <a>role</a> <rref>listview</rref> or an element with <a>role</a> <rref>group</rref> that is the <a>accessibility child</a> of an element with role <rref>listviewitem</rref>.</p>
+				<p>
+					Authors MAY indicate selection for <rref>listviewitem</rref> elements  using either <sref>aria-selected</sref> or <sref>aria-checked</sref>.
+					Some user interfaces indicate selection with <sref>aria-selected</sref> in single-select listviews and with <sref>aria-checked</sref> in multi-select listviews.
+					Authors SHOULD NOT specify both <sref>aria-selected</sref> and <sref>aria-checked</sref> on <rref>listviewitem</rref> elements contained by the same <rref>listview</rref> except in the extremely rare circumstances where all the following conditions are met:
+				</p>
+				<ul>
+					<li>The meaning and purpose of <sref>aria-selected</sref> is different from the meaning and purpose of <sref>aria-checked</sref> in the user interface.</li>
+					<li>The user interface makes the meaning and purpose of each state apparent.</li>
+					<li>The user interface provides a separate method for controlling each state.</li>
+				</ul>
+				<p>User agents MUST NOT provide an implicit value for <sref>aria-selected</sref> for <code>listviewitem</code> elements.</p>
+			</div>
+			<table class="role-features">
+				<caption>Characteristics:</caption>
+				<thead>
+					<tr>
+						<th scope="col">Characteristic</th>
+						<th scope="col">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th class="role-abstract-head" scope="row">Is Abstract:</th>
+						<td class="role-abstract"> </td>
+					</tr>
+					<tr>
+						<th class="role-parent-head" scope="row">Superclass Role:</th>
+						<td class="role-parent">
+							<ul>
+								<li><rref>listitem</rref></li>
+								<li><rref>widget</rref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-children-head" scope="row">Subclass Roles:</th>
+						<td class="role-children">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-base-head" scope="row">Base Concept:</th>
+						<td class="role-base"><code>&lt;[^li^]&gt;</code> in HTML</td>
+					</tr>
+					<tr>
+						<th class="role-related-head" scope="row">Related Concepts:</th>
+						<td class="role-related"> </td>
+					</tr>
+					<tr>
+						<th class="role-scope-head" scope="row">Required Accessibility Parent Roles:</th>
+						<td class="role-scope">
+							<ul>
+								<li><rref>listview</rref></li>
+								<li><rref>group</rref> with <a>accessibility parent</a> <rref>listviewitem</rref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-mustcontain-head" scope="row">Allowed Accessibility Child Roles:</th>
+						<td class="role-mustcontain"> </td>
+					</tr>
+					<tr>
+						<th class="role-required-properties-head">Required States and Properties:</th>
+						<td class="role-required-properties"> </td>
+					</tr>
+					<tr>
+						<th class="role-properties-head" scope="row">Supported States and Properties:</th>
+						<td class="role-properties">
+							<ul>
+								<li><rref>aria-checked</rref></li>
+								<li><sref>aria-disabled</sref></li>
+								<li><sref>aria-expanded</sref></li>
+								<li><sref>aria-selected</sref></li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+						<td class="role-inherited">Placeholder</td>
+					</tr>
+					<tr>
+						<th class="role-namefrom-head" scope="row">Name From:</th>
+						<td class="role-namefrom">
+							<ul>
+								<li>contents</li>
+								<li>author</li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+						<td class="role-namerequired"> </td>
+					</tr>
+					<tr>
+						<th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+						<td class="role-namerequired-inherited"> </td>
+					</tr>
+					<tr>
+						<th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+						<td class="role-childpresentational"> </td>
+					</tr>
+					<tr>
+						<th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+						<td class="role-presentational-inherited"> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
 		<div class="role" id="log">
 			<rdef>log</rdef>
 			<div class="role-description">
@@ -4640,8 +4929,8 @@
 				<p>A <rref>landmark</rref> containing the main content of a document.</p>
 				<p>This marks the content that is directly related to or expands upon the central topic of the document. The <code>main</code> <a>role</a> is a non-obtrusive alternative for "skip to main content" links, where the navigation option to go to the main content (or other <a>landmarks</a>) is provided by <a>assistive technologies</a>, or by a <a>user agent</a> or browser extension, through a keyboard shortcut or <abbr title="User Interface">UI</abbr> feature such as a side panel or dialog.</p>
 				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>main</code>.
-  				[=user agents=] SHOULD treat elements with role <code>main</code> as navigational <a>landmarks</a>.
-  				[=user agents=] MAY enable users to quickly navigate to elements with role <code>main</code>.</p>
+					[=user agents=] SHOULD treat elements with role <code>main</code> as navigational <a>landmarks</a>.
+					[=user agents=] MAY enable users to quickly navigate to elements with role <code>main</code>.</p>
 				<!-- keep the following paragraphs synced with the similar paragraphs in #banner and #contentinfo -->
 				<p>The author SHOULD mark no more than one <a>element</a> on a page with the <code>main</code> role.</p>
 				<p class="note">Because <code>document</code> and <code>application</code> elements can be nested in the <abbr title="Document Object Model">DOM</abbr>, they can have multiple <code>main</code> elements as <abbr title="Document Object Model">DOM</abbr> descendants, assuming each of those is associated with different document nodes, either by a DOM nesting (e.g., <rref>document</rref> within <rref>document</rref>) or by use of the <pref>aria-owns</pref> attribute.</p>
@@ -4899,40 +5188,40 @@
 				<h4><abbr title="Mathematical Markup Language">MathML</abbr> Example with Embedded TeX Annotation</h4>
 				<pre class="example highlight">
 					&lt;!-- Note: Use a JavaScript polyfill library to ensure
-					     this renders in user agents that do not support MathML. --&gt;
+							 this renders in user agents that do not support MathML. --&gt;
 					&lt;!-- The math element has an implicit role="math". --&gt;
 					&lt;math xmlns="http://www.w3.org/1998/Math/MathML"&gt;
-					  &lt;mrow&gt;
-					    &lt;mi&gt;x&lt;/mi&gt;
-					    &lt;mo&gt;=&lt;/mo&gt;
-					    &lt;mfrac&gt;
-					      &lt;mrow&gt;
-					        &lt;mo form="prefix"&gt;&#x2212;&lt;/mo&gt;
-					        &lt;mi&gt;b&lt;/mi&gt;
-					        &lt;mo&gt;&#x00B1;&lt;/mo&gt;
-					        &lt;msqrt&gt;
-					          &lt;msup&gt;
-					            &lt;mi&gt;b&lt;/mi&gt;
-					            &lt;mn&gt;2&lt;/mn&gt;
-					          &lt;/msup&gt;
-					          &lt;mo&gt;&#x2212;&lt;/mo&gt;
-					          &lt;mn&gt;4&lt;/mn&gt;
-					          &lt;mo&gt;&amp;#x2062;&lt;!-- &amp;InvisibleTimes; --&gt;&lt;/mo&gt;
-					          &lt;mi&gt;a&lt;/mi&gt;
-					          &lt;mo&gt;&amp;#x2062;&lt;!-- &amp;InvisibleTimes; --&gt;&lt;/mo&gt;
-					          &lt;mi&gt;c&lt;/mi&gt;
-					        &lt;/msqrt&gt;
-					      &lt;/mrow&gt;
-					      &lt;mrow&gt;
-					        &lt;mn&gt;2&lt;/mn&gt;
-					        &lt;mo&gt;&amp;#x2062;&lt;!-- &amp;InvisibleTimes; --&gt;&lt;/mo&gt;
-					        &lt;mi&gt;a&lt;/mi&gt;
-					      &lt;/mrow&gt;
-					    &lt;/mfrac&gt;
-					  &lt;/mrow&gt;
-					  &lt;annotation encoding="TeX"&gt;
-					    x=\frac{-b\pm\sqrt{b^2-4ac}}{2a}
-					  &lt;/annotation&gt;
+						&lt;mrow&gt;
+							&lt;mi&gt;x&lt;/mi&gt;
+							&lt;mo&gt;=&lt;/mo&gt;
+							&lt;mfrac&gt;
+								&lt;mrow&gt;
+									&lt;mo form="prefix"&gt;&#x2212;&lt;/mo&gt;
+									&lt;mi&gt;b&lt;/mi&gt;
+									&lt;mo&gt;&#x00B1;&lt;/mo&gt;
+									&lt;msqrt&gt;
+										&lt;msup&gt;
+											&lt;mi&gt;b&lt;/mi&gt;
+											&lt;mn&gt;2&lt;/mn&gt;
+										&lt;/msup&gt;
+										&lt;mo&gt;&#x2212;&lt;/mo&gt;
+										&lt;mn&gt;4&lt;/mn&gt;
+										&lt;mo&gt;&amp;#x2062;&lt;!-- &amp;InvisibleTimes; --&gt;&lt;/mo&gt;
+										&lt;mi&gt;a&lt;/mi&gt;
+										&lt;mo&gt;&amp;#x2062;&lt;!-- &amp;InvisibleTimes; --&gt;&lt;/mo&gt;
+										&lt;mi&gt;c&lt;/mi&gt;
+									&lt;/msqrt&gt;
+								&lt;/mrow&gt;
+								&lt;mrow&gt;
+									&lt;mn&gt;2&lt;/mn&gt;
+									&lt;mo&gt;&amp;#x2062;&lt;!-- &amp;InvisibleTimes; --&gt;&lt;/mo&gt;
+									&lt;mi&gt;a&lt;/mi&gt;
+								&lt;/mrow&gt;
+							&lt;/mfrac&gt;
+						&lt;/mrow&gt;
+						&lt;annotation encoding="TeX"&gt;
+							x=\frac{-b\pm\sqrt{b^2-4ac}}{2a}
+						&lt;/annotation&gt;
 					&lt;/math&gt;
 				</pre>
 				<h4>Plain HTML or Polyfill DOM Result of the MathML Quadratic Formula</h4>
@@ -5427,7 +5716,7 @@
 				<p>Authors SHOULD enforce that only one <code>menuitemradio</code> in a group can be checked at the same time. When one item in the group is checked, the previously checked item becomes unchecked (its <sref>aria-checked</sref> <a>attribute</a> becomes <code>false</code>).</p>
 				<!-- keep previous sentence synced with radiogroup, etc. -->
 				<p>In order to identify that they are related <a>widgets</a>, authors MUST ensure that menu item radios are <a>accessibility descendants</a> of an element with role <rref>menu</rref> or <rref>menubar</rref>.</p>
-        <p>If a <rref>menu</rref> or <rref>menubar</rref> contains more than one group of <code>menuitemradio</code> elements, or if the menu contains one group and other, unrelated menu items, authors SHOULD contain each set of related <code>menuitemradio</code> elements in an element using the <rref>group</rref> role. Authors MAY also delimit the group from other menu items with an element using the <rref>separator</rref> role, or an element with an equivalent role from the native markup language.
+				<p>If a <rref>menu</rref> or <rref>menubar</rref> contains more than one group of <code>menuitemradio</code> elements, or if the menu contains one group and other, unrelated menu items, authors SHOULD contain each set of related <code>menuitemradio</code> elements in an element using the <rref>group</rref> role. Authors MAY also delimit the group from other menu items with an element using the <rref>separator</rref> role, or an element with an equivalent role from the native markup language.
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -5618,8 +5907,8 @@
 			<div class="role-description">
 				<p>A <rref>landmark</rref> containing a collection of navigational [=elements=] (usually links) for navigating the document or related documents.</p>
 				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>navigation</code>.
-  				[=user agents=] SHOULD treat elements with role <code>navigation</code> as navigational <a>landmarks</a>.
-  				[=user agents=] MAY enable users to quickly navigate to elements with role <code>navigation</code>.</p>
+					[=user agents=] SHOULD treat elements with role <code>navigation</code> as navigational <a>landmarks</a>.
+					[=user agents=] MAY enable users to quickly navigate to elements with role <code>navigation</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -5721,16 +6010,16 @@
 				<p>Authors SHOULD NOT provide a meaningful text alternative (for example, use <code>alt=""</code> in HTML) when the <code>none</code>/<code>presentation</code> role is applied to an image.</p>
 				<p>In the following code sample, the containing <rref>img</rref> and is appropriately labeled by the caption paragraph. In this example the <code>img</code> element can be marked as <rref>none</rref>/<rref>presentation</rref> because the role and the text alternatives are provided by the containing element.</p>
 				<pre class="example highlight">&lt;div role="img" aria-labelledby="caption"&gt;
-  &lt;img src="example.png" role="none" alt=""&gt;
-  &lt;p id="caption"&gt;A visible text caption labeling the image.&lt;/p&gt;
+	&lt;img src="example.png" role="none" alt=""&gt;
+	&lt;p id="caption"&gt;A visible text caption labeling the image.&lt;/p&gt;
 &lt;/div&gt;</pre>
 				<p>In the following code sample, because the anchor (HTML <code>a</code> element) is acting as the treeitem, the list item (HTML <code>li</code> element) is assigned an explicit <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role of <rref>none</rref>/<rref>presentation</rref> to override the user agent's implicit native semantics for list items.</p>
 				<pre class="example highlight">
 &lt;ul role="tree"&gt;
-  &lt;li role="none"&gt;
+	&lt;li role="none"&gt;
 	&lt;a role="treeitem" aria-expanded="true"&gt;An expanded tree node&lt;/a&gt;
-  &lt;/li&gt;
-  …
+	&lt;/li&gt;
+	…
 &lt;/ul&gt;</pre>
 				<h5>Presentational Role Inheritance</h5>
 				<p>The <rref>none</rref>/<rref>presentation</rref> role is used on an element that has implicit native semantics, meaning that there is a default accessibility <abbr title="Application Programing Interface">API</abbr> role for the element. Some elements are only complete when additional descendant elements are provided. For example, in HTML, table elements (matching the <rref>table</rref> role) require <code>tr</code> descendants (which have an implicit <rref>row</rref> <a>role</a>), which in turn require <code>th</code> or <code>td</code> children (the <rref>columnheader</rref> or <rref>rowheader</rref> and <rref>cell</rref> roles, respectively). Similarly, lists require list item children. The descendant elements that complete the semantics of an element are described in <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> as <a href="#mustContain">Allowed Accessibility Child Roles</a>.</p>
@@ -5740,18 +6029,18 @@
 				<p>For example, according to an accessibility <abbr title="Application Programing Interface">API</abbr>, the following markup elements might have identical or very similar role semantics (generic or none role) and identical content.</p>
 				<pre class="example highlight"><span class="comment">&lt;!-- 1. [role="none"] negates the implicit 'list' and 'listitem' role semantics but does not affect the contents. --&gt;</span>
 &lt;ul role="none"&gt;
-  &lt;li&gt; Sample Content &lt;/li&gt;
-  &lt;li&gt; More Sample Content &lt;/li&gt;
+	&lt;li&gt; Sample Content &lt;/li&gt;
+	&lt;li&gt; More Sample Content &lt;/li&gt;
 &lt;/ul&gt;
 
 <span class="comment">&lt;!-- 2. There is no implicit role for "foo", so only the contents are exposed. --&gt;</span>
 &lt;foo&gt;
-  &lt;foo&gt; Sample Content &lt;/foo&gt;
-  &lt;foo&gt; More Sample Content &lt;/foo&gt;
+	&lt;foo&gt; Sample Content &lt;/foo&gt;
+	&lt;foo&gt; More Sample Content &lt;/foo&gt;
 &lt;/foo&gt;</pre>
 				<p class="note">There are other <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles with specific allowed children for which this situation is applicable (e.g., feeds and listboxes), but tables and lists are the most common real-world cases in which the none/presentation inheritance is likely to apply.</p>
 				<p>For any element with an explicit or inherited role of <rref>none</rref>/<rref>presentation</rref>, user agents MUST apply an inherited role of <rref>none</rref> to all host-language-specific labeling elements for the presentational element. For example, a <code>table</code> element with a role of <rref>none</rref>/<rref>presentation</rref> will have the implicit native semantics of its <code>caption</code> element removed, because the caption is merely a label for the presentational table.</p>
-            <p class="ednote">Information about <a href="#conflict_resolution_presentation_none">resolving conflicts in the none/presentation role</a> has been moved to <a href="#document-handling_author-errors">Handling Author Errors</a></p>
+						<p class="ednote">Information about <a href="#conflict_resolution_presentation_none">resolving conflicts in the none/presentation role</a> has been moved to <a href="#document-handling_author-errors">Handling Author Errors</a></p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -5844,8 +6133,8 @@
 				<pre class="example highlight">
 					&lt;p>... the following results outline support for the tested features.&lt;/p>
 					&lt;div role="note">
-					  &lt;p>Please keep in mind that at the time of publishing this page all results were accurate.&lt;/p>
-					  &lt;p>If you find any variations in results, please let us know!&lt;/p>
+						&lt;p>Please keep in mind that at the time of publishing this page all results were accurate.&lt;/p>
+						&lt;p>If you find any variations in results, please let us know!&lt;/p>
 					&lt;/div>
 					&lt;p>...&lt;/p>
 				</pre>
@@ -5855,13 +6144,13 @@
 					<li>If the <code>note</code> is brief and consists of static text, use <pref>aria-describedby</pref>.</li>
 				</ul>
 				<pre class="example highlight">
-				  &lt;!-- using aria-details to reference a note containing a link -->
-				  ...
+					&lt;!-- using aria-details to reference a note containing a link -->
+					...
 					&lt;button aria-details="info-note">Get Started&lt;/button>
 					...
 					&lt;div role="note" id="info-note">
-					  &lt;p>Need more information before you get started?&lt;/p>
-					  &lt;p>Visit our &lt;a href="...">product description page&lt;/a> to get all the information you need.&lt;/p>
+						&lt;p>Need more information before you get started?&lt;/p>
+						&lt;p>Visit our &lt;a href="...">product description page&lt;/a> to get all the information you need.&lt;/p>
 					&lt;/div>
 				</pre>
 			</div>
@@ -5942,30 +6231,30 @@
 			<div class="role-description">
 				<p>An item in a <rref>listbox</rref>.</p>
 				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>option</code> are <a>accessibility children</a> of an element with <a>role</a> <rref>listbox</rref> or of an element with <a>role</a> <rref>group</rref> that is the <a>accessibility child</a> of an element with <a>role</a> <code>listbox</code>. Options not associated with a <rref>listbox</rref> might not be correctly mapped to an <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a>.</p>
-        <p>In certain conditions, a user agent MAY provide an implicit value for <sref>aria-selected</sref> for each <rref>option</rref> in a <rref>listbox</rref>, and if it does, the user agent MUST ensure the following conditions are met before providing an implicit value:</p>
-        <ul>
-          <li>The value of <pref>aria-multiselectable</pref> on the <rref>listbox</rref> is <code>false</code> or <code>undefined</code>.</li>
-          <li>None of the <rref>option</rref> elements in the <rref>listbox</rref> have an explicitly declared value for <sref>aria-selected</sref> or <sref>aria-checked</sref>.</li>
-        </ul>
-        <p>
-          If a user agent provides an implicit <sref>aria-selected</sref> value for an <rref>option</rref>, the value SHOULD be <code>true</code> if the <rref>option</rref> has DOM focus or the <rref>listbox</rref> has DOM focus and the <rref>option</rref> is referenced by <pref>aria-activedescendant</pref>.
-          Otherwise, if a user agent provides an implicit <sref>aria-selected</sref> value for an <rref>option</rref>, the value SHOULD be <code>false</code>.
-        </p>
-        <p>
-          Authors SHOULD indicate selection for <rref>option</rref> elements using one of the following:
-        </p>
-        <ul>
-          <li>An <sref>aria-selected</sref> value of <code>true</code> on the selected option within a single-select <rref>listbox</rref>, and optionally <sref>aria-selected</sref> values of <code>false</code> on unselected options.</li>
-          <li>Either <sref>aria-selected</sref> or <sref>aria-checked</sref> on all options within a multi-select <rref>listbox</rref>, with a value of <code>true</code> on selected options, and a value of <code>false</code> on unselected options.</li>
-        </ul>
-        <p>
-          Authors SHOULD NOT specify both <sref>aria-selected</sref> and <sref>aria-checked</sref> on <rref>option</rref> elements contained by the same <rref>listbox</rref> except in the extremely rare circumstances where all the following conditions are met:
-        </p>
-        <ul>
-          <li>The meaning and purpose of <sref>aria-selected</sref> is different from the meaning and purpose of <sref>aria-checked</sref> in the user interface.</li>
-          <li>The user interface makes the meaning and purpose of each state apparent.</li>
-          <li>The user interface provides a separate method for controlling each state.</li>
-        </ul>
+				<p>In certain conditions, a user agent MAY provide an implicit value for <sref>aria-selected</sref> for each <rref>option</rref> in a <rref>listbox</rref>, and if it does, the user agent MUST ensure the following conditions are met before providing an implicit value:</p>
+				<ul>
+					<li>The value of <pref>aria-multiselectable</pref> on the <rref>listbox</rref> is <code>false</code> or <code>undefined</code>.</li>
+					<li>None of the <rref>option</rref> elements in the <rref>listbox</rref> have an explicitly declared value for <sref>aria-selected</sref> or <sref>aria-checked</sref>.</li>
+				</ul>
+				<p>
+					If a user agent provides an implicit <sref>aria-selected</sref> value for an <rref>option</rref>, the value SHOULD be <code>true</code> if the <rref>option</rref> has DOM focus or the <rref>listbox</rref> has DOM focus and the <rref>option</rref> is referenced by <pref>aria-activedescendant</pref>.
+					Otherwise, if a user agent provides an implicit <sref>aria-selected</sref> value for an <rref>option</rref>, the value SHOULD be <code>false</code>.
+				</p>
+				<p>
+					Authors SHOULD indicate selection for <rref>option</rref> elements using one of the following:
+				</p>
+				<ul>
+					<li>An <sref>aria-selected</sref> value of <code>true</code> on the selected option within a single-select <rref>listbox</rref>, and optionally <sref>aria-selected</sref> values of <code>false</code> on unselected options.</li>
+					<li>Either <sref>aria-selected</sref> or <sref>aria-checked</sref> on all options within a multi-select <rref>listbox</rref>, with a value of <code>true</code> on selected options, and a value of <code>false</code> on unselected options.</li>
+				</ul>
+				<p>
+					Authors SHOULD NOT specify both <sref>aria-selected</sref> and <sref>aria-checked</sref> on <rref>option</rref> elements contained by the same <rref>listbox</rref> except in the extremely rare circumstances where all the following conditions are met:
+				</p>
+				<ul>
+					<li>The meaning and purpose of <sref>aria-selected</sref> is different from the meaning and purpose of <sref>aria-checked</sref> in the user interface.</li>
+					<li>The user interface makes the meaning and purpose of each state apparent.</li>
+					<li>The user interface provides a separate method for controlling each state.</li>
+				</ul>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -6021,7 +6310,7 @@
 							<ul>
 								<li><sref>aria-checked</sref></li>
 								<li><pref>aria-posinset</pref></li>
-                <li><sref>aria-selected</sref></li>
+								<li><sref>aria-selected</sref></li>
 								<li><pref>aria-setsize</pref></li>
 							</ul>
 						</td>
@@ -6063,8 +6352,8 @@
 			</table>
 		</div>
 <!-- FIXME: This is commented out because the ARIA Working Group agreed to move the password role to ARIA 2.0,
-     but we've not branched for 1.1 yet. Once we have branched, this entire section should be deleted from
-     the 1.1 branch and uncommented for the master branch (pending discussion and consensus).
+		 but we've not branched for 1.1 yet. Once we have branched, this entire section should be deleted from
+		 the 1.1 branch and uncommented for the master branch (pending discussion and consensus).
 		<div class="role" id="password">
 			<rdef>password</rdef>
 			<div class="role-description">
@@ -7072,8 +7361,8 @@
 				<p>Authors MUST set the <pref>aria-controls</pref> attribute on the scrollbar element to reference the scrollable area it controls.</p>
 				<p>Authors MAY set <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> to indicate the minimum and maximum thumb position. Otherwise, their implicit values follow the same rules as <code>&lt;input type="[^input/type/range^]"&gt;</code> in HTML:</p>
 				<ul>
-				    <li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero).</li>
-				    <li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100.</li>
+						<li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero).</li>
+						<li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100.</li>
 				</ul>
 				<p>Authors MUST set the <pref>aria-valuenow</pref> attribute to indicate the current thumb position. If aria-valuenow is missing or has an unexpected value, browsers MAY implement the repair techniques specified in the <a href="#authorErrorDefaultValuesTable">section describing handling author errors in states and properties</a>, which are equivalent to the repair techniques for <code>&lt;input type="[^input/type/range^]"&gt;</code> in HTML.</p>
 				<p>Elements with the role <code>scrollbar</code> have an implicit <pref>aria-orientation</pref> value of <code>vertical</code>.</p>
@@ -7182,8 +7471,8 @@
 				<p>A <rref>landmark</rref> region that contains a collection of items and objects that, as a whole, combine to create a search facility. See related <rref>form</rref> and <rref>searchbox</rref>.</p>
 				<p>A search region can be a mix of host language form controls, scripted controls, and hyperlinks.</p>
 				<p><a>Assistive technologies</a> SHOULD enable users to quickly navigate to elements with role <code>search</code>.
-  				[=user agents=] SHOULD treat elements with role <code>search</code> as navigational <a>landmarks</a>.
-  				[=user agents=] MAY enable users to quickly navigate to elements with role <code>search</code>.</p>
+					[=user agents=] SHOULD treat elements with role <code>search</code> as navigational <a>landmarks</a>.
+					[=user agents=] MAY enable users to quickly navigate to elements with role <code>search</code>.</p>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -7549,8 +7838,8 @@
 				<p>Authors MAY make a <code>separator</code> focusable to create a <rref>widget</rref> that both provides a visible boundary between two sections of content and enables the user to change the relative size of the sections by changing the position of the <code>separator</code>. A variable <code>separator</code> widget can be moved continuously within a range, whereas a fixed <code>separator</code> widget supports only two discrete positions. Typically, a fixed <code>separator</code> widget is used to toggle one of the sections between expanded and collapsed states.</p>
 				<p>If the <code>separator</code> is focusable, authors MUST set the value of <pref>aria-valuenow</pref> to a <a href="#valuetype_number">number</a> reflecting the current position of the <code>separator</code> and update that value when it changes. Authors SHOULD also provide the value of <pref>aria-valuemin</pref> if it is not <code>0</code> and the value of <pref>aria-valuemax</pref> if it is not <code>100</code>. If missing or not a number, the implicit values of these attributes are as follows:</p>
 				<ul>
-				    <li>The implicit value of <code>aria-valuemin</code> is <code>0</code>.</li>
-				    <li>The implicit value of <code>aria-valuemax</code> is <code>100</code>.</li>
+						<li>The implicit value of <code>aria-valuemin</code> is <code>0</code>.</li>
+						<li>The implicit value of <code>aria-valuemax</code> is <code>100</code>.</li>
 				</ul>
 				<p>In applications where there is more than one focusable <code>separator</code>, authors SHOULD provide an accessible name for each one.</p>
 				<p>Elements with the role <code>separator</code> have an implicit <pref>aria-orientation</pref> value of <code>horizontal</code>.</p>
@@ -7655,8 +7944,8 @@
 				<p>A slider represents the current value and range of possible values via the size of the slider and position of the thumb. It is typically possible to add to or subtract from the current value by using directional keys such as arrow keys.</p>
 				<p>Authors MAY set the <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> attributes.	Otherwise, their implicit values follow the same rules as <code>&lt;input type="[^input/type/range^]"&gt;</code> in HTML:</p>
 				<ul>
-				    <li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero). </li>
-				    <li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100. </li>
+						<li>If <code>aria-valuemin</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 0 (zero). </li>
+						<li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100. </li>
 				</ul>
 				<p>Authors MUST set the <pref>aria-valuenow</pref> attribute. If aria-valuenow is missing or has an unexpected value, browsers MAY implement the repair techniques specified in the <a href="#authorErrorDefaultValuesTable">section describing handling author errors in states and properties</a>, which are equivalent to the repair techniques for <code>&lt;input type="[^input/type/range^]"&gt;</code> in HTML.</p>
 				<p>Elements with the role <code>slider</code> have an implicit <pref>aria-orientation</pref> value of <code>horizontal</code>.</p>
@@ -8211,16 +8500,16 @@
 					<p>Authors MAY use <pref>aria-details</pref> or <pref>aria-description</pref> to associate the <code>suggestion</code> with related information such as comments, authoring info, and time stamps.</p>
 					<pre class="example highlight">
 						&lt;p&gt;
-						  The best pet is a
-						  &lt;span role="suggestion"&gt;
-						    &lt;span role="deletion"&gt;cat&lt;/span&gt;
-						    &lt;span role="insertion"&gt;dog&lt;/span&gt;
-						  &lt;/span&gt;
+							The best pet is a
+							&lt;span role="suggestion"&gt;
+								&lt;span role="deletion"&gt;cat&lt;/span&gt;
+								&lt;span role="insertion"&gt;dog&lt;/span&gt;
+							&lt;/span&gt;
 						&lt;/p&gt;
 					</pre>
 					<p>When a suggestion is accepted, authors SHOULD remove the <code>suggestion</code> role, indicating that the proposed revision has been made.
 						After the <code>suggestion</code> role is removed, child <rref>insertion</rref> and <rref>deletion</rref> elements can either be retained to document the revision or replaced with the revised content.
-					  </p>
+						</p>
 			</div>
 			<table class="role-features">
 					<caption>Characteristics:</caption>
@@ -8491,11 +8780,11 @@
 				<!-- keep following para synced with its counterpart in #tablist -->
 				<p>For a single-selectable <rref>tablist</rref>, authors SHOULD [=element/hide from all users=] other <code>tabpanel</code> [=elements=] until the user selects the tab associated with that tabpanel. For a multi-selectable <rref>tablist</rref>, authors SHOULD ensure that the <rref>tab</rref> for each visible <rref>tabpanel</rref> has the <sref>aria-expanded</sref> <a>attribute</a> set to <code>true</code>, and that the <code>tabs</code> associated with the remaining [=element/hidden from all users=] <code>tabpanel</code> elements have their <sref>aria-expanded</sref> attributes set to <code>false</code>.</p>
 				<p>Authors SHOULD ensure that a selected tab has its <sref>aria-selected</sref> attribute set to <code>true</code>, that inactive tab elements have their <sref>aria-selected</sref> attribute set to <code>false</code>, and that the currently selected tab provides a visual indication that it is selected.</p>
-        <p>In certain conditions, a user agent MAY provide an implicit value for <sref>aria-selected</sref> for each <rref>tab</rref> in a <rref>tablist</rref>, and if it does, the user agent MUST ensure the following conditions are met before providing an implicit value:</p>
-        <ul>
-          <li>The value of <pref>aria-multiselectable</pref> on the <rref>tablist</rref> is <code>false</code> or <code>undefined</code>.</li>
-          <li>None of the <rref>tab</rref> elements in the <rref>tablist</rref> have an explicitly declared value for <sref>aria-selected</sref> or <sref>aria-expanded</sref>.</li>
-        </ul>
+				<p>In certain conditions, a user agent MAY provide an implicit value for <sref>aria-selected</sref> for each <rref>tab</rref> in a <rref>tablist</rref>, and if it does, the user agent MUST ensure the following conditions are met before providing an implicit value:</p>
+				<ul>
+					<li>The value of <pref>aria-multiselectable</pref> on the <rref>tablist</rref> is <code>false</code> or <code>undefined</code>.</li>
+					<li>None of the <rref>tab</rref> elements in the <rref>tablist</rref> have an explicitly declared value for <sref>aria-selected</sref> or <sref>aria-expanded</sref>.</li>
+				</ul>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -8951,8 +9240,8 @@
 			</table>
 		</div>
 <!-- FIXME: This is commented out because the ARIA Working Group agreed to move the text role to ARIA 2.0,
-     but we've not branched for 1.1 yet. Once we have branched, this entire section should be deleted from
-     the 1.1 branch and uncommented for the master branch.
+		 but we've not branched for 1.1 yet. Once we have branched, this entire section should be deleted from
+		 the 1.1 branch and uncommented for the master branch.
 		<div class="role" id="text">
 			<rdef>text</rdef>
 			<div class="role-description">
@@ -8979,18 +9268,18 @@
 					<p>The text role can also be used to flatten structural semantics without providing an explicit label. The following example would be presented to assistive technologies as one static text element ("I like turtles") rather than three separate paragraphs.</p>
 					<pre class="example highlight">
 						&lt;div role="text"&gt;
-						  &lt;p&gt;I&lt;/p&gt;
-						  &lt;p&gt;like&lt;/p&gt;
-						  &lt;p&gt;turtles&lt;/p&gt;
+							&lt;p&gt;I&lt;/p&gt;
+							&lt;p&gt;like&lt;/p&gt;
+							&lt;p&gt;turtles&lt;/p&gt;
 						&lt;/div&gt;
 					</pre>
 					<p>Use caution when using the text role on structural elements. In particular, avoid using the text role on elements with interactive descendants.</p>
 					<pre class="example highlight">
 						&lt;p role="text"&gt;
-						  &lt;!&dash;&dash; Example of incorrect usage. &dash;&dash;&gt;
-						  This &lt;a href="#"&gt;link&lt;/a&gt; becomes presentational, so
-						  it is no longer a link. The paragraph is just plain text.
-						  This is probably not what the author intended.
+							&lt;!&dash;&dash; Example of incorrect usage. &dash;&dash;&gt;
+							This &lt;a href="#"&gt;link&lt;/a&gt; becomes presentational, so
+							it is no longer a link. The paragraph is just plain text.
+							This is probably not what the author intended.
 						&lt;/p&gt;
 					</pre>
 				</div>
@@ -9720,27 +10009,27 @@
 			<rdef>treeitem</rdef>
 			<div class="role-description">
 				<p>An item in a <rref>tree</rref>.</p>
-        				<p>A <rref>treeitem</rref> <a>element</a> can contain a sub-level group of elements that can be expanded or collapsed. An expandable collection of <code>treeitem</code> elements are enclosed in an element with the <rref>group</rref> <a>role</a>.</p>
+								<p>A <rref>treeitem</rref> <a>element</a> can contain a sub-level group of elements that can be expanded or collapsed. An expandable collection of <code>treeitem</code> elements are enclosed in an element with the <rref>group</rref> <a>role</a>.</p>
 				<p>Authors MUST ensure [=elements=] with <a>role</a> <code>treeitem</code> are <a>accessibility children</a> of an element with role <rref>tree</rref> or an element with role <rref>group</rref> that is the <a>accessibility child</a> of an element with role <rref>treeitem</rref>.</p>
-        <p>In certain conditions, a user agent MAY provide an implicit value for <sref>aria-selected</sref> for each <rref>treeitem</rref> in a <rref>tree</rref>, and if it does, the user agent MUST ensure the following conditions are met before providing an implicit value:</p>
-        <ul>
-          <li>The value of <pref>aria-multiselectable</pref> on the <rref>tree</rref> is <code>false</code> or <code>undefined</code>.</li>
-          <li>None of the <rref>treeitem</rref> elements in the <rref>tree</rref> have an explicitly declared value for <sref>aria-selected</sref> or <sref>aria-checked</sref>.</li>
-        </ul>
-        <p>
-          If a user agent provides an implicit <sref>aria-selected</sref> value for a <rref>treeitem</rref>, the value SHOULD be <code>true</code> if the <rref>treeitem</rref> has DOM focus or the <rref>tree</rref> has DOM focus and the <rref>treeitem</rref> is referenced by <pref>aria-activedescendant</pref>.
-          Otherwise, if a user agent provides an implicit <sref>aria-selected</sref> value for a <rref>treeitem</rref>, the value SHOULD be <code>false</code>.
-        </p>
-        <p>
-          Authors MAY indicate selection for <rref>treeitem</rref> elements  using either <sref>aria-selected</sref> or <sref>aria-checked</sref>.
-          Some user interfaces indicate selection with <sref>aria-selected</sref> in single-select trees and with <sref>aria-checked</sref> in multi-select trees.
-          Authors SHOULD NOT specify both <sref>aria-selected</sref> and <sref>aria-checked</sref> on <rref>treeitem</rref> elements contained by the same <rref>tree</rref> except in the extremely rare circumstances where all the following conditions are met:
-        </p>
-        <ul>
-          <li>The meaning and purpose of <sref>aria-selected</sref> is different from the meaning and purpose of <sref>aria-checked</sref> in the user interface.</li>
-          <li>The user interface makes the meaning and purpose of each state apparent.</li>
-          <li>The user interface provides a separate method for controlling each state.</li>
-        </ul>
+				<p>In certain conditions, a user agent MAY provide an implicit value for <sref>aria-selected</sref> for each <rref>treeitem</rref> in a <rref>tree</rref>, and if it does, the user agent MUST ensure the following conditions are met before providing an implicit value:</p>
+				<ul>
+					<li>The value of <pref>aria-multiselectable</pref> on the <rref>tree</rref> is <code>false</code> or <code>undefined</code>.</li>
+					<li>None of the <rref>treeitem</rref> elements in the <rref>tree</rref> have an explicitly declared value for <sref>aria-selected</sref> or <sref>aria-checked</sref>.</li>
+				</ul>
+				<p>
+					If a user agent provides an implicit <sref>aria-selected</sref> value for a <rref>treeitem</rref>, the value SHOULD be <code>true</code> if the <rref>treeitem</rref> has DOM focus or the <rref>tree</rref> has DOM focus and the <rref>treeitem</rref> is referenced by <pref>aria-activedescendant</pref>.
+					Otherwise, if a user agent provides an implicit <sref>aria-selected</sref> value for a <rref>treeitem</rref>, the value SHOULD be <code>false</code>.
+				</p>
+				<p>
+					Authors MAY indicate selection for <rref>treeitem</rref> elements  using either <sref>aria-selected</sref> or <sref>aria-checked</sref>.
+					Some user interfaces indicate selection with <sref>aria-selected</sref> in single-select trees and with <sref>aria-checked</sref> in multi-select trees.
+					Authors SHOULD NOT specify both <sref>aria-selected</sref> and <sref>aria-checked</sref> on <rref>treeitem</rref> elements contained by the same <rref>tree</rref> except in the extremely rare circumstances where all the following conditions are met:
+				</p>
+				<ul>
+					<li>The meaning and purpose of <sref>aria-selected</sref> is different from the meaning and purpose of <sref>aria-checked</sref> in the user interface.</li>
+					<li>The user interface makes the meaning and purpose of each state apparent.</li>
+					<li>The user interface provides a separate method for controlling each state.</li>
+				</ul>
 			</div>
 			<table class="role-features">
 				<caption>Characteristics:</caption>
@@ -10250,9 +10539,9 @@ button.ariaPressed; // null</pre>
 				<ol>
 					<li>The value of <code>aria-activedescendant</code> refers to an <a>accessibility descendant</a>.</li>
 					<li>
-            The element with DOM focus is a <rref>combobox</rref>, <rref>textbox</rref> or <rref>searchbox</rref> with <pref>aria-controls</pref> referring to an element that supports <code>aria-activedescendant</code>, and the value of <code>aria-activedescendant</code> refers to an <a>accessibility descendant</a> of the controlled element.
-            For example, in a <rref>combobox</rref>, focus can remain on the <rref>combobox</rref> while the value of <code>aria-activedescendant</code> on the <rref>combobox</rref> element refers to a descendant of a popup <rref>listbox</rref> that is controlled by the <rref>combobox</rref>.
-          </li>
+						The element with DOM focus is a <rref>combobox</rref>, <rref>textbox</rref> or <rref>searchbox</rref> with <pref>aria-controls</pref> referring to an element that supports <code>aria-activedescendant</code>, and the value of <code>aria-activedescendant</code> refers to an <a>accessibility descendant</a> of the controlled element.
+						For example, in a <rref>combobox</rref>, focus can remain on the <rref>combobox</rref> while the value of <code>aria-activedescendant</code> on the <rref>combobox</rref> element refers to a descendant of a popup <rref>listbox</rref> that is controlled by the <rref>combobox</rref>.
+					</li>
 				</ol>
 				<p>Authors SHOULD also ensure that the currently active descendant is visible and in view (or scrolls into view) when focused.</p>
 			</div>
@@ -10408,10 +10697,10 @@ button.ariaPressed; // null</pre>
 						<th class="value-name" scope="row">list</th>
 						<td class="value-description">When a user is providing input, an element containing a collection of values that could complete the provided input might be displayed.</td>
 					</tr>
-                    <tr>
-                        <th class="value-name" scope="row">both</th>
-                        <td class="value-description">When a user is providing input, an element containing a collection of values that could complete the provided input might be displayed. If displayed, one value in the collection is automatically selected, and the text needed to complete the automatically selected value appears after the caret in the input.</td>
-                    </tr>
+										<tr>
+												<th class="value-name" scope="row">both</th>
+												<td class="value-description">When a user is providing input, an element containing a collection of values that could complete the provided input might be displayed. If displayed, one value in the collection is automatically selected, and the text needed to complete the automatically selected value appears after the caret in the input.</td>
+										</tr>
 					<tr>
 						<th class="value-name" scope="row"><strong class="default">none (default)</strong></th>
 						<td class="value-description">When a user is providing input, an automatic suggestion that attempts to predict how the user intends to complete the input is not displayed.</td>
@@ -10443,7 +10732,7 @@ button.ariaPressed; // null</pre>
 				</ol>
 				<p>The following example shows the use of <code>aria-braillelabel</code> to customize a button's name in braille output.</p>
 				<pre class="example highlight">&lt;button aria-braillelabel="****"&gt;
-  &lt;img alt="4 stars" src="images/stars.jpg"&gt;
+	&lt;img alt="4 stars" src="images/stars.jpg"&gt;
 &lt;/button&gt;</pre>
 				<p>In the previous example, a braille display would display "btn ****" in Braille rather than the verbose "btn gra 4 stars".</p>			</div>
 			<table class="property-features">
@@ -10664,29 +10953,29 @@ button.ariaPressed; // null</pre>
 				<p>The following example shows a grid with 16 columns, of which columns 2, 3, 4, and 9 are displayed to the user.</p>
 				<pre class="example highlight">
 &lt;div role="grid" <strong>aria-colcount="16"</strong>&gt;
-  &lt;div role="rowgroup"&gt;
-    &lt;div role="row"&gt;
-      &lt;span role="columnheader" aria-colindex="2"&gt;First Name&lt;/span&gt;
-      &lt;span role="columnheader" aria-colindex="3"&gt;Last Name&lt;/span&gt;
-      &lt;span role="columnheader" aria-colindex="4"&gt;Company&lt;/span&gt;
-      &lt;span role="columnheader" aria-colindex="9"&gt;Phone&lt;/span&gt;
-    &lt;/div&gt;
-  &lt;/div&gt;
-  &lt;div role="rowgroup"&gt;
-    &lt;div role="row"&gt;
-      &lt;span role="gridcell" aria-colindex="2"&gt;Fred&lt;/span&gt;
-      &lt;span role="gridcell" aria-colindex="3"&gt;Jackson&lt;/span&gt;
-      &lt;span role="gridcell" aria-colindex="4"&gt;Acme, Inc.&lt;/span&gt;
-      &lt;span role="gridcell" aria-colindex="9"&gt;555-1234&lt;/span&gt;
-    &lt;/div&gt;
-    &lt;div role="row"&gt;
-      &lt;span role="gridcell" aria-colindex="2"&gt;Sara&lt;/span&gt;
-      &lt;span role="gridcell" aria-colindex="3"&gt;James&lt;/span&gt;
-      &lt;span role="gridcell" aria-colindex="4"&gt;Acme, Inc.&lt;/span&gt;
-      &lt;span role="gridcell" aria-colindex="9"&gt;555-1235&lt;/span&gt;
-    &lt;/div&gt;
-   &#8230;
-  &lt;/div&gt;
+	&lt;div role="rowgroup"&gt;
+		&lt;div role="row"&gt;
+			&lt;span role="columnheader" aria-colindex="2"&gt;First Name&lt;/span&gt;
+			&lt;span role="columnheader" aria-colindex="3"&gt;Last Name&lt;/span&gt;
+			&lt;span role="columnheader" aria-colindex="4"&gt;Company&lt;/span&gt;
+			&lt;span role="columnheader" aria-colindex="9"&gt;Phone&lt;/span&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
+	&lt;div role="rowgroup"&gt;
+		&lt;div role="row"&gt;
+			&lt;span role="gridcell" aria-colindex="2"&gt;Fred&lt;/span&gt;
+			&lt;span role="gridcell" aria-colindex="3"&gt;Jackson&lt;/span&gt;
+			&lt;span role="gridcell" aria-colindex="4"&gt;Acme, Inc.&lt;/span&gt;
+			&lt;span role="gridcell" aria-colindex="9"&gt;555-1234&lt;/span&gt;
+		&lt;/div&gt;
+		&lt;div role="row"&gt;
+			&lt;span role="gridcell" aria-colindex="2"&gt;Sara&lt;/span&gt;
+			&lt;span role="gridcell" aria-colindex="3"&gt;James&lt;/span&gt;
+			&lt;span role="gridcell" aria-colindex="4"&gt;Acme, Inc.&lt;/span&gt;
+			&lt;span role="gridcell" aria-colindex="9"&gt;555-1235&lt;/span&gt;
+		&lt;/div&gt;
+	 &#8230;
+	&lt;/div&gt;
 &lt;/div&gt;</pre>
 			</div>
 			<table class="property-features">
@@ -10727,81 +11016,81 @@ button.ariaPressed; // null</pre>
 				<p>The following example shows a grid with 16 columns, of which columns 2 through 5 are displayed to the user. Because the set of columns is contiguous, <pref>aria-colindex</pref> can be placed on each row.</p>
 				<pre class="example highlight">
 &lt;div role="grid" aria-colcount="16"&gt;
-  &lt;div role="rowgroup"&gt;
-    &lt;div role="row" <strong>aria-colindex="2"</strong>&gt;
-      &lt;span role="columnheader"&gt;First Name&lt;/span&gt;
-      &lt;span role="columnheader"&gt;Last Name&lt;/span&gt;
-      &lt;span role="columnheader"&gt;Company&lt;/span&gt;
-      &lt;span role="columnheader"&gt;Address&lt;/span&gt;
-    &lt;/div&gt;
-  &lt;/div&gt;
-  &lt;div role="rowgroup"&gt;
-    &lt;div role="row" <strong>aria-colindex="2"</strong>&gt;
-      &lt;span role="gridcell"&gt;Fred&lt;/span&gt;
-      &lt;span role="gridcell"&gt;Jackson&lt;/span&gt;
-      &lt;span role="gridcell"&gt;Acme, Inc.&lt;/span&gt;
-      &lt;span role="gridcell"&gt;123 Broad St.&lt;/span&gt;
-    &lt;/div&gt;
-    &lt;div role="row" <strong>aria-colindex="2"</strong>&gt;
-      &lt;span role="gridcell"&gt;Sara&lt;/span&gt;
-      &lt;span role="gridcell"&gt;James&lt;/span&gt;
-      &lt;span role="gridcell"&gt;Acme, Inc.&lt;/span&gt;
-      &lt;span role="gridcell"&gt;123 Broad St.&lt;/span&gt;
-    &lt;/div&gt;
-   &#8230;
-  &lt;/div&gt;
+	&lt;div role="rowgroup"&gt;
+		&lt;div role="row" <strong>aria-colindex="2"</strong>&gt;
+			&lt;span role="columnheader"&gt;First Name&lt;/span&gt;
+			&lt;span role="columnheader"&gt;Last Name&lt;/span&gt;
+			&lt;span role="columnheader"&gt;Company&lt;/span&gt;
+			&lt;span role="columnheader"&gt;Address&lt;/span&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
+	&lt;div role="rowgroup"&gt;
+		&lt;div role="row" <strong>aria-colindex="2"</strong>&gt;
+			&lt;span role="gridcell"&gt;Fred&lt;/span&gt;
+			&lt;span role="gridcell"&gt;Jackson&lt;/span&gt;
+			&lt;span role="gridcell"&gt;Acme, Inc.&lt;/span&gt;
+			&lt;span role="gridcell"&gt;123 Broad St.&lt;/span&gt;
+		&lt;/div&gt;
+		&lt;div role="row" <strong>aria-colindex="2"</strong>&gt;
+			&lt;span role="gridcell"&gt;Sara&lt;/span&gt;
+			&lt;span role="gridcell"&gt;James&lt;/span&gt;
+			&lt;span role="gridcell"&gt;Acme, Inc.&lt;/span&gt;
+			&lt;span role="gridcell"&gt;123 Broad St.&lt;/span&gt;
+		&lt;/div&gt;
+	 &#8230;
+	&lt;/div&gt;
 &lt;/div&gt;</pre>
 				<p>The following example shows a grid with 16 columns, of which columns 2 through 5 are displayed to the user. While the set of columns is contiguous, some of the cells span multiple rows. As a result, <pref>aria-colindex</pref> needs to be placed on all of the <a>accessibility children</a> of each row.</p>
 				<pre class="example highlight">
 &lt;div role="grid" aria-colcount="16"&gt;
-  &lt;div role="rowgroup"&gt;
-    &lt;div role="row"&gt;
-      &lt;span role="columnheader" <strong>aria-colindex="2"</strong>&gt;First Name&lt;/span&gt;
-      &lt;span role="columnheader" <strong>aria-colindex="3"</strong>&gt;Last Name&lt;/span&gt;
-      &lt;span role="columnheader" <strong>aria-colindex="4"</strong>&gt;Company&lt;/span&gt;
-      &lt;span role="columnheader" <strong>aria-colindex="5"</strong>&gt;Address&lt;/span&gt;
-    &lt;/div&gt;
-  &lt;/div&gt;
-  &lt;div role="rowgroup"&gt;
-    &lt;div role="row"&gt;
-      &lt;span role="gridcell" <strong>aria-colindex="2"</strong>&gt;Fred&lt;/span&gt;
-      &lt;span role="gridcell" <strong>aria-colindex="3"</strong>&gt;Jackson&lt;/span&gt;
-      &lt;span role="gridcell" <strong>aria-colindex="4"</strong> aria-rowspan="2"&gt;Acme, Inc.&lt;/span&gt;
-      &lt;span role="gridcell" <strong>aria-colindex="5"</strong> aria-rowspan="2"&gt;123 Broad St.&lt;/span&gt;
-    &lt;/div&gt;
-    &lt;div role="row"&gt;
-      &lt;span role="gridcell" <strong>aria-colindex="2"</strong>&gt;Sara&lt;/span&gt;
-      &lt;span role="gridcell" <strong>aria-colindex="3"</strong>&gt;James&lt;/span&gt;
-    &lt;/div&gt;
-   &#8230;
-  &lt;/div&gt;
+	&lt;div role="rowgroup"&gt;
+		&lt;div role="row"&gt;
+			&lt;span role="columnheader" <strong>aria-colindex="2"</strong>&gt;First Name&lt;/span&gt;
+			&lt;span role="columnheader" <strong>aria-colindex="3"</strong>&gt;Last Name&lt;/span&gt;
+			&lt;span role="columnheader" <strong>aria-colindex="4"</strong>&gt;Company&lt;/span&gt;
+			&lt;span role="columnheader" <strong>aria-colindex="5"</strong>&gt;Address&lt;/span&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
+	&lt;div role="rowgroup"&gt;
+		&lt;div role="row"&gt;
+			&lt;span role="gridcell" <strong>aria-colindex="2"</strong>&gt;Fred&lt;/span&gt;
+			&lt;span role="gridcell" <strong>aria-colindex="3"</strong>&gt;Jackson&lt;/span&gt;
+			&lt;span role="gridcell" <strong>aria-colindex="4"</strong> aria-rowspan="2"&gt;Acme, Inc.&lt;/span&gt;
+			&lt;span role="gridcell" <strong>aria-colindex="5"</strong> aria-rowspan="2"&gt;123 Broad St.&lt;/span&gt;
+		&lt;/div&gt;
+		&lt;div role="row"&gt;
+			&lt;span role="gridcell" <strong>aria-colindex="2"</strong>&gt;Sara&lt;/span&gt;
+			&lt;span role="gridcell" <strong>aria-colindex="3"</strong>&gt;James&lt;/span&gt;
+		&lt;/div&gt;
+	 &#8230;
+	&lt;/div&gt;
 &lt;/div&gt;</pre>
 				<p>The following example shows a grid with 16 columns, of which columns 2, 3, 4, and 9 are displayed to the user. Because the set of columns is non-contiguous, <pref>aria-colindex</pref> needs to be placed on all of the <a>accessibility children</a> of each row.</p>
 				<pre class="example highlight">
 &lt;div role="grid" aria-colcount="16"&gt;
-  &lt;div role="rowgroup"&gt;
-    &lt;div role="row"&gt;
-      &lt;span role="columnheader" <strong>aria-colindex="2"</strong>&gt;First Name&lt;/span&gt;
-      &lt;span role="columnheader" <strong>aria-colindex="3"</strong>&gt;Last Name&lt;/span&gt;
-      &lt;span role="columnheader" <strong>aria-colindex="4"</strong>&gt;Company&lt;/span&gt;
-      &lt;span role="columnheader" <strong>aria-colindex="9"</strong>&gt;Phone&lt;/span&gt;
-    &lt;/div&gt;
-  &lt;/div&gt;
-  &lt;div role="rowgroup"&gt;
-    &lt;div role="row"&gt;
-      &lt;span role="gridcell" <strong>aria-colindex="2"</strong>&gt;Fred&lt;/span&gt;
-      &lt;span role="gridcell" <strong>aria-colindex="3"</strong>&gt;Jackson&lt;/span&gt;
-      &lt;span role="gridcell" <strong>aria-colindex="4"</strong>&gt;Acme, Inc.&lt;/span&gt;
-      &lt;span role="gridcell" <strong>aria-colindex="9"</strong>&gt;555-1234&lt;/span&gt;
-    &lt;/div&gt;
-    &lt;div role="row"&gt;
-      &lt;span role="gridcell" <strong>aria-colindex="2"</strong>&gt;Sara&lt;/span&gt;
-      &lt;span role="gridcell" <strong>aria-colindex="3"</strong>&gt;James&lt;/span&gt;
-      &lt;span role="gridcell" <strong>aria-colindex="4"</strong>&gt;Acme, Inc.&lt;/span&gt;
-      &lt;span role="gridcell" <strong>aria-colindex="9"</strong>&gt;555-1235&lt;/span&gt;
-    &lt;/div&gt;
-   &#8230;
-  &lt;/div&gt;
+	&lt;div role="rowgroup"&gt;
+		&lt;div role="row"&gt;
+			&lt;span role="columnheader" <strong>aria-colindex="2"</strong>&gt;First Name&lt;/span&gt;
+			&lt;span role="columnheader" <strong>aria-colindex="3"</strong>&gt;Last Name&lt;/span&gt;
+			&lt;span role="columnheader" <strong>aria-colindex="4"</strong>&gt;Company&lt;/span&gt;
+			&lt;span role="columnheader" <strong>aria-colindex="9"</strong>&gt;Phone&lt;/span&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
+	&lt;div role="rowgroup"&gt;
+		&lt;div role="row"&gt;
+			&lt;span role="gridcell" <strong>aria-colindex="2"</strong>&gt;Fred&lt;/span&gt;
+			&lt;span role="gridcell" <strong>aria-colindex="3"</strong>&gt;Jackson&lt;/span&gt;
+			&lt;span role="gridcell" <strong>aria-colindex="4"</strong>&gt;Acme, Inc.&lt;/span&gt;
+			&lt;span role="gridcell" <strong>aria-colindex="9"</strong>&gt;555-1234&lt;/span&gt;
+		&lt;/div&gt;
+		&lt;div role="row"&gt;
+			&lt;span role="gridcell" <strong>aria-colindex="2"</strong>&gt;Sara&lt;/span&gt;
+			&lt;span role="gridcell" <strong>aria-colindex="3"</strong>&gt;James&lt;/span&gt;
+			&lt;span role="gridcell" <strong>aria-colindex="4"</strong>&gt;Acme, Inc.&lt;/span&gt;
+			&lt;span role="gridcell" <strong>aria-colindex="9"</strong>&gt;555-1235&lt;/span&gt;
+		&lt;/div&gt;
+	 &#8230;
+	&lt;/div&gt;
 &lt;/div&gt;</pre>
 			</div>
 			<table class="property-features">
@@ -10836,9 +11125,9 @@ button.ariaPressed; // null</pre>
 			<pdef>aria-colindextext</pdef>
 			<div class="property-description">
 				<p><a>Defines</a> a human readable text alternative of <pref>aria-colindex</pref>. See related <pref>aria-rowindextext</pref>.</p>
-                                <p>Authors SHOULD only use <code>aria-colindextext</code> when the provided or calculated value of <pref>aria-colindex</pref> is not meaningful or does not reflect the displayed index, as is the case with spreadsheets and chess boards.</p>
-                                <p>Authors SHOULD NOT use <code>aria-colindextext</code> as a replacement for <pref>aria-colindex</pref> because some assistive technologies rely upon the numeric column index for the purpose of keeping track of the user's position or providing alternative table navigation.</p>
-                                <p class="note">Unlike <pref>aria-colindex</pref>, <code>aria-colindextext</code> is not a supported property of <rref>row</rref> because user agents have no way to reliably calculate <code>aria-colindextext</code> for the purpose of exposing its value on the <rref>cell</rref> or <rref>gridcell</rref>.</p>
+																<p>Authors SHOULD only use <code>aria-colindextext</code> when the provided or calculated value of <pref>aria-colindex</pref> is not meaningful or does not reflect the displayed index, as is the case with spreadsheets and chess boards.</p>
+																<p>Authors SHOULD NOT use <code>aria-colindextext</code> as a replacement for <pref>aria-colindex</pref> because some assistive technologies rely upon the numeric column index for the purpose of keeping track of the user's position or providing alternative table navigation.</p>
+																<p class="note">Unlike <pref>aria-colindex</pref>, <code>aria-colindextext</code> is not a supported property of <rref>row</rref> because user agents have no way to reliably calculate <code>aria-colindextext</code> for the purpose of exposing its value on the <rref>cell</rref> or <rref>gridcell</rref>.</p>
 			</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>
@@ -11130,35 +11419,35 @@ button.ariaPressed; // null</pre>
 				<p>It is valid for an element to have both <code>aria-details</code> and a description specified with either <code>aria-describedby</code> or <code>aria-description</code>. If a user agent relies on an accessibility API that does not support exposing multiple descriptive relations, and if an element has both <code>aria-details</code> and <rref>aria-describedby</rref>, the user agent SHOULD expose the <code>aria-details</code> relation and the description string computed from the <rref>aria-describedby</rref> relationship.</p>
 				<p>A common use for <code>aria-details</code> is in digital publishing where an extended description needs to be conveyed in a book that requires structural markup or the embedding of other technology to provide illustrative content. The following example demonstrates this scenario.</p>
 				<pre class="example highlight">
-                                &lt;!-- Provision of an extended description --&gt;
-                                &lt;img src="pythagorean.jpg" alt="Pythagorean Theorem" aria-details="det"&gt;
-                                &lt;details id="det"&gt;
-                                  &lt;summary&gt;Example&lt;/summary&gt;
-                                  &lt;p&gt;
-                                    The Pythagorean Theorem is a relationship in Euclidean Geometry between the three sides of
-                                    a right triangle, where the square of the hypotenuse is the sum of the squares of the two
-                                    opposing sides.
-                                  &lt;/p&gt;
-                                  &lt;p&gt;
-                                    The following drawing illustrates an application of the Pythagorean Theorem when used to
-                                    construct a skateboard ramp.
-                                  &lt;/p&gt;
-                                  &lt;object data="skatebd-ramp.svg"  type="image/svg+xml"&gt;&lt;/object&gt;
-                                  &lt;p&gt;
-                                    In this example you will notice a skateboard ramp with a base and vertical board whose width
-                                    is the width of the ramp. To compute how long the ramp must be, simply calculate the
-                                    base length, square it, sum it with the square of the height of the ramp, and take the
-                                    square root of the sum.
-                                  &lt;/p&gt;
-                                &lt;/details&gt;
+																&lt;!-- Provision of an extended description --&gt;
+																&lt;img src="pythagorean.jpg" alt="Pythagorean Theorem" aria-details="det"&gt;
+																&lt;details id="det"&gt;
+																	&lt;summary&gt;Example&lt;/summary&gt;
+																	&lt;p&gt;
+																		The Pythagorean Theorem is a relationship in Euclidean Geometry between the three sides of
+																		a right triangle, where the square of the hypotenuse is the sum of the squares of the two
+																		opposing sides.
+																	&lt;/p&gt;
+																	&lt;p&gt;
+																		The following drawing illustrates an application of the Pythagorean Theorem when used to
+																		construct a skateboard ramp.
+																	&lt;/p&gt;
+																	&lt;object data="skatebd-ramp.svg"  type="image/svg+xml"&gt;&lt;/object&gt;
+																	&lt;p&gt;
+																		In this example you will notice a skateboard ramp with a base and vertical board whose width
+																		is the width of the ramp. To compute how long the ramp must be, simply calculate the
+																		base length, square it, sum it with the square of the height of the ramp, and take the
+																		square root of the sum.
+																	&lt;/p&gt;
+																&lt;/details&gt;
 				</pre>
 				<p>Alternatively, <code>aria-details</code> can refer to a link to a web page having the extended description, as shown in the following example.</p>
 				<pre class="example highlight">
-                                &lt;!-- Provision of an extended description --&gt;
-                                &lt;img src="pythagorean.jpg" alt="Pythagorean Theorem" aria-details="det"&gt;
-                                &lt;p&gt;
-                                  See an &lt;a href="http://foo.com/pt.html" id="det"&gt;Application of the Pythagorean Theorem&lt;/a&gt;.
-                                &lt;/p&gt;
+																&lt;!-- Provision of an extended description --&gt;
+																&lt;img src="pythagorean.jpg" alt="Pythagorean Theorem" aria-details="det"&gt;
+																&lt;p&gt;
+																	See an &lt;a href="http://foo.com/pt.html" id="det"&gt;Application of the Pythagorean Theorem&lt;/a&gt;.
+																&lt;/p&gt;
 				</pre>
 			</div>
 			<table class="property-features">
@@ -11187,7 +11476,7 @@ button.ariaPressed; // null</pre>
 				<p><a>Indicates</a> that the <a>element</a> is <a>perceivable</a> but disabled, so it is not editable or otherwise <a>operable</a>. See related <sref>aria-hidden</sref> and <pref>aria-readonly</pref>.</p>
 				<p>For example, irrelevant options in a radio group can be disabled. Disabled elements might not receive focus from the tab order. For some disabled elements, applications might choose not to support navigation to descendants. In addition to setting the <sref>aria-disabled</sref> attribute, authors SHOULD change the appearance (grayed out, etc.) to indicate that the item has been disabled.</p>
 				<p>The <a>state</a> of being disabled applies to the element with aria-disabled and all focusable descendant elements of the element on which the <sref>aria-disabled</sref> <a>attribute</a> is applied.</p>
-                <p class="note">While <sref>aria-disabled</sref> and proper scripting can successfully disable an element with role <rref>link</rref>, fully disabling a host language equivalent can be problematic. Authors are advised not to use <sref>aria-disabled</sref> on elements that cannot be disabled through features of the host language alone.</p>
+								<p class="note">While <sref>aria-disabled</sref> and proper scripting can successfully disable an element with role <rref>link</rref>, fully disabling a host language equivalent can be problematic. Authors are advised not to use <sref>aria-disabled</sref> on elements that cannot be disabled through features of the host language alone.</p>
 				<p class="note" title="Usage on columnheader, rowheader and row">While <sref>aria-disabled</sref> is currently supported on <rref>columnheader</rref>, <rref>rowheader</rref>, and <rref>row</rref>, in a future version the working group plans to prohibit its use on elements with any of those three roles except when they are in the context of a <rref>grid</rref> or <rref>treegrid</rref>.</p>
 				<p class="note">This state is being deprecated as a global state in ARIA 1.2. In future versions it will only be allowed on roles where it is specifically supported.</p>
 			</div>
@@ -11241,9 +11530,9 @@ button.ariaPressed; // null</pre>
 		<div class="property deprecated" id="aria-dropeffect">
 			<pdef>aria-dropeffect</pdef>
 			<div class="property-description">
-			  <p>[Deprecated in ARIA 1.1] Indicates what functions can be performed when a dragged object is released on the drop target.</p>
-			  <p class="note">The <code>aria-dropeffect</code> property is expected to be replaced by a new feature in a future version of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>. Authors are therefore advised to treat <code>aria-dropeffect</code> as <a>deprecated</a>.</p>
-			  <p>This [=ARIA/property=] allows assistive technologies to convey the possible drag options available to users, including whether a pop-up menu of choices is provided by the application. Typically, drop effect functions can only be provided once an object has been grabbed for a drag operation as the drop effect functions available are dependent on the object being dragged.</p>
+				<p>[Deprecated in ARIA 1.1] Indicates what functions can be performed when a dragged object is released on the drop target.</p>
+				<p class="note">The <code>aria-dropeffect</code> property is expected to be replaced by a new feature in a future version of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>. Authors are therefore advised to treat <code>aria-dropeffect</code> as <a>deprecated</a>.</p>
+				<p>This [=ARIA/property=] allows assistive technologies to convey the possible drag options available to users, including whether a pop-up menu of choices is provided by the application. Typically, drop effect functions can only be provided once an object has been grabbed for a drag operation as the drop effect functions available are dependent on the object being dragged.</p>
 				<p>More than one drop effect can be supported for a given <a>element</a>. Therefore, the value of this <a>attribute</a> is a space-separated set of tokens indicating the possible effects, or <code>none</code> if there is no supported operation. In addition to setting the <pref>aria-dropeffect</pref> attribute, authors SHOULD show a visual indication of potential drop targets.</p>
 			</div>
 			<table class="property-features">
@@ -11333,7 +11622,7 @@ button.ariaPressed; // null</pre>
 				</pre>
 				<p class="note">This example uses <code>aria-live="assertive"</code> to indicate that assistive technologies should immediately announce the error message rather than completing other queued announcements first. This increases the likelihood that users are aware of the error message before they move focus out of the input.</p>
 				<p class="note">This state is being deprecated as a global state in ARIA 1.2. In future versions it will only be allowed on roles where it is specifically supported.</p>
-      		</div>
+					</div>
 			<table class="property-features">
 				<caption>Characteristics:</caption>
 				<thead>
@@ -11731,7 +12020,7 @@ button.ariaPressed; // null</pre>
 				<p>The valid names for non-modifier keys are any printable character such as "A", "B", "1", "2", "$", "Plus" for a plus sign, "Space" for the spacebar, or the names of any other non-modifier key specified in the <a href="https://www.w3.org/TR/uievents-key/">UI Events KeyboardEvent key Values</a> spec [[!uievents-key]] - for example, "Enter", "Tab", "ArrowRight", "PageDown", "Escape", or "F1". The use of "Space" for the spacebar is an exception to the <a href="https://www.w3.org/TR/uievents-key/">UI Events KeyboardEvent key Values</a> spec [[!uievents-key]] as the space or spacebar key is encoded as <code>'&#160;'</code> and would be treated as a whitespace character.</p>
 				<p>Authors MUST ensure modifier keys come first when they are part of a keyboard shortcut. Authors MUST ensure that required non-modifier keys come last when they are part of a shortcut. The order of the modifier keys is not otherwise significant, so "Alt+Shift+T" and "Shift+Alt+T" are equivalent, but "T+Shift+Alt" is not valid because all of the modifier keys don't come first, and "Alt" is not valid because it doesn't include at least one non-modifier key.</p>
 				<p>When specifying an alphabetic key, both the uppercase and lowercase variants are considered equivalent: "a" and "A" are the same.</p>
-                                <p>When implementing keyboard shortcuts authors should consider the keyboards they intend to support to avoid unintended results. Keyboard designs vary significantly based on the device used and the languages supported. For example, many modifier keys are used in conjunction with other keys to create common punctuation symbols, create number characters, swap keyboard sides on bilingual keyboards to switch languages, and perform a number of other functions.</p>
+																<p>When implementing keyboard shortcuts authors should consider the keyboards they intend to support to avoid unintended results. Keyboard designs vary significantly based on the device used and the languages supported. For example, many modifier keys are used in conjunction with other keys to create common punctuation symbols, create number characters, swap keyboard sides on bilingual keyboards to switch languages, and perform a number of other functions.</p>
 				<p>For many supported keyboards, authors can prevent conflicts by avoiding keys other than ASCII letters, as number characters and common punctuation often require modifiers. Here, the keyboard shortcut entered does not equate to the key generated. For example, in French keyboard layouts, the number characters are not available until you press the Control key, so a keyboard shortcut defined as "Control+2" would be ambiguous as this is how one would type the "2" character on a French keyboard.</p>
 				<p>If the character used is determined by a modifier key, the author MUST specify the actual key used to generate the character, that is generated by the key, and not the resulting character. This convention enables the assistive technology to accurately convey what keys must be used to generate the shortcut. For example, on most U.S. English keyboards, the percent sign "%" can be input by pressing Shift+5. The correct way to specify this shortcut is "Shift+5". It is incorrect to specify "%" or "Shift+%". However, note that on some international keyboards the percent sign might be an unmodified key, in which case "%" and "Shift+%" could be correct on those keyboards.</p>
 				<p>If the key that needs to be specified is illegal in the host language or would cause a string to be terminated, authors MUST use the string escaping sequence of the host language to specify it. For example, the single-quote character can be encoded as "&amp;#39;" in HTML.</p>
@@ -11858,7 +12147,7 @@ button.ariaPressed; // null</pre>
 				<p>Levels increase with depth. If the <abbr title="Document Object Model">DOM</abbr> ancestry does not accurately represent the level, authors SHOULD explicitly define the <pref>aria-level</pref> <a>attribute</a>.</p>
 				<p>This attribute is applied to elements that act as leaf nodes within the orientation of the set, for example, on elements with role <rref>treeitem</rref> rather than elements with role <rref>group</rref>. This means that multiple elements in a set can have the same value for this attribute. Although it would be less repetitive to provide a single value on the container, restricting this to leaf nodes ensures that there is a single way for <a>assistive technologies</a> to use the attribute.</p>
 				<p>If the <abbr title="Document Object Model">DOM</abbr> ancestry accurately represents the level, the <a>user agent</a> can calculate the level of an item from the document structure. This attribute can be used to provide an explicit indication of the level when that is not possible to calculate from the document structure or the <pref>aria-owns</pref> attribute. User agent support for automatic calculation of level might vary; authors SHOULD test with [=user agents=] and assistive technologies to determine whether this attribute is needed. If the author intends for the user agent to calculate the level, the author SHOULD omit this attribute.</p>
-                <p class="note"> In the case of a <rref>treegrid</rref>, <pref>aria-level</pref> is supported on elements with the role <rref>row</rref>, not elements with role <rref>gridcell</rref>. At first glance, this might seem inconsistent with the application of <pref>aria-level</pref> on <rref>treeitem</rref> elements, but it is consistent in that the <rref>row</rref> acts as the leaf node within the vertical orientation of the <rref>grid</rref>, whereas the <rref>gridcell</rref> is a leaf node within the horizontal orientation of each <rref>row</rref>. Level is not supported on sets of cells within rows, so the <pref>aria-level</pref> attribute is applied to the element with the role <rref>row</rref>.</p>
+								<p class="note"> In the case of a <rref>treegrid</rref>, <pref>aria-level</pref> is supported on elements with the role <rref>row</rref>, not elements with role <rref>gridcell</rref>. At first glance, this might seem inconsistent with the application of <pref>aria-level</pref> on <rref>treeitem</rref> elements, but it is consistent in that the <rref>row</rref> acts as the leaf node within the vertical orientation of the <rref>grid</rref>, whereas the <rref>gridcell</rref> is a leaf node within the horizontal orientation of each <rref>row</rref>. Level is not supported on sets of cells within rows, so the <pref>aria-level</pref> attribute is applied to the element with the role <rref>row</rref>.</p>
 <p class="note">On elements with role <pref>heading</pref>, values for <pref>aria-level</pref> above 6 can create difficulties for users. Also, at the time of this writing, most combinations of user agents and assistive technologies only support <pref>aria-level</pref> integers 1-9 on headings.</p>
 			</div>
 			<table class="property-features">
@@ -12263,10 +12552,10 @@ button.ariaPressed; // null</pre>
 				<p>The following example shows items 5 through 8 in a set of 16.</p>
 				<pre class="example highlight">&lt;h2 id="label_fruit"&gt; Available Fruit &lt;/h2&gt;
 &lt;ul role="listbox" aria-labelledby="label_fruit"&gt;
-  &lt;li role="option" aria-setsize="16" <strong>aria-posinset="5"</strong>&gt; apples &lt;/li&gt;
-  &lt;li role="option" aria-setsize="16" <strong>aria-posinset="6"</strong>&gt; bananas &lt;/li&gt;
-  &lt;li role="option" aria-setsize="16" <strong>aria-posinset="7"</strong>&gt; cantaloupes &lt;/li&gt;
-  &lt;li role="option" aria-setsize="16" <strong>aria-posinset="8"</strong>&gt; dates &lt;/li&gt;
+	&lt;li role="option" aria-setsize="16" <strong>aria-posinset="5"</strong>&gt; apples &lt;/li&gt;
+	&lt;li role="option" aria-setsize="16" <strong>aria-posinset="6"</strong>&gt; bananas &lt;/li&gt;
+	&lt;li role="option" aria-setsize="16" <strong>aria-posinset="7"</strong>&gt; cantaloupes &lt;/li&gt;
+	&lt;li role="option" aria-setsize="16" <strong>aria-posinset="8"</strong>&gt; dates &lt;/li&gt;
 &lt;/ul&gt;</pre>
 				<p>When specifying <pref>aria-posinset</pref>, authors MUST specify a value that is an integer greater than or equal to 1, and less than or equal to the size of the set when that size is known. If authors specify <pref>aria-posinset</pref>,  authors MUST also specify a value for <pref>aria-setsize</pref>.</p>
 				<p>When specifying <code>aria-posinset</code> on a <rref>menuitem</rref>, <rref>menuitemcheckbox</rref>, or <rref>menuitemradio</rref>, authors SHOULD set the value of <code>aria-posinset</code> with respect to the total number of items in the <rref>menu</rref>, excluding any separators.</p>
@@ -12614,34 +12903,34 @@ button.ariaPressed; // null</pre>
 				<p>The following example shows a grid with 2000 rows, of which the first row and rows 100 through 102 are displayed to the user.</p>
 				<pre class="example highlight">
 &lt;div role="grid" <strong>aria-rowcount="2000"</strong>&gt;
-  &lt;div role="rowgroup"&gt;
-    &lt;div role="row" aria-rowindex="1"&gt;
-      &lt;span role="columnheader"&gt;First Name&lt;/span&gt;
-      &lt;span role="columnheader"&gt;Last Name&lt;/span&gt;
-      &lt;span role="columnheader"&gt;Company&lt;/span&gt;
-      &lt;span role="columnheader"&gt;Phone&lt;/span&gt;
-    &lt;/div&gt;
-  &lt;/div&gt;
-  &lt;div role="rowgroup"&gt;
-    &lt;div role="row" aria-rowindex="100"&gt;
-      &lt;span role="gridcell"&gt;Fred&lt;/span&gt;
-      &lt;span role="gridcell"&gt;Jackson&lt;/span&gt;
-      &lt;span role="gridcell"&gt;Acme, Inc.&lt;/span&gt;
-      &lt;span role="gridcell"&gt;555-1234&lt;/span&gt;
-    &lt;/div&gt;
-    &lt;div role="row" aria-rowindex="101"&gt;
-      &lt;span role="gridcell"&gt;Sara&lt;/span&gt;
-      &lt;span role="gridcell"&gt;James&lt;/span&gt;
-      &lt;span role="gridcell"&gt;Acme, Inc.&lt;/span&gt;
-      &lt;span role="gridcell"&gt;555-1235&lt;/span&gt;
-    &lt;/div&gt;
-    &lt;div role="row" aria-rowindex="102"&gt;
-      &lt;span role="gridcell"&gt;Taylor&lt;/span&gt;
-      &lt;span role="gridcell"&gt;Johnson&lt;/span&gt;
-      &lt;span role="gridcell"&gt;Acme, Inc.&lt;/span&gt;
-      &lt;span role="gridcell"&gt;555-1236&lt;/span&gt;
-    &lt;/div&gt;
-  &lt;/div&gt;
+	&lt;div role="rowgroup"&gt;
+		&lt;div role="row" aria-rowindex="1"&gt;
+			&lt;span role="columnheader"&gt;First Name&lt;/span&gt;
+			&lt;span role="columnheader"&gt;Last Name&lt;/span&gt;
+			&lt;span role="columnheader"&gt;Company&lt;/span&gt;
+			&lt;span role="columnheader"&gt;Phone&lt;/span&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
+	&lt;div role="rowgroup"&gt;
+		&lt;div role="row" aria-rowindex="100"&gt;
+			&lt;span role="gridcell"&gt;Fred&lt;/span&gt;
+			&lt;span role="gridcell"&gt;Jackson&lt;/span&gt;
+			&lt;span role="gridcell"&gt;Acme, Inc.&lt;/span&gt;
+			&lt;span role="gridcell"&gt;555-1234&lt;/span&gt;
+		&lt;/div&gt;
+		&lt;div role="row" aria-rowindex="101"&gt;
+			&lt;span role="gridcell"&gt;Sara&lt;/span&gt;
+			&lt;span role="gridcell"&gt;James&lt;/span&gt;
+			&lt;span role="gridcell"&gt;Acme, Inc.&lt;/span&gt;
+			&lt;span role="gridcell"&gt;555-1235&lt;/span&gt;
+		&lt;/div&gt;
+		&lt;div role="row" aria-rowindex="102"&gt;
+			&lt;span role="gridcell"&gt;Taylor&lt;/span&gt;
+			&lt;span role="gridcell"&gt;Johnson&lt;/span&gt;
+			&lt;span role="gridcell"&gt;Acme, Inc.&lt;/span&gt;
+			&lt;span role="gridcell"&gt;555-1236&lt;/span&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
 &lt;/div&gt;</pre>
 			</div>
 			<table class="property-features">
@@ -12682,66 +12971,66 @@ button.ariaPressed; // null</pre>
 				<p>The following example shows a grid with 2000 rows, of which the first row and rows 100 through 102 are displayed to the user.</p>
 				<pre class="example highlight">
 &lt;div role="grid" aria-rowcount="2000"&gt;
-  &lt;div role="rowgroup"&gt;
-    &lt;div role="row" <strong>aria-rowindex="1"</strong>&gt;
-      &lt;span role="columnheader"&gt;First Name&lt;/span&gt;
-      &lt;span role="columnheader"&gt;Last Name&lt;/span&gt;
-      &lt;span role="columnheader"&gt;Company&lt;/span&gt;
-      &lt;span role="columnheader"&gt;Phone&lt;/span&gt;
-    &lt;/div&gt;
-  &lt;/div&gt;
-  &lt;div role="rowgroup"&gt;
-    &lt;div role="row" <strong>aria-rowindex="100"</strong>&gt;
-      &lt;span role="gridcell"&gt;Fred&lt;/span&gt;
-      &lt;span role="gridcell"&gt;Jackson&lt;/span&gt;
-      &lt;span role="gridcell"&gt;Acme, Inc.&lt;/span&gt;
-      &lt;span role="gridcell"&gt;555-1234&lt;/span&gt;
-    &lt;/div&gt;
-    &lt;div role="row" <strong>aria-rowindex="101"</strong>&gt;
-      &lt;span role="gridcell"&gt;Sara&lt;/span&gt;
-      &lt;span role="gridcell"&gt;James&lt;/span&gt;
-      &lt;span role="gridcell"&gt;Acme, Inc.&lt;/span&gt;
-      &lt;span role="gridcell"&gt;555-1235&lt;/span&gt;
-    &lt;/div&gt;
-    &lt;div role="row" <strong>aria-rowindex="102"</strong>&gt;
-      &lt;span role="gridcell"&gt;Taylor&lt;/span&gt;
-      &lt;span role="gridcell"&gt;Johnson&lt;/span&gt;
-      &lt;span role="gridcell"&gt;Acme, Inc.&lt;/span&gt;
-      &lt;span role="gridcell"&gt;555-1236&lt;/span&gt;
-    &lt;/div&gt;
-  &lt;/div&gt;
+	&lt;div role="rowgroup"&gt;
+		&lt;div role="row" <strong>aria-rowindex="1"</strong>&gt;
+			&lt;span role="columnheader"&gt;First Name&lt;/span&gt;
+			&lt;span role="columnheader"&gt;Last Name&lt;/span&gt;
+			&lt;span role="columnheader"&gt;Company&lt;/span&gt;
+			&lt;span role="columnheader"&gt;Phone&lt;/span&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
+	&lt;div role="rowgroup"&gt;
+		&lt;div role="row" <strong>aria-rowindex="100"</strong>&gt;
+			&lt;span role="gridcell"&gt;Fred&lt;/span&gt;
+			&lt;span role="gridcell"&gt;Jackson&lt;/span&gt;
+			&lt;span role="gridcell"&gt;Acme, Inc.&lt;/span&gt;
+			&lt;span role="gridcell"&gt;555-1234&lt;/span&gt;
+		&lt;/div&gt;
+		&lt;div role="row" <strong>aria-rowindex="101"</strong>&gt;
+			&lt;span role="gridcell"&gt;Sara&lt;/span&gt;
+			&lt;span role="gridcell"&gt;James&lt;/span&gt;
+			&lt;span role="gridcell"&gt;Acme, Inc.&lt;/span&gt;
+			&lt;span role="gridcell"&gt;555-1235&lt;/span&gt;
+		&lt;/div&gt;
+		&lt;div role="row" <strong>aria-rowindex="102"</strong>&gt;
+			&lt;span role="gridcell"&gt;Taylor&lt;/span&gt;
+			&lt;span role="gridcell"&gt;Johnson&lt;/span&gt;
+			&lt;span role="gridcell"&gt;Acme, Inc.&lt;/span&gt;
+			&lt;span role="gridcell"&gt;555-1236&lt;/span&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
 &lt;/div&gt;</pre>
 				<p>The following example shows the grid from the previous example with <pref>aria-rowindex</pref> also placed on all of the <a>accessibility children</a> of each row.</p>
 				<pre class="example highlight">
 &lt;div role="grid" aria-rowcount="2000"&gt;
-  &lt;div role="rowgroup"&gt;
-    &lt;div role="row" <strong>aria-rowindex="1"</strong>&gt;
-      &lt;span role="columnheader" <strong>aria-rowindex="1"</strong>&gt;First Name&lt;/span&gt;
-      &lt;span role="columnheader" <strong>aria-rowindex="1"</strong>&gt;Last Name&lt;/span&gt;
-      &lt;span role="columnheader" <strong>aria-rowindex="1"</strong>&gt;Company&lt;/span&gt;
-      &lt;span role="columnheader" <strong>aria-rowindex="1"</strong>&gt;Phone&lt;/span&gt;
-    &lt;/div&gt;
-  &lt;/div&gt;
-  &lt;div role="rowgroup"&gt;
-    &lt;div role="row" <strong>aria-rowindex="100"</strong>&gt;
-      &lt;span role="gridcell" <strong>aria-rowindex="100"</strong>&gt;Fred&lt;/span&gt;
-      &lt;span role="gridcell" <strong>aria-rowindex="100"</strong>&gt;Jackson&lt;/span&gt;
-      &lt;span role="gridcell" <strong>aria-rowindex="100"</strong>&gt;Acme, Inc.&lt;/span&gt;
-      &lt;span role="gridcell" <strong>aria-rowindex="100"</strong>&gt;555-1234&lt;/span&gt;
-    &lt;/div&gt;
-    &lt;div role="row" <strong>aria-rowindex="101"</strong>&gt;
-      &lt;span role="gridcell" <strong>aria-rowindex="101"</strong>&gt;Sara&lt;/span&gt;
-      &lt;span role="gridcell" <strong>aria-rowindex="101"</strong>&gt;James&lt;/span&gt;
-      &lt;span role="gridcell" <strong>aria-rowindex="101"</strong>&gt;Acme, Inc.&lt;/span&gt;
-      &lt;span role="gridcell" <strong>aria-rowindex="101"</strong>&gt;555-1235&lt;/span&gt;
-    &lt;/div&gt;
-    &lt;div role="row" <strong>aria-rowindex="102"</strong>&gt;
-      &lt;span role="gridcell" <strong>aria-rowindex="102"</strong>&gt;Taylor&lt;/span&gt;
-      &lt;span role="gridcell" <strong>aria-rowindex="102"</strong>&gt;Johnson&lt;/span&gt;
-      &lt;span role="gridcell" <strong>aria-rowindex="102"</strong>&gt;Acme, Inc.&lt;/span&gt;
-      &lt;span role="gridcell" <strong>aria-rowindex="102"</strong>&gt;555-1236&lt;/span&gt;
-    &lt;/div&gt;
-  &lt;/div&gt;
+	&lt;div role="rowgroup"&gt;
+		&lt;div role="row" <strong>aria-rowindex="1"</strong>&gt;
+			&lt;span role="columnheader" <strong>aria-rowindex="1"</strong>&gt;First Name&lt;/span&gt;
+			&lt;span role="columnheader" <strong>aria-rowindex="1"</strong>&gt;Last Name&lt;/span&gt;
+			&lt;span role="columnheader" <strong>aria-rowindex="1"</strong>&gt;Company&lt;/span&gt;
+			&lt;span role="columnheader" <strong>aria-rowindex="1"</strong>&gt;Phone&lt;/span&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
+	&lt;div role="rowgroup"&gt;
+		&lt;div role="row" <strong>aria-rowindex="100"</strong>&gt;
+			&lt;span role="gridcell" <strong>aria-rowindex="100"</strong>&gt;Fred&lt;/span&gt;
+			&lt;span role="gridcell" <strong>aria-rowindex="100"</strong>&gt;Jackson&lt;/span&gt;
+			&lt;span role="gridcell" <strong>aria-rowindex="100"</strong>&gt;Acme, Inc.&lt;/span&gt;
+			&lt;span role="gridcell" <strong>aria-rowindex="100"</strong>&gt;555-1234&lt;/span&gt;
+		&lt;/div&gt;
+		&lt;div role="row" <strong>aria-rowindex="101"</strong>&gt;
+			&lt;span role="gridcell" <strong>aria-rowindex="101"</strong>&gt;Sara&lt;/span&gt;
+			&lt;span role="gridcell" <strong>aria-rowindex="101"</strong>&gt;James&lt;/span&gt;
+			&lt;span role="gridcell" <strong>aria-rowindex="101"</strong>&gt;Acme, Inc.&lt;/span&gt;
+			&lt;span role="gridcell" <strong>aria-rowindex="101"</strong>&gt;555-1235&lt;/span&gt;
+		&lt;/div&gt;
+		&lt;div role="row" <strong>aria-rowindex="102"</strong>&gt;
+			&lt;span role="gridcell" <strong>aria-rowindex="102"</strong>&gt;Taylor&lt;/span&gt;
+			&lt;span role="gridcell" <strong>aria-rowindex="102"</strong>&gt;Johnson&lt;/span&gt;
+			&lt;span role="gridcell" <strong>aria-rowindex="102"</strong>&gt;Acme, Inc.&lt;/span&gt;
+			&lt;span role="gridcell" <strong>aria-rowindex="102"</strong>&gt;555-1236&lt;/span&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
 &lt;/div&gt;</pre>
 			</div>
 			<table class="property-features">
@@ -12776,8 +13065,8 @@ button.ariaPressed; // null</pre>
 			<pdef>aria-rowindextext</pdef>
 			<div class="property-description">
 				<p><a>Defines</a> a human readable text alternative of <pref>aria-rowindex</pref>. See related <pref>aria-colindextext</pref>.</p>
-                                <p>Authors SHOULD only use <code>aria-rowindextext</code> when the provided or calculated value of <pref>aria-rowindex</pref> is not meaningful or does not reflect the displayed index, as can be seen in the game Battleship.</p>
-                                <p>Authors SHOULD NOT use <code>aria-rowindextext</code> as a replacement for <pref>aria-rowindex</pref> because some assistive technologies rely upon the numeric row index for the purpose of keeping track of the user's position or providing alternative table navigation.</p>
+																<p>Authors SHOULD only use <code>aria-rowindextext</code> when the provided or calculated value of <pref>aria-rowindex</pref> is not meaningful or does not reflect the displayed index, as can be seen in the game Battleship.</p>
+																<p>Authors SHOULD NOT use <code>aria-rowindextext</code> as a replacement for <pref>aria-rowindex</pref> because some assistive technologies rely upon the numeric row index for the purpose of keeping track of the user's position or providing alternative table navigation.</p>
 				<p>Authors SHOULD place <code>aria-rowindextext</code> on each row. Authors MAY also place <code>aria-rowindextext</code> on all of the <a>accessibility children</a> of each row.</p>
 			</div>
 			<table class="property-features">
@@ -12848,7 +13137,7 @@ button.ariaPressed; // null</pre>
 			<div class="state-description">
 				<p><a>Indicates</a> the current "selected" <a>state</a> of various <a>widgets</a>. See related <sref>aria-checked</sref> and <sref>aria-pressed</sref>.</p>
 				<p>This <a>attribute</a> is used to indicate which elements within single-selection and multiple-selection <rref>composite</rref> widgets are selected.</p>
-        <p>The <rref>option</rref>, <rref>tab</rref>, and <rref>treeitem</rref> roles permit user agents to provide an implicit value for <sref>aria-selected</sref> when specified conditions are met. User agents MUST NOT provide an implicit value for aria-selected in any other circumstance.</p>
+				<p>The <rref>option</rref>, <rref>tab</rref>, and <rref>treeitem</rref> roles permit user agents to provide an implicit value for <sref>aria-selected</sref> when specified conditions are met. User agents MUST NOT provide an implicit value for aria-selected in any other circumstance.</p>
 			</div>
 			<table class="state-features">
 				<caption>Characteristics:</caption>
@@ -12912,18 +13201,18 @@ button.ariaPressed; // null</pre>
 				<p>The following example shows items 5 through 8 in a set of 16.</p>
 				<pre class="example highlight">&lt;h2 id="label_fruit"&gt; Available Fruit &lt;/h2&gt;
 &lt;ul role="listbox" aria-labelledby="label_fruit"&gt;
-  &lt;li role="option" <strong>aria-setsize="16"</strong> aria-posinset="5"&gt; apples &lt;/li&gt;
-  &lt;li role="option" <strong>aria-setsize="16"</strong> aria-posinset="6"&gt; bananas &lt;/li&gt;
-  &lt;li role="option" <strong>aria-setsize="16"</strong> aria-posinset="7"&gt; cantaloupes &lt;/li&gt;
-  &lt;li role="option" <strong>aria-setsize="16"</strong> aria-posinset="8"&gt; dates &lt;/li&gt;
+	&lt;li role="option" <strong>aria-setsize="16"</strong> aria-posinset="5"&gt; apples &lt;/li&gt;
+	&lt;li role="option" <strong>aria-setsize="16"</strong> aria-posinset="6"&gt; bananas &lt;/li&gt;
+	&lt;li role="option" <strong>aria-setsize="16"</strong> aria-posinset="7"&gt; cantaloupes &lt;/li&gt;
+	&lt;li role="option" <strong>aria-setsize="16"</strong> aria-posinset="8"&gt; dates &lt;/li&gt;
 &lt;/ul&gt;</pre>
 				<p>The following example shows items 5 through 8 in a set whose total size is unknown.</p>
 				<pre class="example highlight">&lt;h2 id="label_fruit"&gt; Available Fruit &lt;/h2&gt;
 &lt;ul role="listbox" aria-labelledby="label_fruit"&gt;
-  &lt;li role="option" <strong>aria-setsize="-1"</strong> aria-posinset="5"&gt; apples &lt;/li&gt;
-  &lt;li role="option" <strong>aria-setsize="-1"</strong> aria-posinset="6"&gt; bananas &lt;/li&gt;
-  &lt;li role="option" <strong>aria-setsize="-1"</strong> aria-posinset="7"&gt; cantaloupes &lt;/li&gt;
-  &lt;li role="option" <strong>aria-setsize="-1"</strong> aria-posinset="8"&gt; dates &lt;/li&gt;
+	&lt;li role="option" <strong>aria-setsize="-1"</strong> aria-posinset="5"&gt; apples &lt;/li&gt;
+	&lt;li role="option" <strong>aria-setsize="-1"</strong> aria-posinset="6"&gt; bananas &lt;/li&gt;
+	&lt;li role="option" <strong>aria-setsize="-1"</strong> aria-posinset="7"&gt; cantaloupes &lt;/li&gt;
+	&lt;li role="option" <strong>aria-setsize="-1"</strong> aria-posinset="8"&gt; dates &lt;/li&gt;
 &lt;/ul&gt;</pre>
 			</div>
 			<table class="property-features">
@@ -13167,129 +13456,129 @@ button.ariaPressed; // null</pre>
 	<h1><dfn class="export">Accessibility Tree</dfn></h1>
 	<p>The <a class="termref">accessibility tree</a> and the DOM tree are parallel structures. The <a class="termref">accessibility tree</a> includes the user interface objects of the <a>user agent</a> and the objects of the document. <a>Accessible objects</a> are created in the accessibility tree for every DOM element that should be exposed to an <a>assistive technology</a>, either because it might fire an accessibility <a>event</a> or because it has a [=ARIA/property=], <a>relationship</a> or feature which needs to be exposed.</p>
 	<section id="tree_exclusion">
-	  <h2>Excluding Elements from the Accessibility Tree</h2>
-	  <p>The following [=elements=] are not exposed via the <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> and user agents MUST NOT include them in the <a class="termref">accessibility tree</a>:</p>
-	  <ul>
-	    <li>Elements, including their descendent elements, that have host language semantics specifying that the element is not displayed, such as CSS <code>display:none</code>, <code>visibility:hidden</code>, or the HTML <code>hidden</code> attribute.</li>
-	    <li>Elements with <rref>none</rref> or <rref>presentation</rref> as the first role in the role attribute. However, their exclusion is conditional. In addition, the element's descendants and text content are generally included. These exceptions and conditions are documented in the <a href="#presentation">presentation (role)</a> section.</li>
-    </ul>
-	  <p>If not already excluded from the accessibility tree per the above rules, user agents SHOULD NOT include the following elements in the accessibility tree:</p>
-	  <ul>
-	    <li>Elements, including their descendants, that have <sref>aria-hidden</sref> set to <code>true</code>. In other words, <code>aria-hidden=&quot;true&quot;</code> on a parent overrides <code>aria-hidden=&quot;false&quot;</code> on descendants.</li>
-            <li>
-              <p>Any descendants of elements that have the characteristic &quot;<a href="#childrenArePresentational">Children Presentational: True</a>&quot; unless the descendant is not allowed to be presentational because it meets one of the conditions for exception described in <a href="#conflict_resolution_presentation_none">Presentational Roles Conflict Resolution</a>. However, the text content of any excluded descendants is included.</p>
-              <p>Elements with the following roles have the characteristic &quot;Children Presentational: True&quot;:</p>
-	        <ul>
-	          <li><rref>button</rref></li>
-	          <li><rref>checkbox</rref></li>
-	          <li><rref>img</rref></li>
-	          <li><rref>menuitemcheckbox</rref></li>
-	          <li><rref>menuitemradio</rref></li>
-	          <li><rref>meter</rref></li>
-	          <li><rref>option</rref></li>
-	          <li><rref>progressbar</rref></li>
-	          <li><rref>radio</rref></li>
-	          <li><rref>scrollbar</rref></li>
-	          <li><rref>separator</rref></li>
-	          <li><rref>slider</rref></li>
-	          <li><rref>switch</rref></li>
-	          <li><rref>tab</rref></li>
+		<h2>Excluding Elements from the Accessibility Tree</h2>
+		<p>The following [=elements=] are not exposed via the <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> and user agents MUST NOT include them in the <a class="termref">accessibility tree</a>:</p>
+		<ul>
+			<li>Elements, including their descendent elements, that have host language semantics specifying that the element is not displayed, such as CSS <code>display:none</code>, <code>visibility:hidden</code>, or the HTML <code>hidden</code> attribute.</li>
+			<li>Elements with <rref>none</rref> or <rref>presentation</rref> as the first role in the role attribute. However, their exclusion is conditional. In addition, the element's descendants and text content are generally included. These exceptions and conditions are documented in the <a href="#presentation">presentation (role)</a> section.</li>
 		</ul>
-            </li>
-          </ul>
+		<p>If not already excluded from the accessibility tree per the above rules, user agents SHOULD NOT include the following elements in the accessibility tree:</p>
+		<ul>
+			<li>Elements, including their descendants, that have <sref>aria-hidden</sref> set to <code>true</code>. In other words, <code>aria-hidden=&quot;true&quot;</code> on a parent overrides <code>aria-hidden=&quot;false&quot;</code> on descendants.</li>
+						<li>
+							<p>Any descendants of elements that have the characteristic &quot;<a href="#childrenArePresentational">Children Presentational: True</a>&quot; unless the descendant is not allowed to be presentational because it meets one of the conditions for exception described in <a href="#conflict_resolution_presentation_none">Presentational Roles Conflict Resolution</a>. However, the text content of any excluded descendants is included.</p>
+							<p>Elements with the following roles have the characteristic &quot;Children Presentational: True&quot;:</p>
+					<ul>
+						<li><rref>button</rref></li>
+						<li><rref>checkbox</rref></li>
+						<li><rref>img</rref></li>
+						<li><rref>menuitemcheckbox</rref></li>
+						<li><rref>menuitemradio</rref></li>
+						<li><rref>meter</rref></li>
+						<li><rref>option</rref></li>
+						<li><rref>progressbar</rref></li>
+						<li><rref>radio</rref></li>
+						<li><rref>scrollbar</rref></li>
+						<li><rref>separator</rref></li>
+						<li><rref>slider</rref></li>
+						<li><rref>switch</rref></li>
+						<li><rref>tab</rref></li>
+		</ul>
+						</li>
+					</ul>
 	</section>
 	<section id="tree_inclusion">
-	  <h2>Including Elements in the Accessibility Tree</h2>
-          <p>If not excluded from the accessibility tree per the rules above in <a href="#tree_exclusion">Excluding Elements in the Accessibility Tree</a>, user agents MUST provide an <a>accessible object</a> in the <a class="termref">accessibility tree</a> for <abbr title="Document Object Model">DOM</abbr> [=elements=] that meet any of the following criteria:</p>
-          <ul>
-            <li>Elements that are not [=element/hidden=] and can fire an <a>accessibility <abbr title="Application Program Interface">API</abbr></a> <a>event</a>, including:
-              <ul>
-                <li>Elements that are currently focused, even if the element or one of its ancestor elements has its <sref>aria-hidden</sref> attribute set to <code>true</code>.</li>
-                <li>Elements that are a valid target of an <pref>aria-activedescendant</pref> attribute.</li>
-              </ul>
-	        </li>
-            <li>Elements that have an explicit role or a global <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> attribute and do not have <sref>aria-hidden</sref> set to <code>true</code>. (See <a href="#tree_exclusion">Excluding Elements in the Accessibility Tree</a> for additional guidance on <sref>aria-hidden</sref>.)</li>
-            <li>Elements that are not [=element/hidden=] and have an ID that is referenced by another element via a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> property.
-            <p class="note">Text equivalents for [=element/hidden=] referenced objects can still be used in the <a href="#mapping_additional_nd" class="accname">name and description computation</a> even when not included in the accessibility tree.</p>
-            </li>
-          </ul>
+		<h2>Including Elements in the Accessibility Tree</h2>
+					<p>If not excluded from the accessibility tree per the rules above in <a href="#tree_exclusion">Excluding Elements in the Accessibility Tree</a>, user agents MUST provide an <a>accessible object</a> in the <a class="termref">accessibility tree</a> for <abbr title="Document Object Model">DOM</abbr> [=elements=] that meet any of the following criteria:</p>
+					<ul>
+						<li>Elements that are not [=element/hidden=] and can fire an <a>accessibility <abbr title="Application Program Interface">API</abbr></a> <a>event</a>, including:
+							<ul>
+								<li>Elements that are currently focused, even if the element or one of its ancestor elements has its <sref>aria-hidden</sref> attribute set to <code>true</code>.</li>
+								<li>Elements that are a valid target of an <pref>aria-activedescendant</pref> attribute.</li>
+							</ul>
+					</li>
+						<li>Elements that have an explicit role or a global <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> attribute and do not have <sref>aria-hidden</sref> set to <code>true</code>. (See <a href="#tree_exclusion">Excluding Elements in the Accessibility Tree</a> for additional guidance on <sref>aria-hidden</sref>.)</li>
+						<li>Elements that are not [=element/hidden=] and have an ID that is referenced by another element via a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> property.
+						<p class="note">Text equivalents for [=element/hidden=] referenced objects can still be used in the <a href="#mapping_additional_nd" class="accname">name and description computation</a> even when not included in the accessibility tree.</p>
+						</li>
+					</ul>
 	</section>
 	<section id="tree_relationships">
-	  <h2>Relationships in the Accessibility Tree</h2>
-          <p>The following terms are used to describe relationships between <abbr title="Document Object Model">DOM</abbr> elements.</p>
-          <p>The <dfn data-export="" data-lt="accessibility child|owned child|child element|child|children|child elements">accessibility children</dfn> of a DOM element are all of the children of that element's corresponding <a>accessible object</a> in the <a>accessibility tree</a>. In terms of the DOM, that includes the following (with exclusions listed blow):</p>
-          <ul>
-            <li>The <abbr title="Document Object Model">DOM</abbr> children of the <a>element</a>.
-            </li>
-            <li>All DOM descendants of the <a>element</a> with only elements of role <rref>generic</rref> or <rref>none</rref> intervening.
-            </li>
-            <li>All DOM elements specified via an <pref>aria-owns</pref> relationship to the element.
-            </li>
-            <li>All DOM descendants of an element with role <rref>generic</rref> or <rref>none</rref> specified via <pref>aria-owns</pref> with only elements of role <rref>generic</rref> or <rref>none</rref> intervening.
-            </li>
-          </ul>
-          <p>And excludes the following:
-          <ul>
-            <li>All DOM elements that have no corresponding <a>accessible object</a> because they have been <a href="#tree_exclusion">excluded from the accessibility tree</a>.</li>
-            <li>All DOM elements whose corresponding <a>accessible object</a> have been reparented in the <a>accessibility tree</a> via <pref>aria-owns</pref>.</li>
-          </ul>
-          </p>
-          <p>In the following example, the <rref>list</rref> element has four accessibility children:</p>
-	  <pre class="example highlight">
+		<h2>Relationships in the Accessibility Tree</h2>
+					<p>The following terms are used to describe relationships between <abbr title="Document Object Model">DOM</abbr> elements.</p>
+					<p>The <dfn data-export="" data-lt="accessibility child|owned child|child element|child|children|child elements">accessibility children</dfn> of a DOM element are all of the children of that element's corresponding <a>accessible object</a> in the <a>accessibility tree</a>. In terms of the DOM, that includes the following (with exclusions listed blow):</p>
+					<ul>
+						<li>The <abbr title="Document Object Model">DOM</abbr> children of the <a>element</a>.
+						</li>
+						<li>All DOM descendants of the <a>element</a> with only elements of role <rref>generic</rref> or <rref>none</rref> intervening.
+						</li>
+						<li>All DOM elements specified via an <pref>aria-owns</pref> relationship to the element.
+						</li>
+						<li>All DOM descendants of an element with role <rref>generic</rref> or <rref>none</rref> specified via <pref>aria-owns</pref> with only elements of role <rref>generic</rref> or <rref>none</rref> intervening.
+						</li>
+					</ul>
+					<p>And excludes the following:
+					<ul>
+						<li>All DOM elements that have no corresponding <a>accessible object</a> because they have been <a href="#tree_exclusion">excluded from the accessibility tree</a>.</li>
+						<li>All DOM elements whose corresponding <a>accessible object</a> have been reparented in the <a>accessibility tree</a> via <pref>aria-owns</pref>.</li>
+					</ul>
+					</p>
+					<p>In the following example, the <rref>list</rref> element has four accessibility children:</p>
+		<pre class="example highlight">
 &lt;div role="list" aria-owns="child3 child4"&gt;
-  &lt;div role="listitem"&gt;Accessibility Child 1&lt;/div&gt;
-  &lt;div&gt;
-    &lt;div role="listitem"&gt;Accessibility Child 2&lt;/div&gt;
-  &lt;/div&gt;
+	&lt;div role="listitem"&gt;Accessibility Child 1&lt;/div&gt;
+	&lt;div&gt;
+		&lt;div role="listitem"&gt;Accessibility Child 2&lt;/div&gt;
+	&lt;/div&gt;
 &lt;/div&gt;
 &lt;div id="child3" role="listitem"&gt;Accessibility Child 3&lt;/div&gt;
 &lt;div id="child4"&gt;
-  &lt;div role="listitem"&gt;Accessibility Child 4&lt;/div&gt;
+	&lt;div role="listitem"&gt;Accessibility Child 4&lt;/div&gt;
 &lt;/div&gt;
-          </pre>
-          <p>In the following example, the first <rref>list</rref> element has no accessibility children, where as the second <rref>list</rref> element has one accessibility child, specifically the <rref>listitem</rref> with ID value "reparented".</p>
-	  <pre class="example highlight">
+					</pre>
+					<p>In the following example, the first <rref>list</rref> element has no accessibility children, where as the second <rref>list</rref> element has one accessibility child, specifically the <rref>listitem</rref> with ID value "reparented".</p>
+		<pre class="example highlight">
 &lt;div role="list"&gt;
-  &lt;div role="listitem" aria-hidden="true"&gt;Excluded element&lt;/div&gt;
-  &lt;div role="listitem" id="reparented"&gt;Reparented element&lt;/div&gt;
+	&lt;div role="listitem" aria-hidden="true"&gt;Excluded element&lt;/div&gt;
+	&lt;div role="listitem" id="reparented"&gt;Reparented element&lt;/div&gt;
 &lt;/div&gt;
 &lt;div role="list" aria-owns="reparented"&gt;&lt;/div&gt;
-          </pre>
-          <p>The <dfn data-export="" data-lt="accessibility descendant|accessibility descendants">accessibility descendants</dfn> of a DOM element are all DOM elements which correspond to descendants of the corresponding <a>accessible object</a> in the <a class="termref">accessibility tree</a>.</p>
-          <p>The <dfn data-export="" data-lt="accessibility parent|parent element|parent">accessibility parent</dfn> of a DOM element is the parent of the corresponding <a>accessible object</a> in the <a>accessibility tree</a>. In terms of the DOM, the accessibility parent is one of the following:</p>
-          <ul>
-            <li>The <abbr title="Document Object Model">DOM</abbr> parent of the <a>element</a>.
-            </li>
-            <li>The DOM ancestor of the <a>element</a> with only elements of role <rref>generic</rref> or <rref>none</rref> intervening.
-            </li>
-            <li>A DOM element with <pref>aria-owns</pref> set to the DOM ID of the DOM element in question.
-            </li>
-            <li>A DOM element with <pref>aria-owns</pref> set to the DOM ID of an ancestor of the DOM element in question, with only elements of role <rref>generic</rref> or <rref>none</rref> intervening.
-            </li>
-          </ul>
-          <p>The following four examples all contain a <rref>listitem</rref> element with an accessibility parent of role <rref>list</rref>:</p>
-          <pre class="example highlight">
+					</pre>
+					<p>The <dfn data-export="" data-lt="accessibility descendant|accessibility descendants">accessibility descendants</dfn> of a DOM element are all DOM elements which correspond to descendants of the corresponding <a>accessible object</a> in the <a class="termref">accessibility tree</a>.</p>
+					<p>The <dfn data-export="" data-lt="accessibility parent|parent element|parent">accessibility parent</dfn> of a DOM element is the parent of the corresponding <a>accessible object</a> in the <a>accessibility tree</a>. In terms of the DOM, the accessibility parent is one of the following:</p>
+					<ul>
+						<li>The <abbr title="Document Object Model">DOM</abbr> parent of the <a>element</a>.
+						</li>
+						<li>The DOM ancestor of the <a>element</a> with only elements of role <rref>generic</rref> or <rref>none</rref> intervening.
+						</li>
+						<li>A DOM element with <pref>aria-owns</pref> set to the DOM ID of the DOM element in question.
+						</li>
+						<li>A DOM element with <pref>aria-owns</pref> set to the DOM ID of an ancestor of the DOM element in question, with only elements of role <rref>generic</rref> or <rref>none</rref> intervening.
+						</li>
+					</ul>
+					<p>The following four examples all contain a <rref>listitem</rref> element with an accessibility parent of role <rref>list</rref>:</p>
+					<pre class="example highlight">
 &lt;div role="list"&gt;
-  &lt;div role="listitem"&gt;The "list" is my accessibility parent.&lt;/div&gt;
+	&lt;div role="listitem"&gt;The "list" is my accessibility parent.&lt;/div&gt;
 &lt;/div&gt;
-          </pre>
-	  <pre class="example highlight">
+					</pre>
+		<pre class="example highlight">
 &lt;div role="list"&gt;
-  &lt;div&gt;
-    &lt;div role="listitem"&gt;The "list" is my accessibility parent.&lt;/div&gt;
-  &lt;/div&gt;
+	&lt;div&gt;
+		&lt;div role="listitem"&gt;The "list" is my accessibility parent.&lt;/div&gt;
+	&lt;/div&gt;
 &lt;/div&gt;
-          </pre>
-	  <pre class="example highlight">
+					</pre>
+		<pre class="example highlight">
 &lt;div role="list" aria-owns="child"&gt;&lt;/div&gt;
 &lt;div id="child" role="listitem"&gt;The "list" is my accessibility parent.&lt;/div&gt;
-          </pre>
-	  <pre class="example highlight">
+					</pre>
+		<pre class="example highlight">
 &lt;div role="list" aria-owns="child"&gt;&lt;/div&gt;
 &lt;div id="child"&gt;
-  &lt;div role="listitem"&gt;The "list" is my accessibility parent.&lt;/div&gt;
+	&lt;div role="listitem"&gt;The "list" is my accessibility parent.&lt;/div&gt;
 &lt;/div&gt;
-          </pre>
+					</pre>
 	</section>
 </section>
 <section class="normative" id="host_languages">
@@ -13367,12 +13656,12 @@ button.ariaPressed; // null</pre>
 		<p>Elements that have implicit WAI-ARIA semantics support the full set of WAI-ARIA states and properties supported by the corresponding role. Therefore, authors MAY omit the role when setting states and properties. The role is only needed when the implicit WAI-ARIA role of the element needs to be changed.</p>
 		<p>Sometimes states and properties are present in the DOM but have a zero-length string ("") as their value. Authors MAY specify a zero-length string ("") for any supported (but not required) state or property. User agents SHOULD treat state and property attributes with a value of "" the same as they treat an absent attribute.  For supported states and properties, this corresponds to the default value, but if it is a required attribute, it signals an author error and is processed as detailed at <a href="#document-handling_author-errors">Handling Author Errors</a>. </p>
 		<section id="mapping_additional_relations_error_processing">
-	        <h3>ID Reference Error Processing</h3>
-	        <p>[=user agents=] SHOULD ignore ID references that do not match the ID of another <a>element</a> in the same document.</p>
-	        <p>It is the author's responsibility to ensure that IDs are unique. If more than one element has the same ID, the user agent SHOULD use the first element found with the given ID. The behavior will be the same as <code>getElementById</code>.</p>
-	        <p>If the same element is specified multiple times in a single <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> relation, user agents SHOULD return multiple pointers to the same <a>element</a>.</p>
-	        <p><pref>aria-activedescendant</pref> is defined as referencing only a single ID reference. Any <code>aria-activedescendant</code> value that does not match an existing ID reference exactly is an author error and will not match any element in the <abbr title="Document Object Model">DOM</abbr>.</p>
-        </section>
+					<h3>ID Reference Error Processing</h3>
+					<p>[=user agents=] SHOULD ignore ID references that do not match the ID of another <a>element</a> in the same document.</p>
+					<p>It is the author's responsibility to ensure that IDs are unique. If more than one element has the same ID, the user agent SHOULD use the first element found with the given ID. The behavior will be the same as <code>getElementById</code>.</p>
+					<p>If the same element is specified multiple times in a single <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> relation, user agents SHOULD return multiple pointers to the same <a>element</a>.</p>
+					<p><pref>aria-activedescendant</pref> is defined as referencing only a single ID reference. Any <code>aria-activedescendant</code> value that does not match an existing ID reference exactly is an author error and will not match any element in the <abbr title="Document Object Model">DOM</abbr>.</p>
+				</section>
 	</section>
 	<section id="document-handling_css-selectors">
 		<h3>CSS Selectors</h3>
@@ -13523,7 +13812,7 @@ button.ariaPressed; // null</pre>
 		<ul>
 			<li>If an element is focusable, user agents MUST ignore the <rref>none</rref>/<rref>presentation</rref> role and expose the element with its implicit role, in order to ensure that the element is <a>operable</a>.</li>
 			<li>If an <a href="#mustContain">allowed child element</a> has an explicit non-presentational role, user agents MUST ignore an inherited presentational role and expose the element with its explicit role. If the action of exposing the explicit role causes the accessibility tree to be malformed, the expected results are undefined.</li>
-      <li>If an element has <a>global</a> WAI-ARIA states or properties, user agents MUST ignore the <rref>none</rref>/<rref>presentation</rref> role and instead expose the element's implicit role. However, if an element has only non-global, role-specific WAI-ARIA states or properties, the element MUST NOT be exposed unless the presentational role is inherited and an explicit non-presentational role is applied.</li>
+			<li>If an element has <a>global</a> WAI-ARIA states or properties, user agents MUST ignore the <rref>none</rref>/<rref>presentation</rref> role and instead expose the element's implicit role. However, if an element has only non-global, role-specific WAI-ARIA states or properties, the element MUST NOT be exposed unless the presentational role is inherited and an explicit non-presentational role is applied.</li>
 		</ul>
 		<p class="note">Some <a>global</a> WAI-ARIA states and properties are <a>prohibited</a> on certain roles. These states and properties are still considered global for the purposes of Presentational Role Conflict resolution.</p>
 		<p>For example, <pref>aria-describedby</pref> is a global attribute and would always be applied; <pref>aria-level</pref> is not a global attribute and would therefore only apply if the element was not in a presentational state.</p>
@@ -13698,7 +13987,7 @@ button.ariaPressed; // null</pre>
 
 <!-- ReSpec needs these examples to be unindented. -->
 <pre>&lt;div id="inaccessibleButton"&gt;
-    &lt;!-- Use semantic markup instead. This is just a retrofit example. --&gt;
+		&lt;!-- Use semantic markup instead. This is just a retrofit example. --&gt;
 &lt;/div&gt;</pre>
 <pre>// Get a reference to the element.
 let el = document.getElementById('inaccessibleButton');
@@ -14045,7 +14334,7 @@ el.getAttribute("aria-label"); // Returns "Publish"</pre>
 					href="https://github.com/w3c/aria/pull/1137">#1137</a>)</li>
 			<li><a href="https://github.com/w3c/aria/commit/b3017b3">Add mark role</a> (<a
 					href="https://github.com/w3c/aria/pull/1133">#1133</a>)</li>
-      </ul>
+			</ul>
 	</section>
 </section>
 <!--


### PR DESCRIPTION
Closes #2036 

* Adds two roles: listview and listviewitem.
* Implementation of [A proposal for an interactive lists role](https://gist.github.com/smhigley/a613aab8287726f61202869e2f479553)
* Implementation of [Proposal: Interactive Lists · w3c/aria Wiki](https://github.com/w3c/aria/wiki/Proposal:-Interactive-Lists)

Related issues:
* #1325 
* #1994 
* #2162 

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests:
* [ ] Browser implementations (link to issue or commit):
   * WebKit:
   * Gecko:
   * Blink:
* [ ] Does this need AT implementations? Yes.
* [ ] Related APG Issue/PR:
* [ ] MDN Issue/PR:
