### PR TITLE
Normative update: if a tab is active a corresponding tabpanel must be rendered

### DIFF
--- a/index.html
+++ b/index.html
@@ -10233,7 +10233,7 @@
               for details on implementing a tab set design pattern.
             </p>
             <p>Authors MUST ensure [=elements=] with <a>role</a> <rref>tab</rref> are <a>accessibility children</a> of an element with the role <rref>tablist</rref>.</p>
-	    <p>Authors MUST ensure that if a <code>tab</code> is active, a corresponding <code>tabpanel</code> element that represents the active <code>tab</code> is rendered.</p>
+            <p>Authors MUST ensure that if a <code>tab</code> is active, a corresponding <code>tabpanel</code> element that represents the active <code>tab</code> is rendered.</p>
             <p>Authors SHOULD ensure the <rref>tabpanel</rref> associated with the currently active tab is <a>perceivable</a> to the user.</p>
             <!-- keep following para synced with its counterpart in #tablist -->
             <p>
@@ -10463,8 +10463,8 @@
               tabpanel. For a multi-selectable <rref>tablist</rref>, authors SHOULD ensure that the <rref>tab</rref> for each visible <rref>tabpanel</rref> has the <sref>aria-expanded</sref>
               <a>attribute</a> set to <code>true</code>, and that the <code>tabs</code> associated with the remaining [=element/hidden from all users=] <code>tabpanel</code> elements have their
               <sref>aria-expanded</sref> attributes set to <code>false</code>.
-            </p>  
-	
+            </p>
+
             <!-- keep following para synced with its counterpart in #tabpanel -->
             <p>
               <rref>tablist</rref> elements are typically placed near, and usually preceding, a series of <rref>tabpanel</rref> elements. See the

--- a/index.html
+++ b/index.html
@@ -10233,7 +10233,7 @@
               for details on implementing a tab set design pattern.
             </p>
             <p>Authors MUST ensure [=elements=] with <a>role</a> <rref>tab</rref> are <a>accessibility children</a> of an element with the role <rref>tablist</rref>.</p>
-            <p>Authors MUST ensure that if a <code>tab</code> is active, a corresponding <code>tabpanel</code> element that represents the active <code>tab</code> is rendered.</p>
+            <p>Authors MUST ensure that if a <code>tab</code> is active, a corresponding <code>tabpanel</code> that represents the active <code>tab</code> is rendered.</p>
             <p>Authors SHOULD ensure the <rref>tabpanel</rref> associated with the currently active tab is <a>perceivable</a> to the user.</p>
             <!-- keep following para synced with its counterpart in #tablist -->
             <p>

--- a/index.html
+++ b/index.html
@@ -10233,6 +10233,7 @@
               for details on implementing a tab set design pattern.
             </p>
             <p>Authors MUST ensure [=elements=] with <a>role</a> <rref>tab</rref> are <a>accessibility children</a> of an element with the role <rref>tablist</rref>.</p>
+	    <p>Authors MUST ensure that if a <code>tab</code> is active, a corresponding <code>tabpanel</code> element that represents the active <code>tab</code> is rendered.</p>
             <p>Authors SHOULD ensure the <rref>tabpanel</rref> associated with the currently active tab is <a>perceivable</a> to the user.</p>
             <!-- keep following para synced with its counterpart in #tablist -->
             <p>
@@ -10462,11 +10463,11 @@
               tabpanel. For a multi-selectable <rref>tablist</rref>, authors SHOULD ensure that the <rref>tab</rref> for each visible <rref>tabpanel</rref> has the <sref>aria-expanded</sref>
               <a>attribute</a> set to <code>true</code>, and that the <code>tabs</code> associated with the remaining [=element/hidden from all users=] <code>tabpanel</code> elements have their
               <sref>aria-expanded</sref> attributes set to <code>false</code>.
-            </p>
-
+            </p>  
+	
             <!-- keep following para synced with its counterpart in #tabpanel -->
             <p>
-              <rref>tablist</rref> elements are typically placed near usually preceding, a series of <rref>tabpanel</rref> elements. See the
+              <rref>tablist</rref> elements are typically placed near, and usually preceding, a series of <rref>tabpanel</rref> elements. See the
               <cite
                 ><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">ARIA</abbr> Authoring Practices Guide</a></cite
               >
@@ -10572,7 +10573,7 @@
             </p>
             <!-- keep following para synced with its counterpart in #tablist -->
             <p>
-              <rref>tablist</rref> elements are typically placed near, usually preceding, a series of <rref>tabpanel</rref> elements. See the
+              <rref>tablist</rref> elements are typically placed near, and usually preceding, a series of <rref>tabpanel</rref> elements. See the
               <cite
                 ><a href="" class="practices"><abbr title="Accessible Rich Internet Applications">ARIA</abbr> Authoring Practices Guide</a></cite
               >


### PR DESCRIPTION
closes #2497 initial stab at creating the new author must requirement so that if there is an activate tab, a corresponding tabpanel element must be rendered.

question is should this requirement be copied over to tabpanel as well?  i assume yes, but will wait to be told that before i add in more dupe content between these rules.

I've removed the checks for this PR that I don't think are applicable.  this should really just be an author requirement that should be picked up by a11y checkers / code validators

* [ ] "author MUST" tests:
* [X] Related APG Issue/PR: not necessary, basically indicates this
* [X] MDN Issue/PR: not necessay, basically indicates this


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2500.html" title="Last updated on Apr 17, 2025, 7:17 PM UTC (1e32f94)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2500/ab288d2...1e32f94.html" title="Last updated on Apr 17, 2025, 7:17 PM UTC (1e32f94)">Diff</a>