### PR TITLE
Editorial: normalize “browsers” to “user agents”

### DIFF
--- a/index.html
+++ b/index.html
@@ -8521,7 +8521,7 @@
               <li>If <code>aria-valuemax</code> is missing or not a <a href="#valuetype_number">number</a>, it defaults to 100.</li>
             </ul>
             <p>
-              Authors MUST set the <pref>aria-valuenow</pref> attribute to indicate the current thumb position. If aria-valuenow is missing or has an unexpected value, browsers MAY implement the
+              Authors MUST set the <pref>aria-valuenow</pref> attribute to indicate the current thumb position. If aria-valuenow is missing or has an unexpected value, <a>user agents</a> MAY implement the
               repair techniques specified in the <a href="#authorErrorDefaultValuesTable">section describing handling author errors in states and properties</a>, which are equivalent to the repair
               techniques for <code>&lt;input type="[^input/type/range^]"&gt;</code> in HTML.
             </p>


### PR DESCRIPTION
While working on #2290, I noticed that [the spec seems to prefer “_user agent_” over “_browser_”](https://github.com/w3c/aria/pull/2290#issuecomment-2257367495).

I replaced one instance of “_user agent_” in the `slider` section for that PR since it was already involved. This PR replaces a second occurrence that was unrelated to that PR, in the `scrollbar` section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/adampage/aria/pull/2472.html" title="Last updated on Mar 9, 2025, 10:26 PM UTC (0578242)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2472/ff9dd6b...adampage:0578242.html" title="Last updated on Mar 9, 2025, 10:26 PM UTC (0578242)">Diff</a>