### PR TITLE
Fix incorrect role specified for html element - 571

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -2974,7 +2974,7 @@
             </tr>
             <tr>
               <th>[[wai-aria-1.2]]</th>
-              <td><a class="core-mapping" href="#role-map-document">`document`</a> role</td>
+              <td><a class="core-mapping" href="#role-map-generic">`generic`</a> role</td>
             </tr>
             <tr>
               <th><a data-cite="core-aam-1.2/#roleMappingComputedRole">Computed Role</a></th>
@@ -3009,7 +3009,10 @@
             <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
             <tr>
               <th>Comments</th>
-              <td>User agents MUST ignore the `aria-hidden` attribute if specified on the `html` element.</td>
+              <td>
+                <p>User agents MUST ignore the `aria-hidden` attribute if specified on the `html` element.</p>
+                <p class="note">The `document` role of a web page is not exposed by the `html` element, but rather from a parent `document node` created by the user agent.</p>
+              </td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
closes #571

changes the listed mapping for the html element to be the generic role, rather than the document role.

A note is added to clarify the document role of a web page is exposed by a parent `document node` created by the user agent.

From what i can tell, no implementation bugs need to be filed, as browsers have been doing the right thing - and this is a spec correction to match reality.