### PR TITLE
editorial: doc-pagelist section has been moved in the correct alphabetical-order

### DIFF
--- a/dpub-aria/index.html
+++ b/dpub-aria/index.html
@@ -3282,105 +3282,6 @@
         </div>
 
         <div class="role">
-          <rdef>doc-pagelist</rdef>
-
-          <div class="role-description">
-            <p>A navigational aid that provides a list of links to the page breaks in the content.</p>
-
-            <pre class="example highlight">
-&lt;nav role="doc-pagelist"&gt;
-   &lt;h2&gt;Pages&lt;/h2&gt;
-   &lt;ol&gt;
-      &lt;li&gt;&lt;a href="chapter.xhtml#Page_1"&gt;1&lt;/a&gt;&lt;/li&gt;
-      &lt;li&gt;&lt;a href="chapter.xhtml#Page_2"&gt;2&lt;/a&gt;&lt;/li&gt;
-      &#8230;
-   &lt;/ol&gt;
-&lt;/nav&gt;</pre
-            >
-          </div>
-
-          <table class="role-features">
-            <caption>
-              Characteristics of
-              <code>doc-pagelist</code
-              >:
-            </caption>
-            <thead>
-              <tr>
-                <th scope="col">Characteristic</th>
-                <th scope="col">Value</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th class="role-abstract-head" scope="row">Is Abstract:</th>
-                <td class="role-abstract"> </td>
-              </tr>
-              <tr>
-                <th class="role-parent-head" scope="row">Superclass Role:</th>
-                <td class="role-parent"><rref>navigation</rref></td>
-              </tr>
-              <tr>
-                <th class="role-children-head" scope="row">Subclass Roles:</th>
-                <td class="role-children"> </td>
-              </tr>
-              <tr>
-                <th class="role-base-head" scope="row">Base Concept:</th>
-                <td class="role-base"> </td>
-              </tr>
-              <tr>
-                <th class="role-related-head" scope="row">Related Concepts:</th>
-                <td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#page-list">page-list</a> [[EPUB-SSV]]</td>
-              </tr>
-              <tr>
-                <th class="role-scope-head" scope="row">Required Context Role:</th>
-                <td class="role-scope"> </td>
-              </tr>
-              <tr>
-                <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
-                <td class="role-mustcontain"></td>
-              </tr>
-              <tr>
-                <th class="role-required-properties-head">Required States and Properties:</th>
-                <td class="role-required-properties"> </td>
-              </tr>
-              <tr>
-                <th class="role-properties-head" scope="row">Supported States and Properties:</th>
-                <td class="role-properties"> </td>
-              </tr>
-              <tr>
-                <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
-                <td class="role-inherited"> </td>
-              </tr>
-              <tr>
-                <th class="role-namefrom-head" scope="row">Name From:</th>
-                <td class="role-namefrom">author</td>
-              </tr>
-              <tr>
-                <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
-                <td class="role-namerequired">False</td>
-              </tr>
-              <tr>
-                <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
-                <td class="role-namerequired-inherited"></td>
-              </tr>
-              <tr>
-                <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
-                <td class="role-childpresentational"></td>
-              </tr>
-              <tr>
-                <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
-                <td class="role-presentational-inherited"> </td>
-              </tr>
-              <tr>
-                <th class="implicit-values-head">Implicit Value for Role:</th>
-                <td class="implicit-values"> </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <div class="role">
           <rdef>doc-pagefooter</rdef>
 
           <div class="role-description">
@@ -3590,6 +3491,105 @@
           </table>
         </div>
 
+	<div class="role">
+          <rdef>doc-pagelist</rdef>
+
+          <div class="role-description">
+            <p>A navigational aid that provides a list of links to the page breaks in the content.</p>
+
+            <pre class="example highlight">
+&lt;nav role="doc-pagelist"&gt;
+   &lt;h2&gt;Pages&lt;/h2&gt;
+   &lt;ol&gt;
+      &lt;li&gt;&lt;a href="chapter.xhtml#Page_1"&gt;1&lt;/a&gt;&lt;/li&gt;
+      &lt;li&gt;&lt;a href="chapter.xhtml#Page_2"&gt;2&lt;/a&gt;&lt;/li&gt;
+      &#8230;
+   &lt;/ol&gt;
+&lt;/nav&gt;</pre
+            >
+          </div>
+
+          <table class="role-features">
+            <caption>
+              Characteristics of
+              <code>doc-pagelist</code
+              >:
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">Characteristic</th>
+                <th scope="col">Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th class="role-abstract-head" scope="row">Is Abstract:</th>
+                <td class="role-abstract"> </td>
+              </tr>
+              <tr>
+                <th class="role-parent-head" scope="row">Superclass Role:</th>
+                <td class="role-parent"><rref>navigation</rref></td>
+              </tr>
+              <tr>
+                <th class="role-children-head" scope="row">Subclass Roles:</th>
+                <td class="role-children"> </td>
+              </tr>
+              <tr>
+                <th class="role-base-head" scope="row">Base Concept:</th>
+                <td class="role-base"> </td>
+              </tr>
+              <tr>
+                <th class="role-related-head" scope="row">Related Concepts:</th>
+                <td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#page-list">page-list</a> [[EPUB-SSV]]</td>
+              </tr>
+              <tr>
+                <th class="role-scope-head" scope="row">Required Context Role:</th>
+                <td class="role-scope"> </td>
+              </tr>
+              <tr>
+                <th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
+                <td class="role-mustcontain"></td>
+              </tr>
+              <tr>
+                <th class="role-required-properties-head">Required States and Properties:</th>
+                <td class="role-required-properties"> </td>
+              </tr>
+              <tr>
+                <th class="role-properties-head" scope="row">Supported States and Properties:</th>
+                <td class="role-properties"> </td>
+              </tr>
+              <tr>
+                <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
+                <td class="role-inherited"> </td>
+              </tr>
+              <tr>
+                <th class="role-namefrom-head" scope="row">Name From:</th>
+                <td class="role-namefrom">author</td>
+              </tr>
+              <tr>
+                <th class="role-namerequired-head" scope="row">Accessible Name Required:</th>
+                <td class="role-namerequired">False</td>
+              </tr>
+              <tr>
+                <th class="role-namerequired-inherited-head" scope="row">Inherits Name Required:</th>
+                <td class="role-namerequired-inherited"></td>
+              </tr>
+              <tr>
+                <th class="role-childpresentational-head" scope="row">Children Presentational:</th>
+                <td class="role-childpresentational"></td>
+              </tr>
+              <tr>
+                <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
+                <td class="role-presentational-inherited"> </td>
+              </tr>
+              <tr>
+                <th class="implicit-values-head">Implicit Value for Role:</th>
+                <td class="implicit-values"> </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+	      
         <div class="role">
           <rdef>doc-part</rdef>
 


### PR DESCRIPTION
Closes: https://github.com/w3c/dpub-aria/issues/55

Very minor editorial change.

From the comparison, it may not be immediately clear, but the change simply repositions doc-pagelist to its correct alphabetical order. In [the W3C DPUB-ARIA 1.1 role definitions](https://www.w3.org/TR/dpub-aria-1.1/#role_definitions), the previous ordering was incorrect.