### PR TITLE
Editorial: remove vague meaningful and parenthetical example (clone #2069)

### DIFF
--- a/index.html
+++ b/index.html
@@ -6977,7 +6977,7 @@
               accessibility guidelines for the image content.
             </p>
             <p>
-              Authors SHOULD NOT provide a meaningful text alternative (for example, use <code>alt=""</code> in HTML) when the <code>none</code>/<code>presentation</code> role is applied to an image.
+              Authors SHOULD NOT provide a non-empty text alternative when the <code>none</code>/<code>presentation</code> role is applied to an image.
             </p>
             <p>
               In the following code sample, the containing <rref>img</rref> and is appropriately labeled by the caption paragraph. In this example the <code>img</code> element can be marked as

--- a/index.html
+++ b/index.html
@@ -6976,9 +6976,7 @@
               object using an <code>&lt;object&gt;</code> or <code>&lt;iframe&gt;</code> <a>element</a>, or use inline <abbr title="Scalable Vector Graphics">SVG</abbr> code, and follow the
               accessibility guidelines for the image content.
             </p>
-            <p>
-              Authors SHOULD NOT provide a non-empty text alternative when the <code>none</code>/<code>presentation</code> role is applied to an image.
-            </p>
+            <p>Authors SHOULD NOT provide a non-empty text alternative when the <code>none</code>/<code>presentation</code> role is applied to an image.</p>
             <p>
               In the following code sample, the containing <rref>img</rref> and is appropriately labeled by the caption paragraph. In this example the <code>img</code> element can be marked as
               <rref>none</rref>/<rref>presentation</rref> because the role and the text alternatives are provided by the containing element.


### PR DESCRIPTION
Closes #????

Replacement of https://github.com/w3c/aria/pull/2069 to fix headache of merge conflicts
Following up on https://github.com/w3c/aria/pull/2062.
Closes https://github.com/w3c/aria/issues/2068


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2505.html" title="Last updated on Apr 1, 2025, 5:53 PM UTC (d5f5d9f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2505/f694d7c...d5f5d9f.html" title="Last updated on Apr 1, 2025, 5:53 PM UTC (d5f5d9f)">Diff</a>