### PR TITLE
PDF-AAM initial HTML tables import

### DIFF
--- a/pdf-aam/index.html
+++ b/pdf-aam/index.html
@@ -53,7 +53,7 @@
           },
           {
             name: "Zak Kinsey",
-            company: "Target Stream",
+            company: "TargetStream",
             companyURL: "https://www.targetstream.com",
             w3cid: "160220",
           },

--- a/pdf-aam/index.html
+++ b/pdf-aam/index.html
@@ -4,9 +4,15 @@
     <title>PDF Accessibility API Mappings 1.0</title>
     <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-    <script src="../common/script/resolveReferences.js" class="remove"></script>
-    <script src="../common/script/utility.js" class="remove"></script>
-    <script src="../common/biblio.js" class="remove" defer></script>
+    <script src="common/script/resolveReferences.js" class="remove"></script>
+    <script src="common/script/utility.js" class="remove"></script>
+    <script src="common/biblio.js" class="remove" defer></script>
+
+    <link href="common/css/mapping-tables.css" rel="stylesheet" type="text/css" />
+    <link href="common/css/common.css" rel="stylesheet" type="text/css" />
+
+    <!-- note: may need to move the core-aam style sheet to common at some point -->
+    <link href="../core-aam/css/core-aam.css" rel="stylesheet" type="text/css" />
 
     <script class="remove">
       var respecConfig = {
@@ -53,7 +59,7 @@
           },
           {
             name: "Zak Kinsey",
-            company: "TargetStream",
+            company: "Target Stream",
             companyURL: "https://www.targetstream.com",
             w3cid: "160220",
           },
@@ -74,7 +80,7 @@
           },
           {
             name: "Zak Kinsey",
-            company: "Target Stream",
+            company: "TargetStream",
             companyURL: "https://www.targetstream.com",
             /* todo: add w3cid */
           },
@@ -199,7 +205,7 @@
         <section id="mapping_role_table">
           <h3>Role Mapping Tables</h3>
           <h4 id="role-map-example"><code>example</code></h4>
-          <table class="data" aria-labelledby="role-map-example">
+          <table aria-labelledby="role-map-example">
             <tbody>
               <tr>
                 <th>ARIA Specification</th>
@@ -238,6 +244,12070 @@
             </tbody>
           </table>
           
+                   
+          <h4 id="role-map-example"><code>Document Logical document within a parent document</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-generic"><code>generic - New in ARIA 1.2</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-div">Role: <code>div</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>We may need to wordsmith the description</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>DocumentFragment Grouping</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-group"><code>group</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>DocumentFragment Block</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-generic"><code>generic - New in ARIA 1.2</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-div">Role: <code>div</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Part</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-article"><code>article</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Div has attributes</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-group"><code>group</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Div does not have attributes</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-generic"><code>generic - New in ARIA 1.2</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-div">Role: <code>div</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Sect</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-region   https://www.w3.org/TR/core-aam-1.2/#role-map-generic"><code>region   "region" IF there is an accessible name.     Otherwise use generic</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-section ">Role: <code>section </code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>To calculate the "accessible name":   The first Hn descendant that is not a descendant of another Sect element provides the accessible name.</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Aside</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-complementary"><code>complementary </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-aside">Role: <code>aside  (scoped to the body or main element)</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>NonStruct</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-generic"><code>generic - New in ARIA 1.2</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>P</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-paragraph"><code>paragraph - New in ARIA 1.2</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-p">Role: <code>p</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Hn H1, H2 .. H6</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="heading:   https://www.w3.org/TR/core-aam-1.2/#role-map-heading   level:  https://www.w3.org/TR/core-aam-1.2/#ariaLevel"><code>ARIA heading (role)  ARIA level (property)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-h1-h6 ">Role: <code>h1, h2, h3, h4, h5, and h6</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>heading with the aria-level property set to the number in the element's tag name.</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Hn H7..n</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-heading   https://www.w3.org/TR/core-aam-1.2/#ariaLevelHeading"><code>ARIA heading (role)  ARIA level (property)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>H</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-heading"><code>heading</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Title</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-heading"><code>heading</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Sub</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-generic"><code>generic - New in ARIA 1.2 </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>span</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Lbl In the context of forms</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-label">Role: <code>label (no corresponding ARIA role)</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Needs further discussion/ consideration. No corresponding ARIA role</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Lbl In the context of lists - but NOT description lists</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>No obvious HTML or ARIA mapping was identified.</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Lbl other uses - numbered headings, etc.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-generic"><code>generic - New in ARIA 1.2 </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Lbl ListNumbering   Description   New ListNumbering in PDF 2.0</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-term"><code>term </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-dt">Role: <code>dt  Use WAI-ARIA mapping - BUT - "computed role" may change</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Em</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-emphasis"><code>emphasis - New in ARIA 1.2 </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-em">Role: <code>em (HTML)</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Strong</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-strong"><code>strong - New in ARIA 1.2</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-strong">Role: <code>strong</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Span</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-generic"><code>generic - New in ARIA 1.2 </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-span">Role: <code>span</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Link</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-link"><code>link</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="hyperlink URL https://www.w3.org/TR/html-aam-1.0/#el-a   area URL https://www.w3.org/TR/html-aam-1.0/#el-area ">Role: <code>a (represents a hyperlink)   OR  area (represents a hyperlink)</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>both "a" and "area" point to "link" in ARIA and say to use WAI-ARIA mapping</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Link Does not contain an annotation OR contains an annotation that doesn't go anywhere</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-generic"><code>generic - New in ARIA 1.2 </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="a (no href) URL https://www.w3.org/TR/html-aam-1.0/#el-a-no-href   area (no href) URL https://www.w3.org/TR/html-aam-1.0/#el-area-no-href">Role: <code>a (no href attribute)  OR  area (no href attribute)  Use WAI-ARIA mapping BUT there is a Comment</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annot Parked - What really matters is that the Alt, Contents entry, etc., are exposed, not necessarily how the Annot tag itself is handled.   Possibly ignore the content in the Annot (except for the annotation itself) and expose the Contents and/or Alt (depending on priorities in UA/2.)  The content of the Alt and/or Contents entry becomes ARIA described by.    So, if we have parked this, maybe its "Placement" doesn't matter?  Placement could be Grouping, Block, or Inline.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>Parked - What really matters is that the Alt, Contents entry, etc., are exposed, not necessarily how the Annot tag itself is handled.   Possibly ignore the content in the Annot (except for the annotation itself) and expose the Contents and/or Alt (depending on priorities in UA/2.)  The content of the Alt and/or Contents entry becomes ARIA described by.</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Form Parked - what really matters here is the Widget, its Contents entry, and the Lbl and its content.  We will address the Widget annotations elsewhere in this document.   So, if this is parked, does "Placement" matter?  Placement can be Grouping, Block, or Inline.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>Parked - what really matters here is the Widget, its Contents entry, and the Lbl and its content.  We will address the Widget annotations elsewhere in this document.</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Ruby</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>No corresponding role</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-ruby">Role: <code>ruby</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>RB</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>30-Sept-2019: Remove mappings for rb and rtc elements as they are marked as obsolete in HTML. See GitHub issue #115 and pull request #253.  Question - So, what do we do when a PDF has an RB tag in it!?   Still map them to the obsolete things, just in case. -- BUT, those mappings are not in the tables anymore.  HOLD for consultation with W3C experts.</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>RT</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>No corresponding role</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-rt">Role: <code>rt</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>RP</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>No corresponding role</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-rp">Role: <code>rp</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Warichu</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-generic"><code>generic - New in ARIA 1.2 </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-span">Role: <code>span</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>WT</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>Question:  There is not WT in HTML, so... treat it like "span" with generic ARIA role, or...?   HOLD for consultation with W3C experts</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>WP</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>Question:  There is not WP in HTML, so... treat it like "span" with generic ARIA role, or...?   HOLD for consultation with W3C experts</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>FENote NoteType = Footnote</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-footnote"><code>doc-footnote (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Consult with W3C:   This is "richer" than "generic" in ARIA</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>FENote NoteType = Endnote</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-listitem  "><code>listitem  doc-endnote is deprecated in DPUB-ARIA 1.1. It is advised to use the ARAI listitem role instead   From PDF/UA-2 Annex A: doc-footnote (as a footnote, but should be used in association with doc-noteref for the reference pointing to it)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Consult with W3C:   This is "richer" than "generic" in ARIA</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>FENote NoteType = None Placement = Block</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-div">Role: <code>div</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Consult with W3C:   This is "richer" than "generic" in ARIA</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>FENote NoteType = None Placement = Inline</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-p ">Role: <code>p</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Consult with W3C:   This is "richer" than "generic" in ARIA</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>FENote   See "Note" (Tag) at row 98 (or so)...  Putting this note here… From the meeting in Paris, Note should be treated however we decide to handle FENote.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>doc-footnote (DPub) https://www.w3.org/TR/dpub-aam-1.1/#role-map-footnote</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Consult with W3C:   This is "richer" than "generic" in ARIA</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>L ListNumbering = one of: Ordered, Decimal, UpperRoman, LowerRoman, UpperAlpha or LowerAlpha Placement = Block or Inline</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-list"><code>list</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-ol">Role: <code>ol</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>L ListNumbering = unordered Placement = Block or Inline</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-list"><code>list</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-ul">Role: <code>ul</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>L  ListNumbering = Description Placement = Block or Inline</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-list"><code>list</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-dl">Role: <code>dl</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>HTML-AAM does NOT say "use ARIA" so what do we do when the two don't "jive"?  Hold for consultation with W3C experts  CRITICAL NOTE:  There is a note in the HTML -AAM that the "computed role" may change depending on resolution of: https://github.com/w3c/aria/issues/1662</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>L  ListNumbering = None Placement = Block or Inline</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-list"><code>list Is this correct? </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-ul">Role: <code>ul</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>LI</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="ARIA listitem: https://www.w3.org/TR/core-aam-1.2/#role-map-listitem  aria-setsize: https://www.w3.org/TR/core-aam-1.1/#ariaSetsize  aria-posinset: https://www.w3.org/TR/core-aam-1.1/#ariaPosinset "><code>listitem </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-li">Role: <code>li  AAM says to Use WAI-ARIA mapping but there are other comments, etc., there, too. </code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>from Derivation:  with aria-setsize value reflecting number of li elements within the parent ol, menu or ul and aria-posinset value reflecting the li elements position within the set.   Question:  what if one or more of those things mentioned above are not set?    If li element is not a child of ol , menu or ul then expose the li element with a generic role.  BUT, in PDF, is this a non-issue?  Would we have an LI that is not a child of L?</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>LBody</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-generic"><code>generic </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-div">Role: <code>div</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>LBody If the L ListNumbering is Description.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-definition"><code>definition</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-dd">Role: <code>dd Use ARIA but there is also a comment</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Table</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-table"><code>table</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-table">Role: <code>table</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>TR</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-row"><code>row not inside treegrid</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-tr">Role: <code>tr</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>TH  scope = column</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-columnheader"><code>columnheader</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-th-columnheader">Role: <code>th (is a column header or column group header)</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>TH  scope = row</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-rowheader"><code>rowheader</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-th-rowheader">Role: <code>th (is a row header or row group header)</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>TH  scope = both</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>Note: There is no analagous ARIA role. it is either rowheader or columnheader</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>Note: There is no analagous HTML element. it is either Header or Column</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>TH  scope = not set headers array is set</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-cell"><code>cell </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="  https://www.w3.org/TR/html-aam-1.0/#el-th ">Role: <code>th Use WAI-ARIA mapping but there are comments</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>HTML uses headers array/ IDs for TH and TD  https://www.w3.org/TR/html-aam-1.0/#el-th</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>TH  scope = both headers array is set</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>Note: There is no analagous ARIA role. it is either rowheader or columnheader</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>Note: There is no analagous HTML element. it is either Header or Column  Note:  This is unique to PDF and requires us to create an AAM</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>TD</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-cell"><code>cell </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-td">Role: <code>td (ancestor table element has table role)</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>THead</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-rowgroup"><code>rowgroup</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-thead">Role: <code>thead</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>TBody</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-rowgroup"><code>rowgroup</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-tbody">Role: <code>tbody</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>TFoot</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-rowgroup"><code>rowgroup</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-tfoot">Role: <code>tfoot</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Caption  NOT a child of Figure</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-caption"><code>caption</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-caption ">Role: <code>caption  HTML-AAM says to Use WAI-ARIA mapping but there is also other "stuff" there.</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>If a descendant of a table, the first instance of a caption element will provide the table its accessible name.</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Caption  Caption (if child of Figure)</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>If the Caption is a child of a Figure, the Alt on the Figure *and* the text in the Caption should both be available to end users.</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Figure Block-level and Contains substructure OR (Alt is missing and text content is present) figure</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-figure"><code>figure</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-figure">Role: <code>figure</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Need guidance from ARIA editors - open an issue in GitHub</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Figure Only contains image (including line art, etc.) and Alt is present img</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="image: https://www.w3.org/TR/core-aam-1.2/#role-map-image  img: https://www.w3.org/TR/core-aam-1.2/#role-map-img "><code>the HTML table points to image or img role in ARIA</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-img ">Role: <code>img  Use WAI-ARIA mapping - BUT, there are comments, here</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Do we need to clarify/ specify? Or, if HTML can point to two different things, can we, too?   Need guidance from ARIA editors - open an issue in GitHub</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Figure Inline, child of block-level element (P, for example) and containing substructure</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-generic"><code>generic - New in ARIA 1.2 </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-span">Role: <code>span</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Need guidance from ARIA editors - open an issue in GitHub - does this need to be treated differently, because it's inline, as opposed to block-level Figure containing substructure?</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Figure There's no Alt text  We added this in the 1/30/25 meeting but row 61 above already mentions if there is no alt...  OR, is this row for if the Figure is inline, not block, and doesn't have Alt?</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-paragraph"><code>paragraph</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-p">Role: <code>p</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Formula   Contains a math element as a child AND the processor can handle MathML</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-generic"><code>generic - New in ARIA 1.2 </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-div">Role: <code>Div</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Use the MathML Ignore any Associated File Ignore Alt  Need guidance from ARIA editors - open an issue in GitHub</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Formula MathML is not present OR processor cannot handle MathML BUT  Contains Associated File with AFRelationship Supplement and when Subtype = MathML AND the processor can handle Associated Files</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-generic"><code>generic - New in ARIA 1.2 </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-div">Role: <code>Div</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Use the Associcated File Ignore Alt  Need guidance from ARIA editors - open an issue in GitHub</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Formula  MathML and Associated Files are not present OR processor cannot handle them AND Alt (or ActualText) is present</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-figure"><code>figure</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-figure ">Role: <code>figure</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Need guidance from ARIA editors - open an issue in GitHub</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Formula No MathML, no Associated File, no Alt (or ActualText)</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-paragraph"><code>paragraph</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-p">Role: <code>p</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>math The MathML inside the Formula tag</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href=" https://www.w3.org/TR/core-aam-1.2/#role-map-math"><code>math</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-math  MathML: https://w3c.github.io/mathml-aam/">Role: <code>math That said, the HTML table points to MathML:   </code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>HTML "math" points to MathML.   ARIA math does not point to MathML and has comments  MathML namespace</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Content of the Associated File Associated File with AFRelationship Supplement and when Subtype = MathML</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href=" https://www.w3.org/TR/core-aam-1.2/#role-map-math"><code>math</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-math  MathML: https://w3c.github.io/mathml-aam/">Role: <code>math That said, the HTML table points to MathML:   </code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>MathML namespace  Need guidance from ARIA editors - open an issue in GitHub</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Formula   On Hold  If Formula tag's Properties contains Associated file "declaring" Math (AFRelationship entry has a value of Supplement), treat the content of the Associated File as math (and ignore the other children of the Formula tag).  Unless the "children of the Formula tag" is MathML!</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href=" https://www.w3.org/TR/core-aam-1.2/#role-map-math"><code>math</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-math  MathML: https://w3c.github.io/mathml-aam/">Role: <code> (Formula tag becomes "transparent") math </code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Need guidance from ARIA editors - open an issue in GitHub</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Artifact Placement can be Grouping, Block, or Inline.  Which "Placement" applies here and do we need additional rows for the other Placement values?</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="presentation: https://www.w3.org/TR/core-aam-1.2/#role-map-presentation   none: - https://www.w3.org/TR/core-aam-1.2/#role-map-none"><code>presentation OR none</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-img-empty-alt">Role: <code>img (alt attribute value is an empty string, i.e. alt="" or alt with no value in the markup) </code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Do we need to decide which to use?</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Artifact Type - Pagination   Subtype - Header, Footer, Watermark, PageNum, LineNum, Redaction, Bates, "others" that comply with naming conventions in Annex E (of 32000-2)</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>Handle this...   (handle all Pagination artifacts, with subtype, the same.    Don't do anything with other artifacts</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>BUT - Pagination Artifacts, with these subtypes, "exist" in PDF 1.7, too.</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Artifact Type - Layout, Page, Background, Type, BBox, Attached, Subtype</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>Do not process</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>BUT - Artifacts of these types do "exist" in PDF 1.7, too.</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Art</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-article"><code>article</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-article ">Role: <code>article</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>This is the default handling unless a different ARIA role is present</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Art  With DPub role assigned doc-acknowledgements</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-acknowledgments"><code>doc-acknowledgements (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Invent a language specific attribute and how it is used on specific structure element(s). Potentially a symbolic way to represent. -Roman</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Art With DPub role assigned doc-appendix</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-appendix"><code>doc-appendix (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Invent a language specific attribute and how it is used on specific structure element(s). Potentially a symbolic way to represent. -Roman</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Art With DPub role assigned doc-chapter</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-chapter"><code>doc-chapter (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Invent a language specific attribute and how it is used on specific structure element(s). Potentially a symbolic way to represent. -Roman</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Art With DPub role assigned doc-colophon</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>doc-colophon (DPub) https://www.w3.org/TR/dpub-aam-1.1/#role-map-colophon</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Invent a language specific attribute and how it is used on specific structure element(s). Potentially a symbolic way to represent. -Roman</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Art With DPub role assigned doc-epilogue</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-epilogue"><code>doc-epilogue (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Invent a language specific attribute and how it is used on specific structure element(s). Potentially a symbolic way to represent. -Roman</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Art With DPub role assigned doc-forward</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-foreword"><code>doc-forward (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Invent a language specific attribute and how it is used on specific structure element(s). Potentially a symbolic way to represent. -Roman</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Art With DPub role assigned doc-glossary</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-glossary"><code>doc-glossary (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Invent a language specific attribute and how it is used on specific structure element(s). Potentially a symbolic way to represent. -Roman</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Art With DPub role assigned doc-introduction</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-introduction"><code>doc-introduction (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Invent a language specific attribute and how it is used on specific structure element(s). Potentially a symbolic way to represent. -Roman</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Art With DPub role assigned doc-part</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-part"><code>doc-part (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Invent a language specific attribute and how it is used on specific structure element(s). Potentially a symbolic way to represent. -Roman</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Art With DPub role assigned doc-qna</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-qna"><code>doc-qna (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Invent a language specific attribute and how it is used on specific structure element(s). Potentially a symbolic way to represent. -Roman</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>BlockQuote  We used this one in our "article" Use HTML "blockquote" unless another ARIA/ DPub role is assigned</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-blockquote"><code>blockquote - New in ARIA 1.2</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-blockquote">Role: <code>blockquote</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>BlockQuote  With DPub role assigned</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-epigraph"><code>doc-epigraph (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>BlockQuote  With DPub role assigned</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-pullquote"><code>doc-pullquote (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>TOC Discussed in Paris:  It’s more like a “nav” element than a DPub-TOC (and “nav” may be better supported) so use HTML “nav” which says to use the ARIA role mapping “navigation”</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-navigation"><code>navigation</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-nav">Role: <code>nav </code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code> (See column C - and this one should be our "preferred" one? )</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>TOC</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-directory"><code>directory</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>TOC</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-pagelist"><code>doc-pagelist (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>TOC</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-toc"><code>doc-toc (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>TOC</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-list"><code>list </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>TOCI</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-directory"><code>directory</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>TOCI</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-listitem"><code>listitem</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Index</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-index"><code>doc-index (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Index</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-navigation"><code>navigation</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Index</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="region with an accessible name: https://www.w3.org/TR/core-aam-1.2/#role-map-region "><code>region (with an accessible name) OR generic (if no accessible name)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-section ">Role: <code>section - IF the section element has an accessible name</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>NOTE: There is no "section with (or without) accessible name" but the ARIA role could be different based on whether or not there is an accessible name.</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Index</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-generic"><code>generic </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-section ">Role: <code>section - IF the section element does not have an accessible name</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Hold for consultation with W3C experts.   The HTML table and Derivation group said to use "generic," (and the related ARIA mapping), but the ARIA roll mapping table says otherwise.</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Private Content in a Private tag should not be exposed to end-users.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>not required</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>not required</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Quote  Treat Quote like "q" (HTML) unless there is a different ARIA role assigned.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-pullquote"><code>doc-pullquote (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Quote   See note on "Quote" above - we used this one in our "article"</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-generic"><code>generic - New in ARIA 1.2 </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-q ">Role: <code>q  Use WAI-ARIA mapping - BUT, there are comments in the table</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>::before and ::after CSS pseudo content is used by platforms to render the element's quotation marks.</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Note   FENote is rows 36 - 40  See row 98 - that might clarify?   Putting this note here… From the meeting in Paris, Note should be treated however we decide to handle FENote. Question based on Derivation group conversation (6/28/23) - Note to be derived to "small" - how does this impact us, here?</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-endnote"><code>doc-endnote (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Consult with W3C:   This is "richer" than "generic" in ARIA</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Note</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-footnote"><code>doc-footnote (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Consult with W3C:   This is "richer" than "generic" in ARIA</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Note</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-tip"><code>doc-tip (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Consult with W3C:   This is "richer" than "generic" in ARIA</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Note Placement = Block</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-generic "><code>generic - New in ARIA 1.2 </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-div">Role: <code>div</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Unique to PDF - in HTML derivation, Note (and FENote) derive to Div.   Consult with W3C:   This is "richer" than "generic" in ARIA</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Note Placement = Inline</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-paragraph "><code>paragraph - New in ARIA 1.2</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-p ">Role: <code> p</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Unique to PDF - in HTML derivation, Note (and FENote) derive to P.   Consult with W3C:   This is "richer" than "generic" in ARIA</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Note Question/ comment:  I'm not sure about "listitem" for "Note" (or FENote) - there is a "note" ARIA role in ARIA 1.2 but is that intended as a footnote or more as, for example, "Please note..."</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-listitem"><code>listitem</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Consult with W3C:   This is "richer" than "generic" in ARIA</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Note</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-paragraph "><code>paragraph - New in ARIA 1.2</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-p">Role: <code>p</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Consult with W3C:   This is "richer" than "generic" in ARIA</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Reference   Placement = Inline  Question: If, in PDF, Reference is for a link to somewhere else in the same document (as opposed to an external link) then should we treat this more like "link"?  Also, seeing as "link" is in HTML and ARIA, it might be better supported than the DPub roles? That said, HTML just says to use ARIA mapping.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-biblioref"><code>doc-biblioref (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Reference  Placement = Inline</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-glossref"><code>doc-glossref (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Reference  Placement = Inline</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-glossref"><code>doc-noteref (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>BibEntry</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-biblioentry"><code>doc-biblioentry (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>BibEntry</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-listitem"><code>listitem</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>BibEntry  We used this one in our "article"</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-paragraph "><code>paragraph - New in ARIA 1.2</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-p">Role: <code>p</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Code   We used this one in our "article"</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-code"><code>code - New in ARIA 1.2</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-code">Role: <code>code</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Code</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/dpub-aam-1.1/#role-map-example"><code>doc-example (DPub)</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation Text (markup - like sticky note annotation)  Expose Contents entry Expose Name entry? ("should" match author's semantic intent)  FOR ALL MARKUP ANNOTATIONS:</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>"Shall" be enclosed in Annot tags. Expose RC and/or Contents entries, if present.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation Link Expose Contents entry.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.3 FreeText (markup)   FOR ALL MARKUP ANNOTATIONS:</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>"Shall" be enclosed in Annot tags. Expose RC and/or Contents entries, if present.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.3 Line (markup)  FOR ALL MARKUP ANNOTATIONS:</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>"Shall" be enclosed in Annot tags. Expose RC and/or Contents entries, if present.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.3 Square (markup)  FOR ALL MARKUP ANNOTATIONS:</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>"Shall" be enclosed in Annot tags. Expose RC and/or Contents entries, if present.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.3 Circle (markup)  FOR ALL MARKUP ANNOTATIONS:</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>"Shall" be enclosed in Annot tags. Expose RC and/or Contents entries, if present.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.5 Polygon (markup)  FOR ALL MARKUP ANNOTATIONS:</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>"Shall" be enclosed in Annot tags. Expose RC and/or Contents entries, if present.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.5 PolyLine (markup)  FOR ALL MARKUP ANNOTATIONS:</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>"Shall" be enclosed in Annot tags. Expose RC and/or Contents entries, if present.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.3 Highlight (markup)  FOR ALL MARKUP ANNOTATIONS:</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>"Shall" be enclosed in Annot tags. Expose RC and/or Contents entries, if present.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.3 Underline (markup)  FOR ALL MARKUP ANNOTATIONS:</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>"Shall" be enclosed in Annot tags. Expose RC and/or Contents entries, if present.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.4 Squiggly (markup)  FOR ALL MARKUP ANNOTATIONS:</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>"Shall" be enclosed in Annot tags. Expose RC and/or Contents entries, if present.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.3 StrikeOut (markup)</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.5 Caret (markup)  FOR ALL MARKUP ANNOTATIONS:</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>"Shall" be enclosed in Annot tags. Expose RC and/or Contents entries, if present.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.3 Stamp (markup)  Expose Contents entry Expose Name entry? (describes the intent)  FOR ALL MARKUP ANNOTATIONS:</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>"Shall" be enclosed in Annot tags. Expose RC and/or Contents entries, if present.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.3 Ink (markup)  Expose the Contents entry.  FOR ALL MARKUP ANNOTATIONS:</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>"Shall" be enclosed in Annot tags. Expose RC and/or Contents entries, if present.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.3 Popup  Shall not be present in the structure tree.  Expose nothing.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.3 FileAttachment (markup)  Prioritize Contents entry over Desc entry.   FOR ALL MARKUP ANNOTATIONS:</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>"Shall" be enclosed in Annot tags. Expose RC and/or Contents entries, if present.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.2 - Deprecated in 2.0 Sound</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>no corresponding role</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-audio">Role: <code>audio</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.2 - Deprecated in 2.0 Sound, Movie  Shall not be in the structure tree in 2.0 files. BUT, may still be present in 1.7 files.  I looked in earlier specs but didn't really see/ understand "guidance."  That said, this is already handled in HTML so probably won't be too hard to figure out.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.5 Screen  Expose the Contents entry.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.2 Widget - see 8.10  Expose the Contents entry, if present.  Note:  UA-2 also specifies things like the use of Lbl tags, etc., when tagging forms.  Handling Lbl tags, though, is specified elsewhere in this document.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.4 PrinterMark - shall be an artifact - expose nothing</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.3 - Deprecated in 2.0 TrapNet  Shall not be in 2.0 files. BUT, may still be present in 1.7 files.  I looked in earlier specs but didn't really see/ understand "guidance."</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.6 Watermark   When used as real content, handle like markup annotations</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.6 3D  Expose the Contents entry</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 1.7 Redact (markup)</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 2.0 Projection - handle like markup</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 2.0 RichMedia Audio only</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>no corresponding role</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-audio">Role: <code>audio</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 2.0 RichMedia  Expose the Contents entry Video only</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Annotation - PDF 2.0 RichMedia  Expose the Contents entry Audio and video content</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Form field Button field pushbutton</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-button"><code>button </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-button ">Role: <code>button  Use WAI-ARIA mapping - BUT, there are comments in the table</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Per the HTML table:  This will change if aria-pressed or aria-haspopup attributes are specified</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Form field Button field push-button  Note: this is for push-button acting as a link.  Are there other "types" of push buttons, though?  See comment in ARIA comments column. ->>></code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-link"><code>link</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-a">Role: <code>a (represents a hyperlink)</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>ARIA link role is advised when the PDF push button is associated with predefined GoTo actions (such as Next, Prev)</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Form field Putting a note here:   For all fields, the TU entry, on the fields, should be exposed</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Form field Button field check box</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Form field Button field radio button</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Form field Text field</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Form field Choice field list boxes</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Form field Choice field combo boxes</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Form field Signature field</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Action types (interactive forms) submit-form action</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Action types (interactive forms) reset-form action</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Action types (interactive forms) import-data action</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Any Structure Element Placement  I have put "Grouping," "Block," and "Inline" into the revelant tags.  However, do we need to address "Before," "Start," and "End?"</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Any Structure Element WritingMode TBD: WritingMode attribute</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-generic"><code>generic - New in ARIA 1.2 </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-bdi ">Role: <code>bdi  Use WAI-ARIA mapping - BUT, there are comments in the table</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>IA2/ATK: May affect on "writing-mode" text attribute on its text container.</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Any Structure Element WritingMode TBD: WritingMode attribute</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-generic"><code>generic - New in ARIA 1.2 </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-bdo ">Role: <code>bdo  Use WAI-ARIA mapping - BUT, there are comments in the table</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>IA2/ATK: Exposed as "writing-mode" text attribute on its text container.</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Any Structure Element BackgroundColor  Refer to UA - Annex B for which Attributes are semantically significant - and we don't have to worry about the others   NOTE:  PDF/UA TWG meeting 2/13/24 - there was discussion, etc., regarding Table B.2 and on (I think it was B.2)  I don't think it'll impact us but need to be sure.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Hold for consultation with W3C experts.   Proposed in Tokyo - layout attributes map to CSS AAM?    But... is there one?  I was not able to find a CSS AAM.</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Any Structure Element BorderColor</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Any Structure Element BorderStyle</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Any Structure Element BorderThickness</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Any Structure Element Color</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Any Structure Element Padding</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Any BLSE: ILSE if Placement is not Inline SpaceBefore</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Any BLSE: ILSE if Placement is not Inline SpaceAfter</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Any BLSE: ILSE if Placement is not Inline StartIndent</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Any BLSE: ILSE if Placement is not Inline EndIndent</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - BLSE containing text TextIndent</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - BLSE containing text TextAlign</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Figure,Form,Formula,Table elements BBox</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Figure,Form,Formula,Table elements Width</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Figure,Form,Formula,Table elements Height</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - TH; TD Width  On hold for version 1 - edge-case relevance that should be addressed at some point...</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - TH; TD Height  On hold for version 1 - edge-case relevance that should be addressed at some point...</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - TH; TD BlockAlign  On hold for version 1 - edge-case relevance that should be addressed at some point...</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - TH; TD InlineAlign  On hold for version 1 - edge-case relevance that should be addressed at some point...</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - TH; TD TBorderStyle  On hold for version 1 - edge-case relevance that should be addressed at some point...</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - TH; TD TPadding  On hold for version 1 - edge-case relevance that should be addressed at some point...</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - ILSE; BLSE containing ILSE or direct/nested content items LineHeight  Check Annex B - save for PDF week</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - ILSE; BLSE containing ILSE or direct/nested content items BaselineShift  Check Annex B - save for PDF week</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - ILSE; BLSE containing ILSE or direct/nested content items TextDecorationType LineThrough</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-deletion "><code>deletion </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-s">Role: <code>s</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - ILSE; BLSE containing ILSE or direct/nested content items TextDecorationType no specific rule for del (see s)</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-deletion"><code>deletion - New in ARIA 1.2</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-del">Role: <code>del</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - ILSE; BLSE containing ILSE or direct/nested content items TextDecorationType Underline</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-generic"><code>generic - New in ARIA 1.2 </code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-u">Role: <code>u  Use WAI-ARIA mapping - BUT, there's a comment in the table</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>Exposed by platform specific underline text styles.</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - ILSE; BLSE containing ILSE or direct/nested content items TextPosition Sub</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-subscript"><code>subscript - New in ARIA 1.2</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-sub">Role: <code>sub</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - ILSE; BLSE containing ILSE or direct/nested content items TextPosition Sup</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="https://www.w3.org/TR/core-aam-1.2/#role-map-superscript"><code>superscript - New in ARIA 1.2</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-sup">Role: <code>sup</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - ILSE; BLSE containing ILSE or direct/nested content items TextDecorationColor</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - ILSE; BLSE containing ILSE or direct/nested content items TextDecorationThickness</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Grouping Elements ColumnCount</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Grouping Elements ColumnWidths</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Grouping Elements ColumnGap</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Vertical text GlyphOrientationVertical</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Ruby text RubyAlign</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Ruby text RubyPosition</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - List ListNumbering</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - List ContinuedList</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - List ContinuedFrom</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - PrintField Role</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - PrintField Checked, checked</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - PrintField Desc</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Table RowSpan - similar to placement - covered with TH</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>x</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>x</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Table ColSpan - similar to placement - covered with TH</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>x</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>x</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Table Headers - similar to placement - covered with TH</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>x</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>x</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Table Scope - similar to placement - covered with TH</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>x</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>x</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Table Summary</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>No corresponding role</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-summary">Role: <code>summary (HTML property)</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Attribute - Table Short TH</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>No corresponding role</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-abbr">Role: <code>abbr</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Entry Ref  Note:  Ref entry not only needs to be "exposed" but processors should also provide the functionality to go to wherever the Ref entry is pointing!</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Entry Alt   Should be "self explanatory" except that there are a lot of questions around how to handle Alt - and Actual - Text - and how to handle them when both are present, etc.  See "Questions" doc.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Entry ActualText   Should be "self explanatory" except that there are a lot of questions around how to handle Alt - and Actual - Text - and how to handle them when both are present, etc.  See "Questions" doc.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Entry E (expansion)</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>No corresponding role</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="https://www.w3.org/TR/html-aam-1.0/#el-abbr">Role: <code>abbr</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Entry Contents (annotation)   How should Contents entries be handled when a single tag contains multiple Annotations? (A Link tag, for example, with multiple link Annotations inside.)</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>If there is a Contents entry on an Annotation and Alt on the containing tag, those shall be identical. So, both should (shall?)  not be exposed.</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Entry - Structure element (PDF 2.0) PhoneticAlphabet</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Entry - Structure element (PDF 2.0) Phoneme</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+          
+          
+          <h4 id="role-map-example"><code>Entry - Structure tree root (PDF 2.0) PronunciationLexicons</code></h4>
+          <table aria-labelledby="role-map-example">
+              <tbody>
+                  <tr>
+                      <th>ARIA Specification</th>
+                      <td>
+                          <a class="role-reference" href="TODO"><code>TODO</code></a>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>Analogous HTML Element</th>
+                      <td>
+                          <span class="property" href="TODO">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                          <span class="property">Control Type: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                      <td>
+                          <span class="property">Role: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th>
+                          <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
+                      </th>
+                      <td>
+                          <span class="property">AXRole: <code>TODO</code></span><br>
+                          <span class="property">AXSubrole: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+                  <tr>
+                      <th><abbr title="Notes">Notes:</abbr></th>
+                      <td>
+                          <span class="property">Note from PDFa: <code>TODO</code></span><br>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+
 
           <div class="note" id="ftn.note1">
             <p>
@@ -271,7 +12341,7 @@
           </section>
           
           <h4 id="ariaExample"><code>aria-example</code>=<code>true</code></h4>
-          <table class="data" aria-labelledby="ariaExample">
+          <table aria-labelledby="ariaExample">
             <tbody>
               <tr>
                 <th>ARIA Specification</th>
@@ -339,8 +12409,8 @@
       <ul id="gh-contributors">
         <!-- list of contributors will appear here, along with link to their GitHub profiles -->
       </ul>
-      <div data-include="../common/acknowledgements/aria-wg-active.html" data-include-replace="true"></div>
-      <div data-include="../common/acknowledgements/funders.html" data-include-replace="true"></div>
+      <div data-include="common/acknowledgements/aria-wg-active.html" data-include-replace="true"></div>
+      <div data-include="common/acknowledgements/funders.html" data-include-replace="true"></div>
     </section>
   </body>
 </html>


### PR DESCRIPTION
Closes PDF-AAM #7

This PR consists of the initial import of the HTML tables for the PDF-AAM mappings. My understanding is with this PR we will officially have our first public working draft of the PDF-AAM. 

**I am unsure what, if any, tests need to be run for this PR.** I expect at this stage most, or all, of these tests do not need to be run, please correct me if that assumption is incorrect. 

* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests:
* [ ] Browser implementations (link to issue or commit):
   * WebKit:
   * Gecko:
   * Blink:
* [ ] Does this need AT implementations?
* [ ] Related APG Issue/PR:
* [ ] MDN Issue/PR:
