### PR TITLE
Disambiguate footer/sectionfooter title and html spec description in HTML AAM

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -2504,12 +2504,12 @@
             </tr>
           </tbody>
         </table>
-        <h4 id="el-footer">`footer` (scoped to the `main` element,a sectioning content element)</h4>
+        <h4 id="el-footer">`footer` (scoped to the `main` element, or a sectioning content element)</h4>
         <table class="data" aria-labelledby="el-footer">
           <tbody>
             <tr>
               <th>HTML Specification</th>
-              <td><a data-cite="HTML">`footer`</a> (scoped to the <a data-cite="HTML">`main`</a> element, a <a data-cite="HTML/dom.html#sectioning-content">sectioning content</a> element)</td>
+              <td><a data-cite="HTML">`footer`</a> (scoped to the <a data-cite="HTML">`main`</a> element, or a <a data-cite="HTML/dom.html#sectioning-content">sectioning content</a> element)</td>
             </tr>
             <tr>
               <th>[[wai-aria-1.2]]</th>


### PR DESCRIPTION
Closes #2550

Disambiguate footer/sectionfooter title and html spec description in HTML AAM

from 
`footer (scoped to the main element,a sectioning content element)`
to 
`footer (scoped to the main element, or a sectioning content element)`