### PR TITLE
Editorial: Update links, fix typos

### DIFF
--- a/accname/index.html
+++ b/accname/index.html
@@ -628,7 +628,8 @@
                 <li id="comp_host_language_label">
                   <span id="step2E"><!-- Don't link to this legacy numbered ID. --></span><em>Host Language Label:</em> Otherwise, if the <code>current node</code>'s native markup provides an
                   [=attribute=] (e.g. <code>alt</code>) or [=element=] (e.g. HTML <code>label</code> or SVG <code>title</code>) that defines a text alternative, return that alternative in the form of
-                  a <code>flat string</code> as defined by the host language, unless the <code>current node</code> is exposed as presentational (<code>role="presentation"</code> or <code>role="none"</code>).
+                  a <code>flat string</code> as defined by the host language, unless the <code>current node</code> is exposed as presentational (<code>role="presentation"</code> or
+                  <code>role="none"</code>).
                   <div class="note">
                     See <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a>,
                     <a href="https://www.w3.org/TR/svg-aam-1.0/#mapping_additional_nd">SVG-AAM</a>, or other host language documentation for more information on markup that defines a text alternative.

--- a/common/terms.html
+++ b/common/terms.html
@@ -93,7 +93,7 @@
     </dd>
     <dt><dfn>Keyboard Accessible</dfn></dt>
     <dd>
-    	<p>Accessible to the user using a keyboard or <a>assistive technologies</a> that mimic keyboard input, such as a sip and puff tube. References in this document relate to <cite><a href="https://www.w3.org/TR/WCAG21/#keyboard-accessible"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.1 Guideline 2.1: Make all functionality available from a keyboard</a></cite> [[WCAG21]].</p>
+    	<p>Accessible to the user using a keyboard or <a>assistive technologies</a> that mimic keyboard input, such as a sip and puff tube. References in this document relate to <cite><a href="https://www.w3.org/TR/WCAG22/#keyboard-accessible"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.2 Guideline 2.1: Make all functionality available from a keyboard</a></cite> [[WCAG22]].</p>
     </dd>
     <dt><dfn data-lt="landmark|landmarks">Landmark</dfn></dt>
     <dd>
@@ -134,7 +134,7 @@
     </dd>
     <dt><dfn>Operable</dfn></dt>
     <dd>
-      <p>Usable by users in ways they can control. References in this document relate to <cite><a href="https://www.w3.org/TR/WCAG21/#operable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.1 Principle 2: Content must be operable</a></cite> [[WCAG21]]. See <a>Keyboard Accessible</a>.</p>
+      <p>Usable by users in ways they can control. References in this document relate to <cite><a href="https://www.w3.org/TR/WCAG22/#operable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.2 Principle 2: Content must be operable</a></cite> [[WCAG22]]. See <a>Keyboard Accessible</a>.</p>
     </dd>
     <dt><dfn data-lt="owned element|owned|owned element's|owned elements">Owned Element</dfn></dt>
     <dd>
@@ -146,7 +146,7 @@
     </dd>
     <dt><dfn>Perceivable</dfn></dt>
     <dd>
-      <p>Presentable to users in ways they can sense. References in this document relate to <cite><a href="https://www.w3.org/TR/WCAG21/#perceivable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.1 Principle 1: Content must be perceivable</a></cite> [[WCAG21]].</p>
+      <p>Presentable to users in ways they can sense. References in this document relate to <cite><a href="https://www.w3.org/TR/WCAG22/#perceivable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.2 Principle 1: Content must be perceivable</a></cite> [[WCAG22]].</p>
     </dd>
     <dt><dfn data-lt="property|properties">Property</dfn></dt>
     <dd>
@@ -194,7 +194,7 @@
     </dd>
     <dt><dfn>Understandable</dfn></dt>
     <dd>
-      <p>Presentable to users in ways they can construct an appropriate meaning. References in this document relate to <cite><a href="https://www.w3.org/TR/WCAG21/#understandable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.1 Principle 3: Information and the operation of user interface must be understandable</a></cite> [[WCAG21]].</p>
+      <p>Presentable to users in ways they can construct an appropriate meaning. References in this document relate to <cite><a href="https://www.w3.org/TR/WCAG22/#understandable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.2 Principle 3: Information and the operation of user interface must be understandable</a></cite> [[WCAG22]].</p>
     </dd>
 	<dt><dfn data-lt="unicode braille">Unicode Braille Patterns</dfn></dt>
 	<dd>

--- a/index.html
+++ b/index.html
@@ -233,8 +233,8 @@
       </ul>
       <p>
         WAI-ARIA is a technical specification that provides a framework to improve the accessibility and interoperability of web content and applications. This document is primarily for developers
-        creating custom widgets and other web application components. Please see the <a href="https://www.w3.org/WAI/standards-guidelines/aria/">WAI-ARIA Overview</a> for links to related documents for other
-        audiences, such as
+        creating custom widgets and other web application components. Please see the <a href="https://www.w3.org/WAI/standards-guidelines/aria/">WAI-ARIA Overview</a> for links to related documents
+        for other audiences, such as
         <cite
           ><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">ARIA</abbr> Authoring Practices Guide</a></cite
         >
@@ -6957,9 +6957,9 @@
             </ul>
             <p>
               For any element with a role of <rref>none</rref>/<rref>presentation</rref> and which is not focusable, the user agent MUST NOT expose the implicit native semantics of the element (the
-              role and its states and properties) to accessibility <abbr title="Application Programming Interfaces">APIs</abbr>. However, the user agent MUST expose content and descendant elements that
-              do not have an explicit or inherited role of <rref>none</rref>/<rref>presentation</rref>. Thus, the <rref>none</rref>/<rref>presentation</rref> role causes a given element to be treated
-              as having no role or to be removed from the <a>accessibility tree</a>, but does not cause the content contained within the element to be removed from the accessibility tree.
+              role and its states and properties) to accessibility <abbr title="Application Programming Interfaces">APIs</abbr>. However, the user agent MUST expose content and descendant elements
+              that do not have an explicit or inherited role of <rref>none</rref>/<rref>presentation</rref>. Thus, the <rref>none</rref>/<rref>presentation</rref> role causes a given element to be
+              treated as having no role or to be removed from the <a>accessibility tree</a>, but does not cause the content contained within the element to be removed from the accessibility tree.
             </p>
             <p>For example, the following two markup snippets will be exposed similarly to an accessibility <abbr title="Application Programming Interface">API</abbr>.</p>
             <pre
@@ -13788,8 +13788,8 @@ button.ariaPressed; // null</pre
             </p>
             <p>
               In the case of one or more ID references, [=user agents=] or assistive technologies SHOULD give the user the option of navigating to any of the targeted elements. The name of the path
-              can be determined by the name of the target element of the <pref>aria-flowto</pref> <a>attribute</a>. <a>Accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a> can
-              provide named path <a>relationships</a>.
+              can be determined by the name of the target element of the <pref>aria-flowto</pref> <a>attribute</a>.
+              <a>Accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a> can provide named path <a>relationships</a>.
             </p>
           </div>
           <table class="def">

--- a/index.html
+++ b/index.html
@@ -517,7 +517,7 @@
             <p>
               Operating systems and other platforms provide a set of interfaces that expose information about <a class="termref">objects</a> and <a class="termref">events</a> to
               <a>assistive technologies</a>. Assistive technologies use these interfaces to get information about and interact with those <a class="termref">widgets</a>. Examples of accessibility APIs
-              are <a href="https://docs.microsoft.com/en-us/windows/win32/winauto/microsoft-active-accessibility">Microsoft Active Accessibility</a> [[MSAA]],
+              are <a href="https://learn.microsoft.com/en-us/windows/win32/winauto/microsoft-active-accessibility">Microsoft Active Accessibility</a> [[MSAA]],
               <a href="https://learn.microsoft.com/en-us/windows/win32/winauto/entry-uiauto-win32">Microsoft User Interface Automation</a> [[UI-AUTOMATION]],
               <abbr title="Microsoft Active Accessibility">MSAA</abbr> with
               <cite

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
           {
             name: "Daniel Montalvo",
             company: "W3C",
-            companyURL: "http://www.w3.org",
+            companyURL: "https://www.w3.org",
             w3cid: 114058,
           },
         ],
@@ -103,8 +103,8 @@
         // only "name" is required. Same format as editors.
 
         //authors:  [
-        //    { name: "Your Name", url: "http://example.org/",
-        //      company: "Your Company", companyURL: "http://example.com/" },
+        //    { name: "Your Name", url: "https://example.org/",
+        //      company: "Your Company", companyURL: "https://example.com/" },
         //],
 
         /*
@@ -115,7 +115,7 @@
 		],
 		*/
 
-        // errata: 'http://www.w3.org/2010/02/rdfa/errata.html',
+        // errata: 'https://www.w3.org/2010/02/rdfa/errata.html',
 
         // name of the WG
         group: "aria",
@@ -214,7 +214,7 @@
       <p>
         The Accessible Rich Internet Applications Working Group seeks feedback on any aspect of the specification. When submitting feedback, please consider issues in the context of the companion
         documents. To comment, <a href="https://github.com/w3c/aria/issues/new">file an issue in the <abbr title="World Wide Web Consortium">W3C</abbr> ARIA GitHub repository</a>. If this is not
-        feasible, send email to <a href="mailto:public-aria@w3.org?subject=Comment%20on%20WAI-ARIA%201.2">public-aria@w3.org</a> (<a href="http://lists.w3.org/Archives/Public/public-aria/"
+        feasible, send email to <a href="mailto:public-aria@w3.org?subject=Comment%20on%20WAI-ARIA%201.2">public-aria@w3.org</a> (<a href="https://lists.w3.org/Archives/Public/public-aria/"
           >comment archive</a
         >). In-progress updates to the document can be viewed in the <a href="https://w3c.github.io/aria/">publicly visible editors' draft</a>.
       </p>
@@ -233,7 +233,7 @@
       </ul>
       <p>
         WAI-ARIA is a technical specification that provides a framework to improve the accessibility and interoperability of web content and applications. This document is primarily for developers
-        creating custom widgets and other web application components. Please see the <a href="http://www.w3.org/WAI/intro/aria">WAI-ARIA Overview</a> for links to related documents for other
+        creating custom widgets and other web application components. Please see the <a href="https://www.w3.org/WAI/standards-guidelines/aria/">WAI-ARIA Overview</a> for links to related documents for other
         audiences, such as
         <cite
           ><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">ARIA</abbr> Authoring Practices Guide</a></cite
@@ -248,9 +248,9 @@
         [[WAI-ARIA-PRACTICES-1.2]] for the use of roles in making interactive content accessible.
       </p>
       <p>
-        Roles defined by this specification are designed to support the roles used by platform <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a
+        Roles defined by this specification are designed to support the roles used by platform <a>accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a
         >. Declaration of these roles on elements within dynamic web content is intended to support interoperability between the web content and assistive technologies that utilize
-        <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a
+        <a>accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a
         >.
       </p>
       <p>
@@ -261,7 +261,7 @@
       <p>
         <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 1.2 is a member of the
         <a href="https://www.w3.org/WAI/intro/aria"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 1.2 suite</a> that defines how to expose semantics of WAI-ARIA and other web
-        content languages to <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a
+        content languages to <a>accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a
         >.
       </p>
       <section class="section" id="intro_ria_accessibility">
@@ -293,11 +293,11 @@
           accessible, usable, and interoperable with assistive technologies. This specification identifies the types of widgets and structures that are commonly recognized by accessibility products,
           by providing an <a>ontology</a> of corresponding <a>roles</a> that can be attached to content. This allows elements with a given role to be understood as a particular widget or structural
           type regardless of any semantics inherited from the implementing host language. Roles are a common property of platform
-          <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a> which assistive technologies use to provide the user with effective presentation and interaction.
+          <a>accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a> which assistive technologies use to provide the user with effective presentation and interaction.
         </p>
         <p>
           The Roles Model includes interaction <a>widgets</a> and elements denoting document structure. The Roles Model describes inheritance and details the [=attributes=] each role supports.
-          Information about mapping of roles to accessibility <abbr title="Application Programing Interfaces">APIs</abbr> is provided by the
+          Information about mapping of roles to accessibility <abbr title="Application Programming Interfaces">APIs</abbr> is provided by the
           <cite><a href="" class="core-mapping">Core Accessibility API Mappings</a></cite> [[CORE-AAM-1.2]].
         </p>
         <p>
@@ -310,21 +310,21 @@
           software, need to be able to recognize and effectively manipulate and communicate various interaction states (e.g., disabled, checked) to the user.
         </p>
         <p>
-          While it is possible for assistive technologies to access these properties directly through the <cite><a href="https://www.w3.org/TR/dom/">Document Object Model</a></cite> [[DOM]], the
-          preferred mechanism is for the user agent to map the states and properties to the accessibility <abbr title="Application Programing Interfaces">API</abbr> of the operating system. See the
+          While it is possible for assistive technologies to access these properties directly through the <cite><a href="https://dom.spec.whatwg.org/">Document Object Model</a></cite> [[DOM]], the
+          preferred mechanism is for the user agent to map the states and properties to the accessibility <abbr title="Application Programming Interfaces">API</abbr> of the operating system. See the
           <cite><a href="" class="core-mapping">Core Accessibility API Mappings</a></cite> [[CORE-AAM-1.2]] and the
           <cite><a href="" class="accname">Accessible Name and Description Computation</a></cite> [[ACCNAME-1.2]] for details.
         </p>
         <p id="desc_contractmodel">
           <a href="#fig-contractmodel"></a> illustrates the relationship between user agents (e.g., browsers), accessibility APIs, and assistive technologies. It describes the "contract" provided by
-          the user agent to assistive technologies, which includes typical accessibility information found in the accessibility <abbr title="Application Programing Interfaces">API</abbr> for many of
+          the user agent to assistive technologies, which includes typical accessibility information found in the accessibility <abbr title="Application Programming Interfaces">API</abbr> for many of
           our accessible platforms for GUIs (role, state, selection, <a>event</a> notification, <a>relationship</a> information, and descriptions). The DOM, usually HTML, acts as the data model and
           view in a typical model-view-controller relationship, and JavaScript acts as the controller by manipulating the style and content of the displayed data. The user agent conveys relevant
           information to the operating system's accessibility API, which can be used by any assistive technologies, such as screen readers.
         </p>
         <figure id="fig-contractmodel">
           <img alt="The contract model with accessibility APIs" height="389" src="img/accessibleelement.png" width="723" />
-          <figcaption>The contract model with accessibility <abbr title="Application Programing Interfaces">APIs</abbr></figcaption>
+          <figcaption>The contract model with accessibility <abbr title="Application Programming Interfaces">APIs</abbr></figcaption>
         </figure>
         <p>
           For more information see
@@ -483,7 +483,7 @@
           <h3>Testing Practices and Tools</h3>
           <p>
             The accessibility of interactive content cannot be confirmed by static checks alone. Developers of interactive content should test for device-independent access to <a>widgets</a> and
-            applications, and should verify accessibility <abbr title="application programing interface">API</abbr> access to all content and changes during user interaction.
+            applications, and should verify accessibility <abbr title="Application Programming Interface">API</abbr> access to all content and changes during user interaction.
           </p>
         </section>
       </section>
@@ -532,7 +532,7 @@
           <dt><dfn data-export="">Accessible object</dfn></dt>
           <dd>
             <p>
-              A [=nodes|node=] in the <a class="termref">accessibility tree</a> of a platform <a>accessibility <abbr title="application programming interface">API</abbr></a
+              A [=nodes|node=] in the <a class="termref">accessibility tree</a> of a platform <a>accessibility <abbr title="Application Programming Interface">API</abbr></a
               >. Accessible objects expose various <a class="termref">states</a>, [=ARIA/properties=], and <a class="termref">events</a> for use by <a>assistive technologies</a>. In the context of
               markup languages (e.g., HTML and SVG) in general, and of WAI-ARIA in particular, markup [=elements=] and their [=attributes=] are represented as accessible objects.
             </p>
@@ -575,7 +575,7 @@
           </dd>
           <dt><dfn data-local-lt="desktop focus">Desktop focus event</dfn></dt>
           <dd>
-            <p>Event from/to the host operating system via the accessibility <abbr title="application programming interface">API</abbr>, notifying of a change of input focus.</p>
+            <p>Event from/to the host operating system via the accessibility <abbr title="Application Programming Interface">API</abbr>, notifying of a change of input focus.</p>
           </dd>
           <dt><dfn>Event</dfn></dt>
           <dd>
@@ -777,7 +777,7 @@
         Normative sections provide requirements that authors and [=user agents=] must follow for an implementation to conform to this specification. The keywords <em class="rfc2119">MUST</em>,
         <em class="rfc2119">MUST NOT</em>, <em class="rfc2119">REQUIRED</em>, <em class="rfc2119">SHALL</em>, <em class="rfc2119">SHALL NOT</em>, <em class="rfc2119">SHOULD</em>,
         <em class="rfc2119">RECOMMENDED</em>, <em class="rfc2119">MAY</em>, and <em class="rfc2119">OPTIONAL</em> in this document are to be interpreted as described in
-        <cite><a href="http://www.rfc-editor.org/rfc/rfc2119.txt">Keywords for use in RFCs to indicate requirement levels</a></cite> [[!RFC2119]]. RFC-2119 keywords are formatted in uppercase and
+        <cite><a href="https://www.rfc-editor.org/rfc/rfc2119.txt">Keywords for use in RFCs to indicate requirement levels</a></cite> [[!RFC2119]]. RFC-2119 keywords are formatted in uppercase and
         contained in an element with <code>class="rfc2119"</code>. When the keywords shown above are used, but do not share this format, they do not convey formal information in the RFC 2119 sense,
         and are merely explanatory, i.e., informative. As much as possible, such usages are avoided in this specification.
       </p>
@@ -794,7 +794,7 @@
         <p>
           If a CSS selector includes a WAI-ARIA attribute (e.g., <code class="highlight lang-css">input[aria-invalid="true"]</code>), user agents MUST update the visual display of any elements
           matching (or no longer matching) the selector any time the attribute is added/changed/removed in the <abbr title="Document Object Model">DOM</abbr>. The user agent MAY alter the mapping of
-          the host language features into an <a>accessibility <abbr title="Application Programing Interface">API</abbr></a
+          the host language features into an <a>accessibility <abbr title="Application Programming Interface">API</abbr></a
           >, but the user agent MUST NOT alter the <abbr title="Document Object Model">DOM</abbr> in order to remap <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> markup into host
           language features.
         </p>
@@ -884,8 +884,8 @@
         <h2><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> States and Properties</h2>
         <p>
           <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> provides a collection of accessibility <a>states</a> and [=ARIA/properties=] which are used to support platform
-          <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a> on various operating system platforms. <a>Assistive technologies</a> can access this information through an
-          exposed <a>user agent</a> DOM or through a mapping to the platform accessibility <abbr title="Application Programing Interfaces">API</abbr>. When combined with <a>roles</a>, the user agent
+          <a>accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a> on various operating system platforms. <a>Assistive technologies</a> can access this information through an
+          exposed <a>user agent</a> DOM or through a mapping to the platform accessibility <abbr title="Application Programming Interfaces">API</abbr>. When combined with <a>roles</a>, the user agent
           can supply the assistive technologies with user interface information to convey to the user at any time. Changes in states or properties will result in a notification to assistive
           technologies, which could alert the user that a change has occurred.
         </p>
@@ -901,7 +901,7 @@
           <abbr title="Cascading Style Sheets">CSS</abbr> pseudo-classes (such as <code>:focus</code> and <code>::selection</code>) to define style changes. In contrast, the states in this
           specification are typically controlled by the author and are called <em>unmanaged states.</em> Some states are managed by the user agent, such as <pref>aria-posinset</pref> and
           <pref>aria-setsize</pref>, but the author can override them if the <abbr title="Document Object Model">DOM</abbr> is incomplete and would cause the user agent calculation to be incorrect.
-          User agents map both managed and unmanaged states to the platform accessibility <abbr title="Application Programing Interfaces">APIs</abbr>.
+          User agents map both managed and unmanaged states to the platform accessibility <abbr title="Application Programming Interfaces">APIs</abbr>.
         </p>
         <p>
           Most modern user agents support
@@ -1006,13 +1006,13 @@
           <ol>
             <li>Implement the host language method for keyboard navigation so that widgets that support <code>aria-activedescendant</code> can be included in the tab order.</li>
             <li>
-              For platforms that expose <a>desktop focus</a> or <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> focus separately from
-              <abbr title="Document Object Model">DOM</abbr> focus, do not expose the focused state in the accessibility <abbr title="application programming interface">API</abbr> for any element when
+              For platforms that expose <a>desktop focus</a> or <a>accessibility <abbr title="Application Programming Interface">API</abbr></a> focus separately from
+              <abbr title="Document Object Model">DOM</abbr> focus, do not expose the focused state in the accessibility <abbr title="Application Programming Interface">API</abbr> for any element when
               it has <abbr title="Document Object Model">DOM</abbr> focus and also has <pref>aria-activedescendant</pref> which points to a valid <a href="#valuetype_idref">ID reference</a>.
             </li>
             <li>
               When the <pref>aria-activedescendant</pref> attribute changes on an element that currently has <abbr title="Document Object Model">DOM</abbr> focus, remove the focused state from the
-              previously focused object and fire an accessibility <abbr title="application programming interface">API</abbr> <a>desktop focus event</a> on the new element referenced by
+              previously focused object and fire an accessibility <abbr title="Application Programming Interface">API</abbr> <a>desktop focus event</a> on the new element referenced by
               <code>aria-activedescendant</code>. If <pref>aria-activedescendant</pref> is cleared or does not point to an element in the current document, fire a desktop focus event for the
               <a>object</a> that had the attribute change.
             </li>
@@ -1036,7 +1036,7 @@
             </li>
           </ol>
           <p>
-            When an assistive technology uses its platform's accessibility <abbr title="Application Programming Interfaces">API</abbr> to request a change of focus, user agents MUST do the following:
+            When an assistive technology uses its platform's accessibility <abbr title="Application Programming Interface">API</abbr> to request a change of focus, user agents MUST do the following:
           </p>
           <ol>
             <li>Remove the platform's focused state from the previously focused object.</li>
@@ -1137,7 +1137,7 @@
           </dl>
           <p>
             Abstract <a>roles</a> are the foundation upon which all other <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles are built. Authors MUST NOT use abstract roles
-            because they are not implemented in the <abbr title="application programing interface">API</abbr> binding. User agents MUST NOT map abstract roles to the standard role mechanism of the
+            because they are not implemented in the <abbr title="Application Programming Interface">API</abbr> binding. User agents MUST NOT map abstract roles to the standard role mechanism of the
             accessibility API. Abstract roles are provided to help with the following:
           </p>
           <ol>
@@ -1311,7 +1311,7 @@
           </dl>
           <p>
             The <abbr title="Document Object Model">DOM</abbr> descendants are presentational. [=user agents=] SHOULD NOT expose descendants of this <a>element</a> through the platform
-            <a>accessibility <abbr title="Application Programing Interface">API</abbr></a
+            <a>accessibility <abbr title="Application Programming Interface">API</abbr></a
             >. If [=user agents=] do not hide the descendant nodes, some information might be read twice.
           </p>
           <p>Authors MUST NOT specify <pref>aria-owns</pref> on an element which has Presentational Children.</p>
@@ -1616,7 +1616,7 @@
               Unlike <rref>alert</rref>, <code>alertdialog</code> can receive a response from the user. For example, to confirm that the user understands the alert being generated. When the alert
               dialog is displayed, authors SHOULD set focus to an active element within the alert dialog, such as a form control or confirmation button. The <a>user agent</a> SHOULD fire a system
               alert <a>event</a> through the accessibility API when the alert is created, provided one is specified by the intended
-              <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a
+              <a>accessibility <abbr title="Application Programming Interface">API</abbr></a
               >.
             </p>
             <p>Authors SHOULD provide an accessible name for an <code>alertdialog</code>, which can be done with the <pref>aria-label</pref> or <pref>aria-labelledby</pref> attribute.</p>
@@ -6930,7 +6930,7 @@
           <rdef>none</rdef>
           <div class="role-description">
             <p>
-              An <a>element</a> whose implicit native role semantics will not be mapped to the <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a
+              An <a>element</a> whose implicit native role semantics will not be mapped to the <a>accessibility <abbr title="Application Programming Interface">API</abbr></a
               >. See synonym <rref>presentation</rref>.
             </p>
             <div class="note" id="role-none-note-none">
@@ -6957,11 +6957,11 @@
             </ul>
             <p>
               For any element with a role of <rref>none</rref>/<rref>presentation</rref> and which is not focusable, the user agent MUST NOT expose the implicit native semantics of the element (the
-              role and its states and properties) to accessibility <abbr title="Application Programing Interfaces">APIs</abbr>. However, the user agent MUST expose content and descendant elements that
+              role and its states and properties) to accessibility <abbr title="Application Programming Interfaces">APIs</abbr>. However, the user agent MUST expose content and descendant elements that
               do not have an explicit or inherited role of <rref>none</rref>/<rref>presentation</rref>. Thus, the <rref>none</rref>/<rref>presentation</rref> role causes a given element to be treated
               as having no role or to be removed from the <a>accessibility tree</a>, but does not cause the content contained within the element to be removed from the accessibility tree.
             </p>
-            <p>For example, the following two markup snippets will be exposed similarly to an accessibility <abbr title="Application Programing Interface">API</abbr>.</p>
+            <p>For example, the following two markup snippets will be exposed similarly to an accessibility <abbr title="Application Programming Interface">API</abbr>.</p>
             <pre
               class="example highlight"
             ><span class="comment">&lt;!-- 1. role="none" negates the implicit 'heading' role semantics but does not affect the contents, including the nested hyperlink. --&gt;</span>
@@ -7005,7 +7005,7 @@
             <h5>Presentational Role Inheritance</h5>
             <p>
               The <rref>none</rref>/<rref>presentation</rref> role is used on an element that has implicit native semantics, meaning that there is a default accessibility
-              <abbr title="Application Programing Interface">API</abbr> role for the element. Some elements are only complete when additional descendant elements are provided. For example, in HTML,
+              <abbr title="Application Programming Interface">API</abbr> role for the element. Some elements are only complete when additional descendant elements are provided. For example, in HTML,
               table elements (matching the <rref>table</rref> role) require <code>tr</code> descendants (which have an implicit <rref>row</rref> <a>role</a>), which in turn require <code>th</code> or
               <code>td</code> children (the <rref>columnheader</rref> or <rref>rowheader</rref> and <rref>cell</rref> roles, respectively). Similarly, lists require list item children. The descendant
               elements that complete the semantics of an element are described in <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> as
@@ -7033,7 +7033,7 @@
               role of <rref>none</rref>/<rref>presentation</rref> specified.
             </p>
             <p>
-              For example, according to an accessibility <abbr title="Application Programing Interface">API</abbr>, the following markup elements might have identical or very similar role semantics
+              For example, according to an accessibility <abbr title="Application Programming Interface">API</abbr>, the following markup elements might have identical or very similar role semantics
               (generic or none role) and identical content.
             </p>
             <pre class="example highlight"><span class="comment">&lt;!-- 1. [role="none"] negates the implicit 'list' and 'listitem' role semantics but does not affect the contents. --&gt;</span>
@@ -7267,7 +7267,7 @@
             <p>
               Authors MUST ensure [=elements=] with <a>role</a> <code>option</code> are <a>accessibility children</a> of an element with <a>role</a> <rref>listbox</rref> or of an element with
               <a>role</a> <rref>group</rref> that is the <a>accessibility child</a> of an element with <a>role</a> <code>listbox</code>. Options not associated with a <rref>listbox</rref> might not be
-              correctly mapped to an <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a
+              correctly mapped to an <a>accessibility <abbr title="Application Programming Interface">API</abbr></a
               >.
             </p>
             <p>
@@ -7587,7 +7587,7 @@
           <rdef>presentation</rdef>
           <div class="role-description">
             <p>
-              An <a>element</a> whose implicit native role semantics will not be mapped to the <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a
+              An <a>element</a> whose implicit native role semantics will not be mapped to the <a>accessibility <abbr title="Application Programming Interface">API</abbr></a
               >. See synonym <rref>none</rref>.
             </p>
             <div class="note" id="role-presentation-note-none">
@@ -9753,7 +9753,7 @@
             <p>A document structural <a>element</a>.</p>
             <p>
               <a>Roles</a> for document structure support the accessibility of dynamic web content by helping <a>assistive technologies</a> determine active content versus static document content.
-              Structural roles by themselves do not all map to <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a
+              Structural roles by themselves do not all map to <a>accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a
               >, but are used to create <a>widget</a> roles or assist content adaptation for assistive technologies.
             </p>
             <p><code>structure</code> is an <a href="#isAbstract">abstract role</a> used for the ontology. Authors MUST NOT use <code>structure</code> role in content.</p>
@@ -11701,7 +11701,7 @@
             <p>An interactive component of a graphical user interface (<abbr title="Graphical User Interface">GUI</abbr>).</p>
             <p>
               Widgets are discrete user interface objects with which the user can interact. Widget <a>roles</a> map to standard features in
-              <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a
+              <a>accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a
               >. When the user navigates an element assigned any of the non-abstract subclass roles of <code>widget</code>, <a>assistive technologies</a> that typically intercept standard keyboard
               events SHOULD switch to an application browsing mode, and pass keyboard events through to the web application. The intent is to hint to certain <a>assistive technologies</a> to switch
               from normal browsing mode into a mode more appropriate for interacting with a web application; some [=user agents=] have a browse navigation mode where keys, such as up and down arrows,
@@ -12111,7 +12111,7 @@ button.ariaPressed; // null</pre
             <li><pref>aria-valuetext</pref></li>
           </ul>
           <p>
-            Widget attributes might be mapped by a <a>user agent</a> to platform <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> <a>state</a>, for access by
+            Widget attributes might be mapped by a <a>user agent</a> to platform <a>accessibility <abbr title="Application Programming Interface">API</abbr></a> <a>state</a>, for access by
             <a>assistive technologies</a>, or they might be accessed directly from the <abbr title="Document Object Model">DOM</abbr>.
           </p>
         </section>
@@ -12170,7 +12170,7 @@ button.ariaPressed; // null</pre
         <h3>State change notification</h3>
         <p>
           User agents MUST provide a way for assistive technologies to be notified when states change, either through <abbr title="Document Object Model">DOM</abbr> attribute change <a>events</a> or
-          platform accessibility <abbr title="Application Programing Interfaces">API</abbr> events.
+          platform accessibility <abbr title="Application Programming Interface">API</abbr> events.
         </p>
       </section>
       <section id="state_prop_def">
@@ -12251,7 +12251,7 @@ button.ariaPressed; // null</pre
               <pref>aria-relevant</pref> attribute.
             </p>
             <p>
-              Both <a>accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a> and the <cite><a href="https://www.w3.org/TR/dom/">Document Object Model</a></cite> [[DOM]] provide
+              Both <a>accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a> and the <cite><a href="https://www.w3.org/TR/dom/">Document Object Model</a></cite> [[DOM]] provide
               events to allow the assistive technologies to determine changed areas of the document.
             </p>
             <p>
@@ -13309,7 +13309,7 @@ button.ariaPressed; // null</pre
             </p>
             <p>
               The purpose of <pref>aria-description</pref> is the same as that of <pref>aria-describedby</pref>. It provides the user with additional descriptive text for the object. The most common
-              <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> mapping for a description is the <a class="informative">accessible description</a> property. User agents
+              <a>accessibility <abbr title="Application Programming Interface">API</abbr></a> mapping for a description is the <a class="informative">accessible description</a> property. User agents
               MUST give precedence to <pref>aria-describedby</pref> over <pref>aria-description</pref> when computing the accessible description property.
             </p>
             <p>
@@ -13432,7 +13432,7 @@ button.ariaPressed; // null</pre
                                 &lt;!-- Provision of an extended description --&gt;
                                 &lt;img src="pythagorean.jpg" alt="Pythagorean Theorem" aria-details="det"&gt;
                                 &lt;p&gt;
-                                  See an &lt;a href="http://foo.com/pt.html" id="det"&gt;Application of the Pythagorean Theorem&lt;/a&gt;.
+                                  See an &lt;a href="https://example.com/pt.html" id="det"&gt;Application of the Pythagorean Theorem&lt;/a&gt;.
                                 &lt;/p&gt;
 				</pre
             >
@@ -13788,7 +13788,7 @@ button.ariaPressed; // null</pre
             </p>
             <p>
               In the case of one or more ID references, [=user agents=] or assistive technologies SHOULD give the user the option of navigating to any of the targeted elements. The name of the path
-              can be determined by the name of the target element of the <pref>aria-flowto</pref> <a>attribute</a>. <a>Accessibility <abbr title="Application Programing Interfaces">APIs</abbr></a> can
+              can be determined by the name of the target element of the <pref>aria-flowto</pref> <a>attribute</a>. <a>Accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a> can
               provide named path <a>relationships</a>.
             </p>
           </div>
@@ -14282,7 +14282,7 @@ button.ariaPressed; // null</pre
             <p><a>Defines</a> a string value that labels the current element. See related <pref>aria-labelledby</pref>.</p>
             <p>
               The purpose of <pref>aria-label</pref> is the same as that of <pref>aria-labelledby</pref>. It provides the user with a recognizable name of the object. The most common
-              <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> mapping for a label is the <a class="informative">accessible name</a> property.
+              <a>accessibility <abbr title="Application Programming Interface">API</abbr></a> mapping for a label is the <a class="informative">accessible name</a> property.
             </p>
             <p>
               Most host languages provide an attribute that could be used to name the element (e.g., the <code>[^html-global/title^]</code> attribute in HTML), yet this could present a browser
@@ -14331,7 +14331,7 @@ button.ariaPressed; // null</pre
             <p><a>Identifies</a> the <a>element</a> (or elements) that labels the current element. See related <pref>aria-label</pref> and <pref>aria-describedby</pref>.</p>
             <p>
               The purpose of <pref>aria-labelledby</pref> is the same as that of <pref>aria-label</pref>. It provides the user with a recognizable name of the object. The most common
-              <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> mapping for a label is the <a class="informative">accessible name</a> property.
+              <a>accessibility <abbr title="Application Programming Interface">API</abbr></a> mapping for a label is the <a class="informative">accessible name</a> property.
             </p>
             <p>
               If the interface is such that it is not possible to have a visible label on the screen, authors SHOULD use <pref>aria-label</pref> and SHOULD NOT use <pref>aria-labelledby</pref>.
@@ -14346,7 +14346,7 @@ button.ariaPressed; // null</pre
             <!-- keep previous sentence synced with the associated description in #aria-describedby -->
             <p class="note">
               The expected spelling of this property in <abbr title="United States">U.S.</abbr> English is "labeledby." However, the
-              <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> features to which this property is mapped have established the "labelledby" spelling. This property is
+              <a>accessibility <abbr title="Application Programming Interface">API</abbr></a> features to which this property is mapped have established the "labelledby" spelling. This property is
               spelled that way to match the convention and minimize the difficulty for developers.
             </p>
           </div>
@@ -16068,7 +16068,7 @@ button.ariaPressed; // null</pre
       <section id="tree_exclusion">
         <h2>Excluding Elements from the Accessibility Tree</h2>
         <p>
-          The following [=elements=] are not exposed via the <a>accessibility <abbr title="Application Programing Interfaces">API</abbr></a> and user agents MUST NOT include them in the
+          The following [=elements=] are not exposed via the <a>accessibility <abbr title="Application Programming Interface">API</abbr></a> and user agents MUST NOT include them in the
           <a class="termref">accessibility tree</a>:
         </p>
         <ul>
@@ -16499,7 +16499,7 @@ button.ariaPressed; // null</pre
         <p>User agents are expected to perform validation of <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a>roles</a>.</p>
         <p>
           As stated in the <a href="#role_definitions">Definition of Roles</a> section, it is considered an authoring error to use <a href="#abstract_roles">abstract roles</a> in content. User agents
-          MUST NOT map abstract roles via the standard role mechanism of the accessibility <abbr title="application programming interface">API</abbr>.
+          MUST NOT map abstract roles via the standard role mechanism of the accessibility <abbr title="Application Programming Interface">API</abbr>.
         </p>
         <p>
           If the <code>role</code> attribute contains no tokens matching the name of a non-abstract <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role, the user agent MUST treat
@@ -16552,7 +16552,7 @@ button.ariaPressed; // null</pre
         <ul>
           <li>When exposing as a platform accessibility API attribute, expose the unknown value &#8212; do not vet it against possible values.</li>
           <li>
-            When exposing as a platform <abbr title="application programming interface">API</abbr> Boolean state:
+            When exposing as a platform <abbr title="Application Programming Interface">API</abbr> Boolean state:
             <ul>
               <li>
                 For values of &quot;&quot; (empty string), &quot;undefined&quot; or no [=attribute=] present:


### PR DESCRIPTION
Closes #2111

## terms.html
Updated references to WCAG 2.1 to WCAG 2.2

## index.html
- updated relevant http URLs to https
- changed a foo.com example URL to example.com as foo.com goes to a domain parking site
- corrected multiple misspellings of “programming”
- updated some out of date URLs

@cookiecrook, @rahimabdi In the [Informative References section](https://www.w3.org/TR/wai-aria-1.2/#informative-references) there's a link to [NSAccessibility](https://developer.apple.com/documentation/appkit/nsaccessibility) which is described as "A legacy, informal protocol that Apple doesn’t recommend for active use". Could we update that link to something up to date?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2476.html" title="Last updated on Mar 13, 2025, 3:48 PM UTC (8b29e92)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2476/bf8e158...8b29e92.html" title="Last updated on Mar 13, 2025, 3:48 PM UTC (8b29e92)">Diff</a>