### PR TITLE
Tentative: update point E. Host Language Label of the Acc Name algorithm

### DIFF
--- a/accname/index.html
+++ b/accname/index.html
@@ -610,7 +610,7 @@
                 <li id="comp_host_language_label">
                   <span id="step2E"><!-- Don't link to this legacy numbered ID. --></span><em>Host Language Label:</em> Otherwise, if the <code>current node</code>'s native markup provides an
                   [=attribute=] (e.g. <code>alt</code>) or [=element=] (e.g. HTML <code>label</code> or SVG <code>title</code>) that defines a text alternative, return that alternative in the form of
-                  a <code>flat string</code> as defined by the host language, unless the element is marked as presentational (<code>role="presentation"</code> or <code>role="none"</code>).
+                  a <code>flat string</code> as defined by the host language, unless the <code>current node</code> is exposed as presentational (<code>role="presentation"</code> or <code>role="none"</code>).
                   <div class="note">
                     See <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a>,
                     <a href="https://www.w3.org/TR/svg-aam-1.0/#mapping_additional_nd">SVG-AAM</a>, or other host language documentation for more information on markup that defines a text alternative.


### PR DESCRIPTION
Closes: https://github.com/w3c/accname/issues/108

This change clarifies the following:
- The term "_element_" in "_unless the element is marked as presentational_" is replaced with "_current node_" for clarity.
- The ambiguity regarding presentational role conflicts is removed by replacing "_marked as decorative_" with "_exposed as decorative_." Replacing this eliminates the need for additional notes, where we would need to clarify that "marked as decorative" could cause presentational role conflicts, which, for this point of the algorithm, should be resolved by ignoring the "marked as decorative" bit. Moreover, this would introduce complexity, as the statement "_If exposing the explicit role causes the accessibility tree to be malformed, the expected results are undefined_" adds further complications.

Should this be marked as editorial?