### PR TITLE
ARIA IDL updates: convert eligible attributes to enumerated, new ARIA IDL guidance and examples

### DIFF
--- a/common/css/common.css
+++ b/common/css/common.css
@@ -99,10 +99,10 @@ caption{
 	margin:1em 0 0.1em;
 	padding:0 0 0 0.3em;
 }
-table.role-features th, table.role-features td, table.state-features th, table.state-features td, table.property-features th, table.property-features td, table.value-descriptions th, table.value-descriptions td {
+table.role-features th, table.role-features td, table.state-features th, table.state-features td, table.property-features th, table.property-features td, table.value-descriptions th, table.value-descriptions td, table.state-descriptions th, table.state-descriptions td {
 	min-width:20em;
 }
-table.role-features tbody th, table.state-features tbody th, table.property-features tbody th, table.value-descriptions tbody th {
+table.role-features tbody th, table.state-features tbody th, table.property-features tbody th, table.value-descriptions tbody th, table.state-descriptions tbody th {
     text-align: left !important;
 }
 th+th, td+td{

--- a/index.html
+++ b/index.html
@@ -12335,7 +12335,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="property-value-head" scope="row">Value:</th>
-						<td class="property-value"><a href="#valuetype_true-false">true/false</a></td>
+						<td class="property-value"><a href="#valuetype_enumerated">Enumerated</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -12343,21 +12343,26 @@ button.ariaPressed; // null</pre>
 				<caption>Values:</caption>
 				<thead>
 					<tr>
-						<th scope="col">Value</th>
+						<th scope="col">Value (keyword)</th>
+                        <th scope="col">State</th>
 						<th scope="col">Description</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
-						<th class="value-name" scope="row"><strong class="default">false (default)</strong></th>
+						<th class="value-name" scope="row"><strong class="default">false, empty string (<code>&quot;&quot;</code>)</strong></th>
+						<th class="state-description" scope="row">False</th>
 						<td class="value-description">Only one item can be selected.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">true</th>
+						<th class="state-description" scope="row">True</th>
 						<td class="value-description">More than one item in the widget can be selected at a time.</td>
 					</tr>
 				</tbody>
 			</table>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> are both the False state.</p>
+			<p>For the purposes of <a data-cite="html/common-dom-interfaces.html#reflect">reflection</a>, the canonical keyword for the False state is the "false" keyword.</p>
 		</div>
 		<div class="property" id="aria-orientation">
 			<pdef>aria-orientation</pdef>

--- a/index.html
+++ b/index.html
@@ -11913,7 +11913,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="state-value-head" scope="row">Value:</th>
-						<td class="state-value"><a href="#valuetype_token">token</a></td>
+						<td class="property-value"><a href="#valuetype_enumerated">Enumerated</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -11921,29 +11921,36 @@ button.ariaPressed; // null</pre>
 				<caption>Values:</caption>
 				<thead>
 					<tr>
-						<th scope="col">Value</th>
+						<th scope="col">Value (keyword)</th>
+                        <th scope="col">State</th>
 						<th scope="col">Description</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
 						<th class="value-name" scope="row">grammar</th>
+						<th class="state-description" scope="row">Grammar</th>
 						<td class="value-description">A grammatical error was detected.</td>
 					</tr>
 					<tr>
-						<th class="value-name" scope="row"><strong class="default">false (default)</strong></th>
+						<th class="value-name" scope="row"><strong class="default">false, empty string (<code>&quot;&quot;</code>)</strong></th>
+						<th class="state-description" scope="row">False</th>
 						<td class="value-description">There are no detected errors in the value.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">spelling</th>
+						<th class="state-description" scope="row">Spelling</th>
 						<td class="value-description">A spelling error was detected.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">true</th>
+						<th class="state-description" scope="row">True</th>
 						<td class="value-description">The value entered by the user has failed validation.</td>
 					</tr>
 				</tbody>
 			</table>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> is the False state, and its <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> is the True state.</p>
+			<p>For the purposes of <a data-cite="html/common-dom-interfaces.html#reflect">reflection</a>, the canonical keyword for the False state is the "false" keyword.</p>
 		</div>
 		<div class="property" id="aria-keyshortcuts">
 			<pdef>aria-keyshortcuts</pdef>

--- a/index.html
+++ b/index.html
@@ -11597,7 +11597,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="state-value-head" scope="row">Value:</th>
-						<td class="state-value"><a href="#valuetype_true-false-undefined">true/false/undefined</a></td>
+						<td class="property-value"><a href="#valuetype_enumerated">Enumerated</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -11605,17 +11605,20 @@ button.ariaPressed; // null</pre>
 				<caption>Values:</caption>
 				<thead>
 					<tr>
-						<th scope="col">Value</th>
+						<th scope="col">Value (keyword)</th>
+                        <th scope="col">State</th>
 						<th scope="col">Description</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
 						<th class="value-name" scope="row">false</th>
+						<th class="state-description" scope="row">False</th>
 						<td class="value-description">The grouping element this element controls or is the accessibility parent of is collapsed.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">true</th>
+						<th class="state-description" scope="row">True</th>
 						<td class="value-description">The grouping element this element controls or is the accessibility parent of is expanded.</td>
 					</tr>
 					<tr>
@@ -11624,6 +11627,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 				</tbody>
 			</table>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> are both the Undefined state.</p>
 		</div>
 		<div class="property" id="aria-flowto">
 			<pdef>aria-flowto</pdef>

--- a/index.html
+++ b/index.html
@@ -10229,9 +10229,6 @@
 			otherwise, the IDL attribute must get the value in a transparent, case-preserving manner.
 			On setting, if the new value is null, the content attribute must be removed, and otherwise,
 			the content attribute must be set to the specified new value in a transparent, case-preserving manner.</p>
-			<p class="note">
-			Note: As of ARIA 1.2, all ARIA attributes exposed via IDL are defined as nullable {{DOMString}}s. This matches the current implementation of all major rendering engines. This specification change should result in no implementation changes; it will merely represent the current reality of web engines.
-			However, in a future draft, the ARIA Working Group intends to change several ARIA attributes to non-nullable DOMStrings, and seek implementations. The proposed change will bring ARIA into alignment with the HTML’s usage of <a data-cite="html/common-microsyntaxes.html#enumerated-attribute">enumerated attributes</a>.</p>
 			<section class="informative" id="enumeration-example">
 				<h4>Example Attribute Usage</h4>
 				<aside class="example">

--- a/index.html
+++ b/index.html
@@ -10751,7 +10751,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="state-value-head" scope="row">Value:</th>
-						<td class="state-value"><a href="#valuetype_true-false">true/false</a></td>
+						<td class="property-value"><a href="#valuetype_enumerated">Enumerated</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -10759,21 +10759,25 @@ button.ariaPressed; // null</pre>
 				<caption>Values:</caption>
 				<thead>
 					<tr>
-						<th scope="col">Value</th>
+						<th scope="col">Value (keyword)</th>
+						<th scope="col">State</th>
 						<th scope="col">Description</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
-						<th class="value-name" scope="row"><strong class="default">false (default)</strong>:</th>
+						<th class="value-name" scope="row"><strong class="default">false</strong>:</th>
+						<th class="state-description" scope="row">False</th>
 						<td class="value-description">There are no expected updates for the element.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">true</th>
+						<th class="state-description" scope="row">True</th>
 						<td class="value-description">The element is being updated.</td>
 					</tr>
 				</tbody>
 			</table>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> are both the False state.</p>
 		</div>
 		<div class="state" id="aria-checked">
 			<sdef>aria-checked</sdef>

--- a/index.html
+++ b/index.html
@@ -10220,7 +10220,7 @@
 			[[[#supportedState]]], and in [[[CORE-AAM]]].</p>
 		</section>
 		<section id="enumerated-attribute-values-html">
-			<h3>ARIA nullable DOMString Attributes</h3>
+			<h3>ARIA IDL Attribute Types</h3>
 			<p>As noted in [[[#typemapping]]], attributes are included in host languages, and the syntax for representation of WAI-ARIA types is governed by the host language.</p>
 			<p>ARIA attributes [=reflect=] in IDL as defined in HTML.</p>
 			<section class="informative" id="enumeration-example">

--- a/index.html
+++ b/index.html
@@ -12687,7 +12687,7 @@ button.ariaPressed; // null</pre>
 				</tbody>
 			</table>
 			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> are both the False state.</p>
-			
+			<p>For the purposes of <a data-cite="html/common-dom-interfaces.html#reflect">reflection</a>, the canonical keyword for the False state is the "false" keyword.</p>
 		</div>
 		<div class="property" id="aria-relevant">
 			<pdef>aria-relevant</pdef>

--- a/index.html
+++ b/index.html
@@ -13146,7 +13146,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="state-value-head" scope="row">Value:</th>
-						<td class="state-value"><a href="#valuetype_true-false-undefined">true/false/undefined</a></td>
+						<td class="property-value"><a href="#valuetype_enumerated">Enumerated</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -13154,25 +13154,31 @@ button.ariaPressed; // null</pre>
 				<caption>Values:</caption>
 				<thead>
 					<tr>
-						<th scope="col">Value</th>
+						<th scope="col">Value (keyword)</th>
+                        <th scope="col">State</th>
 						<th scope="col">Description</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
-						<th class="value-name" scope="row">false</th>
+						<th class="value-name" scope="row">false, empty string (<code>&quot;&quot;</code>)</th>
+						<th class="state-description" scope="row">False</th>
 						<td class="value-description">The selectable element is not selected.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">true</th>
+						<th class="state-description" scope="row">True</th>
 						<td class="value-description">The selectable element is selected.</td>
 					</tr>
 					<tr>
-						<th class="value-name" scope="row"><strong class="default">undefined (default)</strong></th>
+						<th class="value-name" scope="row"><strong class="default">undefined</strong></th>
+						<th class="state-description" scope="row">Undefined</th>
 						<td class="value-description">The element is not selectable.</td>
 					</tr>
 				</tbody>
 			</table>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> are both the Undefined state.</p>
+			<p>For the purposes of <a data-cite="html/common-dom-interfaces.html#reflect">reflection</a>, the canonical keyword for the Undefined state is the "undefined" keyword.</p>
 		</div>
 		<div class="property" id="aria-setsize">
 			<pdef>aria-setsize</pdef>

--- a/index.html
+++ b/index.html
@@ -343,7 +343,7 @@
 			</dd>
 			<dt><dfn>Indicates</dfn></dt>
 			<dd>
-			  <p>Used in an attribute description to denote that the value <a href="#propcharacteristic_value">type</a> is a named token or otherwise token-like, including the Boolean-like <a href="#valuetype_true-false">true/false</a>, <a href="#valuetype_true-false-undefined">true/false/undefined</a>, <a href="#valuetype_tristate">tristate (true/false/mixed)</a>, a single named <a href="#valuetype_token">token</a>, or a <a href="#valuetype_token_list">token list</a>.</p>
+			  <p>Used in an attribute description to denote that the value <a href="#propcharacteristic_value">type</a> is a named token or otherwise token-like, including a single named <a href="#valuetype_token">token</a> or a <a href="#valuetype_token_list">token list</a>.</p>
 			  <p>Related Terms: <a>Defines</a>, <a>Identifies</a></p>
 			</dd>
 			<dt><dfn>Keyboard Accessible</dfn></dt>

--- a/index.html
+++ b/index.html
@@ -10520,7 +10520,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 				</tbody>
 			</table>
-			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a>. are both the Missing state.</p>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> are both the Missing state.</p>
 		</div>
 		<div class="property" id="aria-autocomplete">
 			<pdef>aria-autocomplete</pdef>

--- a/index.html
+++ b/index.html
@@ -11766,7 +11766,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="property-value-head" scope="row">Value:</th>
-						<td class="property-value"><a href="#valuetype_token">token</a></td>
+						<td class="property-value"><a href="#valuetype_enumerated">Enumerated</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -11774,7 +11774,8 @@ button.ariaPressed; // null</pre>
 				<caption>Values:</caption>
 				<thead>
 					<tr>
-						<th scope="col">Value</th>
+						<th scope="col">Value (keyword)</th>
+                        <th scope="col">State</th>
 						<th scope="col">Description</th>
 					</tr>
 				</thead>
@@ -11785,30 +11786,37 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">true</th>
+						<th class="state-description" scope="row">True</th>
 						<td class="value-description">Indicates the popup is a <rref>menu</rref>.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">menu</th>
+						<th class="state-description" scope="row">Menu</th>
 						<td class="value-description">Indicates the popup is a <rref>menu</rref>.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">listbox</th>
+						<th class="state-description" scope="row">Listbox</th>
 						<td class="value-description">Indicates the popup is a <rref>listbox</rref>.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">tree</th>
+						<th class="state-description" scope="row">Tree</th>
 						<td class="value-description">Indicates the popup is a <rref>tree</rref>.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">grid</th>
+						<th class="state-description" scope="row">Grid</th>
 						<td class="value-description">Indicates the popup is a <rref>grid</rref>.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">dialog</th>
+						<th class="state-description" scope="row">Dialog</th>
 						<td class="value-description">Indicates the popup is a <rref>dialog</rref>.</td>
 					</tr>
 				</tbody>
 			</table>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> is the Undefined state, and its <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> is the Menu state.</p>
 		</div>
 		<div class="state" id="aria-hidden">
 			<sdef>aria-hidden</sdef>

--- a/index.html
+++ b/index.html
@@ -10766,7 +10766,7 @@ button.ariaPressed; // null</pre>
 				</thead>
 				<tbody>
 					<tr>
-						<th class="value-name" scope="row"><strong class="default">false</strong>:</th>
+						<th class="value-name" scope="row"><strong class="default">false, empty string (<code>&quot;&quot;</code>)</strong>:</th>
 						<th class="state-description" scope="row">False</th>
 						<td class="value-description">There are no expected updates for the element.</td>
 					</tr>
@@ -10778,6 +10778,7 @@ button.ariaPressed; // null</pre>
 				</tbody>
 			</table>
 			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> are both the False state.</p>
+			<p>For the purposes of <a data-cite="html/common-dom-interfaces.html#reflect">reflection</a>, the canonical keyword for the False state is the "false" keyword.</p>
 		</div>
 		<div class="state" id="aria-checked">
 			<sdef>aria-checked</sdef>

--- a/index.html
+++ b/index.html
@@ -11852,7 +11852,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="state-value-head" scope="row">Value:</th>
-						<td class="state-value"><a href="#valuetype_true-false-undefined">true/false/undefined</a></td>
+						<td class="property-value"><a href="#valuetype_enumerated">Enumerated</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -11860,25 +11860,26 @@ button.ariaPressed; // null</pre>
 				<caption>Values:</caption>
 				<thead>
 					<tr>
-						<th scope="col">Value</th>
+						<th scope="col">Value (keyword)</th>
+                        <th scope="col">State</th>
 						<th scope="col">Description</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
-						<th class="value-name" scope="row">false</th>
-						<td class="value-description">The element's [=element/hidden=] state is determined by the user agent based on whether it is rendered. Synonym of <code>undefined</code>.</td>
+						<th class="value-name" scope="row">false, undefined, empty string (<code>&quot;&quot;</code>)</th>
+						<th class="state-description" scope="row">False</th>
+						<td class="value-description">The element's [=element/hidden=] state is determined by the user agent based on whether it is rendered.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">true</th>
+						<th class="state-description" scope="row">True</th>
 						<td class="value-description">The element is [=element/hidden=] from the accessibility API.</td>
-					</tr>
-					<tr>
-						<th class="value-name" scope="row"><strong class="default">undefined (default)</strong></th>
-						<td class="value-description">The element's [=element/hidden=] state is determined by the user agent based on whether it is rendered.</td>
 					</tr>
 				</tbody>
 			</table>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> are both the Undefined state.</p>
+			<p>For the purposes of <a data-cite="html/common-dom-interfaces.html#reflect">reflection</a>, the canonical keyword for the Undefined state is the "undefined" keyword.</p>
 		</div>
 		<div class="state" id="aria-invalid">
 			<sdef>aria-invalid</sdef>

--- a/index.html
+++ b/index.html
@@ -10208,11 +10208,6 @@
 		<section id="idl-reflection-attribute-values">
 			<h3>IDL reflection of ARIA attributes</h3>
 			<p>ARIA attributes may reflect as several IDL attribute types such as [=nullable type|nullable=] {{DOMString}} attributes, [=nullable type|nullable=] {{FrozenArray}} attributes or [=nullable type|nullable=] {{Element}} attributes.
-			<p>Default values from the ARIA values tables MUST NOT reflect to IDL as the
-			<a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> or the
-			<a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> for the attribute.
-			On getting, a missing ARIA attribute will return <code>null</code>. ARIA attributes are not validated on get.
-			If an ARIA value is invalid, on getting, it will return its set value as a literal string, and will not return an invalid value default.</p>
 		</section>
 		<section id="os-aapi-attribute-mapping">
 			<h3>Operating System Accessibility API mapping of multi-value ARIA attributes</h3>

--- a/index.html
+++ b/index.html
@@ -10819,22 +10819,26 @@ button.ariaPressed; // null</pre>
 				<caption>Values:</caption>
 				<thead>
 					<tr>
-						<th scope="col">Value</th>
+						<th scope="col">Value (keyword)</th>
+                        <th scope="col">State</th>
 						<th scope="col">Description</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
 						<th class="value-name" scope="row">false</th>
+						<th class="state-description" scope="row">False</th>
 						<td class="value-description">The element supports being checked but is not currently checked.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">mixed</th>
+						<th class="state-description" scope="row">Mixed</th>
 						<!-- make sure this value remains synced with its counterpart in #aria-pressed -->
 						<td class="value-description">Indicates a mixed mode value for a tri-state checkbox or menuitemcheckbox.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">true</th>
+						<th class="state-description" scope="row">True</th>
 						<td class="value-description">The element is checked.</td>
 					</tr>
 					<tr>
@@ -10843,6 +10847,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 				</tbody>
 			</table>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> are both the Undefined state.</p>
 		</div>
 		<div class="property" id="aria-colcount">
 			<pdef>aria-colcount</pdef>

--- a/index.html
+++ b/index.html
@@ -10811,7 +10811,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="state-value-head" scope="row">Value:</th>
-						<td class="state-value"><a href="#valuetype_tristate">tristate</a></td>
+						<td class="property-value"><a href="#valuetype_enumerated">Enumerated</a></td>
 					</tr>
 				</tbody>
 			</table>

--- a/index.html
+++ b/index.html
@@ -14024,7 +14024,6 @@ el.getAttribute("aria-label"); // Returns "Publish"</pre>
 <section class="informative appendix" id="typemapping">
 	<h2>Mapping WAI-ARIA Value types to languages</h2>
 	<p class="note">The HTML column of the table below is advisory. Guidance on use of WAI-ARIA state and properties in HTML is provided in <a data-cite="html-aria/#docconformance">Document conformance requirements for use of ARIA attributes in HTML</a> ([[HTML-ARIA]]).</p>
-	<p class="note">The suggested mappings for true/false values in HTML use <a data-cite="html/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of <code>true</code> and <code>false</code>, instead of using the HTML boolean value type. <!--@@ can't rely on attribute absence because of default value in true/false/undefined case.--></p>
 	<p>The table below provides recommended mappings between WAI-ARIA state and property types and attribute types from [[[HTML]]] and [[[XMLSCHEMA11-2]]].</p>
 	<p>Languages not listed below might have appropriate value types defined in the language. If they do not, we recommend XML Schema Datatypes for general purpose XML languages. Documents using DTDs instead of schemas will not be able to validate automatically and require additional processing on WAI-ARIA attributes.</p>
 	<table>

--- a/index.html
+++ b/index.html
@@ -10200,18 +10200,17 @@
 	<section data-cite="webidl">
 		<h2>ARIA Attributes</h2>
 		<section id="enumerated-attribute-values">
-			<h3>Multi-value Attribute Values</h3>
+			<h3>Enumerated Attribute Values</h3>
 			<p>When the ARIA attribute definition includes a table listing the attribute's allowed <span>values</span>,
-			that attribute is a multi-value nullable attribute.
-			Each value in the table is a keyword for the attribute, mapping to a state of the same name. </p>
+			it is an [=enumerated attribute=]. Each value in the table is a keyword for the attribute, mapping to a state of the same name and one or more keywords may map to the same state. </p>
 		</section>
 		<section id="idl-reflection-attribute-values">
 			<h3>IDL reflection of ARIA attributes</h3>
 			<p>ARIA attributes may reflect as several IDL attribute types such as [=nullable type|nullable=] {{DOMString}} attributes, [=nullable type|nullable=] {{FrozenArray}} attributes or [=nullable type|nullable=] {{Element}} attributes.
-			<p>Default values from the ARIA values tables MUST NOT reflect to IDL as the
+			<p>For non-enumerated attributes, default values from the ARIA values tables MUST NOT reflect to IDL as the
 			<a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> or the
 			<a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> for the attribute.
-			On getting, a missing ARIA attribute will return <code>null</code>. ARIA attributes are not validated on get.
+			On getting (a non-enumerated attribute), a missing ARIA attribute will return <code>null</code> as such ARIA attributes are not validated on get.
 			If an ARIA value is invalid, on getting, it will return its set value as a literal string, and will not return an invalid value default.</p>
 		</section>
 		<section id="os-aapi-attribute-mapping">
@@ -10223,11 +10222,7 @@
 		<section id="enumerated-attribute-values-html">
 			<h3>ARIA nullable DOMString Attributes</h3>
 			<p>As noted in [[[#typemapping]]], attributes are included in host languages, and the syntax for representation of WAI-ARIA types is governed by the host language.</p>
-			<p>The following algorithm should be used for ARIA nullable {{DOMString}} attributes in HTML:</p>
-			<p>On getting, if the corresponding content attribute is not present, then the IDL attribute must return null,
-			otherwise, the IDL attribute must get the value in a transparent, case-preserving manner.
-			On setting, if the new value is null, the content attribute must be removed, and otherwise,
-			the content attribute must be set to the specified new value in a transparent, case-preserving manner.</p>
+			<p>ARIA attributes [=reflect=] in IDL as defined in HTML.</p>
 			<section class="informative" id="enumeration-example">
 				<h4>Example Attribute Usage</h4>
 				<aside class="example">

--- a/index.html
+++ b/index.html
@@ -10177,12 +10177,6 @@
 			<h3>Value</h3>
 			<p>Value type of the <a>state</a> or [=ARIA/property=]. The value is one of the following types:</p>
 			<dl>
-				<dt id="valuetype_true-false">true/false</dt>
-				<dd>Value representing either <code>true</code> or <code>false</code>. The default value for this value type is <code>false</code> unless otherwise specified.</dd>
-				<dt id="valuetype_tristate">tristate</dt>
-				<dd>Value representing <code>true</code>, <code>false</code>, <code>mixed</code>, or <code>undefined</code> values. The default value for this value type is <code>undefined</code> unless otherwise specified.</dd>
-				<dt id="valuetype_true-false-undefined">true/false/undefined</dt>
-				<dd>Value representing <code>true</code>, <code>false</code>, or <code>undefined</code> (not applicable). The default value for this value type is <code>undefined</code> unless otherwise specified. For example, an element with <sref>aria-expanded</sref> set to <code>false</code> is not currently expanded; an element with <sref>aria-expanded</sref> set to <code>undefined</code> is not expandable.</dd>
 				<dt id="valuetype_enumerated">enumerated</dt>
 				<dd>Values are limited to a predefined, finite set of states including two special states: <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a>.
 				<dt id="valuetype_idref">ID reference</dt>

--- a/index.html
+++ b/index.html
@@ -14034,21 +14034,6 @@ el.getAttribute("aria-label"); // Returns "Publish"</pre>
 			<th scope="col">XML Schema</th>
 		</tr>
 		<tr>
-			<td>true/false</td>
-			<td><a data-cite="html/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of &quot;true&quot; and &quot;false&quot;</td>
-			<td><a data-cite="xmlschema11-2/#boolean">boolean</a></td>
-		</tr>
-		<tr>
-			<td>true/false/undefined</td>
-			<td><a data-cite="html/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of <code>true</code>, <code>false</code>, and <code>undefined</code></td>
-			<td><a data-cite="xmlschema11-2/#NMTOKEN">NMTOKEN</a> with an <a href="https://www.w3.org/TR/xmlschema11-2/#NMTOKEN">enumeration constraint</a> allowing values of <code>true</code>, <code>false</code>, and <code>undefined</code></td>
-		</tr>
-		<tr>
-			<td>tristate</td>
-			<td><a data-cite="html/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a> with allowed values of &quot;true&quot;, &quot;false&quot;, and &quot;mixed&quot;</td>
-			<td><a data-cite="xmlschema11-2/#NMTOKEN">NMTOKEN</a> with an <a href="https://www.w3.org/TR/xmlschema11-2/#NMTOKEN">enumeration constraint</a> allowing values of &quot;true&quot;, &quot;false&quot;, and &quot;mixed&quot;</td>
-		</tr>
-		<tr>
 			<td>number</td>
 			<td><a data-cite="html/common-microsyntaxes.html#floating-point-numbers">Floating-point numbers</a></td>
 			<td><a data-cite="xmlschema11-2/#decimal">decimal</a></td>
@@ -14059,7 +14044,7 @@ el.getAttribute("aria-label"); // Returns "Publish"</pre>
 			<td><a data-cite="xmlschema11-2/#integer">integer</a></td>
 		</tr>
 		<tr>
-			<td>token</td>
+			<td>enumerated</td>
 			<td><a data-cite="html/common-microsyntaxes.html#keywords-and-enumerated-attributes">Keyword and enumerated attributes</a></td>
 			<td><a data-cite="xmlschema11-2/#NMTOKEN">NMTOKEN</a> with an <a data-cite="xmlschema11-2/#dt-enumeration">enumeration constraint</a> allowing values listed in the state or property definition</td>
 		</tr>

--- a/index.html
+++ b/index.html
@@ -10208,6 +10208,11 @@
 		<section id="idl-reflection-attribute-values">
 			<h3>IDL reflection of ARIA attributes</h3>
 			<p>ARIA attributes may reflect as several IDL attribute types such as [=nullable type|nullable=] {{DOMString}} attributes, [=nullable type|nullable=] {{FrozenArray}} attributes or [=nullable type|nullable=] {{Element}} attributes.
+			<p>Default values from the ARIA values tables MUST NOT reflect to IDL as the
+			<a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> or the
+			<a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> for the attribute.
+			On getting, a missing ARIA attribute will return <code>null</code>. ARIA attributes are not validated on get.
+			If an ARIA value is invalid, on getting, it will return its set value as a literal string, and will not return an invalid value default.</p>
 		</section>
 		<section id="os-aapi-attribute-mapping">
 			<h3>Operating System Accessibility API mapping of multi-value ARIA attributes</h3>

--- a/index.html
+++ b/index.html
@@ -10183,6 +10183,8 @@
 				<dd>Value representing <code>true</code>, <code>false</code>, <code>mixed</code>, or <code>undefined</code> values. The default value for this value type is <code>undefined</code> unless otherwise specified.</dd>
 				<dt id="valuetype_true-false-undefined">true/false/undefined</dt>
 				<dd>Value representing <code>true</code>, <code>false</code>, or <code>undefined</code> (not applicable). The default value for this value type is <code>undefined</code> unless otherwise specified. For example, an element with <sref>aria-expanded</sref> set to <code>false</code> is not currently expanded; an element with <sref>aria-expanded</sref> set to <code>undefined</code> is not expandable.</dd>
+				<dt id="valuetype_enumerated">enumerated</dt>
+				<dd>Values are limited to a predefined, finite set of states including two special states: <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a>.
 				<dt id="valuetype_idref">ID reference</dt>
 				<dd>Reference to the ID of another <a>element</a> in the same document</dd>
 				<dt id="valuetype_idref_list">ID reference list</dt>
@@ -10492,7 +10494,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="property-value-head" scope="row">Value:</th>
-						<td class="property-value"><a href="#valuetype_true-false">true/false</a></td>
+						<td class="property-value"><a href="#valuetype_enumerated">Enumerated</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -10500,21 +10502,25 @@ button.ariaPressed; // null</pre>
 				<caption>Values:</caption>
 				<thead>
 					<tr>
-						<th scope="col">Value</th>
+						<th scope="col">Value (keyword)</th>
+						<th scope="col">State</th>
 						<th scope="col">Description</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
 						<th class="value-name" scope="row">false</th>
+						<th class="state-description" scope="row">False</th>
 						<td class="value-description">Assistive technologies will present only the changed node or nodes.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">true</th>
+						<th class="state-description" scope="row">True</th>
 						<td class="value-description">Assistive technologies will present the entire changed region as a whole, including the author-defined label if one exists.</td>
 					</tr>
 				</tbody>
 			</table>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a>. are both the Missing state.</p>
 		</div>
 		<div class="property" id="aria-autocomplete">
 			<pdef>aria-autocomplete</pdef>

--- a/index.html
+++ b/index.html
@@ -12660,7 +12660,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="property-value-head" scope="row">Value:</th>
-						<td class="property-value"><a href="#valuetype_true-false">true/false</a></td>
+						<td class="property-value"><a href="#valuetype_enumerated">Enumerated</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -12668,21 +12668,26 @@ button.ariaPressed; // null</pre>
 				<caption>Values:</caption>
 				<thead>
 					<tr>
-						<th scope="col">Value</th>
+						<th scope="col">Value (keyword)</th>
+                        <th scope="col">State</th>
 						<th scope="col">Description</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
-						<th class="value-name" scope="row"><strong class="default">false (default)</strong></th>
+						<th class="value-name" scope="row"><strong class="default">false, empty string (<code>&quot;&quot;</code>)</strong></th>
+						<th class="state-description" scope="row">False</th>
 						<td class="value-description">The user can set the value of the element.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">true</th>
+						<th class="state-description" scope="row">True</th>
 						<td class="value-description">The user cannot change the value of the element.</td>
 					</tr>
 				</tbody>
 			</table>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> are both the False state.</p>
+			
 		</div>
 		<div class="property" id="aria-relevant">
 			<pdef>aria-relevant</pdef>

--- a/index.html
+++ b/index.html
@@ -11178,7 +11178,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="state-value-head" scope="row">Value:</th>
-						<td class="property-value"><a href="#valuetype_token">token</a></td>
+						<td class="property-value"><a href="#valuetype_enumerated">Enumerated</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -11186,41 +11186,51 @@ button.ariaPressed; // null</pre>
 				<caption>Values:</caption>
 				<thead>
 					<tr>
-						<th scope="col">Value</th>
+						<th scope="col">Value (keyword)</th>
+                        <th scope="col">State</th>
 						<th scope="col">Description</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
 						<th class="value-name" scope="row">page</th>
+						<th class="state-description" scope="row">Page</th>
 						<td class="value-description">Represents the current page within a set of pages.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">step</th>
+						<th class="state-description" scope="row">Step</th>
 						<td class="value-description">Represents the current step within a process.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">location</th>
+						<th class="state-description" scope="row">Location</th>
 						<td class="value-description">Represents the current location within an environment or context.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">date</th>
+						<th class="state-description" scope="row">Date</th>
 						<td class="value-description">Represents the current date within a collection of dates.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">time</th>
+						<th class="state-description" scope="row">Time</th>
 						<td class="value-description">Represents the current time within a set of times.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">true</th>
+						<th class="state-description" scope="row">True</th>
 						<td class="value-description">Represents the current item within a set.</td>
 					</tr>
 					<tr>
-						<th class="value-name" scope="row"><strong class="default">false (default)</strong></th>
+						<th class="value-name" scope="row"><strong class="default">false, undefined, empty string (<code>&quot;&quot;</code>)</th>
+						<th class="state-description" scope="row">False</th>
 						<td class="value-description">Does not represent the current item within a set.</td>
 					</tr>
 				</tbody>
 			</table>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> is the False state, and its <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> are both the True state.</p>
+			<p>For the purposes of <a data-cite="html/common-dom-interfaces.html#reflect">reflection</a>, the canonical keyword for the False state is the "false" keyword.</p>
 		</div>
 		<div class="property" id="aria-describedby">
 			<pdef>aria-describedby</pdef>

--- a/index.html
+++ b/index.html
@@ -13262,7 +13262,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="property-value-head" scope="row">Value:</th>
-						<td class="property-value"><a href="#valuetype_token">token</a></td>
+						<td class="property-value"><a href="#valuetype_enumerated">Enumerated</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -13270,29 +13270,35 @@ button.ariaPressed; // null</pre>
 				<caption>Values:</caption>
 				<thead>
 					<tr>
-						<th scope="col">Value</th>
+						<th scope="col">Value (keyword)</th>
+                        <th scope="col">State</th>
 						<th scope="col">Description</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
 						<th class="value-name" scope="row">ascending</th>
+						<th class="state-description" scope="row">Ascending</th>
 						<td class="value-description">Items are sorted in ascending order.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">descending</th>
+						<th class="state-description" scope="row">Descending</th>
 						<td class="value-description">Items are sorted in descending order.</td>
 					</tr>
 					<tr>
-						<th class="value-name" scope="row"><strong class="default">none (default)</strong></th>
+						<th class="value-name" scope="row"><strong class="default">none</strong></th>
+						<th class="state-description" scope="row">None</th>
 						<td class="value-description">There is no defined sort applied.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">other</th>
+						<th class="state-description" scope="row">Other</th>
 						<td class="value-description">A sort algorithm other than ascending or descending has been applied.</td>
 					</tr>
 				</tbody>
 			</table>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> are both the None state.</p>
 		</div>
 		<div class="property" id="aria-valuemax">
 			<pdef>aria-valuemax</pdef>

--- a/index.html
+++ b/index.html
@@ -12276,7 +12276,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="property-value-head" scope="row">Value:</th>
-						<td class="property-value"><a href="#valuetype_true-false">true/false</a></td>
+						<td class="property-value"><a href="#valuetype_enumerated">Enumerated</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -12284,21 +12284,26 @@ button.ariaPressed; // null</pre>
 				<caption>Values:</caption>
 				<thead>
 					<tr>
-						<th scope="col">Value</th>
+						<th scope="col">Value (keyword)</th>
+                        <th scope="col">State</th>
 						<th scope="col">Description</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
-						<th class="value-name" scope="row"><strong class="default">false (default)</strong></th>
+						<th class="value-name" scope="row"><strong class="default">false, empty string (<code>&quot;&quot;</code>)</strong></th>
+						<th class="state-description" scope="row">False</th>
 						<td class="value-description">This is a single-line text box.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">true</th>
+						<th class="state-description" scope="row">True</th>
 						<td class="value-description">This is a multi-line text box.</td>
 					</tr>
 				</tbody>
 			</table>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> are both the False state.</p>
+			<p>For the purposes of <a data-cite="html/common-dom-interfaces.html#reflect">reflection</a>, the canonical keyword for the False state is the "false" keyword.</p>
 		</div>
 		<div class="property" id="aria-multiselectable">
 			<pdef>aria-multiselectable</pdef>

--- a/index.html
+++ b/index.html
@@ -12585,7 +12585,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="state-value-head" scope="row">Value:</th>
-						<td class="state-value"><a href="#valuetype_tristate">tristate</a></td>
+						<td class="property-value"><a href="#valuetype_enumerated">Enumerated</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -12593,30 +12593,37 @@ button.ariaPressed; // null</pre>
 				<caption>Values:</caption>
 				<thead>
 					<tr>
-						<th scope="col">Value</th>
+						<th scope="col">Value (keyword)</th>
+                        <th scope="col">State</th>
 						<th scope="col">Description</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
 						<th class="value-name" scope="row">false</th>
+						<th class="state-description" scope="row">False</th>
 						<td class="value-description">The element supports being pressed but is not currently pressed.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">mixed</th>
+						<th class="state-description" scope="row">Mixed</th>
 						<!-- make sure this value remains synced with its counterpart in #aria-checked -->
 						<td class="value-description">Indicates a mixed mode value for a tri-state toggle button.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">true</th>
+						<th class="state-description" scope="row">True</th>
 						<td class="value-description">The element is pressed.</td>
 					</tr>
 					<tr>
-						<th class="value-name" scope="row"><strong class="default">undefined (default)</strong></th>
+						<th class="value-name" scope="row"><strong class="default">undefined, empty string (<code>&quot;&quot;</code>)</strong></th>
+						<th class="state-description" scope="row">Undefined</th>
 						<td class="value-description">The element does not support being pressed.</td>
 					</tr>
 				</tbody>
 			</table>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> are both the Undefined state.</p>
+			<p>For the purposes of <a data-cite="html/common-dom-interfaces.html#reflect">reflection</a>, the canonical keyword for the Undefined state is the "undefined" keyword.</p>
 		</div>
 		<div class="property" id="aria-readonly">
 			<pdef>aria-readonly</pdef>

--- a/index.html
+++ b/index.html
@@ -10230,6 +10230,21 @@
 			<section class="informative" id="enumeration-example">
 				<h4>Example Attribute Usage</h4>
 				<aside class="example">
+<!-- ReSpec needs these examples to be unindented. -->
+<pre>// aria-label example
+
+	el.ariaLabel; // null
+
+	// Assignment of content attribute to empty string.
+	el.setAttribute("aria-label", "");
+	el.ariaLabel; // ""
+
+	// Removal of content attribute results in null value.
+	el.removeAttribute("aria-label");
+	el.ariaLabel; // null</pre>
+
+				</aside>
+				<aside class="example">
 
 <!-- ReSpec needs these examples to be unindented. -->
 <pre>// HTML hidden="" example (not aria-hidden="true")
@@ -10247,8 +10262,7 @@ el.hidden; // false</pre>
 			<aside class="example">
 
 <!-- ReSpec needs these examples to be unindented. -->
-<pre>// aria-busy example
-// true/false ~ boolean-like nullable string; returns null unless set
+<pre>// aria-busy example (enumerated attribute)
 
 el.ariaBusy; // null
 
@@ -10256,11 +10270,11 @@ el.ariaBusy; // null
 el.ariaBusy = "true";
 el.ariaBusy; // "true"
 
-// Removal of content attribute results in missing value default: string "false".
+// Removal of content attribute results in missing value default of "false".
 el.removeAttribute("aria-busy");
 el.ariaBusy; // null
 
-// Assignment of invalid "busy" value. Not validated on set or get and the literal string value "busy" is returned.
+// Assignment of invalid "busy" value results in invalid value default of "false".
 el.setAttribute("aria-busy", "busy");
 el.ariaBusy; // "busy"</pre>
 
@@ -10268,8 +10282,7 @@ el.ariaBusy; // "busy"</pre>
 			<aside class="example">
 
 <!-- ReSpec needs these examples to be unindented. -->
-<pre>// aria-pressed example
-// Tristate ~ true/false/mixed/undefined string; null if unspecified
+<pre>// aria-pressed example (enumerated attribute)
 
 // no value has been defined
 button.ariaPressed; // null
@@ -10277,14 +10290,14 @@ button.ariaPressed; // null
 // A value of "true", "false", or "mixed" for aria-pressed on a button denotes a toggle button.
 button.setAttribute("aria-pressed", "true"); // Content attribute assignment.
 button.ariaPressed; // "true"
-button.ariaPressed = "false"; // DOM property assignment.
+button.ariaPressed = "false"; // IDL attribute assignment.
 button.ariaPressed; // "false"
 
-// Assignment of invalid "foo" value. Not validated on set or get and the literal string value "foo" is returned.
-button.ariaPressed = "foo";
+// Assignment of invalid "foo" value results in invalid value default of "undefined".
+button.ariaPressed = "undefined";
 button.ariaPressed; // "foo" (Note: button is no longer a toggle button.)
 
-// Removal of content attribute results in a null value
+// Removal of content attribute results in a null value.
 button.removeAttribute("aria-pressed");
 button.ariaPressed; // null</pre>
 

--- a/index.html
+++ b/index.html
@@ -12393,7 +12393,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="property-value-head" scope="row">Value:</th>
-						<td class="property-value"><a href="#valuetype_token">token</a></td>
+						<td class="property-value"><a href="#valuetype_enumerated">Enumerated</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -12401,25 +12401,31 @@ button.ariaPressed; // null</pre>
 				<caption>Values:</caption>
 				<thead>
 					<tr>
-						<th scope="col">Value</th>
+						<th scope="col">Value (keyword)</th>
+                        <th scope="col">State</th>
 						<th scope="col">Description</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
 						<th class="value-name" scope="row">horizontal</th>
+						<th class="state-description" scope="row">Horizontal</th>
 						<td class="value-description">The element is oriented horizontally.</td>
 					</tr>
 					<tr>
-						<th class="value-name" scope="row"><strong class="default">undefined (default)</strong></th>
+						<th class="value-name" scope="row"><strong class="default">undefined, empty string (<code>&quot;&quot;</code>)</strong></th>
+						<th class="state-description" scope="row">Undefined</th>
 						<td class="value-description">The element's orientation is unknown/ambiguous.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">vertical</th>
+						<th class="state-description" scope="row">Vertical</th>
 						<td class="value-description">The element is oriented vertically.</td>
 					</tr>
 				</tbody>
 			</table>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> are both the Undefined state.</p>
+			<p>For the purposes of <a data-cite="html/common-dom-interfaces.html#reflect">reflection</a>, the canonical keyword for the Undefined state is the "undefined" keyword.</p>
 		</div>
 		<div class="property" id="aria-owns">
 			<pdef>aria-owns</pdef>

--- a/index.html
+++ b/index.html
@@ -10207,8 +10207,7 @@
 		</section>
 		<section id="idl-reflection-attribute-values">
 			<h3>IDL reflection of ARIA attributes</h3>
-			<p>All ARIA attributes reflect in IDL as [=nullable type|nullable=] {{DOMString}} attributes.
-			This includes the boolean-like <a href="#valuetype_true-false">true/false</a> type, and all other ARIA attributes.</p>
+			<p>ARIA attributes may reflect as several IDL attribute types such as [=nullable type|nullable=] {{DOMString}} attributes, [=nullable type|nullable=] {{FrozenArray}} attributes or [=nullable type|nullable=] {{Element}} attributes.
 			<p>Default values from the ARIA values tables MUST NOT reflect to IDL as the
 			<a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> or the
 			<a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> for the attribute.

--- a/index.html
+++ b/index.html
@@ -10199,10 +10199,14 @@
 	</section>
 	<section data-cite="webidl">
 		<h2>ARIA Attributes</h2>
+		<section id="content-vs-idl-attributes">
+			<h3>Distinguishing Between Content and IDL Attributes</h3>
+			<p>HTML content attributes, including ARIA states and properties, are set in HTML markup, while IDL attributes (or DOM properties) are the corresponding JavaScript properties exposed on DOM elements.
+			See [=reflect|reflection=] in HTML for more details.</p>
 		<section id="enumerated-attribute-values">
 			<h3>Enumerated Attribute Values</h3>
 			<p>When the ARIA attribute definition includes a table listing the attribute's allowed <span>values</span>,
-			it is an [=enumerated attribute=]. Each value in the table is a keyword for the attribute, mapping to a state of the same name and one or more keywords may map to the same state. </p>
+			it is an [=enumerated attribute=]. Each value in the table is a keyword for the attribute, mapping to a state of the same name and one or more keywords may map to the same state.</p>
 		</section>
 		<section id="idl-reflection-attribute-values">
 			<h3>IDL reflection of ARIA attributes</h3>

--- a/index.html
+++ b/index.html
@@ -11418,7 +11418,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="state-value-head" scope="row">Value:</th>
-						<td class="state-value"><a href="#valuetype_true-false">true/false</a></td>
+						<td class="property-value"><a href="#valuetype_enumerated">Enumerated</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -11426,21 +11426,26 @@ button.ariaPressed; // null</pre>
 				<caption>Values:</caption>
 				<thead>
 					<tr>
-						<th scope="col">Value</th>
+						<th scope="col">Value (keyword)</th>
+                        <th scope="col">State</th>
 						<th scope="col">Description</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
-						<th class="value-name" scope="row"><strong class="default">false (default)</strong></th>
+						<th class="value-name" scope="row"><strong class="default">false, empty string (<code>&quot;&quot;</code>)</strong></th>
+						<th class="state-description" scope="row">False</th>
 						<td class="value-description">The element is enabled.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">true</th>
+						<th class="state-description" scope="row">True</th>
 						<td class="value-description">The element and all focusable descendants are disabled and its value cannot be changed by the user.</td>
 					</tr>
 				</tbody>
 			</table>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> are both the False state.</p>
+			<p>For the purposes of <a data-cite="html/common-dom-interfaces.html#reflect">reflection</a>, the canonical keyword for the False state is the "false" keyword.</p>
 		</div>
 		<div class="property deprecated" id="aria-dropeffect">
 			<pdef>aria-dropeffect</pdef>

--- a/index.html
+++ b/index.html
@@ -12791,7 +12791,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="property-value-head" scope="row">Value:</th>
-						<td class="property-value"><a href="#valuetype_true-false">true/false</a></td>
+						<td class="property-value"><a href="#valuetype_enumerated">Enumerated</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -12799,21 +12799,26 @@ button.ariaPressed; // null</pre>
 				<caption>Values:</caption>
 				<thead>
 					<tr>
-						<th scope="col">Value</th>
+						<th scope="col">Value (keyword)</th>
+                        <th scope="col">State</th>
 						<th scope="col">Description</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
-						<th class="value-name" scope="row"><strong class="default">false (default)</strong></th>
+						<th class="value-name" scope="row"><strong class="default">false, empty string (<code>&quot;&quot;</code>)</strong></th>
+						<th class="state-description" scope="row">False</th>
 						<td class="value-description">User input is not necessary to submit the form.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">true</th>
+						<th class="state-description" scope="row">True</th>
 						<td class="value-description">Users need to provide input on an element before a form is submitted.</td>
 					</tr>
 				</tbody>
 			</table>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> are both the False state.</p>
+			<p>For the purposes of <a data-cite="html/common-dom-interfaces.html#reflect">reflection</a>, the canonical keyword for the False state is the "false" keyword.</p>
 		</div>
 		<div class="property" id="aria-roledescription">
 			<pdef>aria-roledescription</pdef>

--- a/index.html
+++ b/index.html
@@ -11868,7 +11868,7 @@ button.ariaPressed; // null</pre>
 				<tbody>
 					<tr>
 						<th class="value-name" scope="row">false, undefined, empty string (<code>&quot;&quot;</code>)</th>
-						<th class="state-description" scope="row">False</th>
+						<th class="state-description" scope="row">Undefined</th>
 						<td class="value-description">The element's [=element/hidden=] state is determined by the user agent based on whether it is rendered.</td>
 					</tr>
 					<tr>

--- a/index.html
+++ b/index.html
@@ -12217,7 +12217,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="property-value-head" scope="row">Value:</th>
-						<td class="property-value"><a href="#valuetype_true-false">true/false</a></td>
+						<td class="property-value"><a href="#valuetype_enumerated">Enumerated</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -12225,21 +12225,26 @@ button.ariaPressed; // null</pre>
 				<caption>Values:</caption>
 				<thead>
 					<tr>
-						<th scope="col">Value</th>
+						<th scope="col">Value (keyword)</th>
+                        <th scope="col">State</th>
 						<th scope="col">Description</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
-						<th class="value-name" scope="row"><strong class="default">false (default)</strong></th>
+						<th class="value-name" scope="row"><strong class="default">false, empty string (<code>&quot;&quot;</code>)</strong></th>
+						<th class="state-description" scope="row">False</th>
 						<td class="value-description">Element is not modal.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">true</th>
+						<th class="state-description" scope="row">True</th>
 						<td class="value-description">Element is modal.</td>
 					</tr>
 				</tbody>
 			</table>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> are both the False state.</p>
+			<p>For the purposes of <a data-cite="html/common-dom-interfaces.html#reflect">reflection</a>, the canonical keyword for the False state is the "false" keyword.</p>
 		</div>
 		<div class="property" id="aria-multiline">
 			<pdef>aria-multiline</pdef>

--- a/index.html
+++ b/index.html
@@ -10565,7 +10565,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="property-value-head" scope="row">Value:</th>
-						<td class="property-value"><a href="#valuetype_token">token</a></td>
+						<td class="property-value"><a href="#valuetype_enumerated">Enumerated</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -10573,29 +10573,35 @@ button.ariaPressed; // null</pre>
 				<caption>Values:</caption>
 				<thead>
 					<tr>
-						<th scope="col">Value</th>
+						<th scope="col">Value (keyword)</th>
+						<th scope="col">State</th>
 						<th scope="col">Description</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
 						<th class="value-name" scope="row">inline</th>
+						<th class="state-description" scope="row">Inline</th>
 						<td class="value-description">When a user is providing input, text suggesting one way to complete the provided input might be dynamically inserted after the caret.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">list</th>
+						<th class="state-description" scope="row">List</th>
 						<td class="value-description">When a user is providing input, an element containing a collection of values that could complete the provided input might be displayed.</td>
 					</tr>
                     <tr>
                         <th class="value-name" scope="row">both</th>
+						<th class="state-description" scope="row">Both</th>
                         <td class="value-description">When a user is providing input, an element containing a collection of values that could complete the provided input might be displayed. If displayed, one value in the collection is automatically selected, and the text needed to complete the automatically selected value appears after the caret in the input.</td>
                     </tr>
 					<tr>
-						<th class="value-name" scope="row"><strong class="default">none (default)</strong></th>
+						<th class="value-name" scope="row"><strong class="default">none</strong></th>
+						<th class="state-description" scope="row">None</th>
 						<td class="value-description">When a user is providing input, an automatic suggestion that attempts to predict how the user intends to complete the input is not displayed.</td>
 					</tr>
 				</tbody>
 			</table>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> are both the None state.</p>
 		</div>
 		<div class="property" id="aria-braillelabel">
 			<pdef>aria-braillelabel</pdef>

--- a/index.html
+++ b/index.html
@@ -12153,7 +12153,7 @@ button.ariaPressed; // null</pre>
 					</tr>
 					<tr>
 						<th class="property-value-head" scope="row">Value:</th>
-						<td class="property-value"><a href="#valuetype_token">token</a></td>
+						<td class="property-value"><a href="#valuetype_enumerated">Enumerated</a></td>
 					</tr>
 				</tbody>
 			</table>
@@ -12161,25 +12161,30 @@ button.ariaPressed; // null</pre>
 				<caption>Values:</caption>
 				<thead>
 					<tr>
-						<th scope="col">Value</th>
+						<th scope="col">Value (keyword)</th>
+                        <th scope="col">State</th>
 						<th scope="col">Description</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
 						<th class="value-name" scope="row">assertive</th>
+						<th class="state-description" scope="row">Assertive</th>
 						<td class="value-description">Indicates that updates to the region have the highest priority and should be presented the user immediately.</td>
 					</tr>
 					<tr>
-						<th class="value-name" scope="row"><strong class="default">off (default)</strong></th>
+						<th class="value-name" scope="row"><strong class="default">off</strong></th>
+						<th class="state-description" scope="row">Off</th>
 						<td class="value-description">Indicates that updates to the region should not be presented to the user unless the user is currently focused on that region.</td>
 					</tr>
 					<tr>
 						<th class="value-name" scope="row">polite</th>
+						<th class="state-description" scope="row">Polite</th>
 						<td class="value-description">Indicates that updates to the region should be presented at the next graceful opportunity, such as at the end of speaking the current sentence or when the user pauses typing.</td>
 					</tr>
 				</tbody>
 			</table>
+			<p>The attribute's <a data-cite="html/common-microsyntaxes.html#missing-value-default">missing value default</a> and <a data-cite="html/common-microsyntaxes.html#invalid-value-default">invalid value default</a> are both the Off state.</p>
 		</div>
 		<div class="property" id="aria-modal">
 			<pdef>aria-modal</pdef>


### PR DESCRIPTION
Closes #2281 
Closes #2279 

* [ ]  add enumerated attribute definitions for the following attributes including missing value default, invalid value default, keywords/states and canonical keyword:
  * aria-atomic
  * aria-autocomplete
  * aria-busy
  * aria-checked
  * aria-current
  * aria-disabled
  * aria-expanded
  * aria-haspopup
  * aria-hidden
  * aria-invalid
  * aria-live
  * aria-modal
  * aria-multiline
  * aria-multiselectable
  * aria-orientation
  * aria-pressed
  * aria-readonly
  * aria-required
  * aria-selected
  * aria-sort
 * [ ] Revise "A. Mapping WAI-ARIA Value types to languages" to include enumerated attributes
 * [ ] Revise "6.2.4 Value" for permissible values (remove all other types except "enumerated"?)
 * [ ] Update "6.3 ARIA Attributes"
   * Remove obsolete note in "6.3.4 ARIA nullable DOMString Attributes" about ARIA transitioning to non-nullable DOMString?
   * Remote spec guidance around getting/setting to only apply to non-enumerated attributes
   * Provide updated examples for "6.3.4.1 Example Attribute Usage"

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests: https://github.com/web-platform-tests/interop-accessibility/issues/177
* [ ] Browser implementations (link to issue or commit):
   * WebKit:
   * Gecko:
   * Blink:
* [ ] Does this need AT implementations?
* [ ] Related APG Issue/PR:
* [ ] MDN Issue/PR:
  - https://developer.mozilla.org/en-US/docs/Glossary/Enumerated


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2413.html" title="Last updated on Mar 6, 2025, 6:50 PM UTC (509091f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2413/a2d34fe...509091f.html" title="Last updated on Mar 6, 2025, 6:50 PM UTC (509091f)">Diff</a>