### PR TITLE
Editorial: Update accname step 2E (Host Language Label) to specify empty string treatment

### DIFF
--- a/accname/index.html
+++ b/accname/index.html
@@ -629,7 +629,7 @@
                   <span id="step2E"><!-- Don't link to this legacy numbered ID. --></span><em>Host Language Label:</em> Otherwise, if the <code>current node</code>'s native markup provides an
                   [=attribute=] (e.g. <code>alt</code>) or [=element=] (e.g. HTML <code>label</code> or SVG <code>title</code>) that defines a text alternative, return that alternative in the form of
                   a <code>flat string</code> as defined by the host language, unless the <code>current node</code> is exposed as presentational (<code>role="presentation"</code> or
-                  <code>role="none"</code>).
+                  <code>role="none"</code>) or the empty string holds meaning (i.e., <code>alt=""</code> is treated as decorative).
                   <div class="note">
                     See <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a>,
                     <a href="https://www.w3.org/TR/svg-aam-1.0/#mapping_additional_nd">SVG-AAM</a>, or other host language documentation for more information on markup that defines a text alternative.


### PR DESCRIPTION
Closes https://github.com/w3c/accname/issues/234.

This PR clarifies that the empty string is special as part of host language label calculation.
