### PR TITLE
Editorial: Add back the superclass role for doc-biblioentry

### DIFF
--- a/dpub-aria/index.html
+++ b/dpub-aria/index.html
@@ -846,7 +846,7 @@
               </tr>
               <tr>
                 <th class="role-parent-head" scope="row">Superclass Role:</th>
-                <td class="role-parent"></td>
+                <td class="role-parent"><rref>listitem</rref></td>
               </tr>
               <tr>
                 <th class="role-children-head" scope="row">Subclass Roles:</th>


### PR DESCRIPTION
Fixes the missing inherited states and properties row in the characteristics table by adding back the superclass listitem role.

Addresses part of the issue raised in https://github.com/w3c/dpub-aria/issues/70
