### PR TITLE
Editorial: Point to "element reference attribute" definitions in HTML for IDREF attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -17168,14 +17168,13 @@ el.getAttribute("aria-label"); // Returns "Publish"</pre
         </tr>
         <tr>
           <td>ID reference</td>
-          <td>The value of a defined <a data-cite="html/dom.html#the-id-attribute">id attribute</a> on another element</td>
+          <td><a data-cite="html/common-microsyntaxes.html#single-element-reference">Single element reference attributes</a></td>
           <td><a data-cite="xmlschema11-2/#IDREF">IDREF</a></td>
         </tr>
         <tr>
           <td>ID reference list</td>
           <td>
-            The value of one or more defined <a data-cite="html/dom.html#the-id-attribute">id attributes</a> on other element(s), represented as
-            <a data-cite="html/common-microsyntaxes.html#space-separated-tokens">Space-separated tokens</a>
+            <a data-cite="html/common-microsyntaxes.html#set-of-element-references">Set of element references attributes</a>
           </td>
           <td><a data-cite="xmlschema11-2/#IDREFS">IDREFS</a></td>
         </tr>


### PR DESCRIPTION
https://github.com/whatwg/html/pull/10995 adds definitions for "single element reference" and "set of element references" attributes, formalizing the concept of attributes that reference other elements via ID.

In this change, update the "Mapping WAI-ARIA Value types to languages" to use these new definitions for "ID Reference" and "ID Reference List" attributes.

This whole section is non-normative.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dandclark/aria/pull/2474.html" title="Last updated on Mar 17, 2025, 10:19 PM UTC (72adb11)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2474/5b667ad...dandclark:72adb11.html" title="Last updated on Mar 17, 2025, 10:19 PM UTC (72adb11)">Diff</a>