### PR TITLE
Editorial: Fix several instances of incorrect 'i.e.' and 'e.g.' references missing commas

### DIFF
--- a/index.html
+++ b/index.html
@@ -1052,7 +1052,7 @@
                   set <abbr title="Document Object Model">DOM</abbr> focus to the element that has the <pref>aria-activedescendant</pref> attribute.
                   <p class="note">
                     An element with an ID can be referenced when it is an <a>accessibility descendant</a> of a container element that has the <pref>aria-activedescendant</pref> attribute or by a
-                    container element that is controlled by an element that has the <pref>aria-activedescendant</pref> attribute (e.g. see <rref>combobox</rref>). Otherwise the
+                    container element that is controlled by an element that has the <pref>aria-activedescendant</pref> attribute (e.g., see <rref>combobox</rref>). Otherwise the
                     <pref>aria-activedescendant</pref> attribute reference indicates an author error.
                   </p>
                   <p class="note">The inability to set <abbr title="Document Object Model">DOM</abbr> focus to the containing element indicates an author error.</p>
@@ -2596,7 +2596,7 @@
             <p>
               The primary purpose of the code role is to inform assistive technologies that the content is computer code and thus might require special presentation, in particular with respect to
               synthesized speech. More specifically, screen readers and other tools which provide text-to-speech presentation of content SHOULD prefer full punctuation verbosity to ensure common
-              symbols (e.g. "-") are spoken.
+              symbols (e.g., "-") are spoken.
             </p>
           </div>
           <table class="def">
@@ -14287,7 +14287,7 @@ button.ariaPressed; // null</pre
             <p>
               Most host languages provide an attribute that could be used to name the element (e.g., the <code>[^html-global/title^]</code> attribute in HTML), yet this could present a browser
               tooltip. In the cases where DOM content or a tooltip is undesirable, authors MAY set the accessible name of the element using <pref>aria-label</pref>, if the element does not
-              <a href="#prohibitedattributes">prohibit</a> use of the attribute. If the label text is available in the DOM (i.e. typically visible text content), authors SHOULD use
+              <a href="#prohibitedattributes">prohibit</a> use of the attribute. If the label text is available in the DOM (i.e., typically visible text content), authors SHOULD use
               <pref>aria-labelledby</pref> and SHOULD NOT use <pref>aria-label</pref>. There might be instances where the name of an element cannot be determined programmatically from the DOM, and
               there are cases where referencing DOM content is not the desired user experience. Authors MUST NOT specify <code>aria-label</code> on an element which has an explicit or implicit
               WAI-ARIA role where <code>aria-label</code> is <a href="#prohibitedattributes">prohibited</a>. As required by the
@@ -17018,7 +17018,7 @@ button.ariaPressed; // null</pre
               example, the only valid spelling for "multi-selectable" is hyphenated, so <pref>aria-multiselectable</pref> becomes <code>ariaMultiSelectable</code> with both the M and S capitalized.
             </li>
             <li>
-              When trusted dictionary sources list both hyphenated or non-hyphenated spellings (e.g. "multi-line" and "multiline" are both valid spellings) use the hyphenated version and apply the
+              When trusted dictionary sources list both hyphenated or non-hyphenated spellings (e.g., "multi-line" and "multiline" are both valid spellings) use the hyphenated version and apply the
               hyphenation rule above. For example, <pref>aria-multiline</pref> becomes <code>ariaMultiLine</code> with both the M and L capitalized.
             </li>
             <li>
@@ -17026,7 +17026,7 @@ button.ariaPressed; // null</pre
               “place-holder” nor “place holder” are considered valid spellings of the term “placeholder,” so <pref>aria-placeholder</pref> becomes <code>ariaPlaceholder</code> with only the P
               capitalized.
             </li>
-            <li>There are currently no acronym-based ARIA attributes, but if future attributes include acronym usage, attempt to match existing DOM conventions (e.g. ID becomes Id).</li>
+            <li>There are currently no acronym-based ARIA attributes, but if future attributes include acronym usage, attempt to match existing DOM conventions (e.g., ID becomes Id).</li>
           </ul>
         </section>
         <section class="informative" id="idl_attr_exceptions">


### PR DESCRIPTION
The following i.e. and e.g. references were missing a comma and this PR adds them:

- [if the element does not [prohibit](https://w3c.github.io/aria/#prohibitedattributes) use of the attribute. If the label text is available in the DOM (i.e. typically visible text]
- [container element that is controlled by an element that has the [aria-activedescendant](https://w3c.github.io/aria/#aria-activedescendant) attribute (e.g. see [combobox](https://w3c.github.io/aria/#combobox)).]
- [SHOULD prefer full punctuation verbosity to ensure common symbols (e.g. "-") are spoken]
- [When trusted dictionary sources list both hyphenated or non-hyphenated spellings (e.g. "multi-line" 
- [but if future attributes include acronym usage, attempt to match existing DOM conventions (e.g. ID becomes Id).]]