### PR TITLE
Editorial: Fix typo (command role)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2222,7 +2222,7 @@
 			<rdef>command</rdef>
 			<div class="role-description">
 				<p>A form of widget that performs an action but does not receive input data.</p>
-				<p><code>command</code> is an <a href="#isAbstract">abstract role</a> used for the ontology. Authors MUST NOT use <code>commmand</code> role in content.</p>
+				<p><code>command</code> is an <a href="#isAbstract">abstract role</a> used for the ontology. Authors MUST NOT use <code>command</code> role in content.</p>
 			</div>
 			<table class="def">
 				<caption>Characteristics:</caption>


### PR DESCRIPTION
Just a simple typo fix:

comm~m~and -> command


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tim-we/aria/pull/2465.html" title="Last updated on Mar 6, 2025, 2:08 PM UTC (80f6bc1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2465/37a8449...tim-we:80f6bc1.html" title="Last updated on Mar 6, 2025, 2:08 PM UTC (80f6bc1)">Diff</a>