### PR TITLE
[aria] Drop “deprecated on this role” attributes from per-role tables

### DIFF
--- a/common/script/aria.js
+++ b/common/script/aria.js
@@ -479,12 +479,10 @@ function ariaAttributeReferences() {
                     var property = sortedList[k];
                     var req = "";
                     var dep = "";
+                    if (property.deprecated)
+                        continue;
                     if (property.required) {
                         req = " <strong>(required)</strong>";
-                    }
-                    if (property.deprecated) {
-                        dep =
-                            " <strong>(deprecated on this role in ARIA 1.2)</strong>";
                     }
                     if (prev != property.name) {
                         output += "<li>";


### PR DESCRIPTION
This change causes the Inherited States and Properties rows of the per-role Characteristics tables in the ARIA spec to stop including all the attributes that has been marked “deprecated on this role in ARIA 1.2”.

If the intent is to clearly to signal to authors that those attributes shouldn’t be use with those roles, then it makes sense to just stop including those attributes in the tables for those roles — rather than indefinitely continuing to include them.

# Test, Documentation and Implementation tracking

* [ ] "author MUST" tests: N/A
* [ ] "user agent MUST" tests: N/A
* [ ] Browser implementations (link to issue or commit): N/A
   * WebKit:
   * Gecko:
   * Blink:
* [ ] Does this need AT implementations? No
* [ ] Related APG Issue/PR: none
* [ ] MDN Issue/PR: none