### PR TITLE
Add UA SHOULD guidance for role without required accessibility parent

### DIFF
--- a/index.html
+++ b/index.html
@@ -655,6 +655,7 @@
 			<h3>Required Accessibility Parent Role</h3>
 			<p>The required <a>accessibility parent</a> (simplified as "parent") role defines the container where this <a>role</a> is allowed. If a role has a required accessibility parent, authors MUST ensure that an element with the role is an <a>accessibility child</a> of an element with the required accessibility parent role. For example, an element with role <code>listitem</code> is only meaningful when it is a child of an element with role <code>list</code>.</p>
 			<p>To determine whether an element has a parent with the required role, <a>user agents</a> MUST ignore any elements with the role <rref>generic</rref> or <rref>none</rref>.</p>
+			<p>Also, <a>user agents</a> SHOULD ignore the role if it occurs outside the context of a required accessibility parent role. </p>
 			<p class="note">An element with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> fulfills this requirement.</p>
 		</section>
 		<section id="namecalculation">


### PR DESCRIPTION
Closes #2012 

This PR adds additional user agent guidance for how orphan roles SHOULD be treated outside of the context of a required accessibility parent role.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2418.html" title="Last updated on Jan 30, 2025, 6:20 PM UTC (e5b2c09)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2418/a2d34fe...e5b2c09.html" title="Last updated on Jan 30, 2025, 6:20 PM UTC (e5b2c09)">Diff</a>