### PR TITLE
editorial: fix 2 links to dpub-aria

### DIFF
--- a/dpub-aam/index.html
+++ b/dpub-aam/index.html
@@ -2355,7 +2355,7 @@
               <tr>
                 <th>DPUB-ARIA Specification</th>
                 <td>
-                  <a class="dpub-role-reference" href="#doc-preface"><code>doc-qna</code></a>
+                  <a class="dpub-role-reference" href="#doc-qna"><code>doc-qna</code></a>
                 </td>
               </tr>
               <tr>
@@ -2409,7 +2409,7 @@
               <tr>
                 <th>DPUB-ARIA Specification</th>
                 <td>
-                  <a class="dpub-role-reference" href="#doc-preface"><code>doc-subtitle</code></a>
+                  <a class="dpub-role-reference" href="#doc-subtitle"><code>doc-subtitle</code></a>
                 </td>
               </tr>
               <tr>

--- a/index.html
+++ b/index.html
@@ -792,9 +792,9 @@
           language.
         </p>
         <p>
-          If a CSS selector includes a WAI-ARIA attribute (e.g., <code class="highlight css">input[aria-invalid="true"]</code>), user agents MUST update the visual display of any elements
-          matching (or no longer matching) the selector any time the attribute is added/changed/removed in the <abbr title="Document Object Model">DOM</abbr>. The user agent MAY alter the mapping of
-          the host language features into an <a>accessibility <abbr title="Application Programming Interface">API</abbr></a
+          If a CSS selector includes a WAI-ARIA attribute (e.g., <code class="highlight css">input[aria-invalid="true"]</code>), user agents MUST update the visual display of any elements matching (or
+          no longer matching) the selector any time the attribute is added/changed/removed in the <abbr title="Document Object Model">DOM</abbr>. The user agent MAY alter the mapping of the host
+          language features into an <a>accessibility <abbr title="Application Programming Interface">API</abbr></a
           >, but the user agent MUST NOT alter the <abbr title="Document Object Model">DOM</abbr> in order to remap <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> markup into host
           language features.
         </p>


### PR DESCRIPTION
Looks like old copy & paste errors.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2492.html" title="Last updated on Mar 25, 2025, 4:31 PM UTC (dd2f6ab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2492/e5f0305...dd2f6ab.html" title="Last updated on Mar 25, 2025, 4:31 PM UTC (dd2f6ab)">Diff</a>