### PR TITLE
editorial: add classes for highlightjs

### DIFF
--- a/accname/index.html
+++ b/accname/index.html
@@ -628,7 +628,8 @@
                 <li id="comp_host_language_label">
                   <span id="step2E"><!-- Don't link to this legacy numbered ID. --></span><em>Host Language Label:</em> Otherwise, if the <code>current node</code>'s native markup provides an
                   [=attribute=] (e.g. <code>alt</code>) or [=element=] (e.g. HTML <code>label</code> or SVG <code>title</code>) that defines a text alternative, return that alternative in the form of
-                  a <code>flat string</code> as defined by the host language, unless the <code>current node</code> is exposed as presentational (<code>role="presentation"</code> or <code>role="none"</code>).
+                  a <code>flat string</code> as defined by the host language, unless the <code>current node</code> is exposed as presentational (<code>role="presentation"</code> or
+                  <code>role="none"</code>).
                   <div class="note">
                     See <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a>,
                     <a href="https://www.w3.org/TR/svg-aam-1.0/#mapping_additional_nd">SVG-AAM</a>, or other host language documentation for more information on markup that defines a text alternative.

--- a/index.html
+++ b/index.html
@@ -2853,7 +2853,7 @@
               </li>
             </ul>
             <pre class="example highlight html">
-          &lt;label id="tag_label" for="tag_combo">Tag&lt;/label>
+      &lt;label id="tag_label" for="tag_combo">Tag&lt;/label>
 		      &lt;input type="text" id="tag_combo"
             role="combobox" aria-autocomplete="list"
             aria-haspopup="listbox" aria-expanded="true"

--- a/index.html
+++ b/index.html
@@ -861,7 +861,7 @@
           A <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a>role</a> is set on an <a>element</a> using a <code>role</code> <a>attribute</a>, similar to the
           <code>role</code> attribute defined in <cite><a href="https://www.w3.org/TR/role-attribute/">Role Attribute</a></cite> [[ROLE-ATTRIBUTE]].
         </p>
-        <pre class="example highlight">&lt;li role="menuitem"&gt;Open file…&lt;/li&gt;</pre>
+        <pre class="example highlight html">&lt;li role="menuitem"&gt;Open file…&lt;/li&gt;</pre>
         <p>The definition of each role in the model provides the following information :</p>
         <ul>
           <li>an informative description of the role;</li>
@@ -894,7 +894,7 @@
           value of <sref>aria-checked</sref>. A role is used to make the behavior of this simple <a>widget</a> known to the user agent. [=attribute|Attributes=] that change with user actions (such as
           <sref>aria-checked</sref>) are defined in the <a href="#states_and_properties">states and properties</a> section.
         </p>
-        <pre class="example highlight">&lt;li role=&quot;menuitemcheckbox&quot; aria-checked=&quot;true&quot;&gt;Sort by Last Modified&lt;/li&gt;</pre>
+        <pre class="example highlight html">&lt;li role=&quot;menuitemcheckbox&quot; aria-checked=&quot;true&quot;&gt;Sort by Last Modified&lt;/li&gt;</pre>
         <p>
           Some accessibility states, called <em><a>managed states</a></em
           >, are controlled by the user agent. Examples of managed state include keyboard focus and selection. Managed states often have corresponding
@@ -920,7 +920,7 @@
           If CSS is not used to toggle the visual representation of the check mark, the author could include additional markup and scripts to manage an image that represents whether or not the
           <rref>menuitemcheckbox</rref> is checked.
         </p>
-        <pre class="example highlight">&lt;li role=&quot;menuitemcheckbox&quot; aria-checked=&quot;true&quot;&gt;
+        <pre class="example highlight html">&lt;li role=&quot;menuitemcheckbox&quot; aria-checked=&quot;true&quot;&gt;
   &lt;img src=&quot;checked.gif&quot; alt=&quot;&quot;&gt;
   <span class="comment">&lt;!-- note: additional scripts required to toggle image source --&gt;</span>
   Sort by Last Modified
@@ -1206,7 +1206,7 @@
             <li>
               Direct DOM child:
               <!-- ReSpec needs these examples to be unindented. -->
-              <pre>
+              <pre class="example highlight html">
 &lt;div role="listbox"&gt;
 	&lt;div role="option"&gt;option text&lt;/div&gt;
 &lt;/div&gt;</pre
@@ -1215,7 +1215,7 @@
             <li>
               DOM child with generics intervening:
               <!-- ReSpec needs these examples to be unindented. -->
-              <pre>
+              <pre class="example highlight html">
 &lt;div role="listbox"&gt;
 	&lt;div&gt;
 		&lt;div role="option"&gt;option text&lt;/div&gt;
@@ -1226,7 +1226,7 @@
             <li>
               Direct <code>aria-owns</code> relationship:
               <!-- ReSpec needs these examples to be unindented. -->
-              <pre>
+              <pre class="example highlight html">
 &lt;div role="listbox" aria-owns="id1"&gt;&lt;/div&gt;
 &lt;div role="option" id="id1"&gt;option text&lt;/div&gt;</pre
               >
@@ -1234,7 +1234,7 @@
             <li>
               <code>aria-owns</code> relationship with generics intervening:
               <!-- ReSpec needs these examples to be unindented. -->
-              <pre>
+              <pre class="example highlight html">
 &lt;div role="listbox" aria-owns="id1"&gt;&lt;/div&gt;
 &lt;div id="id1"&gt;
 	&lt;div&gt;
@@ -2213,7 +2213,7 @@
               element with role <code>caption</code>.
             </p>
 
-            <pre class="example highlight">
+            <pre class="example highlight html">
 					&lt;div role="radiogroup" aria-labelledby="cap"&gt;
 				    &lt;div role="caption" id="cap"&gt;
 				      Choose your favorite fruit
@@ -2228,7 +2228,7 @@
               <code>caption</code> that represents the descriptive content.
             </p>
 
-            <pre class="example highlight">
+            <pre class="example highlight html">
 					&lt;div role="table" aria-labelledby="name" aria-describedby="desc"&gt;
 				    &lt;div role="caption"&gt;
 				      &lt;div id="name"&gt;Contest Entrants&lt;/div&gt;
@@ -2247,7 +2247,7 @@
               <pref>aria-details</pref> to reference an element within the <code>caption</code> that represents the descriptive content.
             </p>
 
-            <pre class="example highlight">
+            <pre class="example highlight html">
 					&lt;div role="figure" aria-labelledby="name" aria-details="details"&gt;
 					  &lt;!-- figure content here, such as a complex data viz SVG -->
 				    &lt;div role="caption"&gt;
@@ -2269,7 +2269,7 @@
               <pref>aria-details</pref>.
             </p>
 
-            <pre class="example highlight">
+            <pre class="example highlight html">
 					&lt;div role="figure" aria-label="Sales information" aria-details="details"&gt;
 					  &lt;!-- figure content here, such as a complex data viz SVG -->
 				    &lt;div role="caption" id="details"&gt;
@@ -2852,7 +2852,7 @@
                 <rref>button</rref> from its descendant content.
               </li>
             </ul>
-            <pre class="example highlight">
+            <pre class="example highlight html">
           &lt;label id="tag_label" for="tag_combo">Tag&lt;/label>
 		      &lt;input type="text" id="tag_combo"
             role="combobox" aria-autocomplete="list"
@@ -3666,7 +3666,7 @@
                 In the following example, the first text field will receive initial focus when the dialog is rendered. As this means focus will be set "after" the preceding content that provides
                 instructions for the form fields, an <code>aria-describedby</code> attribute is used to expose this content as a description for the <code>dialog</code>.
               </p>
-              <pre>
+              <pre class="example highlight html">
 &lt;div role="dialog" aria-labelledby="h" aria-describedby="d" aria-modal="true" ...>
   &lt;h2 id="h">Add Shipping Address&lt;/h2>
   &lt;p id="d">By placing an order on this website, you acknowledge we will be sending you tons of junk mail for you to immediately recycle. Thanks!&lt;/p>
@@ -6059,7 +6059,7 @@
               </p>
             </div>
             <h4><abbr title="Mathematical Markup Language">MathML</abbr> Example with Embedded TeX Annotation</h4>
-            <pre class="example highlight">
+            <pre class="example highlight xml">
 					&lt;!-- Note: Use a JavaScript polyfill library to ensure
 					     this renders in user agents that do not support MathML. --&gt;
 					&lt;!-- The math element has an implicit role="math". --&gt;
@@ -6103,7 +6103,7 @@
               If a rendering engine does not support a native math format such as MathML, authors MAY use JavaScript to downgrade the content to a format the browser can display, such as this HTML
               image using a data URI and plain text alternative.
             </p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 					&lt;img role="math" src="..." alt="x=&#x27ee;&#x2212;b&#x00B1;&#8730;&#x27ee;b²&#x2212;4ac&#x27ef;&#x27ef;&#247;2a"&gt;
 				</pre
             >
@@ -6963,7 +6963,7 @@
             </p>
             <p>For example, the following two markup snippets will be exposed similarly to an accessibility <abbr title="Application Programing Interface">API</abbr>.</p>
             <pre
-              class="example highlight"
+              class="example highlight html"
             ><span class="comment">&lt;!-- 1. role="none" negates the implicit 'heading' role semantics but does not affect the contents, including the nested hyperlink. --&gt;</span>
 &lt;h1 role="none"&gt; Sample Content &lt;a href="...">let's go!&lt;/a> &lt;/h1&gt;
 
@@ -6983,7 +6983,7 @@
               In the following code sample, the containing <rref>img</rref> and is appropriately labeled by the caption paragraph. In this example the <code>img</code> element can be marked as
               <rref>none</rref>/<rref>presentation</rref> because the role and the text alternatives are provided by the containing element.
             </p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 &lt;div role="img" aria-labelledby="caption"&gt;
   &lt;img src="example.png" role="none" alt=""&gt;
   &lt;p id="caption"&gt;A visible text caption labeling the image.&lt;/p&gt;
@@ -6994,7 +6994,7 @@
               <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role of <rref>none</rref>/<rref>presentation</rref> to override the user agent's implicit native semantics for list
               items.
             </p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 &lt;ul role="tree"&gt;
   &lt;li role="none"&gt;
 	&lt;a role="treeitem" aria-expanded="true"&gt;An expanded tree node&lt;/a&gt;
@@ -7036,7 +7036,7 @@
               For example, according to an accessibility <abbr title="Application Programing Interface">API</abbr>, the following markup elements might have identical or very similar role semantics
               (generic or none role) and identical content.
             </p>
-            <pre class="example highlight"><span class="comment">&lt;!-- 1. [role="none"] negates the implicit 'list' and 'listitem' role semantics but does not affect the contents. --&gt;</span>
+            <pre class="example highlight html"><span class="comment">&lt;!-- 1. [role="none"] negates the implicit 'list' and 'listitem' role semantics but does not affect the contents. --&gt;</span>
 &lt;ul role="none"&gt;
   &lt;li&gt; Sample Content &lt;/li&gt;
   &lt;li&gt; More Sample Content &lt;/li&gt;
@@ -7157,7 +7157,7 @@
               When used within the normal flow of a page's content, a <code>note</code> has an implicit association with the content that it supplements. The following example demonstrates using a
               <code>note</code> to call out additional information in the natural reading order of a page:
             </p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 					&lt;p>... the following results outline support for the tested features.&lt;/p>
 					&lt;div role="note">
 					  &lt;p>Please keep in mind that at the time of publishing this page all results were accurate.&lt;/p>
@@ -7174,7 +7174,7 @@
               <li>If the <code>note</code> contains structured or interactive content (for example, a link, button, list, table, etc.) use <pref>aria-details</pref>.</li>
               <li>If the <code>note</code> is brief and consists of static text, use <pref>aria-describedby</pref>.</li>
             </ul>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 				  &lt;!-- using aria-details to reference a note containing a link -->
 				  ...
 					&lt;button aria-details="info-note">Get Started&lt;/button>
@@ -9930,7 +9930,7 @@
               Authors MAY use <pref>aria-details</pref> or <pref>aria-description</pref> to associate the <code>suggestion</code> with related information such as comments, authoring info, and time
               stamps.
             </p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 						&lt;p&gt;
 						  The best pet is a
 						  &lt;span role="suggestion"&gt;
@@ -10761,7 +10761,7 @@
 				<p>Authors SHOULD NOT use the <code>text</code> role on interactive controls (buttons, links, etc.) or ancestors of those controls, because it could prevent users of assistive technologies from accessing the controls. Authors wishing to retain the semantics of subtree contents could consider the ARIA 1.0 <rref>presentation</rref> or ARIA 1.1 <rref>none</rref> role instead.</p>
 				<div class="note">
 					<p>As with any ARIA 1.1 role, authors can provide a fallback ARIA 1.0 role.</p>
-					<pre class="example highlight">
+					<pre class="example highlight html">
 						&lt;p&gt;I &lt;span role="text img" aria-label="love"&gt;♥︎&lt;/span&gt; New York.&lt;/p&gt;
 						&lt;p&gt;My &lt;span role="text img" aria-label="heart"&gt;♥︎&lt;/span&gt; bleeds.&lt;/p&gt;
 						&lt;p&gt;&lt;span role="text img" aria-label="3 of 5 stars"&gt;★★★☆☆︎&lt;/span&gt;&lt;/p&gt;
@@ -10770,14 +10770,14 @@
 				</div>
 				<div class="note">
 					<p>It is not necessary to use the fallback role if the implicit role for the element provides sufficient fallback. In this example, an ARIA 1.0-capable browser would not recognize the "text" role token, and fall back to the default image role.</p>
-					<pre class="example highlight">
+					<pre class="example highlight html">
 						&lt;p&gt;I &lt;img src="icon.gif" alt="love" role="text"&gt; New York.︎&lt;/p&gt;
 						&lt;p&gt;My &lt;img src="icon.gif" alt="heart" role="text"&gt; bleeds.︎&lt;/p&gt;
 					</pre>
 				</div>
 				<div class="note">
 					<p>The text role can also be used to flatten structural semantics without providing an explicit label. The following example would be presented to assistive technologies as one static text element ("I like turtles") rather than three separate paragraphs.</p>
-					<pre class="example highlight">
+					<pre class="example highlight html">
 						&lt;div role="text"&gt;
 						  &lt;p&gt;I&lt;/p&gt;
 						  &lt;p&gt;like&lt;/p&gt;
@@ -10785,7 +10785,7 @@
 						&lt;/div&gt;
 					</pre>
 					<p>Use caution when using the text role on structural elements. In particular, avoid using the text role on elements with interactive descendants.</p>
-					<pre class="example highlight">
+					<pre class="example highlight html">
 						&lt;p role="text"&gt;
 						  &lt;!&dash;&dash; Example of incorrect usage. &dash;&dash;&gt;
 						  This &lt;a href="#"&gt;link&lt;/a&gt; becomes presentational, so
@@ -11977,7 +11977,7 @@
             <h4>Example Attribute Usage</h4>
             <aside class="example">
               <!-- ReSpec needs these examples to be unindented. -->
-              <pre>
+              <pre class="example highlight javascript">
 // HTML hidden="" example (not aria-hidden="true")
 // Actual boolean type; defaults to false.
 
@@ -11992,7 +11992,7 @@ el.hidden; // false</pre
             </aside>
             <aside class="example">
               <!-- ReSpec needs these examples to be unindented. -->
-              <pre>
+              <pre class="example highlight javascript">
 // aria-busy example
 // true/false ~ boolean-like nullable string; returns null unless set
 
@@ -12013,7 +12013,7 @@ el.ariaBusy; // "busy"</pre
             </aside>
             <aside class="example">
               <!-- ReSpec needs these examples to be unindented. -->
-              <pre>
+              <pre class="example highlight javascript">
 // aria-pressed example
 // Tristate ~ true/false/mixed/undefined string; null if unspecified
 
@@ -12485,7 +12485,7 @@ button.ariaPressed; // null</pre
               <li>Otherwise, pass the value to the user without translation.</li>
             </ol>
             <p>The following example shows the use of <code>aria-braillelabel</code> to customize a button's name in braille output.</p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 &lt;button aria-braillelabel="****"&gt;
   &lt;img alt="4 stars" src="images/stars.jpg"&gt;
 &lt;/button&gt;</pre
@@ -12599,13 +12599,13 @@ button.ariaPressed; // null</pre
               The following two examples show the use of <code>aria-brailleroledescription</code> to abbreviate the role of a repeated non-interactive "slide" container in a web-based presentation
               application.
             </p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 &lt;div role="article" aria-roledescription="slide" aria-brailleroledescription="sld" id="slide" aria-labelledby="slideheading"&gt;
 &lt;h1 id="slideheading">Quarterly Report&lt;/h1&gt;
 &lt;!-- remaining slide contents --&gt;
 &lt;/div&gt;</pre
             >
-            <pre class="example highlight">
+            <pre class="example highlight html">
 &lt;article aria-roledescription="slide" aria-brailleroledescription="sld" id="slide" aria-labelledby="slideheading"&gt;
 &lt;h1 id="slideheading">Quarterly Report&lt;/h1&gt;
 &lt;!-- remaining slide contents --&gt;
@@ -12810,7 +12810,7 @@ button.ariaPressed; // null</pre
               value of <pref>aria-colcount</pref> to <code>-1</code> to indicate that the value should not be calculated by the user agent.
             </p>
             <p>The following example shows a grid with 16 columns, of which columns 2, 3, 4, and 9 are displayed to the user.</p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 &lt;div role="grid" <strong>aria-colcount="16"</strong>&gt;
   &lt;div role="rowgroup"&gt;
     &lt;div role="row"&gt;
@@ -12894,7 +12894,7 @@ button.ariaPressed; // null</pre
               The following example shows a grid with 16 columns, of which columns 2 through 5 are displayed to the user. Because the set of columns is contiguous, <pref>aria-colindex</pref> can be
               placed on each row.
             </p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 &lt;div role="grid" aria-colcount="16"&gt;
   &lt;div role="rowgroup"&gt;
     &lt;div role="row" <strong>aria-colindex="2"</strong>&gt;
@@ -12925,7 +12925,7 @@ button.ariaPressed; // null</pre
               The following example shows a grid with 16 columns, of which columns 2 through 5 are displayed to the user. While the set of columns is contiguous, some of the cells span multiple rows.
               As a result, <pref>aria-colindex</pref> needs to be placed on all of the <a>accessibility children</a> of each row.
             </p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 &lt;div role="grid" aria-colcount="16"&gt;
   &lt;div role="rowgroup"&gt;
     &lt;div role="row"&gt;
@@ -12954,7 +12954,7 @@ button.ariaPressed; // null</pre
               The following example shows a grid with 16 columns, of which columns 2, 3, 4, and 9 are displayed to the user. Because the set of columns is non-contiguous,
               <pref>aria-colindex</pref> needs to be placed on all of the <a>accessibility children</a> of each row.
             </p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 &lt;div role="grid" aria-colcount="16"&gt;
   &lt;div role="rowgroup"&gt;
     &lt;div role="row"&gt;
@@ -13403,7 +13403,7 @@ button.ariaPressed; // null</pre
               A common use for <code>aria-details</code> is in digital publishing where an extended description needs to be conveyed in a book that requires structural markup or the embedding of other
               technology to provide illustrative content. The following example demonstrates this scenario.
             </p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
                                 &lt;!-- Provision of an extended description --&gt;
                                 &lt;img src="pythagorean.jpg" alt="Pythagorean Theorem" aria-details="det"&gt;
                                 &lt;details id="det"&gt;
@@ -13428,7 +13428,7 @@ button.ariaPressed; // null</pre
 				</pre
             >
             <p>Alternatively, <code>aria-details</code> can refer to a link to a web page having the extended description, as shown in the following example.</p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
                                 &lt;!-- Provision of an extended description --&gt;
                                 &lt;img src="pythagorean.jpg" alt="Pythagorean Theorem" aria-details="det"&gt;
                                 &lt;p&gt;
@@ -13660,7 +13660,7 @@ button.ariaPressed; // null</pre
               <q>Invalid time: the time must be between 9:00 AM and 5:00 PM.</q> The following example code shows markup for an initial valid state and for a subsequent invalid state. Note the changes
               to <sref>aria-invalid</sref> on the text input <a>object</a>, and to <pref>aria-live</pref> on the <a>element</a> containing the text of the error message:
             </p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 				&lt;!-- Initial valid state --&gt;
 				&lt;label for="startTime"&gt; Please enter a start time for the meeting: &lt;/label&gt;
 				&lt;input id="startTime" type="text" aria-errormessage="msgID" value="" aria-invalid="false"&gt;
@@ -14876,13 +14876,13 @@ button.ariaPressed; // null</pre
             </p>
             <p class="note">The following examples do not use the HTML <code>label</code> element as it cannot be used to label HTML elements with <code>contenteditable</code>.</p>
             <p>The following example shows a <rref>searchbox</rref> in which the user has entered a value:</p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 &lt;span id="label"&gt;Birthday:&lt;/span&gt;
 &lt;div contenteditable role="searchbox" aria-labelledby="label" <strong>aria-placeholder="MM-DD-YYYY"</strong>&gt;03-14-1879&lt;/div&gt;
 				</pre
             >
             <p>The following example shows the same <rref>searchbox</rref> in which the user has not yet entered a value or has removed a previously-entered value:</p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 &lt;span id="label"&gt;Birthday:&lt;/span&gt;
 &lt;div contenteditable role="searchbox" aria-labelledby="label" <strong>aria-placeholder="MM-DD-YYYY"</strong>&gt;MM-DD-YYYY&lt;/div&gt;
 				</pre
@@ -14931,7 +14931,7 @@ button.ariaPressed; // null</pre
               of an element's position.
             </p>
             <p>The following example shows items 5 through 8 in a set of 16.</p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 &lt;h2 id="label_fruit"&gt; Available Fruit &lt;/h2&gt;
 &lt;ul role="listbox" aria-labelledby="label_fruit"&gt;
   &lt;li role="option" aria-setsize="16" <strong>aria-posinset="5"</strong>&gt; apples &lt;/li&gt;
@@ -15332,13 +15332,13 @@ button.ariaPressed; // null</pre
               <rref>button</rref> SHOULD allow those functions to navigate to regions and buttons that have an <code>aria-roledescription</code>.
             </p>
             <p>The following two examples show the use of <code>aria-roledescription</code> to indicate that a non-interactive container is a "slide" in a web-based presentation application.</p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 &lt;div role="article" aria-roledescription="slide" id="slide" aria-labelledby="slideheading"&gt;
 &lt;h1 id="slideheading">Quarterly Report&lt;/h1&gt;
 &lt;!-- remaining slide contents --&gt;
 &lt;/div&gt;</pre
             >
-            <pre class="example highlight">
+            <pre class="example highlight html">
 &lt;article aria-roledescription="slide" id="slide" aria-labelledby="slideheading"&gt;
 &lt;h1 id="slideheading">Quarterly Report&lt;/h1&gt;
 &lt;!-- remaining slide contents --&gt;
@@ -15390,7 +15390,7 @@ button.ariaPressed; // null</pre
               of <pref>aria-rowcount</pref> to <code>-1</code> to indicate that the value should not be calculated by the user agent.
             </p>
             <p>The following example shows a grid with 2000 rows, of which the first row and rows 100 through 102 are displayed to the user.</p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 &lt;div role="grid" <strong>aria-rowcount="2000"</strong>&gt;
   &lt;div role="rowgroup"&gt;
     &lt;div role="row" aria-rowindex="1"&gt;
@@ -15472,7 +15472,7 @@ button.ariaPressed; // null</pre
             </p>
             <p>Authors SHOULD place <pref>aria-rowindex</pref> on each row. Authors MAY also place <pref>aria-rowindex</pref> on all of the <a>accessibility children</a> of each row.</p>
             <p>The following example shows a grid with 2000 rows, of which the first row and rows 100 through 102 are displayed to the user.</p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 &lt;div role="grid" aria-rowcount="2000"&gt;
   &lt;div role="rowgroup"&gt;
     &lt;div role="row" <strong>aria-rowindex="1"</strong>&gt;
@@ -15505,7 +15505,7 @@ button.ariaPressed; // null</pre
 &lt;/div&gt;</pre
             >
             <p>The following example shows the grid from the previous example with <pref>aria-rowindex</pref> also placed on all of the <a>accessibility children</a> of each row.</p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 &lt;div role="grid" aria-rowcount="2000"&gt;
   &lt;div role="rowgroup"&gt;
     &lt;div role="row" <strong>aria-rowindex="1"</strong>&gt;
@@ -15749,7 +15749,7 @@ button.ariaPressed; // null</pre
               <code>aria-setsize</code> based on the total number of items in the <rref>menu</rref>, excluding any separators.
             </p>
             <p>The following example shows items 5 through 8 in a set of 16.</p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 &lt;h2 id="label_fruit"&gt; Available Fruit &lt;/h2&gt;
 &lt;ul role="listbox" aria-labelledby="label_fruit"&gt;
   &lt;li role="option" <strong>aria-setsize="16"</strong> aria-posinset="5"&gt; apples &lt;/li&gt;
@@ -15759,7 +15759,7 @@ button.ariaPressed; // null</pre
 &lt;/ul&gt;</pre
             >
             <p>The following example shows items 5 through 8 in a set whose total size is unknown.</p>
-            <pre class="example highlight">
+            <pre class="example highlight html">
 &lt;h2 id="label_fruit"&gt; Available Fruit &lt;/h2&gt;
 &lt;ul role="listbox" aria-labelledby="label_fruit"&gt;
   &lt;li role="option" <strong>aria-setsize="-1"</strong> aria-posinset="5"&gt; apples &lt;/li&gt;
@@ -16162,7 +16162,7 @@ button.ariaPressed; // null</pre
           <li>All DOM elements whose corresponding <a>accessible object</a> have been reparented in the <a>accessibility tree</a> via <pref>aria-owns</pref>.</li>
         </ul>
         <p>In the following example, the <rref>list</rref> element has four accessibility children:</p>
-        <pre class="example highlight">
+        <pre class="example highlight html">
 &lt;div role="list" aria-owns="child3 child4"&gt;
   &lt;div role="listitem"&gt;Accessibility Child 1&lt;/div&gt;
   &lt;div&gt;
@@ -16179,7 +16179,7 @@ button.ariaPressed; // null</pre
           In the following example, the first <rref>list</rref> element has no accessibility children, where as the second <rref>list</rref> element has one accessibility child, specifically the
           <rref>listitem</rref> with ID value "reparented".
         </p>
-        <pre class="example highlight">
+        <pre class="example highlight html">
 &lt;div role="list"&gt;
   &lt;div role="listitem" aria-hidden="true"&gt;Excluded element&lt;/div&gt;
   &lt;div role="listitem" id="reparented"&gt;Reparented element&lt;/div&gt;
@@ -16204,13 +16204,13 @@ button.ariaPressed; // null</pre
           </li>
         </ul>
         <p>The following four examples all contain a <rref>listitem</rref> element with an accessibility parent of role <rref>list</rref>:</p>
-        <pre class="example highlight">
+        <pre class="example highlight html">
 &lt;div role="list"&gt;
   &lt;div role="listitem"&gt;The "list" is my accessibility parent.&lt;/div&gt;
 &lt;/div&gt;
           </pre
         >
-        <pre class="example highlight">
+        <pre class="example highlight html">
 &lt;div role="list"&gt;
   &lt;div&gt;
     &lt;div role="listitem"&gt;The "list" is my accessibility parent.&lt;/div&gt;
@@ -16218,12 +16218,12 @@ button.ariaPressed; // null</pre
 &lt;/div&gt;
           </pre
         >
-        <pre class="example highlight">
+        <pre class="example highlight html">
 &lt;div role="list" aria-owns="child"&gt;&lt;/div&gt;
 &lt;div id="child" role="listitem"&gt;The "list" is my accessibility parent.&lt;/div&gt;
           </pre
         >
-        <pre class="example highlight">
+        <pre class="example highlight html">
 &lt;div role="list" aria-owns="child"&gt;&lt;/div&gt;
 &lt;div id="child"&gt;
   &lt;div role="listitem"&gt;The "list" is my accessibility parent.&lt;/div&gt;
@@ -16693,7 +16693,7 @@ button.ariaPressed; // null</pre
           For example, <pref>aria-describedby</pref> is a global attribute and would always be applied; <pref>aria-level</pref> is not a global attribute and would therefore only apply if the element
           was not in a presentational state.
         </p>
-        <pre class="example highlight">
+        <pre class="example highlight html">
 <span class="comment">&lt;!-- 1. [role="none"] is ignored due to the global aria-describedby property. --&gt;</span>
 &lt;h1 role="none" aria-describedby="comment-1"&gt; Sample Content &lt;/h1&gt;
 <span class="comment">&lt;!-- 2. [role="none"] negates both the implicit 'heading' and the non-global aria-level. --&gt;</span>
@@ -17046,12 +17046,12 @@ button.ariaPressed; // null</pre
         <p>The primary purpose of ARIA IDL attribute reflection is to ease JavaScript-based manipulation of values. The following examples demonstrate its usage.</p>
         <aside class="example">
           <!-- ReSpec needs these examples to be unindented. -->
-          <pre>
+          <pre class="example highlight html">
 &lt;div id="inaccessibleButton"&gt;
     &lt;!-- Use semantic markup instead. This is just a retrofit example. --&gt;
 &lt;/div&gt;</pre
           >
-          <pre>
+          <pre class="example highlight javascript">
 // Get a reference to the element.
 let el = document.getElementById('inaccessibleButton');
 el.tabIndex = 0; // Make it focusable.


### PR DESCRIPTION
Adds classes to avoid incorrect language detection by highlightjs.

Part of #2462


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2480.html" title="Last updated on Mar 20, 2025, 6:42 PM UTC (2e532e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2480/bf8e158...2e532e8.html" title="Last updated on Mar 20, 2025, 6:42 PM UTC (2e532e8)">Diff</a>