### PR TITLE
Update: minor popover clarification

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -13368,7 +13368,7 @@
                   <li>when the element has a `popovertarget=hide` attribute value,</li>
                   <li>or when the element is a descendant of the `popover` and its `popovertarget` is the "`auto`" state.</li>
                 </ul>
-                <p>If specified on an element with an implicit role of `generic`, then the element's role instead maps to <a class="core-mapping" href="#role-map-group">`group`</a>.</p>
+                <p>If specified on an element with an implicit role of `generic`, then the element's role instead maps to <a class="core-mapping" href="#role-map-group">`group`</a> for all <a data-cite="html/popover.html#the-popover-attribute">`popover` states</a>.</p>
               </td>
             </tr>
           </tbody>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -13365,7 +13365,7 @@
                 <p>User agents MUST NOT expose a details relation between a `popover` and its invoking element under the following conditions:</p>
                 <ul>
                   <li>when the `popover` is the next immediate accessibility sibling to the invoking element,</li>
-                  <li>when the element has a `popovertarget=hide` attribute value,</li>
+                  <li>when the element has a `popovertargetaction=hide` attribute value,</li>
                   <li>or when the element is a descendant of the `popover` and its `popovertarget` is the "`auto`" state.</li>
                 </ul>
                 <p>If specified on an element with an implicit role of `generic`, then the element's role instead maps to <a class="core-mapping" href="#role-map-group">`group`</a> for all <a data-cite="html/popover.html#the-popover-attribute">`popover` states</a>.</p>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -13369,6 +13369,7 @@
                   <li>or when the element is a descendant of the `popover` and its `popovertarget` is the "`auto`" state.</li>
                 </ul>
                 <p>If specified on an element with an implicit role of `generic`, then the element's role instead maps to <a class="core-mapping" href="#role-map-group">`group`</a> for all <a data-cite="html/popover.html#the-popover-attribute">`popover` states</a>.</p>
+                <p class="note">There are no unique mappings for the different `popover` states. Any accessibility mapping changes for the popover element would be the responsibility of the author. e.g., using different base HTML elements, attributes, or ARIA attributes to make such changes.</p>
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
to acknowledge there are different popover states (manual, auto/empty-string, and the proposed hint) this minor update clarifies that the minimum role of group applies to all popover states.

Is it worth also adding this note, or something like it?

There are no unique mappings for different popover states. Any additional accessibility mapping changes would be the responsibility of the author. e.g, using different base HTML elements, attributes, or ARIA attributes to make such changes.
