### PR TITLE
Update: legend to provide name to optgroup

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -4647,7 +4647,10 @@
               </th>
               <td>
                 <div class="role"><span class="type">Roles:</span> `ROLE_SYSTEM_STATICTEXT`; `IA2_ROLE_LABEL`</div>
-                <div class="relations"><span class="type">Relations:</span> `IA2_RELATION_LABEL_FOR` with the parent <a href="#el-fieldset">`fieldset`</a></div>
+                <div class="relations">
+                  <span class="type">Relations:</span> `IA2_RELATION_LABEL_FOR` with the parent <a href="#el-fieldset">`fieldset`</a> 
+                  or <a href="#el-optgroup">`optgroup`</a>
+                </div>
               </td>
             </tr>
             <tr>
@@ -4657,7 +4660,8 @@
                 <div class="properties">
                   <span class="type">Other properties:</span>
                   The `LabeledBy` property for the parent
-                  <a href="#el-fieldset">`fieldset`</a> points to the UIA element for the `legend` element.
+                  <a href="#el-fieldset">`fieldset`</a> or <a href="#el-optgroup">`optgroup`</a> points to the 
+                  UIA element for the `legend` element.
                 </div>
               </td>
             </tr>
@@ -4667,7 +4671,8 @@
                 <div class="role"><span class="type">Role:</span> `ATK_ROLE_LABEL`</div>
                 <div class="relations">
                   <span class="type">Relations:</span>
-                  `ATK_RELATION_LABEL_FOR` with parent <a href="#el-fieldset">`fieldset`</a> element
+                  `ATK_RELATION_LABEL_FOR` with parent <a href="#el-fieldset">`fieldset`</a> 
+                  or <a href="#el-optgroup">`optgroup`</a> element
                 </div>
               </td>
             </tr>


### PR DESCRIPTION
In regards to the updated content model for the select element and its allowed children, an `optgroup` can have a `legend` element as its first child, and this `legend` needs to be able to name the `optgroup` similarly to how a `legend` names a `fieldset`.

see:
https://github.com/whatwg/html/pull/10586

<!--- IF EDITORIAL or CHORE, delete the rest of this template -->

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests:
* [ ] Browser implementations (link to issue or commit):
   * WebKit:
   * Gecko:
   * Blink:
* [ ] Does this need AT implementations?
* [ ] Related APG Issue/PR:
* [ ] MDN Issue/PR:
