### PR TITLE
[html-aam] Make HTML img accname use “title” text if alt is empty

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -16218,13 +16218,13 @@
               <a href="" class="accname">Accessible Name and Description: Computation and API Mappings</a>.
             </li>
             <li>
-              Otherwise use `alt` attribute, even if its value is the empty string.
+              Otherwise use the `alt` attribute, unless its value is the empty string.
               <div class="note">
                 An `img` with an `alt` attribute whose value is the empty string is mapped to the
-                <a class="core-mapping" href="#role-map-presentation">`presentation`</a> role. It has no accessible name.
+                <a class="core-mapping" href="#role-map-presentation">`presentation`</a> role. And for any `role="presentation"` element, the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings</a> requires skipping past the “Host Language Label” step (which would otherwise result in using the value of the `alt` attribute) to subsequent steps — culminating in the “Tooltip” step, which for HTML elements requires using the value of the `title` attribute, if present.
               </div>
             </li>
-            <li>Otherwise, if there is no `alt` attribute use the `title` attribute.</li>
+            <li>Otherwise, use the `title` attribute.</li>
             <li>Otherwise there is no <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.</li>
           </ol>
         </section>


### PR DESCRIPTION
This change updates the accessible-name computation steps for the `img` element to require that in the case of an `alt=""` (empty `alt`) `img` element which has a non-empty `title` attribute, the value of the `title` attribute is included in computation of the element’s accessible name.

Otherwise, without this change, the spec as written doesn’t match the behavior as implemented in existing UAs, nor the corresponding requirements in https://w3c.github.io/accname/#comp_host_language_label in the AccName spec — specifically, the requirement to skip past the _“Host Language Label”_ step in the `alt=""` case, and to move on to subsequent steps, culminating in the _“Tooltip”_ step, which for HTML elements requires using the value of any `title` attribute, if present.

Also, without this change, the spec doesn’t match the expectations in https://wpt.fyi/results/accname/name/comp_tooltip.html for the _“img with tooltip label with empty alt”_ subtest.

# Test, Documentation and Implementation tracking

* [ ] "author MUST" tests: N/A
* [X] "user agent MUST" tests: https://wpt.fyi/results/accname/name/comp_tooltip.html
* [X] Browser implementations (link to issue or commit): WebKit, Gecko, and* Blink all implement the if-alt-is-empty-use-title behavior in this patch.
* [x] Does this need AT implementations? No
* [ ] Related APG Issue/PR: N/A
* [ ] MDN Issue/PR: N/A
