### PR TITLE
editorial: update html-aam note

### DIFF
--- a/accname/index.html
+++ b/accname/index.html
@@ -642,7 +642,7 @@
                   a <code>flat string</code> as defined by the host language, unless the <code>current node</code> is exposed as presentational (<code>role="presentation"</code> or
                   <code>role="none"</code>).
                   <div class="note">
-                    Important! The accessible name for native HTML elements may be calculated a little differently. See <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a> for more information for how markup define a text alternative.
+                    Important! The accessible name for native HTML elements may be calculated differently. See <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a> for more information.
                   </div>
                   <div class="note">
                     <p>

--- a/accname/index.html
+++ b/accname/index.html
@@ -642,7 +642,7 @@
                   a <code>flat string</code> as defined by the host language, unless the <code>current node</code> is exposed as presentational (<code>role="presentation"</code> or
                   <code>role="none"</code>).
                   <div class="note">
-                    Important! The accessible name for native HTML elements may be calculated differently. See <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a> for more information.
+                    Important! The accessible name for native HTML elements may be calculated differently. Make sure to review <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a> for more information.
                   </div>
                   <div class="note">
                     <p>

--- a/accname/index.html
+++ b/accname/index.html
@@ -642,7 +642,7 @@
                   a <code>flat string</code> as defined by the host language (e.g., <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a>), unless the
                   <code>current node</code> is exposed as presentational (<code>role="presentation"</code> or <code>role="none"</code>).
                   <div class="note">
-                    Important! The accessible name for native HTML elements may be calculated differently. Make sure to review
+                    Important! The accessible name for native HTML elements may be calculated differently depending on host language. Make sure to review
                     <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a> for more information.
                   </div>
                   <div class="note">

--- a/accname/index.html
+++ b/accname/index.html
@@ -642,7 +642,7 @@
                   a <code>flat string</code> as defined by the host language, unless the <code>current node</code> is exposed as presentational (<code>role="presentation"</code> or
                   <code>role="none"</code>).
                   <div class="note">
-                    Important! HTML may calculate the accessible name a little differently. See <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a> for more information on markup that defines a text alternative.
+                    Important! The accessible name for native HTML elements may be calculated a little differently. See <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a> for more information for how markup define a text alternative.
                   </div>
                   <div class="note">
                     <p>

--- a/accname/index.html
+++ b/accname/index.html
@@ -642,8 +642,7 @@
                   a <code>flat string</code> as defined by the host language, unless the <code>current node</code> is exposed as presentational (<code>role="presentation"</code> or
                   <code>role="none"</code>).
                   <div class="note">
-                    See <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a>,
-                    <a href="https://www.w3.org/TR/svg-aam-1.0/#mapping_additional_nd">SVG-AAM</a>, or other host language documentation for more information on markup that defines a text alternative.
+                    Important! HTML may calculate the accessible name a little differently. See <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a> for more information on markup that defines a text alternative.
                   </div>
                   <div class="note">
                     <p>

--- a/accname/index.html
+++ b/accname/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <head>
     <title>Accessible Name and Description Computation 1.2</title>

--- a/accname/index.html
+++ b/accname/index.html
@@ -639,10 +639,11 @@
                 <li id="comp_host_language_label">
                   <span id="step2E"><!-- Don't link to this legacy numbered ID. --></span><em>Host Language Label:</em> Otherwise, if the <code>current node</code>'s native markup provides an
                   [=attribute=] (e.g. <code>alt</code>) or [=element=] (e.g. HTML <code>label</code> or SVG <code>title</code>) that defines a text alternative, return that alternative in the form of
-                  a <code>flat string</code> as defined by the host language (e.g., <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a>), unless the <code>current node</code> is exposed as presentational (<code>role="presentation"</code> or
-                  <code>role="none"</code>).
+                  a <code>flat string</code> as defined by the host language (e.g., <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a>), unless the
+                  <code>current node</code> is exposed as presentational (<code>role="presentation"</code> or <code>role="none"</code>).
                   <div class="note">
-                    Important! The accessible name for native HTML elements may be calculated differently. Make sure to review <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a> for more information.
+                    Important! The accessible name for native HTML elements may be calculated differently. Make sure to review
+                    <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a> for more information.
                   </div>
                   <div class="note">
                     <p>

--- a/accname/index.html
+++ b/accname/index.html
@@ -639,7 +639,7 @@
                 <li id="comp_host_language_label">
                   <span id="step2E"><!-- Don't link to this legacy numbered ID. --></span><em>Host Language Label:</em> Otherwise, if the <code>current node</code>'s native markup provides an
                   [=attribute=] (e.g. <code>alt</code>) or [=element=] (e.g. HTML <code>label</code> or SVG <code>title</code>) that defines a text alternative, return that alternative in the form of
-                  a <code>flat string</code> as defined by the host language, unless the <code>current node</code> is exposed as presentational (<code>role="presentation"</code> or
+                  a <code>flat string</code> as defined by the host language (e.g., <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a>), unless the <code>current node</code> is exposed as presentational (<code>role="presentation"</code> or
                   <code>role="none"</code>).
                   <div class="note">
                     Important! The accessible name for native HTML elements may be calculated differently. Make sure to review <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a> for more information.

--- a/accname/index.html
+++ b/accname/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <head>
     <title>Accessible Name and Description Computation 1.2</title>


### PR DESCRIPTION
Closes [AccName 250](https://github.com/w3c/accname/issues/250)

I am making this change in an effort to make it more obvious that readers should be checking HTML-AAM in specific instances. Due to the recent issues filed against SVG-AAM wherein it's made clear that SVG-AAM should be referring to AccName instead, I've removed the note's reference to SVG-AAM.

Before: 
> See [HTML-AAM](https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation), [SVG-AAM](https://www.w3.org/TR/svg-aam-1.0/#mapping_additional_nd), or other host language documentation for more information on markup that defines a text alternative.

![CleanShot 2025-03-28 at 16 23 32@2x](https://github.com/user-attachments/assets/070cef78-4f46-4dd5-9d09-a34cc28493a0)

After: 
> Important! The accessible name for native HTML elements may be calculated differently. Make sure to review [HTML-AAM](https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation) for more information.

![CleanShot 2025-03-28 at 16 34 33@2x](https://github.com/user-attachments/assets/65917590-29de-4960-b628-b240f63d5bf2)
