### PR TITLE
Editorial: Relative links for PR and branch netlify previews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,6 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+# Local Netlify folder
+.netlify

--- a/accname/index.html
+++ b/accname/index.html
@@ -628,7 +628,8 @@
                 <li id="comp_host_language_label">
                   <span id="step2E"><!-- Don't link to this legacy numbered ID. --></span><em>Host Language Label:</em> Otherwise, if the <code>current node</code>'s native markup provides an
                   [=attribute=] (e.g. <code>alt</code>) or [=element=] (e.g. HTML <code>label</code> or SVG <code>title</code>) that defines a text alternative, return that alternative in the form of
-                  a <code>flat string</code> as defined by the host language, unless the <code>current node</code> is exposed as presentational (<code>role="presentation"</code> or <code>role="none"</code>).
+                  a <code>flat string</code> as defined by the host language, unless the <code>current node</code> is exposed as presentational (<code>role="presentation"</code> or
+                  <code>role="none"</code>).
                   <div class="note">
                     See <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a>,
                     <a href="https://www.w3.org/TR/svg-aam-1.0/#mapping_additional_nd">SVG-AAM</a>, or other host language documentation for more information on markup that defines a text alternative.

--- a/common/script/pr-preview.sh
+++ b/common/script/pr-preview.sh
@@ -7,7 +7,7 @@ find . -maxdepth 1 -type f -name "index.html" -exec sed -i 's|ED: "https://w3c\.
 find . -mindepth 2 -type f -name "index.html" -exec sed -i 's|ED: "https://w3c\.github\.io/aria/|ED: "/|g' {} +
 
 # build relative links for child specs
-find . -mindepth 2 -type f -name "index.html" -exec sed -i 's|ED: "https://w3c\.github\.io/(?!aria)|ED: "/|g' {} +
+find . -mindepth 2 -type f -name "index.html" -exec perl -pi -e 's|ED: "https://w3c\.github\.io/(?!aria)|ED: "/|g' {} +
 # build all specs
 npx respec -s index.html -o index.html --localhost
 npx respec -s accname/index.html -o accname/index.html --localhost

--- a/common/script/pr-preview.sh
+++ b/common/script/pr-preview.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# build relative links to ARIA spec
+find . -maxdepth 1 -type f -name "index.html" -exec sed -i 's|ED: "https://w3c\.github\.io/|ED: "./|g' {} +
+
+# build lins to ARIA from chil specs
+find . -mindepth 2 -type f -name "index.html" -exec sed -i 's|ED: "https://w3c\.github\.io/aria/|ED: "/|g' {} +
+
+# build relative links for child specs
+find . -mindepth 2 -type f -name "index.html" -exec sed -i 's|ED: "https://w3c\.github\.io/(?!aria)|ED: "/|g' {} +
+# build all specs
+npx respec -s index.html -o index.html --localhost
+npx respec -s accname/index.html -o accname/index.html --localhost
+npx respec -s core-aam/index.html -o core-aam/index.html --localhost
+npx respec -s dpub-aam/index.html -o dpub-aam/index.html --localhost
+npx respec -s dpub-aria/index.html -o dpub-aria/index.html --localhost
+npx respec -s graphics-aam/index.html -o graphics-aam/index.html --localhost
+npx respec -s graphics-aria/index.html -o graphics-aria/index.html --localhost
+npx respec -s svg-aam/index.html -o svg-aam/index.html --localhost
+npx respec -s mathml-aam/index.html -o mathml-aam/index.html --localhost

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,6 +16,5 @@
   NODE_ENV = "Deploy"
   command = "bash ./common/script/pr-preview.sh"
 
-[context.branch-deploy.environment]
-  NODE_ENV = "development"
+[context.branch-deploy]
   command = "bash ./common/script/pr-preview.sh"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 # netlify.toml
 # Basic configuration for a Netlify deployment
 [build]
-  publish = "" # Directory to publish
+  publish = "build" # Directory to publish
   command = "npx respec -s index.html -o index.html --localhost; npx respec -s accname/index.html -o accname/index.html --localhost; npx respec -s core-aam/index.html -o core-aam/index.html --localhost; npx respec -s dpub-aam/index.html -o dpub-aam/index.html --localhost; npx respec -s dpub-aria/index.html -o dpub-aria/index.html --localhost; npx respec -s graphics-aam/index.html -o graphics-aam/index.html --localhost; npx respec -s graphics-aria/index.html -o graphics-aria/index.html --localhost; npx respec -s svg-aam/index.html -o svg-aam/index.html --localhost; npx respec -s mathml-aam/index.html -o mathml-aam/index.html --localhost"
 
 [[redirects]]
@@ -14,6 +14,8 @@
 
 [context.deploy-preview]
   NODE_ENV = "Deploy"
+  command = "bash ./common/script/pr-preview.sh"
 
 [context.branch-deploy.environment]
   NODE_ENV = "development"
+  command = "bash ./common/script/pr-preview.sh"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 # netlify.toml
 # Basic configuration for a Netlify deployment
 [build]
-  publish = "build" # Directory to publish
+  publish = "" # Directory to publish
   command = "npx respec -s index.html -o index.html --localhost; npx respec -s accname/index.html -o accname/index.html --localhost; npx respec -s core-aam/index.html -o core-aam/index.html --localhost; npx respec -s dpub-aam/index.html -o dpub-aam/index.html --localhost; npx respec -s dpub-aria/index.html -o dpub-aria/index.html --localhost; npx respec -s graphics-aam/index.html -o graphics-aam/index.html --localhost; npx respec -s graphics-aria/index.html -o graphics-aria/index.html --localhost; npx respec -s svg-aam/index.html -o svg-aam/index.html --localhost; npx respec -s mathml-aam/index.html -o mathml-aam/index.html --localhost"
 
 [[redirects]]


### PR DESCRIPTION
Partially addresses w3c/aria#2242

This only picks up references to roles, states, and properties. Some definitions are still pointing to the editors draft or TR documents because they are not processed by the script due to the way they are written.

For example, `<a>assistive technologies</a>` would rely on [Xref](https://respec.org/xref) for processing.
We should decide if we are happy with landing this or we want another approach, like waiting for respec to process the files and then just search and replace all absolute links (no matter where they link to) with relative links.
