### PR TITLE
editorial: remove redundant rfc2119 markup

### DIFF
--- a/graphics-aam/index.html
+++ b/graphics-aam/index.html
@@ -285,9 +285,9 @@
         requirements that impact a conformance claim.
       </p>
       <p>
-        Normative sections provide requirements that <a class="termref">user agents</a> must follow for an implementation to conform to this specification. The keywords <em class="rfc2119">MUST</em>,
-        <em class="rfc2119">MUST NOT</em>, <em class="rfc2119">REQUIRED</em>, <em class="rfc2119">SHALL</em>, <em class="rfc2119">SHALL NOT</em>, <em class="rfc2119">SHOULD</em>,
-        <em class="rfc2119">RECOMMENDED</em>, <em class="rfc2119">MAY</em>, and <em class="rfc2119">OPTIONAL</em> in this document are to be interpreted as described in
+        Normative sections provide requirements that <a class="termref">user agents</a> must follow for an implementation to conform to this specification. The keywords MUST,
+        MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD,
+        RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in
         <cite><a href="http://www.rfc-editor.org/rfc/rfc2119.txt">Keywords for use in RFCs to indicate requirement levels</a></cite> [[!RFC2119]]. RFC-2119 keywords are formatted in uppercase and
         contained in an element with <code>class="rfc2119"</code>. When the keywords shown above are used, but do not share this format, they do not convey formal information in the RFC 2119 sense,
         and are merely explanatory, i.e., informative. As much as possible, such usages are avoided in this specification.

--- a/graphics-aria/index.html
+++ b/graphics-aria/index.html
@@ -388,9 +388,9 @@
         create requirements that impact a conformance claim.
       </p>
       <p>
-        Normative sections provide requirements that <a class="termref">user agents</a> must follow for an implementation to conform to this specification. The keywords <em class="rfc2119">MUST</em>,
-        <em class="rfc2119">MUST NOT</em>, <em class="rfc2119">REQUIRED</em>, <em class="rfc2119">SHALL</em>, <em class="rfc2119">SHALL NOT</em>, <em class="rfc2119">SHOULD</em>,
-        <em class="rfc2119">RECOMMENDED</em>, <em class="rfc2119">MAY</em>, and <em class="rfc2119">OPTIONAL</em> in this document are to be interpreted as described in
+        Normative sections provide requirements that <a class="termref">user agents</a> must follow for an implementation to conform to this specification. The keywords MUST,
+        MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD,
+        RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in
         <cite><a href="http://www.rfc-editor.org/rfc/rfc2119.txt">Keywords for use in RFCs to indicate requirement levels</a></cite> [[!RFC2119]]. RFC-2119 keywords are formatted in uppercase and
         contained in an element with <code>class="rfc2119"</code>. When the keywords shown above are used, but do not share this format, they do not convey formal information in the RFC 2119 sense,
         and are merely explanatory, i.e., informative. As much as possible, such usages are avoided in this specification.

--- a/index.html
+++ b/index.html
@@ -774,9 +774,9 @@
         does not create requirements that impact a conformance claim.
       </p>
       <p>
-        Normative sections provide requirements that authors and [=user agents=] must follow for an implementation to conform to this specification. The keywords <em class="rfc2119">MUST</em>,
-        <em class="rfc2119">MUST NOT</em>, <em class="rfc2119">REQUIRED</em>, <em class="rfc2119">SHALL</em>, <em class="rfc2119">SHALL NOT</em>, <em class="rfc2119">SHOULD</em>,
-        <em class="rfc2119">RECOMMENDED</em>, <em class="rfc2119">MAY</em>, and <em class="rfc2119">OPTIONAL</em> in this document are to be interpreted as described in
+        Normative sections provide requirements that authors and [=user agents=] must follow for an implementation to conform to this specification. The keywords MUST,
+        MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD,
+        RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in
         <cite><a href="https://www.rfc-editor.org/rfc/rfc2119.txt">Keywords for use in RFCs to indicate requirement levels</a></cite> [[!RFC2119]]. RFC-2119 keywords are formatted in uppercase and
         contained in an element with <code>class="rfc2119"</code>. When the keywords shown above are used, but do not share this format, they do not convey formal information in the RFC 2119 sense,
         and are merely explanatory, i.e., informative. As much as possible, such usages are avoided in this specification.


### PR DESCRIPTION
Prevents duplicate/nested em elements since respec generates those.

Part of #2433
