### PR TITLE
Editorial: companyURI -> companyURL

### DIFF
--- a/graphics-aria/graphics2.html
+++ b/graphics-aria/graphics2.html
@@ -59,21 +59,21 @@
 				name: "Fred Esch",
                           mailto: "fesch@us.ibm.com",
 				company: "IBM Corporation",
-				companyURI: "http://www.ibm.com",
+				companyURL: "http://www.ibm.com",
 				w3cid: 73593
 			},
 			{
 				name: "Rich Schwerdtfeger",
 				mailto: "richschwer@gmail.com",
 				company: "Knowbility", 
-				companyURI: "https://www.knowbility.org/",
+				companyURL: "https://www.knowbility.org/",
 				w3cid: 2460
 			},
 			{
 				name: "Léonie Watson",
 				mailto: "lwatson@paciellogroup.com ",
 				company: "The Paciello Group",
-				companyURI: 'http://www.paciellogroup.com',
+				companyURL: 'http://www.paciellogroup.com',
 				w3cid: 44692
 			},
 		],
@@ -84,7 +84,7 @@
 
 		//authors:  [
 		//    { name: "Your Name", url: "http://example.org/",
-		//      company: "Your Company", companyURI: "http://example.com/" },
+		//      company: "Your Company", companyURL: "http://example.com/" },
 		//],
 
 		/*

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -46,7 +46,7 @@
         // only "name" is required. Same format as editors.
         //authors:  [
         //    { name: "Your Name", url: "http://example.org/",
-        //      company: "Your Company", companyURI: "http://example.com/" },
+        //      company: "Your Company", companyURL: "http://example.com/" },
         //],
 
         // Spec URLs

--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
 
 		//authors:  [
 		//    { name: "Your Name", url: "http://example.org/",
-		//      company: "Your Company", companyURI: "http://example.com/" },
+		//      company: "Your Company", companyURL: "http://example.com/" },
 		//],
 
 		/*

--- a/requirements/aria-requirements.html
+++ b/requirements/aria-requirements.html
@@ -46,7 +46,7 @@
 				url: 'http://www.w3.org',
 				mailto: "cooper@w3.org",
 				company: "W3C",
-				companyURI: "http://www.w3.org"
+				companyURL: "http://www.w3.org"
 			}
 		],
 
@@ -56,7 +56,7 @@
 
 		//authors:  [
 		//    { name: "Your Name", url: "http://example.org/",
-		//      company: "Your Company", companyURI: "http://example.com/" },
+		//      company: "Your Company", companyURL: "http://example.com/" },
 		//],
 
 		/*

--- a/svg-aam/index.html
+++ b/svg-aam/index.html
@@ -43,7 +43,7 @@
         // only "name" is required
         editors: [
           { name: "Amelia Bellamy-Royds", company: "Invited Expert", mailto: "amelia.bellamy.royds@gmail.com", w3cid: 75809 },
-          { name: "Ian Pouncey", company: "The Paciello Group, LLC", companyURI: "https://www.paciellogroup.com/", mailto: "w3c@ipouncey.co.uk", w3cid: 44477 },
+          { name: "Ian Pouncey", company: "The Paciello Group, LLC", companyURL: "https://www.paciellogroup.com/", mailto: "w3c@ipouncey.co.uk", w3cid: 44477 },
         ],
         // authors, add as many as you like.
         // This is optional, uncomment if you have authors as well as editors.
@@ -56,12 +56,12 @@
             mailto: "amelia.bellamy.royds@gmail.com",
             w3cid: 75809,
           },
-          { name: "Ian Pouncey", company: "The Paciello Group, LLC", companyURI: "https://www.paciellogroup.com/", mailto: "w3c@ipouncey.co.uk", w3cid: 44477 },
+          { name: "Ian Pouncey", company: "The Paciello Group, LLC", companyURL: "https://www.paciellogroup.com/", mailto: "w3c@ipouncey.co.uk", w3cid: 44477 },
           {
             name: "Richard Schwerdtfeger",
             mailto: "richschwer@gmail.com",
             company: "Knowbility",
-            companyURI: "https://www.knowbility.org/",
+            companyURL: "https://www.knowbility.org/",
             w3cid: 2460,
             note: "until August 2017",
           },
@@ -69,7 +69,7 @@
             name: "Doug Schepers",
             mailto: "schepers@w3.org",
             company: "W3C",
-            companyURI: "https://www.w3.org/",
+            companyURL: "https://www.w3.org/",
             w3cid: 38635,
             note: "until December 2016",
           },


### PR DESCRIPTION
The right property for the [person object](https://respec.org/docs/#person) is `companyURL`. This updates our specs accordingly.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2457.html" title="Last updated on Feb 26, 2025, 10:50 AM UTC (4ab6da2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2457/6cec5e4...4ab6da2.html" title="Last updated on Feb 26, 2025, 10:50 AM UTC (4ab6da2)">Diff</a>