### PR TITLE
UA SHOULD guidance for roles outside of required a11y parent role

### DIFF
--- a/index.html
+++ b/index.html
@@ -1249,6 +1249,7 @@
             only meaningful when it is a child of an element with role <code>list</code>.
           </p>
           <p>To determine whether an element has a parent with the required role, <a>user agents</a> MUST ignore any elements with the role <rref>generic</rref> or <rref>none</rref>.</p>
+          <p>Also, <a>user agents</a> SHOULD ignore the role if it occurs outside the context of a required accessibility parent role.</p>
           <p class="note">An element with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> fulfills this requirement.</p>
         </section>
         <section id="namecalculation">


### PR DESCRIPTION
Replicates #2418 by @rahimabdi

Closes https://github.com/w3c/aria/issues/2012, closes https://github.com/w3c/aria/pull/2418

This PR adds additional user agent guidance for how orphan roles SHOULD be treated outside of the context of a required accessibility parent role.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2562.html" title="Last updated on Jul 9, 2025, 4:27 PM UTC (ab43d35)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2562/3030dd8...ab43d35.html" title="Last updated on Jul 9, 2025, 4:27 PM UTC (ab43d35)">Diff</a>