### PR TITLE
[accname] Do “AriaLabel” substep before “Embedded Control” substep

### DIFF
--- a/accname/index.html
+++ b/accname/index.html
@@ -546,6 +546,35 @@
                     </aside>
                   </div>
                 </li>
+                <li id="comp_label">
+                  <span id="step2D"><!-- Don't link to this legacy numbered ID. --></span><em>AriaLabel:</em> Otherwise, if the <code>current node</code> has an <code>aria-label</code> [=attribute=]
+                  whose value is not undefined, not the empty string, nor, when trimmed of [=ascii whitespace|whitespace=], is not the empty string:
+                  <ol>
+                    <li>
+                      If traversal of the <code>current node</code> is due to recursion <strong>and</strong> the <code>current node</code> is an embedded control, ignore <code>aria-label</code> and
+                      skip to rule <a href="#comp_embedded_control">Embedded Control</a>.
+                    </li>
+                    <li>Otherwise, return the value of <code>aria-label</code>.</li>
+                  </ol>
+                  <aside class="example">
+                    <p>
+                      The following example shows the interaction of <code>aria-labelledby</code> and <code>aria-label</code> when a [=nodes|node=] has an <code>aria-labelledby</code> that refers to
+                      itself. The <code>&lt;span role="button"&gt;</code> elements have the <a class="termref">accessible names</a> "Delete Documentation.pdf" and "Delete HolidayLetter.pdf",
+                      respectively.
+                    </p>
+                    <pre class="example highlight"><code>&lt;h1&gt;Files&lt;/h1&gt;
+&lt;ul&gt;
+  &lt;li&gt;
+    &lt;a id=&quot;file_row1&quot; href=&quot;./files/Documentation.pdf&quot;&gt;Documentation.pdf&lt;/a&gt;
+    <strong>&lt;span role=&quot;button&quot; tabindex=&quot;0&quot; id=&quot;del_row1&quot; aria-label=&quot;Delete&quot; aria-labelledby=&quot;del_row1 file_row1&quot;&gt;&lt;/span&gt;</strong>
+  &lt;/li&gt;
+  &lt;li&gt;
+    &lt;a id=&quot;file_row2&quot; href=&quot;./files/HolidayLetter.pdf&quot;&gt;HolidayLetter.pdf&lt;/a&gt;
+    <strong>&lt;span role=&quot;button&quot; tabindex=&quot;0&quot; id=&quot;del_row2&quot; aria-label=&quot;Delete&quot; aria-labelledby=&quot;del_row2 file_row2&quot;&gt;&lt;/span&gt;</strong>
+  &lt;/li&gt;
+&lt;/ul&gt;</code></pre>
+                  </aside>
+                </li>
                 <li id="comp_embedded_control">
                   <span id="step2C"><!-- Don't link to this legacy numbered ID. --></span><em>Embedded Control:</em> Otherwise, if the <code>current node</code> is a control embedded within the label
                   (e.g. any element directly referenced by <code>aria-labelledby</code>) for another <a class="termref">widget</a>, where the user can adjust the embedded control's value, then return
@@ -575,35 +604,6 @@
   &lt;input type="checkbox" id="flash"&gt;
   Flash the screen &lt;span tabindex="0" role="textbox" aria-label="number of times" contenteditable&gt;5&lt;/span&gt; times.
 &lt;/label&gt;</code></pre>
-                  </aside>
-                </li>
-                <li id="comp_label">
-                  <span id="step2D"><!-- Don't link to this legacy numbered ID. --></span><em>AriaLabel:</em> Otherwise, if the <code>current node</code> has an <code>aria-label</code> [=attribute=]
-                  whose value is not undefined, not the empty string, nor, when trimmed of [=ascii whitespace|whitespace=], is not the empty string:
-                  <ol>
-                    <li>
-                      If traversal of the <code>current node</code> is due to recursion <strong>and</strong> the <code>current node</code> is an embedded control, ignore <code>aria-label</code> and
-                      skip to rule <a href="#comp_embedded_control">Embedded Control</a>.
-                    </li>
-                    <li>Otherwise, return the value of <code>aria-label</code>.</li>
-                  </ol>
-                  <aside class="example">
-                    <p>
-                      The following example shows the interaction of <code>aria-labelledby</code> and <code>aria-label</code> when a [=nodes|node=] has an <code>aria-labelledby</code> that refers to
-                      itself. The <code>&lt;span role="button"&gt;</code> elements have the <a class="termref">accessible names</a> "Delete Documentation.pdf" and "Delete HolidayLetter.pdf",
-                      respectively.
-                    </p>
-                    <pre class="example highlight"><code>&lt;h1&gt;Files&lt;/h1&gt;
-&lt;ul&gt;
-  &lt;li&gt;
-    &lt;a id=&quot;file_row1&quot; href=&quot;./files/Documentation.pdf&quot;&gt;Documentation.pdf&lt;/a&gt;
-    <strong>&lt;span role=&quot;button&quot; tabindex=&quot;0&quot; id=&quot;del_row1&quot; aria-label=&quot;Delete&quot; aria-labelledby=&quot;del_row1 file_row1&quot;&gt;&lt;/span&gt;</strong>
-  &lt;/li&gt;
-  &lt;li&gt;
-    &lt;a id=&quot;file_row2&quot; href=&quot;./files/HolidayLetter.pdf&quot;&gt;HolidayLetter.pdf&lt;/a&gt;
-    <strong>&lt;span role=&quot;button&quot; tabindex=&quot;0&quot; id=&quot;del_row2&quot; aria-label=&quot;Delete&quot; aria-labelledby=&quot;del_row2 file_row2&quot;&gt;&lt;/span&gt;</strong>
-  &lt;/li&gt;
-&lt;/ul&gt;</code></pre>
                   </aside>
                 </li>
                 <li id="comp_host_language_label">


### PR DESCRIPTION
This change reorders the _“AriaLabel”_ substep in the set of steps in the accname Computation algorithm such that it occurs before the _“Embedded Control”_ substep, rather than after that step.

Otherwise, without this change, the spec as written doesn’t match the behavior as implemented in existing UAs, nor the corresponding requirements at https://w3c.github.io/html-aam/#accname-computation in the HTML-AAM spec:

> If the [embedded-control] element has an `aria-label` or an `aria-labelledby` attribute the accessible name is to be calculated using the algorithm defined in Accessible Name and Description: Computation and API Mappings.

(Which is the first step in accname computation for each control)

Also, without this change, the spec doesn’t match the expectations in http://wpt.fyi/results/accname/name/comp_label.html for the _“input with label for association is superceded by aria-label”_ subtest.

# Test, Documentation and Implementation tracking

Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [ ] "author MUST" tests: N/A
* [x] "user agent MUST" tests: https://wpt.fyi/results/accname/name/comp_label.html
* [X] Browser implementations: WebKit, Gecko, and Blink all implement the AriaLabel-computation-step-before-Embedded-Control-computation-step behavior in this patch.
* [ ] Does this need AT implementations? No
* [ ] Related APG Issue/PR: N/A
* [ ] MDN Issue/PR: N/A
