### PR TITLE
[Core-AAM] Update role=scrollbar AXAPI platform mappings

### DIFF
--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -4259,6 +4259,12 @@
                   ><br />
                   <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
                   ><br />
+                  <p>
+                    <span class="property">Property: <code>NSAccessibilityVerticalScrollBarAttribute</code>: pointer to accessible node matching IDREF of author-provided <code>aria-controls</code> for an element that represents a vertical scrollbar.</span>
+                  </p>
+                  <p>
+                    <span class="property">Property: <code>NSAccessibilityHorizontalScrollBarAttribute</code>: pointer to accessible node matching IDREF of author-provided <code>aria-controls</code> for an element that represents a horizontal scrollbar.</span>
+                  </p>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
Closes https://github.com/w3c/core-aam/issues/242

Update Core-AAM's role=scrollbar AXAPI mapping to use NSAccessibility scrollbar APIs where `aria-controls` is provided, e.g., https://developer.apple.com/documentation/appkit/nsaccessibility-swift.struct/attribute/verticalscrollbar?language=objc.

And a few other todo items (delete this section after performing them):
* [ ] For every spec that this PR edits, please add the appropriate `spec:<spec_name>` label. If you don't have privileges to do this, editors will do it for you.
* [ ] If the change is [editorial](https://github.com/w3c/aria/blob/main/documentation/process.md#editorial-changes), please add "Editorial:" at the start of your PR name, and delete the "Test, Documentation and Implementation tracking" section below.

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests:
* [ ] Browser implementations (link to issue or commit):
   * WebKit:
   * Gecko: n/a
   * Blink: n/a
* [ ] Does this need AT implementations? n/a
* [ ] Related APG Issue/PR: n/a
* [ ] MDN Issue/PR: n/a
