### PR TITLE
[accname] Explicitly state UAs must ignore “aria-label” for slots

### DIFF
--- a/accname/index.html
+++ b/accname/index.html
@@ -578,7 +578,7 @@
                   </aside>
                 </li>
                 <li id="comp_label">
-                  <span id="step2D"><!-- Don't link to this legacy numbered ID. --></span><em>AriaLabel:</em> Otherwise, if the <code>current node</code> has an <code>aria-label</code> [=attribute=]
+                  <span id="step2D"><!-- Don't link to this legacy numbered ID. --></span><em>AriaLabel:</em> Otherwise, if the <code>current node</code> is not a [=slot=] element and has an <code>aria-label</code> [=attribute=]
                   whose value is not undefined, not the empty string, nor, when trimmed of [=ascii whitespace|whitespace=], is not the empty string:
                   <ol>
                     <li>


### PR DESCRIPTION
This change updates the **AriaLabel** substep of the “Computation steps” section of the accname spec to explicitly state that the step must not be performed if the node being visited is a `slot` element.

See the discussion at https://github.com/w3c/accname/issues/173. It seems a requirement to ignore the `aria-label` attribute in this case — or to ignore _any_ ARIA attributes present on `slot` elements — may follow from normative requirements stated in some other spec.

Nevertheless, a specific requirement should be stated at point of use in the text for this step in accname spec itself.

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [ ] "author MUST" tests: N/A
* [X] "user agent MUST" tests: https://wpt.fyi/results/accname/name/shadowdom/slot.html
* [X] Browser implementations (link to issue or commit): WebKit, Gecko, and Blink already implement this.
* [X] WPT Tests: [accname/name/shadowdom/slot.html](https://wpt.fyi/results/accname/name/shadowdom/slot.html?label=master&label=experimental&aligned&q=label%3Aaccessibility)
* [ ] Does this need AT implementations? No
* [ ] Related APG Issue/PR: N/A
* [ ] MDN Issue/PR: N/A
