### PR TITLE
Add placeholder iOS mapping rows

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -349,10 +349,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -399,10 +403,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -456,12 +464,16 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXGroup`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"group"`</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -507,10 +519,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -557,10 +573,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -607,10 +627,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -659,10 +683,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -706,10 +734,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -759,12 +791,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -819,7 +858,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXGroup`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `AXAudio`</div>
@@ -831,7 +870,14 @@
                 </div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -876,12 +922,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -926,12 +979,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>Exposed by platform specific bold font weight text styles.</td>
@@ -976,12 +1036,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -1026,12 +1093,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>IA2/ATK: May affect on "writing-mode" text attribute on its text container.</td>
@@ -1076,12 +1150,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>IA2/ATK: Exposed as "writing-mode" text attribute on its text container.</td>
@@ -1126,12 +1207,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -1176,12 +1264,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>User agents MUST ignore the `aria-hidden` attribute if specified on the `body` element.</td>
@@ -1226,12 +1321,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>May be exposed as '\n' character by the platform interface.</td>
@@ -1276,12 +1378,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>
@@ -1330,14 +1439,21 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXGroup`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `""`</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -1393,7 +1509,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
                 <div class="relations">
@@ -1402,7 +1518,14 @@
                 </div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>If a descendant of a `table`, the first instance of a `caption` element will provide the `table` its accessible name.</td>
@@ -1447,14 +1570,21 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXGroup`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"group"`</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -1499,12 +1629,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -1549,12 +1686,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -1602,12 +1746,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -1652,12 +1803,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -1706,12 +1864,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>If `datalist` is not linked to a proper `input` element, then `datalist` element is not mapped to accessibility APIs.</td>
@@ -1759,12 +1924,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -1809,12 +1981,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -1865,12 +2044,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -1915,12 +2101,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -1965,12 +2158,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>See also the `dialog` element's <a href="#att-open-dialog">`open`</a> attribute.</td>
@@ -2015,12 +2215,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>The `dir` element is marked as obsolete in HTML, and is not to be used by authors.</td>
@@ -2065,12 +2272,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -2119,14 +2333,21 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXList`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `AXDefinitionList`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"definition list"`</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -2174,12 +2395,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -2224,12 +2452,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -2275,10 +2510,17 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>Depends on format of data file</td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -2327,7 +2569,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> Use WAI-ARIA mapping</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `AXFieldset`</div>
@@ -2336,7 +2578,14 @@
                 </div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -2386,14 +2635,21 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXGroup`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"group"`</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -2444,12 +2700,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -2492,12 +2755,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -2544,12 +2814,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>If a `footer` is not scoped to the `body` element, do not expose the element as a `contentinfo` landmark.</td>
@@ -2596,12 +2873,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>If a <a class="core-mapping" href="#role-map-form-nameless">`form` has no accessible name</a>, do not expose the element as a landmark.</td>
@@ -2646,12 +2930,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -2699,12 +2990,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -2749,12 +3047,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -2797,12 +3102,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -2849,12 +3161,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>If a `header` is not scoped to the `body` element, do not expose the element as a `banner` landmark.</td>
@@ -2899,12 +3218,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>
@@ -2952,12 +3278,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>
@@ -3004,12 +3337,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>User agents MUST ignore the `aria-hidden` attribute if specified on the `html` element.</td>
@@ -3054,12 +3394,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>Exposed by platform specific italic text styles.</td>
@@ -3104,12 +3451,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -3157,12 +3511,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>
@@ -3217,12 +3578,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>
@@ -3273,12 +3641,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -3330,12 +3705,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -3390,7 +3772,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">If implemented as a textbox:</div>
                 <div class="role"><span class="type">AXRole:</span> `AXTextField`</div>
@@ -3402,7 +3784,14 @@
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"color well"`</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>
@@ -3457,14 +3846,21 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXDateField`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"date field"`</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -3513,14 +3909,21 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXTextField`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"text field"`</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -3570,12 +3973,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -3634,14 +4044,21 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXButton`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `AXFileUploadButton`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `file upload button`</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -3687,12 +4104,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -3740,12 +4164,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -3791,14 +4222,21 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXTextField`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"text field"`</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -3854,12 +4292,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -3910,14 +4355,21 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXTextField`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `AXSecureTextField`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"secure text field"`</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -3972,12 +4424,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -4023,12 +4482,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -4076,12 +4542,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -4130,12 +4603,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -4183,12 +4663,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -4238,12 +4725,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -4292,12 +4786,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -4353,12 +4854,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -4414,14 +4922,21 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXTimeField`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"time field"`</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -4471,12 +4986,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -4523,14 +5045,21 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXTextField`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"text field"`</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -4575,12 +5104,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -4626,14 +5162,21 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXGroup`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"group"`</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -4699,14 +5242,21 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXGroup`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"group"`</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -4761,14 +5311,21 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXGroup`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"group"`</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -4817,12 +5374,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>
@@ -4870,12 +5434,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -4920,12 +5491,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -4972,7 +5550,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">
                   <span class="type">Role:</span> `AXImageMap` if used as an image map. Otherwise,<br />
@@ -4981,7 +5559,14 @@
                 </div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -5026,12 +5611,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -5070,10 +5662,17 @@
               <td>See comments</td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>See comments</td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>Mapping for `math` is defined by <a href="https://w3c.github.io/mathml-aam/">MathML AAM 1.0</a>.</td>
@@ -5118,12 +5717,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>
@@ -5176,12 +5782,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -5226,12 +5839,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -5276,12 +5896,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -5326,12 +5953,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -5385,10 +6019,17 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>Depends on format of data file.</td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -5433,12 +6074,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -5483,12 +6131,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -5539,12 +6194,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -5591,12 +6253,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>`AXDescription`: value from associated `label` element subtree.</td>
@@ -5645,12 +6314,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -5695,12 +6371,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>`param` is obsolete in HTML</td>
@@ -5745,12 +6428,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -5795,12 +6485,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -5850,12 +6547,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -5900,12 +6604,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>`::before` and `::after` CSS pseudo content is used by platforms to render the element's quotation marks.</td>
@@ -5953,10 +6664,17 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>Not mapped</td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -6004,14 +6722,21 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXGroup`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `AXRubyText`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"group"`</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -6057,14 +6782,21 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXGroup`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `AXRubyInline`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"group"`</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -6109,12 +6841,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -6159,12 +6898,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -6209,12 +6955,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -6259,12 +7012,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -6312,12 +7072,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -6366,12 +7133,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -6420,12 +7194,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -6470,12 +7251,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -6520,12 +7308,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>Exposed by platform specific font size styles.</td>
@@ -6570,12 +7365,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -6620,12 +7422,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -6670,12 +7479,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -6720,12 +7536,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>
@@ -6775,12 +7598,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -6840,14 +7670,21 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXDisclosureTriangle`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"disclosure triangle"`</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>
@@ -6895,12 +7732,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -6939,10 +7783,17 @@
               <td>See comments</td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>See comments</td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>Mapping for `svg` is defined by [[[svg-aam-1.0]]]. See also <a href="https://w3c.github.io/graphics-aam/#mapping_role_table">Graphics Accessibility API Role Mappings</a></td>
@@ -6981,10 +7832,17 @@
               <td>Use WAI-ARIA mapping</td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>Use WAI-ARIA mapping</td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -7023,10 +7881,17 @@
               <td>Use WAI-ARIA mapping</td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>Use WAI-ARIA mapping</td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -7072,12 +7937,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -7123,12 +7995,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -7173,12 +8052,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -7223,12 +8109,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -7273,12 +8166,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -7328,12 +8228,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -7387,12 +8294,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -7438,12 +8352,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -7489,12 +8410,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -7539,12 +8467,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -7589,12 +8524,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -7639,12 +8581,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>A `title` element provides the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> for its document.</td>
@@ -7689,12 +8638,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -7739,12 +8695,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -7789,12 +8752,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td>Exposed by platform specific underline text styles.</td>
@@ -7839,12 +8809,19 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -7889,14 +8866,21 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXGroup`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"group"`</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -7951,7 +8935,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXGroup`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `AXVideo`</div>
@@ -7963,7 +8947,14 @@
                 </div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -8008,14 +8999,21 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="role"><span class="type">AXRole:</span> `AXGroup`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"group"`</div>
               </td>
             </tr>
-            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
+            </tr>
+            <!-- <tr>
+              <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> 
+              <td></td>
+            </tr> -->
             <tr>
               <th>Comments</th>
               <td></td>
@@ -8087,8 +9085,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>`AXDescription: &lt;value&gt;`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -8136,10 +9138,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -8187,10 +9193,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -8242,8 +9252,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>`AXAccessKey: &lt;value&gt;`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -8291,10 +9305,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -8342,10 +9360,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -8393,10 +9415,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -8449,8 +9475,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>`AXDescription: &lt;value&gt;`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -8498,10 +9528,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -8549,10 +9583,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -8600,10 +9638,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -8658,10 +9700,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -8713,10 +9759,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -8762,10 +9812,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -8813,10 +9867,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -8865,10 +9923,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -8916,10 +9978,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -8961,8 +10027,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>`AXValue: 1`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -9007,8 +10077,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>`AXValue: 0`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -9060,8 +10134,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>`AXURL: &lt;value&gt;`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -9109,10 +10187,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="property"><span class="type">Property:</span> `AXDOMClassList`</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -9160,10 +10242,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -9211,8 +10297,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>`AXRangeForLine: &lt;value&gt;`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -9262,10 +10352,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -9333,10 +10427,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -9401,10 +10499,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -9457,10 +10559,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">See comments</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -9511,10 +10617,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -9590,12 +10700,16 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <span class="type">Role:</span>
                 <a href="#el-textarea">AXTextArea</a>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -9643,8 +10757,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>Controls exposed as `AXToolbar`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -9692,10 +10810,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Defines an accessible object's dimensions, exposed via `Frame` property</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -9745,10 +10867,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -9796,10 +10922,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -9847,8 +10977,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>`AXDateTimeValue: &lt;value&gt;`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -9896,8 +11030,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>`AXDateTimeValue: &lt;value&gt;`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -9945,10 +11083,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -9996,10 +11138,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -10047,10 +11193,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -10098,10 +11248,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -10149,10 +11303,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -10200,10 +11358,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -10254,10 +11416,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -10305,10 +11471,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -10351,8 +11521,12 @@
               <td>Not mapped</td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>Not mapped</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -10400,10 +11574,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -10451,10 +11629,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -10502,10 +11684,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -10553,10 +11739,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -10608,10 +11798,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -10673,10 +11867,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="name">Used for <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a></div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -10730,10 +11928,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -10785,10 +11987,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -10837,10 +12043,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -10889,10 +12099,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -10941,10 +12155,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -10993,10 +12211,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -11042,10 +12264,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -11097,8 +12323,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>Expose via `AXColumnHeaderUIElements` and `AXRowHeaderUIElements`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -11150,10 +12380,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Defines an accessible object's height (`AXSize` property)</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -11198,8 +12432,12 @@
               <td>Use WAI-ARIA mapping</td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>Use WAI-ARIA mapping</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -11243,10 +12481,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -11301,8 +12543,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>`AXURL: &lt;value&gt;`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -11350,10 +12596,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -11402,10 +12652,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -11453,10 +12707,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -11504,10 +12762,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="property"><span class="type">Property:</span> `AXDOMIdentifier`</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -11547,8 +12809,12 @@
               <td>See comments</td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>See comments</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -11596,8 +12862,12 @@
               <td>Use WAI-ARIA mapping</td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>Use WAI-ARIA mapping</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -11645,10 +12915,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -11696,10 +12970,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -11747,10 +13025,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -11798,10 +13080,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -11849,10 +13135,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -11900,10 +13190,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -11943,8 +13237,12 @@
               <td>Not mapped</td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>Not mapped</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -11994,8 +13292,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>`AXTitle`: `&lt;value&gt;`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -12046,8 +13348,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>`AXLanguage: &lt;value&gt;`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -12095,10 +13401,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Property: `AXLinkedUIElements`: point to the `datalist` element referred to by the IDREF value of the `list` attribute.</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -12147,10 +13457,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -12196,10 +13510,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -12245,8 +13563,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>`AXMaxValue: &lt;value&gt;`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -12293,8 +13615,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>`AXMaxValue: &lt;value&gt;`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -12341,10 +13667,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -12394,10 +13724,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -12445,10 +13779,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -12494,8 +13832,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>`AXMinValue: &lt;value&gt;`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -12541,8 +13883,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>`AXMinValue: &lt;value&gt;`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -12600,13 +13946,17 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="property">
                   <span class="type">Property:</span>
                   `AXInvalid`: `true` if value doesn't meet the designated minimum length value.
                 </div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -12654,10 +14004,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -12705,10 +14059,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -12757,10 +14115,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -12811,10 +14173,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -12862,10 +14228,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -12914,10 +14284,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -12965,10 +14339,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -13016,10 +14394,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -13067,10 +14449,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -13118,10 +14504,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -13169,10 +14559,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -13220,10 +14614,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -13270,8 +14668,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>`AXExpanded: YES|NO`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -13320,8 +14722,12 @@
               <td>Use WAI-ARIA mapping</td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>Use WAI-ARIA mapping</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -13375,10 +14781,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -13423,8 +14833,12 @@
               <td>Use WAI-ARIA mapping</td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>Use WAI-ARIA mapping</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -13472,10 +14886,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -13524,10 +14942,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -13580,10 +15002,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -13640,7 +15066,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 TBD
                 <!-- https://bugs.webkit.org/show_bug.cgi?id=271485 -->
@@ -13724,10 +15150,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -13788,10 +15218,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -13839,10 +15273,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -13890,10 +15328,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -13942,10 +15384,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -13996,10 +15442,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -14048,10 +15498,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -14100,10 +15554,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -14162,10 +15620,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Reverses the numerical or alphabetical order of the child list item markers.</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -14211,10 +15673,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -14263,10 +15729,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -14314,10 +15784,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -14366,10 +15840,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -14417,10 +15895,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -14468,10 +15950,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -14524,11 +16010,15 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped for `input` elements.</div>
                 <div class="general">For `select` element use WAI-ARIA mapping.</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -14579,10 +16069,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -14631,10 +16125,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -14682,10 +16180,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -14732,10 +16234,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">`AXColumnIndexRange.length: &lt;value>`</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -14783,10 +16289,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -14844,8 +16354,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>`AXURL: &lt;value&gt;` on <a href="#el-img">`img`</a> and <a href="#el-input-image">`input type="image"`</a></td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -14893,10 +16407,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -14944,10 +16462,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -14996,10 +16518,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not Mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -15047,10 +16573,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Changes the first number of the child list item accessible objects to match the `start` attribute's value.</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -15096,8 +16626,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>Not mapped</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -15145,10 +16679,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -15196,10 +16734,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -15251,10 +16793,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -15302,10 +16848,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -15353,10 +16903,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -15407,10 +16961,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -15464,8 +17022,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>`AXExpandedTextValue: &lt;value&gt;`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -15505,8 +17067,12 @@
               <td>Not mapped</td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>Not mapped</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -15552,10 +17118,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -15603,10 +17173,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -15655,10 +17229,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -15704,10 +17282,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general"><a href="#el-input-submit">`submit`</a> type may be a default button in the form.</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -15757,10 +17339,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -15818,7 +17404,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">
                   Defines the accessible role, states and other properties, refer to
@@ -15826,6 +17412,10 @@
                   etc.
                 </div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -15880,13 +17470,17 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Defines the list item marker, which is exposed as content in `AXValue`, and rendered as an <a class="termref">accessible object</a>:</div>
                 <div class="role"><span class="type">AXRole:</span> `AXListMarker`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"list marker"`</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -15941,10 +17535,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Responsible for image map creation.</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -15993,10 +17591,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -16044,10 +17646,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -16099,8 +17705,12 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>`AXValue: &lt;value&gt;`</td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -16151,13 +17761,17 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Exposed as `AXValue: &lt;value&gt;` with accessible object:</div>
                 <div class="role"><span class="type">AXRole:</span> `AXListMarker`</div>
                 <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `list marker`</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -16206,10 +17820,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">`AXValue: &lt;value&gt;`</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -16261,10 +17879,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <code>AXSize: w=<i>n</i></code>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>
@@ -16312,10 +17934,14 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">macOS AX</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
+            </tr>
+            <tr>
+              <th>iOS AX</th>
+              <td>TBD</td>
             </tr>
             <tr>
               <th>Comments</th>


### PR DESCRIPTION
We are planning to add iOS mappings to the html element and attribute tables.  This PR adds the rows for the iOS mappings, but everything is marked as TBD for now.
