### PR TITLE
Editorial: de-duplicate table, fixing build

### DIFF
--- a/index.html
+++ b/index.html
@@ -16776,6 +16776,26 @@ button.ariaPressed; // null</pre
       Element includes ARIAMixin;
 		</pre>
 
+
+        <p>For every IDL attribute <var>idlAttribute</var> defined in <code>ARIAMixin</code> when included on an element:</p>
+
+        <ol>
+          <li>
+            <p>Let <var>contentAttributeName</var> be the local name of the ARIA content attribute determined by looking up <var>idlAttribute</var> in the ARIA Attribute Correspondence table.</p>
+          </li>
+
+          <li>
+            <p><var>idlAttribute</var> must [=reflect=] <var>contentAttributeName</var> and support {{ElementInternals}}.</p>
+          </li>
+        </ol>
+
+        <p class="note">
+          In practice, this means that, e.g., the <code>role</code> IDL attribute on <code>Element</code> reflects the <code>role</code> content attribute; the <code>ariaValueMin</code> IDL attribute
+          reflects the <pref>aria-valuemin</pref> content attribute; etc. Ambiguity clarifications (such as <code>ariaPosInSet</code>) are listed in
+          <a href="#idl_attr_exceptions">IDL Attribute Name Notes or Exceptions</a>.
+        </p>
+      </section>
+
     <section id="accessibilityroleandproperties-correspondence" class="normative" data-dfn-for="ARIAMixin" data-link-for="ARIAMixin">
       <h2>ARIA Attribute Correspondence</h2>
       <p>The following table provides a correspondence between IDL attribute names and content attribute names, for use by <code>ARIAMixin</code>. It also lists their correspondence to value type for informative purposes.</p>
@@ -16839,245 +16859,6 @@ button.ariaPressed; // null</pre
       </table>
 
       <p class="note">Note: Attributes <pref>aria-dropeffect</pref> and <sref>aria-grabbed</sref> were deprecated in ARIA 1.1 and do not have corresponding IDL attributes.</p>
-
-        <p>For every IDL attribute <var>idlAttribute</var> defined in <code>ARIAMixin</code> when included on an element:</p>
-
-        <ol>
-          <li>
-            <p>Let <var>contentAttributeName</var> be the local name of the ARIA content attribute determined by looking up <var>idlAttribute</var> in the ARIA Attribute Correspondence table.</p>
-          </li>
-
-          <li>
-            <p><var>idlAttribute</var> must [=reflect=] <var>contentAttributeName</var> and support {{ElementInternals}}.</p>
-          </li>
-        </ol>
-
-        <p class="note">
-          In practice, this means that, e.g., the <code>role</code> IDL attribute on <code>Element</code> reflects the <code>role</code> content attribute; the <code>ariaValueMin</code> IDL attribute
-          reflects the <pref>aria-valuemin</pref> content attribute; etc. Ambiguity clarifications (such as <code>ariaPosInSet</code>) are listed in
-          <a href="#idl_attr_exceptions">IDL Attribute Name Notes or Exceptions</a>.
-        </p>
-      </section>
-
-      <section id="accessibilityroleandproperties-correspondence" class="normative" data-dfn-for="ARIAMixin" data-link-for="ARIAMixin">
-        <h2>ARIA Attribute Correspondence</h2>
-        <p>The following table provides a correspondence between IDL attribute names and content attribute names, for use by <code>ARIAMixin</code>.</p>
-
-        <table class="def">
-          <tr>
-            <th>IDL Attribute</th>
-            <th>Reflected ARIA Content Attribute</th>
-          </tr>
-          <tr>
-            <td>role</td>
-            <td><a href="#introroles">role</a></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaActiveDescendantElement</dfn></td>
-            <td><pref>aria-activedescendant</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaAtomic</dfn></td>
-            <td><pref>aria-atomic</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaAutoComplete</dfn></td>
-            <td><pref>aria-autocomplete</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaBrailleLabel</dfn></td>
-            <td><pref>aria-braillelabel</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaBrailleRoleDescription</dfn></td>
-            <td><pref>aria-brailleroledescription</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaBusy</dfn></td>
-            <td><sref>aria-busy</sref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaChecked</dfn></td>
-            <td><sref>aria-checked</sref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaColCount</dfn></td>
-            <td><pref>aria-colcount</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaColIndex</dfn></td>
-            <td><pref>aria-colindex</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaColIndexText</dfn></td>
-            <td><pref>aria-colindextext</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaColSpan</dfn></td>
-            <td><pref>aria-colspan</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaControlsElements</dfn></td>
-            <td><pref>aria-controls</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaCurrent</dfn></td>
-            <td><sref>aria-current</sref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaDescribedByElements</dfn></td>
-            <td><pref>aria-describedby</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaDescription</dfn></td>
-            <td><pref>aria-description</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaDetailsElements</dfn></td>
-            <td><pref>aria-details</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaDisabled</dfn></td>
-            <td><sref>aria-disabled</sref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaErrorMessageElements</dfn></td>
-            <td><pref>aria-errormessage</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaExpanded</dfn></td>
-            <td><sref>aria-expanded</sref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaFlowToElements</dfn></td>
-            <td><pref>aria-flowto</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaHasPopup</dfn></td>
-            <td><pref>aria-haspopup</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaHidden</dfn></td>
-            <td><sref>aria-hidden</sref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaInvalid</dfn></td>
-            <td><sref>aria-invalid</sref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaKeyShortcuts</dfn></td>
-            <td><pref>aria-keyshortcuts</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaLabel</dfn></td>
-            <td><pref>aria-label</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaLabelledByElements</dfn></td>
-            <td><pref>aria-labelledby</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaLevel</dfn></td>
-            <td><pref>aria-level</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaLive</dfn></td>
-            <td><pref>aria-live</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaModal</dfn></td>
-            <td><pref>aria-modal</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaMultiLine</dfn></td>
-            <td><pref>aria-multiline</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaMultiSelectable</dfn></td>
-            <td><pref>aria-multiselectable</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaOrientation</dfn></td>
-            <td><pref>aria-orientation</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaOwnsElements</dfn></td>
-            <td><pref>aria-owns</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaPlaceholder</dfn></td>
-            <td><pref>aria-placeholder</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaPosInSet</dfn></td>
-            <td><pref>aria-posinset</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaPressed</dfn></td>
-            <td><sref>aria-pressed</sref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaReadOnly</dfn></td>
-            <td><pref>aria-readonly</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaRelevant</dfn></td>
-            <td><pref>aria-relevant</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaRequired</dfn></td>
-            <td><pref>aria-required</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaRoleDescription</dfn></td>
-            <td><pref>aria-roledescription</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaRowCount</dfn></td>
-            <td><pref>aria-rowcount</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaRowIndex</dfn></td>
-            <td><pref>aria-rowindex</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaRowIndexText</dfn></td>
-            <td><pref>aria-rowindextext</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaRowSpan</dfn></td>
-            <td><pref>aria-rowspan</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaSelected</dfn></td>
-            <td><sref>aria-selected</sref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaSetSize</dfn></td>
-            <td><pref>aria-setsize</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaSort</dfn></td>
-            <td><pref>aria-sort</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaValueMax</dfn></td>
-            <td><pref>aria-valuemax</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaValueMin</dfn></td>
-            <td><pref>aria-valuemin</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaValueNow</dfn></td>
-            <td><pref>aria-valuenow</pref></td>
-          </tr>
-          <tr>
-            <td><dfn>ariaValueText</dfn></td>
-            <td><pref>aria-valuetext</pref></td>
-          </tr>
-        </table>
-        <p class="note">Note: Attributes <pref>aria-dropeffect</pref> and <sref>aria-grabbed</sref> were deprecated in ARIA 1.1 and do not have corresponding IDL attributes.</p>
 
         <section class="informative" id="idl_attr_disambiguation">
           <h3>Disambiguation Pattern</h3>

--- a/index.html
+++ b/index.html
@@ -16800,7 +16800,7 @@ button.ariaPressed; // null</pre
       <h2>ARIA Attribute Correspondence</h2>
       <p>The following table provides a correspondence between IDL attribute names and content attribute names, for use by <code>ARIAMixin</code>. It also lists their correspondence to value type for informative purposes.</p>
 
-      <table>
+      <table class="def">
         <tr><th>IDL Attribute</th><th>Reflected ARIA Content Attribute</th><th>Value type (non-normative)</th></tr>
         <tr><td><dfn data-dfn-for="ARIAMixin">role</dfn></td><td><a href="#introroles">role</a></td><td><a href="#valuetype_token_list">token list</a></td></tr>
         <tr><td><dfn>ariaActiveDescendantElement</dfn></td><td><pref>aria-activedescendant</pref></td><td><a href="#valuetype_idref_list">ID reference list</a></td></tr>

--- a/index.html
+++ b/index.html
@@ -16842,7 +16842,7 @@ button.ariaPressed; // null</pre
         <tr><td><dfn>ariaPosInSet</dfn></td><td><pref>aria-posinset</pref></td><td><a href="#valuetype_integer">integer</a></td></tr>
         <tr><td><dfn>ariaPressed</dfn></td><td><sref>aria-pressed</sref></td><td><a href="#valuetype_tristate">tristate</a></td></tr>
         <tr><td><dfn>ariaReadOnly</dfn></td><td><pref>aria-readonly</pref></td><td><a href="#valuetype_true-false">true/false</a></td></tr>
-        <!-- <tr><td><dfn>ariaRelevant</dfn></td><td><pref>aria-relevant</pref></td></tr> -->
+        <tr><td><dfn>ariaRelevant</dfn></td><td><pref>aria-relevant</pref></td><td><a href="#valuetype_token_list">token list</a></td></tr>
         <tr><td><dfn>ariaRequired</dfn></td><td><pref>aria-required</pref></td><td><a href="#valuetype_true-false">true/false</a></td></tr>
         <tr><td><dfn>ariaRoleDescription</dfn></td><td><pref>aria-roledescription</pref></td><td><a href="#valuetype_string">string</a></td></tr>
         <tr><td><dfn>ariaRowCount</dfn></td><td><pref>aria-rowcount</pref></td><td><a href="#valuetype_integer">integer</a></td></tr>


### PR DESCRIPTION
Following #2105 there was a hidden merge conflict which ended up with the main branch having two tables for aria value correspondence. This PR collapses both tables into one.

It's probably best to ignore the diff as it's not clear on what is happening. Instead review 

https://w3c.github.io/aria/#accessibilityroleandproperties-correspondence 

against this PR's preview:

https://deploy-preview-2541--wai-aria.netlify.app/#accessibilityroleandproperties-correspondence


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/keithamus/aria/pull/2541.html" title="Last updated on May 29, 2025, 6:17 PM UTC (6835ac0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2541/395e7a6...keithamus:6835ac0.html" title="Last updated on May 29, 2025, 6:17 PM UTC (6835ac0)">Diff</a>