### PR TITLE
Editorial: remove erroneous li

### DIFF
--- a/index.html
+++ b/index.html
@@ -11410,9 +11410,7 @@
               </tr>
               <tr>
                 <th class="role-mustcontain-head" scope="row">Allowed Accessibility Child Roles:</th>
-                <td class="role-mustcontain">
-                  <li><rref>treeitem</rref></li>
-                </td>
+                <td class="role-mustcontain"><rref>treeitem</rref></td>
               </tr>
               <tr>
                 <th class="role-required-properties-head">Required States and Properties:</th>


### PR DESCRIPTION
Refs https://github.com/w3c/aria/issues/2463

This removes the erroneous `<li>` causing the aria spec to fail.

And a few other todo items (delete this section after performing them):
* [x] For every spec that this PR edits, please add the appropriate `spec:<spec_name>` label. If you don't have privileges to do this, editors will do it for you.
* [x] If the change is [editorial](https://github.com/w3c/aria/blob/main/documentation/process.md#editorial-changes), please add "Editorial:" at the start of your PR name, and delete the "Test, Documentation and Implementation tracking" section below.

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [x] "author MUST" tests: N/A
* [x] "user agent MUST" tests: N/A
* [x] Browser implementations (link to issue or commit): N/A
   * WebKit: N/A
   * Gecko: N/A
   * Blink: N/A
* [x] Does this need AT implementations? N/A
* [x] Related APG Issue/PR: N/A
* [x] MDN Issue/PR: N/A


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/keithamus/aria/pull/2471.html" title="Last updated on Mar 7, 2025, 11:37 AM UTC (1a5fc8f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2471/92fc573...keithamus:1a5fc8f.html" title="Last updated on Mar 7, 2025, 11:37 AM UTC (1a5fc8f)">Diff</a>