### PR TITLE
Editorial: Set DPUB 1.1 to finished

### DIFF
--- a/dpub-aam/index.html
+++ b/dpub-aam/index.html
@@ -17,7 +17,7 @@
         //prEnd:               "2025-04-21",
         //errata: "https://www.w3.org/WAI/ARIA/1.1/errata/dpub",
         // the specifications short name, as in http://www.w3.org/TR/short-name/
-        shortName: "dpub-aam-1.1",
+        shortName: "dpub-aam-1.2",
         implementationReportURI: "https://www.w3.org/2021/04/wpt-fyi-snapshot.html",
         copyrightStart: "2015",
         license: "w3c-software-doc",

--- a/dpub-aria/index.html
+++ b/dpub-aria/index.html
@@ -14,7 +14,7 @@
         // wg: "Publishing Working Group",
         specStatus: "WD",
         //publishDate: "2025-05-27",
-        shortName: "dpub-aria-1.1",
+        shortName: "dpub-aria-1.2",
         //crEnd: "2023-08-29",
         //prEnd: "2025-04-21",
         implementationReportURI: "https://www.w3.org/2021/04/wpt-fyi-snapshot.html?filter=dpub-aam",


### PR DESCRIPTION
This prevents further pushes to TR space from DPUB 1.1 specs, which are now finished.