### PR TITLE
Editorial: Add deprecated to aria-dropeffect

### DIFF
--- a/accname/index.html
+++ b/accname/index.html
@@ -597,8 +597,8 @@
                   </aside>
                 </li>
                 <li id="comp_label">
-                  <span id="step2D"><!-- Don't link to this legacy numbered ID. --></span><em>AriaLabel:</em> Otherwise, if the <code>current node</code> is not a [=slot=] element and has an <code>aria-label</code> [=attribute=]
-                  whose value is not undefined, not the empty string, nor, when trimmed of [=ascii whitespace|whitespace=], is not the empty string:
+                  <span id="step2D"><!-- Don't link to this legacy numbered ID. --></span><em>AriaLabel:</em> Otherwise, if the <code>current node</code> is not a [=slot=] element and has an
+                  <code>aria-label</code> [=attribute=] whose value is not undefined, not the empty string, nor, when trimmed of [=ascii whitespace|whitespace=], is not the empty string:
                   <ol>
                     <li>
                       If traversal of the <code>current node</code> is due to recursion <strong>and</strong> the <code>current node</code> is an embedded control, ignore <code>aria-label</code> and

--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -6915,7 +6915,9 @@
               </tr>
             </tbody>
           </table>
-          <h4 id="ariaDropeffectMoveLinkExecutePopup"><code>aria-dropeffect</code>=<code>copy</code>, <code>move</code>, <code>link</code>, <code>execute</code>, or <code>popup</code> (deprecated)</h4>
+          <h4 id="ariaDropeffectMoveLinkExecutePopup">
+            <code>aria-dropeffect</code>=<code>copy</code>, <code>move</code>, <code>link</code>, <code>execute</code>, or <code>popup</code> (deprecated)
+          </h4>
           <table class="data" aria-labelledby="ariaDropeffectMoveLinkExecutePopup">
             <tbody>
               <tr>

--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -6915,7 +6915,7 @@
               </tr>
             </tbody>
           </table>
-          <h4 id="ariaDropeffectMoveLinkExecutePopup"><code>aria-dropeffect</code>=<code>copy</code>, <code>move</code>, <code>link</code>, <code>execute</code>, or <code>popup</code></h4>
+          <h4 id="ariaDropeffectMoveLinkExecutePopup"><code>aria-dropeffect</code>=<code>copy</code>, <code>move</code>, <code>link</code>, <code>execute</code>, or <code>popup</code> (deprecated)</h4>
           <table class="data" aria-labelledby="ariaDropeffectMoveLinkExecutePopup">
             <tbody>
               <tr>
@@ -6951,7 +6951,7 @@
               </tr>
             </tbody>
           </table>
-          <h4 id="ariaDropeffectNone"><code>aria-dropeffect</code>=<code>none</code></h4>
+          <h4 id="ariaDropeffectNone"><code>aria-dropeffect</code>=<code>none</code> (deprecated)</h4>
           <table class="data" aria-labelledby="ariaDropeffectNone">
             <tbody>
               <tr>

--- a/index.html
+++ b/index.html
@@ -8521,8 +8521,8 @@
               <li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100.</li>
             </ul>
             <p>
-              Authors MUST set the <pref>aria-valuenow</pref> attribute to indicate the current thumb position. If aria-valuenow is missing or has an unexpected value, <a>user agents</a> MAY implement the
-              repair techniques specified in the <a href="#authorErrorDefaultValuesTable">section describing handling author errors in states and properties</a>, which are equivalent to the repair
+              Authors MUST set the <pref>aria-valuenow</pref> attribute to indicate the current thumb position. If aria-valuenow is missing or has an unexpected value, <a>user agents</a> MAY implement
+              the repair techniques specified in the <a href="#authorErrorDefaultValuesTable">section describing handling author errors in states and properties</a>, which are equivalent to the repair
               techniques for <code>&lt;input type="[^input/type/range^]"&gt;</code> in HTML.
             </p>
             <p>Elements with the role <code>scrollbar</code> have an implicit <pref>aria-orientation</pref> value of <code>vertical</code>.</p>


### PR DESCRIPTION
This is editorial, adding `(deprecated)` to the mapping for `aria-dropeffect` for consistency with other deprecated things that can be found in core-aam.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2468.html" title="Last updated on Mar 11, 2025, 4:46 PM UTC (09ad5c9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2468/6d5a569...09ad5c9.html" title="Last updated on Mar 11, 2025, 4:46 PM UTC (09ad5c9)">Diff</a>