### PR TITLE
Remove redundant UA CSS requirement

### DIFF
--- a/index.html
+++ b/index.html
@@ -792,9 +792,7 @@
           language.
         </p>
         <p>
-          If a CSS selector includes a WAI-ARIA attribute (e.g., <code class="highlight css">input[aria-invalid="true"]</code>), user agents MUST update the visual display of any elements matching (or
-          no longer matching) the selector any time the attribute is added/changed/removed in the <abbr title="Document Object Model">DOM</abbr>. The user agent MAY alter the mapping of the host
-          language features into an <a>accessibility <abbr title="Application Programming Interface">API</abbr></a
+          User agents MAY alter the mapping of host language features into an <a>accessibility <abbr title="Application Programming Interface">API</abbr></a
           >, but the user agent MUST NOT alter the <abbr title="Document Object Model">DOM</abbr> in order to remap <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> markup into host
           language features.
         </p>


### PR DESCRIPTION
closes #2521

removes the following from the spec:
>If a CSS selector includes a WAI-ARIA attribute (e.g.,
input[aria-invalid="true"]
), user agents MUST update the visual display of any elements matching (or no longer matching) the selector any time the attribute is added/changed/removed in the DOM.

as CSS already defines how UAs are to handle element/attribute selectors
