### PR TITLE
[core-aam] add new AX API mappings for colindextext/rowindextext

### DIFF
--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -6372,7 +6372,7 @@
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: TBD</span>
+                  <span class="property">Property: <code>AXARIAColumnIndexText</code>: <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
             </tbody>
@@ -9209,7 +9209,7 @@
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: TBD</span>
+                  <span class="property">Property: <code>AXARIARowIndexText</code>: <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
             </tbody>

--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -6372,7 +6372,7 @@
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXARIAColumnIndexText</code>: <code>&lt;value&gt;</code></span>
+                  <span class="property">Property: <code>AXColumnIndexDescription</code>: <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
             </tbody>
@@ -9209,7 +9209,7 @@
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXARIARowIndexText</code>: <code>&lt;value&gt;</code></span>
+                  <span class="property">Property: <code>AXRowIndexDescription</code>: <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
Closes https://github.com/w3c/core-aam/issues/53

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [x] "author MUST" tests: n/a
* [x] "user agent MUST" tests: 
   * [x] not testable in WPT, so n/a
   * [ ] @spectranaut may wish to add platform mapping tests
* [ ] Browser implementations (link to issue or commit):
   * [ ] WebKit: [#257142](https://webkit.org/b/257142)
   * [ ] Gecko: [#1931415](https://bugzilla.mozilla.org/show_bug.cgi?id=1931415)
   * [x] Blink: [#378698863](https://issues.chromium.org/issues/378698863)
* Does this Mac-specific change need AT implementation? 
   * VoiceOver change is not prioritized b/c there is not a platform equivalent
* [x] Related APG Issue/PR: n/a
* [x] MDN Issue/PR: n/a