### PR TITLE
Update: change default role for custom elements

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -863,7 +863,7 @@
                   <li>If the author assigned a conforming role using the `role` attribute, or by the custom element's internals: map to the specified role.</li>
                   <li>else if the author assigned HTML attributes that result in a <a>minimum role</a>:  map to the minimum role.</li>
                   <li>else if the custom element is focusable: map to the <a class="core-mapping" href="#role-map-generic">`group`</a> role</li>
-                  <li>else if an author specifies a global ARIA attribute on the custom element that creates a relation with another element: map to the <a class="core-mapping" href="#role-map-generic">`group`</a> role</li>
+                  <li>else if an author specifies a global ARIA attribute on the custom element that creates a relation with another element: map to the <a class="core-mapping" href="#role-map-group">`group`</a> role</li>
                   <li>else if the custom element has no attached shadow root: map to the <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
                   <li>else if the custom element has an `aria-live` attribute: map to the <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
                   <li>else if element internals are used to set a global ARIA property: map to the <a class="core-mapping" href="#role-map-generic">`generic`</a> role.</li>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -862,7 +862,7 @@
                 <ul>
                   <li>If the author assigned a conforming role using the `role` attribute, or by the custom element's internals: map to the specified role.</li>
                   <li>else if the author assigned HTML attributes that result in a <a>minimum role</a>:  map to the minimum role.</li>
-                  <li>else if the custom element is focusable: map to the <a class="core-mapping" href="#role-map-generic">`group`</a> role</li>
+                  <li>else if the custom element is focusable: map to the <a class="core-mapping" href="#role-map-group">`group`</a> role</li>
                   <li>else if an author specifies a global ARIA attribute on the custom element that creates a relation with another element: map to the <a class="core-mapping" href="#role-map-group">`group`</a> role</li>
                   <li>else if the custom element has no attached shadow root: map to the <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
                   <li>else if the custom element has an `aria-live` attribute: map to the <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -901,7 +901,7 @@
               <th id=custom-element-comments>Comments</th>
               <td>
                 <p>
-                  Along with the attributes defined in this specification that contribute to modifying an element's <a>minimum role</a>,
+                  Along with the attributes defined in this specification that participate in modifying an element's <a>minimum role</a>,
                   the following conditions will also alter a custom element's computed role, if an author has not otherwise specified an
                   explicit role for the element:
                 </p>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -259,7 +259,7 @@
             specified which would require a more specific <a>minimum role</a> to be exposed.
           </li>
           <li>
-            Where an element is indicated as having &quot;No corresponding (WAI-ARIA) role&quot;, or is mapped to the <a class="core-mapping" href="#role-map-generic">`generic`</a>
+            Where an element is mapped to the <a class="core-mapping" href="#role-map-generic">`generic`</a>
             or <a class="core-mapping" href="#role-map-none">`none`</a> roles, user agents
             MUST NOT expose the <a class="core-mapping" href="#ariaRoleDescription">`aria-roledescription`</a> property value in the <a class="termref">accessibility tree</a> unless the element has an
             explicit, conforming `role` attribute value which [[WAI-ARIA-1.2]] does not prohibit the use of `aria-roledescription`.

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -841,29 +841,33 @@
             </tr>
           </tbody>
         </table>
-        <h4 id="el-autonomous-custom-element">autonomous custom element</h4>
-        <table class="data" aria-labelledby="el-autonomous-custom-element">
+        <h4 id="el-autonomous-custom-element">
+          autonomous custom elements
+          and
+          <span id="el-form-associated-custom-element">form-associated custom elements</span>
+        </h4>
+        <table aria-labelledby="el-autonomous-custom-element">
           <tbody>
             <tr>
               <th>HTML Specification</th>
               <td>
                 <a data-cite="HTML">autonomous custom element</a>
+                and
+                <a data-cite="html/custom-elements.html#custom-elements-face-example">form-associated custom element</a>
               </td>
             </tr>
             <tr>
               <th>[[wai-aria-1.2]]</th>
               <td>
-                <p>
-                  If the author assigned a conforming ARIA role using the `role` attribute, 
-                  or by the custom element's internals, map to the specified role.
-                </p>
-                <p>
-                  If the author assigned attributes that result in a <a>minimum role</a>, then map
-                  to the minimum role (see <a href="#custom-element-comments">comments</a>).
-                </p>
-                <p>
-                  Otherwise, the element maps to the <a class="core-mapping" href="#role-map-none">`none`</a> role.
-                </p>
+                <ul>
+                  <li>If the author assigned a conforming ARIA role using the `role` attribute, or by the custom element's internals, map to the specified role.</li>
+                  <li>else if the author assigned HTML attributes that result in a <a>minimum role</a>, then map to the minimum role.</li>
+                  <li>else if the custom element is focusable: expose the <a class="core-mapping" href="#role-map-generic">`group`</a> role</li>
+                  <li>else if an author specifies an ARIA attribute on the custom element that creates a relation with another element: expose the <a class="core-mapping" href="#role-map-generic">`group`</a> role</li>
+                  <li>else if the custom element has an `aria-live` attribute: expose the <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
+                  <li>else if element internals are used to set a global ARIA property: expose the <a class="core-mapping" href="#role-map-generic">`generic`</a> role.</li>
+                  <li>Otherwise, the element maps to the <a class="core-mapping" href="#role-map-none">`none`</a> role.</li>
+                </ul>
               </td>
             </tr>
             <tr>
@@ -898,20 +902,8 @@
             </tr>
             <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
             <tr>
-              <th id=custom-element-comments>Comments</th>
-              <td>
-                <p>
-                  Along with the attributes defined in this specification that participate in modifying an element's <a>minimum role</a>,
-                  the following conditions will also alter a custom element's computed role, if an author has not otherwise specified an
-                  explicit role for the element:
-                </p>
-                <ul>
-                  <li>if the custom element is focusable: expose the <a class="core-mapping" href="#role-map-generic">`group`</a> role</li>
-                  <li>else if an author specifies an ARIA attribute on the custom element that creates a relation with another element: expose the <a class="core-mapping" href="#role-map-generic">`group`</a> role</li>
-                  <li>else if the custom element has an `aria-live` attribute: expose the <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
-                  <li>else if element internals are used to set a global ARIA property: expose the <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
-                </ul>
-              </td>
+              <th>Comments</th>
+              <td></td>
             </tr>
           </tbody>
         </table>
@@ -2619,56 +2611,6 @@
             <tr>
               <th>Comments</th>
               <td>If a <a class="core-mapping" href="#role-map-form-nameless">`form` has no accessible name</a>, do not expose the element as a landmark.</td>
-            </tr>
-          </tbody>
-        </table>
-        <h4 id="el-form-associated-custom-element">form-associated custom element</h4>
-        <table class="data" aria-labelledby="el-form-associated-custom-element">
-          <tbody>
-            <tr>
-              <th>HTML Specification</th>
-              <td>
-                <a data-cite="html/custom-elements.html#custom-elements-face-example">form-associated custom element</a>
-              </td>
-            </tr>
-            <tr>
-              <th>[[wai-aria-1.2]]</th>
-              <td>If the author assigned a conforming ARIA role using the `role` attribute, map to that role. Otherwise, the <a class="core-mapping" href="#role-map-generic">`generic`</a> role.</td>
-            </tr>
-            <tr>
-              <th><a data-cite="core-aam-1.2/#roleMappingComputedRole">Computed Role</a></th>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-            </tr>
-            <tr>
-              <th>
-                <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
-              </th>
-              <td>
-                <div class="general">Use WAI-ARIA mapping</div>
-              </td>
-            </tr>
-            <tr>
-              <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
-              <td>
-                <div class="general">Use WAI-ARIA mapping</div>
-              </td>
-            </tr>
-            <tr>
-              <th><span class="informative">[[ATK]]</span></th>
-              <td>
-                <div class="general">Use WAI-ARIA mapping</div>
-              </td>
-            </tr>
-            <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
-              <td>
-                <div class="general">Use WAI-ARIA mapping</div>
-              </td>
-            </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
-            <tr>
-              <th>Comments</th>
-              <td></td>
             </tr>
           </tbody>
         </table>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -860,7 +860,7 @@
               <th>[[wai-aria-1.2]]</th>
               <td>
                 <ul>
-                  <li>If the author assigned a conforming ARIA role using the `role` attribute, or by the custom element's internals: map to the specified role.</li>
+                  <li>If the author assigned a conforming role using the `role` attribute, or by the custom element's internals: map to the specified role.</li>
                   <li>else if the author assigned HTML attributes that result in a <a>minimum role</a>:  map to the minimum role.</li>
                   <li>else if the custom element is focusable: map to the <a class="core-mapping" href="#role-map-generic">`group`</a> role</li>
                   <li>else if an author specifies a global ARIA attribute on the custom element that creates a relation with another element: map to the <a class="core-mapping" href="#role-map-generic">`group`</a> role</li>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -860,13 +860,14 @@
               <th>[[wai-aria-1.2]]</th>
               <td>
                 <ul>
-                  <li>If the author assigned a conforming ARIA role using the `role` attribute, or by the custom element's internals, map to the specified role.</li>
-                  <li>else if the author assigned HTML attributes that result in a <a>minimum role</a>, then map to the minimum role.</li>
-                  <li>else if the custom element is focusable: expose the <a class="core-mapping" href="#role-map-generic">`group`</a> role</li>
-                  <li>else if an author specifies an ARIA attribute on the custom element that creates a relation with another element: expose the <a class="core-mapping" href="#role-map-generic">`group`</a> role</li>
-                  <li>else if the custom element has an `aria-live` attribute: expose the <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
-                  <li>else if element internals are used to set a global ARIA property: expose the <a class="core-mapping" href="#role-map-generic">`generic`</a> role.</li>
-                  <li>Otherwise, the element maps to the <a class="core-mapping" href="#role-map-none">`none`</a> role.</li>
+                  <li>If the author assigned a conforming ARIA role using the `role` attribute, or by the custom element's internals: map to the specified role.</li>
+                  <li>else if the author assigned HTML attributes that result in a <a>minimum role</a>:  map to the minimum role.</li>
+                  <li>else if the custom element is focusable: map to the <a class="core-mapping" href="#role-map-generic">`group`</a> role</li>
+                  <li>else if an author specifies a global ARIA attribute on the custom element that creates a relation with another element: map to the <a class="core-mapping" href="#role-map-generic">`group`</a> role</li>
+                  <li>else if the custom element has no attached shadow root: map to the <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
+                  <li>else if the custom element has an `aria-live` attribute: map to the <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
+                  <li>else if element internals are used to set a global ARIA property: map to the <a class="core-mapping" href="#role-map-generic">`generic`</a> role.</li>
+                  <li>Otherwise, the custom element maps to the <a class="core-mapping" href="#role-map-none">`none`</a> role.</li>
                 </ul>
               </td>
             </tr>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -907,16 +907,26 @@
                 </p>
                 <ul>
                   <li>if the custom element is focusable: expose as <a class="core-mapping" href="#role-map-group">`group`</a> role</li>
-                  <li>if the custom element has an `aria-live` or `aria-owns` attribute: expose as <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
+                  <li>if the custom element has an `aria-live` attribute: expose as <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
                   <li>if element internals are used to set a global ARIA property: expose as <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
-                  <li>if an author specifies an ARIA relation via an element attribute: expose <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
+                  <li>if an author specifies an ARIA attribute that creates a relation with another element (via IDRef): expose <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
                 </ul>
                 <div class="example">
-                  <p>The following is an exmaple of an author specifiying an ARIA relation on a custom element, with another element in the DOM.</p>
+                  <p>The following are exmaples of an author specifiying a relationships between custom elements and other elements in the DOM.</p>
                   <pre><code>
-                      &lt;my-element aria-details=ex>...&lt;my-element>
+                      &lt;my-element aria-details=ex>...&lt;/my-element>
                       ...
                       &lt;div id=ex> &lt;!-- details for my-element --> &lt;/div>
+                      ...
+                      &lt;ex-ample aria-owns=u>...&lt;/ex-ample>
+                      ...
+                      &lt;div id=u> &lt;!-- becomes the last a11y child of ex-ample --> &lt;/div>
+
+                      &lt;id-lement> ... &lt;/id-lement>
+                      &lt;script>
+                        ...
+                        document.querySelector('id-lement').ariaDescribedby = anotherEl;
+                      &lt;/script>
                   </code></pre>
                 </div>
               </td>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -259,7 +259,8 @@
             specified which would require a more specific <a>minimum role</a> to be exposed.
           </li>
           <li>
-            Where an element is indicated as having &quot;No corresponding (WAI-ARIA) role&quot;, or is mapped to the <a class="core-mapping" href="#role-map-generic">`generic`</a> role, user agents
+            Where an element is indicated as having &quot;No corresponding (WAI-ARIA) role&quot;, or is mapped to the <a class="core-mapping" href="#role-map-generic">`generic`</a>
+            or <a class="core-mapping" href="#role-map-none">`none`</a> roles, user agents
             MUST NOT expose the <a class="core-mapping" href="#ariaRoleDescription">`aria-roledescription`</a> property value in the <a class="termref">accessibility tree</a> unless the element has an
             explicit, conforming `role` attribute value which [[WAI-ARIA-1.2]] does not prohibit the use of `aria-roledescription`.
           </li>
@@ -851,7 +852,19 @@
             </tr>
             <tr>
               <th>[[wai-aria-1.2]]</th>
-              <td>If the author assigned a conforming ARIA role using the `role` attribute, map to that role. Otherwise, the <a class="core-mapping" href="#role-map-generic">`generic`</a> role.</td>
+              <td>
+                <p>
+                  If the author assigned a conforming ARIA role using the `role` attribute, 
+                  or by the custom element's internals, map to the specified role.
+                </p>
+                <p>
+                  If the author assigned attributes that result in a <a>minimum role</a>, then map
+                  to the minimum role (see <a href="#custom-element-comments">comments</a>.
+                </p>
+                <p>
+                  Otherwise, the element maps to the <a class="core-mapping" href="#role-map-none">`none`</a> role.
+                </p>
+              </td>
             </tr>
             <tr>
               <th><a data-cite="core-aam-1.2/#roleMappingComputedRole">Computed Role</a></th>
@@ -886,7 +899,29 @@
             <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
             <tr>
               <th>Comments</th>
-              <td></td>
+              <td>
+                <p>
+                  Along with the attributes defined in this specification that contribute to modifying an element's <a>minimum role</a>,
+                  the following conditions will also alter a custom element's computed role, if an author has not otherwise specified an
+                  explicit role for the element:
+                </p>
+                <ul>
+                  <li>if the custom element is focusable: expose as <a class="core-mapping" href="#role-map-group">`group`</a> role</li>
+                  <li>if the custom element has an `aria-live` or `aria-owns` attribute: expose as <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
+                  <li>if element internals are used to set a global ARIA property: expose as <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
+                  <li>if an author specifies an ARIA relation via an element attribute: expose <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
+                </ul>
+                <div class="example">
+                  <p>The following is an exmaple of an author specifiying an ARIA relation on a custom element, with another element in the DOM.</p>
+                  <pre>
+                    <code>
+                      &lt;my-element aria-details=ex>...&lt;my-element>
+                      ...
+                      &lt;div id=ex> &lt;!-- details for my-element --> &lt;/div>
+                    </code>
+                  </pre>
+                </div>
+              </td>
             </tr>
           </tbody>
         </table>
@@ -8786,7 +8821,7 @@
             </tr>
             <tr>
               <th>Comments</th>
-              <td>Provides a <a href="termref">minimum role</a> of <a class="core-mapping" href="#role-map-group">`group`</a>.</td>
+              <td>Provides a <a>minimum role</a> of <a class="core-mapping" href="#role-map-group">`group`</a>.</td>
             </tr>
           </tbody>
         </table>
@@ -10475,7 +10510,7 @@
             </tr>
             <tr>
               <th>Comments</th>
-              <td>Provides a <a href="termref">minimum role</a> of <a class="core-mapping" href="#role-map-group">`group`</a>.</td>
+              <td>Provides a <a>minimum role</a> of <a class="core-mapping" href="#role-map-group">`group`</a>.</td>
             </tr>
           </tbody>
         </table>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -859,7 +859,7 @@
                 </p>
                 <p>
                   If the author assigned attributes that result in a <a>minimum role</a>, then map
-                  to the minimum role (see <a href="#custom-element-comments">comments</a>.
+                  to the minimum role (see <a href="#custom-element-comments">comments</a>).
                 </p>
                 <p>
                   Otherwise, the element maps to the <a class="core-mapping" href="#role-map-none">`none`</a> role.
@@ -898,7 +898,7 @@
             </tr>
             <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
             <tr>
-              <th>Comments</th>
+              <th id=custom-element-comments>Comments</th>
               <td>
                 <p>
                   Along with the attributes defined in this specification that contribute to modifying an element's <a>minimum role</a>,

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -906,29 +906,11 @@
                   explicit role for the element:
                 </p>
                 <ul>
-                  <li>if the custom element is focusable: expose as <a class="core-mapping" href="#role-map-group">`group`</a> role</li>
-                  <li>if the custom element has an `aria-live` attribute: expose as <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
-                  <li>if element internals are used to set a global ARIA property: expose as <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
-                  <li>if an author specifies an ARIA attribute on the custom element that creates a relation with another element: expose <a class="core-mapping" href="#role-map-generic">`group`</a> role</li>
+                  <li>if the custom element is focusable: expose the <a class="core-mapping" href="#role-map-generic">`group`</a> role</li>
+                  <li>else if an author specifies an ARIA attribute on the custom element that creates a relation with another element: expose the <a class="core-mapping" href="#role-map-generic">`group`</a> role</li>
+                  <li>else if the custom element has an `aria-live` attribute: expose the <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
+                  <li>else if element internals are used to set a global ARIA property: expose the <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
                 </ul>
-                <div class="example">
-                  <p>The following are exmaples of an author specifiying a relationships between custom elements and other elements in the DOM.</p>
-                  <pre><code>
-   &lt;my-element aria-details=ex>...&lt;/my-element>
-     ...
-    &lt;div id=ex> &lt;!-- details for my-element --> &lt;/div>
-    ...
-    &lt;ex-ample aria-owns=u>...&lt;/ex-ample>
-      ...
-    &lt;div id=u> &lt;!-- becomes the last a11y child of ex-ample --> &lt;/div>
-
-    &lt;id-lement> ... &lt;/id-lement>
-    &lt;script>
-      ...
-      document.querySelector('id-lement').ariaDescribedbyByElements = [ descElement ];
-    &lt;/script>
-                  </code></pre>
-                </div>
               </td>
             </tr>
           </tbody>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -909,7 +909,7 @@
                   <li>if the custom element is focusable: expose as <a class="core-mapping" href="#role-map-group">`group`</a> role</li>
                   <li>if the custom element has an `aria-live` attribute: expose as <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
                   <li>if element internals are used to set a global ARIA property: expose as <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
-                  <li>if an author specifies an ARIA attribute that creates a relation with another element: expose <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
+                  <li>if an author specifies an ARIA attribute on the custom element that creates a relation with another element: expose <a class="core-mapping" href="#role-map-generic">`group`</a> role</li>
                 </ul>
                 <div class="example">
                   <p>The following are exmaples of an author specifiying a relationships between custom elements and other elements in the DOM.</p>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -925,7 +925,7 @@
     &lt;id-lement> ... &lt;/id-lement>
     &lt;script>
       ...
-      document.querySelector('id-lement').ariaDescribedby = anotherEl;
+      document.querySelector('id-lement').ariaDescribedbyByElements = [ descElement ];
     &lt;/script>
                   </code></pre>
                 </div>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -917,8 +917,7 @@
                       &lt;my-element aria-details=ex>...&lt;my-element>
                       ...
                       &lt;div id=ex> &lt;!-- details for my-element --> &lt;/div>
-                    </code>
-                  </pre>
+                  </code></pre>
                 </div>
               </td>
             </tr>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -913,8 +913,7 @@
                 </ul>
                 <div class="example">
                   <p>The following is an exmaple of an author specifiying an ARIA relation on a custom element, with another element in the DOM.</p>
-                  <pre>
-                    <code>
+                  <pre><code>
                       &lt;my-element aria-details=ex>...&lt;my-element>
                       ...
                       &lt;div id=ex> &lt;!-- details for my-element --> &lt;/div>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -909,24 +909,24 @@
                   <li>if the custom element is focusable: expose as <a class="core-mapping" href="#role-map-group">`group`</a> role</li>
                   <li>if the custom element has an `aria-live` attribute: expose as <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
                   <li>if element internals are used to set a global ARIA property: expose as <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
-                  <li>if an author specifies an ARIA attribute that creates a relation with another element (via IDRef): expose <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
+                  <li>if an author specifies an ARIA attribute that creates a relation with another element: expose <a class="core-mapping" href="#role-map-generic">`generic`</a> role</li>
                 </ul>
                 <div class="example">
                   <p>The following are exmaples of an author specifiying a relationships between custom elements and other elements in the DOM.</p>
                   <pre><code>
-                      &lt;my-element aria-details=ex>...&lt;/my-element>
-                      ...
-                      &lt;div id=ex> &lt;!-- details for my-element --> &lt;/div>
-                      ...
-                      &lt;ex-ample aria-owns=u>...&lt;/ex-ample>
-                      ...
-                      &lt;div id=u> &lt;!-- becomes the last a11y child of ex-ample --> &lt;/div>
+   &lt;my-element aria-details=ex>...&lt;/my-element>
+     ...
+    &lt;div id=ex> &lt;!-- details for my-element --> &lt;/div>
+    ...
+    &lt;ex-ample aria-owns=u>...&lt;/ex-ample>
+      ...
+    &lt;div id=u> &lt;!-- becomes the last a11y child of ex-ample --> &lt;/div>
 
-                      &lt;id-lement> ... &lt;/id-lement>
-                      &lt;script>
-                        ...
-                        document.querySelector('id-lement').ariaDescribedby = anotherEl;
-                      &lt;/script>
+    &lt;id-lement> ... &lt;/id-lement>
+    &lt;script>
+      ...
+      document.querySelector('id-lement').ariaDescribedby = anotherEl;
+    &lt;/script>
                   </code></pre>
                 </div>
               </td>


### PR DESCRIPTION
closes #2303

This updates a custom element's default role to none to allow attribute reflection from the custom element parent to its internals.

This change provides additional clarification about how a custom element can be provided a role by authors, and what caveats would change a custom element's default role of none, to another implicit minimum role.


# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests:
* [ ] Browser implementations (link to issue or commit):
   * WebKit:
   * Gecko:
   * Blink:
* [ ] Does this need AT implementations?
* [ ] Related APG Issue/PR:
* [ ] MDN Issue/PR:
