### PR TITLE
use `css` class for highlighting css code examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -792,7 +792,7 @@
           language.
         </p>
         <p>
-          If a CSS selector includes a WAI-ARIA attribute (e.g., <code class="highlight lang-css">input[aria-invalid="true"]</code>), user agents MUST update the visual display of any elements
+          If a CSS selector includes a WAI-ARIA attribute (e.g., <code class="highlight css">input[aria-invalid="true"]</code>), user agents MUST update the visual display of any elements
           matching (or no longer matching) the selector any time the attribute is added/changed/removed in the <abbr title="Document Object Model">DOM</abbr>. The user agent MAY alter the mapping of
           the host language features into an <a>accessibility <abbr title="Application Programming Interface">API</abbr></a
           >, but the user agent MUST NOT alter the <abbr title="Document Object Model">DOM</abbr> in order to remap <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> markup into host
@@ -912,7 +912,7 @@
           information, reducing the amount of scripts necessary to achieve equivalent functionality. In the following example, a <abbr title="Cascading Style Sheets">CSS</abbr> selector is used to
           determine whether or not the text is bold and an image of a check mark is shown, based on the value of the <sref>aria-checked</sref> attribute.
         </p>
-        <pre class="example highlight lang-css">
+        <pre class="example highlight css">
 [aria-checked=&quot;true&quot;] { font-weight: bold; }
 [aria-checked=&quot;true&quot;]::before { background-image: url(checked.gif); }</pre
         >


### PR DESCRIPTION
I commented [in #2480](https://github.com/w3c/aria/pull/2480#discussion_r2006120768) about the `lang-css` highlight class failing, but I wasn't clear enough about the problem. So this fixes it in a separate PR.

The `lang-css` class doesn't seem to be working to highlight CSS. This PR changes this to use the `css` class instead.

**Before**:

![a screenshot of a section of the ARIA spec where a CSS code example is displayed, with no syntax highlighting](https://github.com/user-attachments/assets/f9f98fa2-c375-4900-9b72-c61b056c6b2c)


**After**:

![a screenshot of the same section, from this preview PR spec where the CSS code example is properly syntax highlighting](https://github.com/user-attachments/assets/128af297-2bc2-4942-be95-5c1bd13846b9)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/keithamus/aria/pull/2482.html" title="Last updated on Mar 20, 2025, 6:58 PM UTC (00bfd2d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2482/a813b21...keithamus:00bfd2d.html" title="Last updated on Mar 20, 2025, 6:58 PM UTC (00bfd2d)">Diff</a>