### PR TITLE
editorial: clarify RFC terms

### DIFF
--- a/dpub-aam/index.html
+++ b/dpub-aam/index.html
@@ -228,19 +228,13 @@
       <section id="mapping_general">
         <h3>General rules for exposing <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> semantics</h3>
 
-        <p>
-          This section MUST conform to <a class="core-mapping" data-cite="core-aam-1.1#mapping_general">General rules for exposing WAI-ARIA semantics</a> in
-          [[!CORE-AAM-1.1]].
-        </p>
+        <p>This section MUST conform to <a class="core-mapping" data-cite="core-aam-1.1#mapping_general">General rules for exposing WAI-ARIA semantics</a> in [[!CORE-AAM-1.1]].</p>
       </section>
     </section>
     <section id="mapping_conflicts">
       <h2>Conflicts between native markup semantics and <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr></h2>
 
-      <p>
-        User agents MUST conform to <a class="core-mapping" data-cite="core-aam-1.1#mapping_conflicts">Conflicts between native markup semantics and WAI-ARIA</a> in
-        [[!CORE-AAM-1.1]].
-      </p>
+      <p>User agents MUST conform to <a class="core-mapping" data-cite="core-aam-1.1#mapping_conflicts">Conflicts between native markup semantics and WAI-ARIA</a> in [[!CORE-AAM-1.1]].</p>
     </section>
     <section id="mapping_nodirect">
       <h2>Exposing attributes that do not directly map to accessibility <abbr title="application programming interface">API</abbr> properties</h2>
@@ -267,8 +261,8 @@
         <h3>General Rules</h3>
 
         <p>
-          User agents MUST conform to the Role Mapping <a class="core-mapping" data-cite="core-aam-1.1#roleMappingGeneralRules">General Rules</a> accessibility API
-          computational requirements in [[!CORE-AAM-1.1]].
+          User agents MUST conform to the Role Mapping <a class="core-mapping" data-cite="core-aam-1.1#roleMappingGeneralRules">General Rules</a> accessibility API computational requirements in
+          [[!CORE-AAM-1.1]].
         </p>
       </section>
 
@@ -2599,8 +2593,7 @@
         <h3>Relations</h3>
 
         <p>
-          User agents MUST conform to the <a data-cite="core-aam-1.1#mapping_additional_relations" class="core-mapping">Relation</a> accessibility API computational
-          requirements in [[!CORE-AAM-1.1]].
+          User agents MUST conform to the <a data-cite="core-aam-1.1#mapping_additional_relations" class="core-mapping">Relation</a> accessibility API computational requirements in [[!CORE-AAM-1.1]].
         </p>
       </section>
 
@@ -2608,18 +2601,15 @@
         <h3>Group Position</h3>
 
         <p>
-          User agents MUST conform to the <a data-cite="core-aam-1.1#mapping_additional_position" class="core-mapping">Group Position</a> accessibility API computational
-          requirements in [[!CORE-AAM-1.1]].
+          User agents MUST conform to the <a data-cite="core-aam-1.1#mapping_additional_position" class="core-mapping">Group Position</a> accessibility API computational requirements in
+          [[!CORE-AAM-1.1]].
         </p>
       </section>
     </section>
     <section id="mapping_actions">
       <h2>Actions</h2>
 
-      <p>
-        User agents MUST conform to the <a data-cite="core-aam-1.1#mapping_actions" class="core-mapping">Actions</a> accessibility API computational requirements in
-        [[!CORE-AAM-1.1]].
-      </p>
+      <p>User agents MUST conform to the <a data-cite="core-aam-1.1#mapping_actions" class="core-mapping">Actions</a> accessibility API computational requirements in [[!CORE-AAM-1.1]].</p>
     </section>
     <section id="mapping_events">
       <h2>Events</h2>

--- a/dpub-aam/index.html
+++ b/dpub-aam/index.html
@@ -192,22 +192,13 @@
       </p>
     </section>
     <section id="conformance" class="normative">
-      <section id="rfc-2119-keywords">
-        <h3>RFC-2119 Keywords</h3>
-
-        <p>
-          RFC-2119 keywords are formatted in uppercase and contained in a <code>strong</code> element with <code>class="rfc2119"</code>. When the keywords shown above are used, but do not share this
-          format, they do not convey formal information in the RFC 2119 sense, and are merely explanatory (i.e., informative). As much as possible, such usages are avoided in this specification.
-        </p>
-      </section>
-
       <section id="normative-and-informative-sections">
         <h3>Normative and Informative Sections</h3>
 
         <p>The indication whether a section is normative or non-normative (informative) applies to the entire section including sub-sections.</p>
 
         <p>
-          Informative sections provide information useful to understanding the specification. Such sections may contain examples of recommended practice, but it is not required to follow such
+          Informative sections provide information useful to understanding the specification. Such sections can contain examples of recommended practice, but it is not required to follow such
           recommendations in order to conform to this specification.
         </p>
       </section>
@@ -227,7 +218,7 @@
       <h2>Supporting keyboard navigation</h2>
 
       <p>
-        Enabling keyboard navigation in web applications is a necessary step toward making accessible web applications possible. Conforming [=user agents=] <span class="rfc2119">MUST</span> conform to
+        Enabling keyboard navigation in web applications is a necessary step toward making accessible web applications possible. Conforming [=user agents=] MUST conform to
         <a class="core-mapping" data-cite="core-aam-1.1#keyboard-focus">Supporting Keyboard Navigation</a> requirements in [[!CORE-AAM-1.1]].
       </p>
     </section>
@@ -238,7 +229,7 @@
         <h3>General rules for exposing <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> semantics</h3>
 
         <p>
-          This section <span class="rfc2119">MUST</span> conform to <a class="core-mapping" data-cite="core-aam-1.1#mapping_general">General rules for exposing WAI-ARIA semantics</a> in
+          This section MUST conform to <a class="core-mapping" data-cite="core-aam-1.1#mapping_general">General rules for exposing WAI-ARIA semantics</a> in
           [[!CORE-AAM-1.1]].
         </p>
       </section>
@@ -247,7 +238,7 @@
       <h2>Conflicts between native markup semantics and <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr></h2>
 
       <p>
-        User agents <span class="rfc2119">MUST</span> conform to <a class="core-mapping" data-cite="core-aam-1.1#mapping_conflicts">Conflicts between native markup semantics and WAI-ARIA</a> in
+        User agents MUST conform to <a class="core-mapping" data-cite="core-aam-1.1#mapping_conflicts">Conflicts between native markup semantics and WAI-ARIA</a> in
         [[!CORE-AAM-1.1]].
       </p>
     </section>
@@ -255,7 +246,7 @@
       <h2>Exposing attributes that do not directly map to accessibility <abbr title="application programming interface">API</abbr> properties</h2>
 
       <p>
-        User agents <span class="rfc2119">MUST</span> conform to
+        User agents MUST conform to
         <a class="core-mapping" data-cite="core-aam-1.1#mapping_nodirect"
           >Exposing attributes that do not directly map to accessibility <abbr title="application programming interface">API</abbr> properties</a
         >
@@ -267,7 +258,7 @@
 
       <p>
         Platform <a class="termref">accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a> traditionally have had a finite set of predefined <a class="termref">roles</a> that
-        are expected by <a class="termref">assistive technologies</a> on that platform and only one or two roles may be exposed. In contrast,
+        are expected by <a class="termref">assistive technologies</a> on that platform and only one or two roles are usually exposed. In contrast,
         <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> allows multiple roles to be specified as an ordered set of space-separated valid role tokens. The additional roles are
         fallback roles similar to the concept of specifying multiple fonts in case the first choice font type is not supported.
       </p>
@@ -276,7 +267,7 @@
         <h3>General Rules</h3>
 
         <p>
-          User agents <span class="rfc2119">MUST</span> conform to the Role Mapping <a class="core-mapping" data-cite="core-aam-1.1#roleMappingGeneralRules">General Rules</a> accessibility API
+          User agents MUST conform to the Role Mapping <a class="core-mapping" data-cite="core-aam-1.1#roleMappingGeneralRules">General Rules</a> accessibility API
           computational requirements in [[!CORE-AAM-1.1]].
         </p>
       </section>
@@ -2574,7 +2565,7 @@
         attribute value is the same as the <a data-cite="html#language">language</a> and <a data-cite="html#the-directionality">directionality</a> of the element [[html]].
       </p>
 
-      <p>To be understandable by assistive technology users, the following <code>role</code> mapping values intended for human consumption should be translated when a page is localized:</p>
+      <p>To be understandable by assistive technology users, the following <code>role</code> mapping values intended for human consumption SHOULD be translated when a page is localized:</p>
 
       <ul>
         <li>AXRoleDescription</li>
@@ -2588,7 +2579,7 @@
 
       <p>
         This section describes how to expose <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> <a class="termref">states</a> and object
-        <a class="termref" data-cite="wai-aria#dfn-property">properties</a>. User agents <span class="rfc2119">MUST</span> conform to the
+        <a class="termref" data-cite="wai-aria#dfn-property">properties</a>. User agents MUST conform to the
         <a data-cite="core-aam-1.1#mapping_state-property" class="core-mapping">State and Property Mapping</a> accessibility API computational requirements in [[!CORE-AAM-1.1]].
       </p>
     </section>
@@ -2608,7 +2599,7 @@
         <h3>Relations</h3>
 
         <p>
-          User agents <span class="rfc2119">MUST</span> conform to the <a data-cite="core-aam-1.1#mapping_additional_relations" class="core-mapping">Relation</a> accessibility API computational
+          User agents MUST conform to the <a data-cite="core-aam-1.1#mapping_additional_relations" class="core-mapping">Relation</a> accessibility API computational
           requirements in [[!CORE-AAM-1.1]].
         </p>
       </section>
@@ -2617,7 +2608,7 @@
         <h3>Group Position</h3>
 
         <p>
-          User agents <span class="rfc2119">MUST</span> conform to the <a data-cite="core-aam-1.1#mapping_additional_position" class="core-mapping">Group Position</a> accessibility API computational
+          User agents MUST conform to the <a data-cite="core-aam-1.1#mapping_additional_position" class="core-mapping">Group Position</a> accessibility API computational
           requirements in [[!CORE-AAM-1.1]].
         </p>
       </section>
@@ -2626,7 +2617,7 @@
       <h2>Actions</h2>
 
       <p>
-        User agents <span class="rfc2119">MUST</span> conform to the <a data-cite="core-aam-1.1#mapping_actions" class="core-mapping">Actions</a> accessibility API computational requirements in
+        User agents MUST conform to the <a data-cite="core-aam-1.1#mapping_actions" class="core-mapping">Actions</a> accessibility API computational requirements in
         [[!CORE-AAM-1.1]].
       </p>
     </section>
@@ -2635,7 +2626,7 @@
 
       <p>
         [=user agents=] fire <a class="termref">events</a> for user actions, <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref">state</a> changes, changes to
-        document content or node visibility, changes in selection, and operation of menus. Conforming [=user agents=] <span class="rfc2119">MUST</span> support the [[!CORE-AAM-1.1]]
+        document content or node visibility, changes in selection, and operation of menus. Conforming [=user agents=] MUST support the [[!CORE-AAM-1.1]]
         <a class="core=mappings" data-cite="core-aam-1.1#mapping_events">Events</a> mappings.
       </p>
     </section>

--- a/index.html
+++ b/index.html
@@ -792,9 +792,9 @@
           language.
         </p>
         <p>
-          If a CSS selector includes a WAI-ARIA attribute (e.g., <code class="highlight css">input[aria-invalid="true"]</code>), user agents MUST update the visual display of any elements
-          matching (or no longer matching) the selector any time the attribute is added/changed/removed in the <abbr title="Document Object Model">DOM</abbr>. The user agent MAY alter the mapping of
-          the host language features into an <a>accessibility <abbr title="Application Programming Interface">API</abbr></a
+          If a CSS selector includes a WAI-ARIA attribute (e.g., <code class="highlight css">input[aria-invalid="true"]</code>), user agents MUST update the visual display of any elements matching (or
+          no longer matching) the selector any time the attribute is added/changed/removed in the <abbr title="Document Object Model">DOM</abbr>. The user agent MAY alter the mapping of the host
+          language features into an <a>accessibility <abbr title="Application Programming Interface">API</abbr></a
           >, but the user agent MUST NOT alter the <abbr title="Document Object Model">DOM</abbr> in order to remap <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> markup into host
           language features.
         </p>


### PR DESCRIPTION
- Removes extraneous RFC section (since one is added automatically). 
- Removes extraneus span's with rfc class (which is added automatically) 
- Capitalizes 1x should.
- Replaces 2x "may" with alternative phrasing.

Via w3c/dpub-aam#44


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2488.html" title="Last updated on Mar 26, 2025, 3:02 PM UTC (e8bae65)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2488/e5f0305...e8bae65.html" title="Last updated on Mar 26, 2025, 3:02 PM UTC (e8bae65)">Diff</a>