### PR TITLE
Clarification: include aria-placeholder in accName steps for HTML input elements

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -16353,9 +16353,8 @@
               <a href="" class="accname">Accessible Name and Description: Computation and API Mappings</a>.
             </li>
             <li>
-              If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty: use the value of the associated
-              `label` element or elements <a data-cite="accname-1.2/#dfn-accessible-name">accessible name(s)</a> - if more than one 
-              `label` element is associated; concatenate by DOM order, delimited by spaces.
+              If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty: use the value of the associated `label` element or elements
+              <a data-cite="accname-1.2/#dfn-accessible-name">accessible name(s)</a> - if more than one `label` element is associated; concatenate by DOM order, delimited by spaces.
             </li>
             <li>If no associated `label` is specified: use the control's `title` attribute.</li>
             <li>If a `title` attribute provides no accessible name: use the value of the element's <a href="#att-placeholder">placeholder</a> attribute.</li>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -16353,11 +16353,17 @@
               <a href="" class="accname">Accessible Name and Description: Computation and API Mappings</a>.
             </li>
             <li>
-              If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty: use the value of the associated `label` element or elements
-              <a data-cite="accname-1.2/#dfn-accessible-name">accessible name(s)</a> - if more than one `label` element is associated; concatenate by DOM order, delimited by spaces.
+              If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty: use the 
+              <a data-cite="accname-1.2/#mapping_additional_nd_te">text equivalent computation</a> of the associated `label` element's subtree - if more than one `label` 
+              is associated; concatenate their subtrees by DOM order, delimited by spaces.
+              <p>
+                If the control is encapsulated by its `label` element, exclude the control's author specified or user-entered value from its computed
+                <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.
+              </p>
             </li>
-            <li>If no associated `label` is specified: use the control's `title` attribute.</li>
-            <li>If a `title` attribute provides no accessible name: use the value of the element's <a href="#att-placeholder">placeholder</a> attribute.</li>
+            <li>If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty: use the value of the control's `title` attribute.</li>
+            <li>If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty: use the value of the control's 
+              <a href="#att-placeholder">placeholder</a> attribute.</li>
             <li>Otherwise, use the value of the element's <a data-cite="wai-aria-1.2/#aria-placeholder">`aria-placeholder`</a> attribute.</li>
             <li>If none of the above yield a usable text string there is no <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.</li>
           </ol>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -16353,17 +16353,15 @@
               <a href="" class="accname">Accessible Name and Description: Computation and API Mappings</a>.
             </li>
             <li>
-              If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty: use the 
-              <a data-cite="accname-1.2/#mapping_additional_nd_te">text equivalent computation</a> of the associated `label` element's subtree - if more than one `label` 
-              is associated; concatenate their subtrees by DOM order, delimited by spaces.
+              If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty: use the <a data-cite="accname-1.2/#mapping_additional_nd_te">text equivalent computation</a> of
+              the associated `label` element's subtree - if more than one `label` is associated; concatenate their subtrees by DOM order, delimited by spaces.
               <p>
                 If the control is encapsulated by its `label` element, exclude the control's author specified or user-entered value from its computed
                 <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.
               </p>
             </li>
             <li>If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty: use the value of the control's `title` attribute.</li>
-            <li>If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty: use the value of the control's 
-              <a href="#att-placeholder">placeholder</a> attribute.</li>
+            <li>If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty: use the value of the control's <a href="#att-placeholder">placeholder</a> attribute.</li>
             <li>Otherwise, use the value of the element's <a data-cite="wai-aria-1.2/#aria-placeholder">`aria-placeholder`</a> attribute.</li>
             <li>If none of the above yield a usable text string there is no <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.</li>
           </ol>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -16353,11 +16353,13 @@
               <a href="" class="accname">Accessible Name and Description: Computation and API Mappings</a>.
             </li>
             <li>
-              Otherwise use the associated `label` element or elements <a data-cite="accname-1.2/#dfn-accessible-name">accessible name(s)</a> - if more than one `label` is associated; concatenate by
-              DOM order, delimited by spaces.
+              If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty: use the value of the associated
+              `label` element or elements <a data-cite="accname-1.2/#dfn-accessible-name">accessible name(s)</a> - if more than one 
+              `label` element is associated; concatenate by DOM order, delimited by spaces.
             </li>
-            <li>If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty, then: use the control's `title` attribute.</li>
-            <li>Otherwise use the control's <a href="#att-placeholder">placeholder</a> value.</li>
+            <li>If no associated `label` is specified: use the control's `title` attribute.</li>
+            <li>If a `title` attribute provides no accessible name: use the value of the element's <a href="#att-placeholder">placeholder</a> attribute.</li>
+            <li>Otherwise, use the value of the element's <a data-cite="wai-aria-1.2/#aria-placeholder">`aria-placeholder`</a> attribute.</li>
             <li>If none of the above yield a usable text string there is no <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.</li>
           </ol>
         </section>

--- a/index.html
+++ b/index.html
@@ -13681,9 +13681,15 @@ button.ariaPressed; // null</pre
           <sdef>aria-expanded</sdef>
           <div class="state-description">
             <p><a>Indicates</a> whether a related element is expanded (shown) or collapsed (hidden).</p>
-            <p>The <sref>aria-expanded</sref> attribute is applied to a focusable, interactive element that toggles visibility of content of a different element. If the element with <sref>aria-expanded</sref> is also a <rref>treeitem</rref> in a <rref>tree</rref> or a <rref>row</rref> in a <rref>treegrid</rref>, then it SHOULD also be the <a>accessibility parent</a> of the content it expands and collapses. Otherwise, the element with <sref>aria-expanded</sref> SHOULD NOT be the <a>accessibility parent</a> of the content that is expanding or collapsing. Rather, identify that relationship between the interactive element and the element being controlled using <pref>aria-controls</pref>.</p>
+            <p>
+              The <sref>aria-expanded</sref> attribute is applied to a focusable, interactive element that toggles visibility of content of a different element. If the element with
+              <sref>aria-expanded</sref> is also a <rref>treeitem</rref> in a <rref>tree</rref> or a <rref>row</rref> in a <rref>treegrid</rref>, then it SHOULD also be the
+              <a>accessibility parent</a> of the content it expands and collapses. Otherwise, the element with <sref>aria-expanded</sref> SHOULD NOT be the <a>accessibility parent</a> of the content
+              that is expanding or collapsing. Rather, identify that relationship between the interactive element and the element being controlled using <pref>aria-controls</pref>.
+            </p>
             <p>For example, <sref>aria-expanded</sref> is applied to a parent <rref>treeitem</rref> to indicate whether its child branch of the tree is shown.</p>
-            <pre class="example highlight">&lt;ul role="tree"&gt;
+            <pre class="example highlight">
+&lt;ul role="tree"&gt;
   &lt;li role="treeitem" aria-expanded="false" aria-selected="false"&gt;
     &lt;span&gt;Fruits&lt;/span&gt;
     &lt;ul role="group" hidden&gt;
@@ -13692,12 +13698,15 @@ button.ariaPressed; // null</pre
       &lt;li role="treeitem" aria-selected="false"&gt;Yuzu&lt;/li&gt;
     &lt;/ul&gt;
   &lt;/li&gt;
-&lt;/ul&gt;</pre>
+&lt;/ul&gt;</pre
+            >
             <p>Similarly, it can be applied to a <rref>button</rref> to control the visibility of another element and its content on the current page.</p>
-            <pre class="example highlight">&lt;button type="button" aria-controls="mangosteen" aria-expanded="false"&gt;Mangosteen&lt;/button&gt;
+            <pre class="example highlight">
+&lt;button type="button" aria-controls="mangosteen" aria-expanded="false"&gt;Mangosteen&lt;/button&gt;
 &lt;div id="mangosteen" hidden&gt;
   An edible fruit native to tropical lands surrounding the Indian Ocean.
-&lt;/div&gt;</pre>
+&lt;/div&gt;</pre
+            >
           </div>
           <table class="def">
             <caption>


### PR DESCRIPTION
Closes [#2529](https://github.com/w3c/aria/issues/2529)

clarifies that placeholder attribute value takes priority over aria-placeholder on HTML elements that allow for the use of these attributes.

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests:
* [X] Browser implementations (link to issue or commit): all browsers do this
   * WebKit:
   * Gecko:
   * Blink:
* [ ] Does this need AT implementations?
* [ ] Related APG Issue/PR:
* [ ] MDN Issue/PR:


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2530.html" title="Last updated on May 15, 2025, 5:18 PM UTC (29a2a5d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2530/b085915...29a2a5d.html" title="Last updated on May 15, 2025, 5:18 PM UTC (29a2a5d)">Diff</a>