### PR TITLE
Allow comboboxes to invoke menus

### DIFF
--- a/index.html
+++ b/index.html
@@ -2060,7 +2060,7 @@
 				Authors MUST set <sref>aria-expanded</sref> to <code>true</code> on an element with role <code>combobox</code> when it is expanded and <code>false</code> when it is collapsed.
 				</p>
 				<p>
-				Elements with the role <code>combobox</code> have an implicit <pref>aria-haspopup</pref> value of <code>listbox</code>. If the <code>combobox</code> popup element has a role other than <rref>listbox</rref>, authors MUST specify an <pref>aria-haspopup</pref> value of <rref>tree</rref>, <rref>grid</rref>, or <rref>dialog</rref> that corresponds to the role of its popup.
+				Elements with the role <code>combobox</code> have an implicit <pref>aria-haspopup</pref> value of <code>listbox</code>. If the <code>combobox</code> popup element has a role other than <rref>listbox</rref>, authors MUST specify an <pref>aria-haspopup</pref> value of <rref>tree</rref>, <rref>grid</rref>, <rref>menu</rref> or <rref>dialog</rref> that corresponds to the role of its popup.
 				</p>
 				<p>
 				If the user interface includes an additional icon that allows the visibility of the popup to be controlled via pointer and touch events, authors SHOULD ensure that element has role <rref>button</rref>, that it is focusable but not included in the page <kbd>Tab</kbd> sequence, and that it is not a descendant of the element with role <code>combobox</code>.


### PR DESCRIPTION
closes #2050

This PR simply adds `menu` to the paragraph of text that indicates what value needs to be used for the aria-haspopup attribute, if the popup is not a listbox:

>authors MUST specify an aria-haspopup value of tree, grid, or dialog that corresponds to the role of its popup.

I think some additional text could be written in the `menu` role definition to further acknowledge this new allowance.  But I'll leave that open for discussion, rather than immediately start adding such text.

Describe Change Here!

And a few other todo items (delete this section after performing them):
* [ ] For every spec that this PR edits, please add the appropriate `spec:<spec_name>` label. If you don't have privileges to do this, editors will do it for you.
* [ ] If the change is [editorial](https://github.com/w3c/aria/blob/main/documentation/process.md#editorial-changes), please add "Editorial:" at the start of your PR name, and delete the "Test, Documentation and Implementation tracking" section below.

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests:
* [ ] Browser implementations (link to issue or commit):
   * WebKit:
   * Gecko:
   * Blink:
* [ ] Does this need AT implementations?
* [ ] Related APG Issue/PR:
* [ ] MDN Issue/PR:
