### PR TITLE
Update: clarify / expand value attribute mappings

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -7951,6 +7951,9 @@
             </div>
           </li>
           <li>All elements having an accessible object in IAccessible2 mapping are supposed to implement IAccessible, IAccessible2 and IAccessible2_2 interfaces.</li>
+          <li>
+            User interaction with certain HTML elements will set an element's <a data-cite="html/form-control-infrastructure.html#concept-fe-dirty">dirty value flag</a>. For these elements which are identified in [HTML], if specified such attributes represent only the default value or state for the element. 
+          </li>
         </ul>
         <h4 id="att-abbr">`abbr`</h4>
         <table aria-labelledby="att-abbr">
@@ -15770,46 +15773,232 @@
             <tr>
               <th>Element(s)</th>
               <td>
-                <a data-cite="html/input.html#attr-input-value">`input`</a>
+                <a data-cite="html/input.html#attr-input-value">`input`</a>;
+                <a data-cite="html/input.html#date-state-(type=date)">`input type=date`</a>;
+                <a data-cite="html/input.html#datetime-local-state-(type=datetime-local)">`input type=datetime-local`</a>;
+                <a data-cite="html/input.html#email-state-(type=email)">`input type=email`</a>;
+                <a data-cite="html/input.html#month-state-(type=month)">`input type=month`</a>;
+                <a data-cite="html/input.html#number-state-(type=number)">`input type=number`</a>;
+                <a data-cite="html/input.html#password-state-(type=password)">`input type=password`</a>;
+                <a data-cite="html/input.html#range-state-(type=range)">`input type=range`</a>
+                <a data-cite="html/input.html#search-state-(type=search)">`input type=search`</a>;
+                <a data-cite="html/input.html#tel-state-(type=tel)">`input type=tel`</a>;
+                <a data-cite="html/input.html#text-state-(type=text)">`input type=text`</a>;
+                <a data-cite="html/input.html#url-state-(type=url)">`input type=url`</a>;
+                <a data-cite="html/input.html#week-state-(type=week)">`input type=week`</a>;
               </td>
             </tr>
             <tr>
               <th>[[WAI-ARIA-1.2]]</th>
-              <td>Not mapped</td>
+              <td>
+                <a class="core-mapping" href="#ariaValueNow">`aria-valuenow`</a>
+              </td>
             </tr>
             <tr>
               <th>
                 <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
               </th>
-              <td>
-                <div class="name">
-                  Associates the accessible value for entry type input elements and <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> for button type input elements
-                </div>
-              </td>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
             </tr>
             <tr>
               <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
-              <td>
-                <div class="name">
-                  Associates the accessible value for entry type input elements and <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> for button type input elements
-                </div>
-              </td>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
             </tr>
             <tr>
               <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
-              <td>
-                <div class="name">
-                  Associates the accessible value for entry type input elements and <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> for button type input elements
-                </div>
-              </td>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
             </tr>
             <tr>
               <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
-              <td>`AXValue: &lt;value&gt;`</td>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
             </tr>
             <tr>
               <th>Comments</th>
               <td></td>
+            </tr>
+          </tbody>
+        </table>
+        <h4 id="att-value-input-buttons">`value`</h4>
+        <table aria-labelledby="att-value-input-buttons">
+          <tbody>
+            <tr>
+              <th>HTML Specification</th>
+              <td>`value`</td>
+            </tr>
+            <tr>
+              <th>Element(s)</th>
+              <td>
+                <a data-cite="html/input.html#button-state-(type=button)">`input type=button`</a>;
+                <a data-cite="html/input.html#reset-button-state-(type=reset)">`input type=reset`</a>;
+                <a data-cite="html/input.html#submit-button-state-(type=submit)">`input type=submit`</a>
+              </td>
+            </tr>
+            <tr>
+              <th>[[WAI-ARIA-1.2]]</th>
+              <td>Contributes to the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> of the `input`</td>
+            </tr>
+            <tr>
+              <th>
+                <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
+              </th>
+              <td><div class="general">See comments</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+              <td><div class="general">See comments</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <td><div class="general">See comments</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <td><div class="general">See comments</div></td>
+            </tr>
+            <tr>
+              <th>Comments</th>
+              <td>
+                If specified, the value of the attribute will contribute to the
+                <a href="#input-type-button-input-type-submit-and-input-type-reset-accessible-name-computation">accessible name computations</a> for these `input` elements in the `button`, `reset` and `submit` states, rendering as the button `input` element's text label.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <h4 id="att-value-input-checkbox-hidden-radio">`value`</h4>
+        <table aria-labelledby="att-value-input-checkbox-hidden-radio">
+          <tbody>
+            <tr>
+              <th>HTML Specification</th>
+              <td>`value`</td>
+            </tr>
+            <tr>
+              <th>Element(s)</th>
+              <td>
+                <a data-cite="html/input.html#checkbox-state-(type=checkbox)">`input type=checkbox`</a>;
+                <a data-cite="html/input.html#hidden-state-(type=hidden)">`input type=hidden`</a>;
+                <a data-cite="html/input.html#radio-state-(type=radio)">`input type=radio`</a>
+              </td>
+            </tr>
+            <tr>
+              <th>[[WAI-ARIA-1.2]]</th>
+              <td><div class="general">Not mapped</div></td>
+            </tr>
+            <tr>
+              <th>
+                <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
+              </th>
+              <td><div class="general">Not mapped</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+              <td><div class="general">Not mapped</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <td><div class="general">Not mapped</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <td><div class="general">Not mapped</div></td>
+            </tr>
+            <tr>
+              <th>Comments</th>
+              <td>
+                <p class="note">The `value` attribute of these `input` states is not directly communicated to users.</p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <h4 id="att-value-input-color">`value`</h4>
+        <table aria-labelledby="att-value-input-color">
+          <tbody>
+            <tr>
+              <th>HTML Specification</th>
+              <td>`value`</td>
+            </tr>
+            <tr>
+              <th>Element(s)</th>
+              <td>
+                <a data-cite="html/input.html#color-state-(type=color)">`input type=color`</a>
+              </td>
+            </tr>
+            <tr>
+              <th>[[WAI-ARIA-1.2]]</th>
+              <td>
+                <a class="core-mapping" href="#ariaValueNow">`aria-valuenow`</a> &amp;
+                <a class="core-mapping" href="#ariaValueText">`aria-valuetext`</a>
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
+              </th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th>Comments</th>
+              <td>
+                User agents MAY use the exact text value of the `value` attribute, or a localized variation 
+                of the specified text to present a human friendly representation of the color value.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <h4 id="att-value-input-image">`value`</h4>
+        <table aria-labelledby="att-value-input-image">
+          <tbody>
+            <tr>
+              <th>HTML Specification</th>
+              <td>`value`</td>
+            </tr>
+            <tr>
+              <th>Element(s)</th>
+              <td>
+                <a data-cite="html/input.html#image-button-state-(type=image)">`input type=image`</a>
+              </td>
+            </tr>
+            <tr>
+              <th>[[WAI-ARIA-1.2]]</th>
+              <td>
+                Contributes to the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> of the `input`
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
+              </th>
+              <td><div class="general">See comments</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+              <td><div class="general">See comments</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <td><div class="general">See comments</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <td><div class="general">See comments</div></td>
+            </tr>
+            <tr>
+              <th>Comments</th>
+              <td>
+                If specified, and the `input` in the `image` state has no `alt` attribute specified, then the value of the attribute will contribute to the
+                <a href="#input-type-button-input-type-submit-and-input-type-reset-accessible-name-computation">accessible name computations</a>, and will render as text if the image source is broken. Otherwise, the attribute is ignored.
+              </td>
             </tr>
           </tbody>
         </table>
@@ -15895,25 +16084,25 @@
                 <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
               </th>
               <td>
-                <div class="general">Exposed as `IAccessibleValue::currentValue`</div>
+                <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
             <tr>
               <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
               <td>
-                <div class="general">Exposed as `Value.Value`</div>
+                <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
             <tr>
               <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
               <td>
-                <div class="general">Exposed as `atk_value_get_current_value`</div>
+                <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
             <tr>
               <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
               <td>
-                <div class="general">`AXValue: &lt;value&gt;`</div>
+                <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
replacement for https://github.com/w3c/html-aam/pull/396

closes https://github.com/w3c/html-aam/issues/314

This should largely be reflecting what is currently happening in browsers.