### PR TITLE
[html-aam PR 538] Specify AXAPI behaviour for low, high, and optimum meter attributes

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -10958,7 +10958,7 @@
             <tr>
               <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="general">Expose "optimal value" via `AXValueDescription` if &lt;value&gt; is greater than or equal to &lt;high&gt;. Expose "suboptimal value" if &lt;value&gt; is less than &lt;high&gt; and greater than or equal to &lt;low&gt;.</div>
               </td>
             </tr>
             <tr>
@@ -11911,7 +11911,7 @@
             <tr>
               <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="general">Expose "suboptial value" via `AXValueDescription` if &lt;value&gt; is greater than or equal to &lt;low&gt; and less than &lt;high&gt;. If &lt;value&gt; is less than &lt;low&gt;, expose "critical value".</div>
               </td>
             </tr>
             <tr>
@@ -13090,7 +13090,7 @@
             <tr>
               <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="general">Expose "optimal value" via `AXValueDescription` if &lt;value&gt; is greater than or equal to &lt;optimum&gt;.</div>
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
Moved from https://github.com/w3c/html-aam/pull/538
