### PR TITLE
Remove aria-controls from required scrollbar properties

### DIFF
--- a/index.html
+++ b/index.html
@@ -8571,7 +8571,6 @@
                 <th class="role-properties-head" scope="row">Supported States and Properties:</th>
                 <td class="role-properties">
                   <ul>
-                    <li><pref>aria-controls</pref></li>
                     <li><sref>aria-disabled</sref></li>
                     <li><pref>aria-orientation</pref></li>
                     <li><pref>aria-valuemax</pref></li>

--- a/index.html
+++ b/index.html
@@ -8494,7 +8494,7 @@
               (horizontal or vertical) it controls. Its orientation represents the orientation of the scrollbar and the scrolling effect on the viewing area controlled by the scrollbar. It is
               typically possible to add to or subtract from the current value by using directional keys such as arrow keys.
             </p>
-            <p>Authors MUST set the <pref>aria-controls</pref> attribute on the scrollbar element to reference the scrollable area it controls.</p>
+            <p>Authors MAY set the <pref>aria-controls</pref> attribute on the scrollbar element to reference the scrollable area it controls.</p>
             <p>
               Authors MAY set <pref>aria-valuemin</pref> and <pref>aria-valuemax</pref> to indicate the minimum and maximum thumb position. Otherwise, their implicit values follow the same rules as
               <code>&lt;input type="[^input/type/range^]"&gt;</code> in HTML:
@@ -8563,7 +8563,6 @@
                 <th class="role-required-properties-head">Required States and Properties:</th>
                 <td class="role-required-properties">
                   <ul>
-                    <li><pref>aria-controls</pref></li>
                     <li><pref>aria-valuenow</pref></li>
                   </ul>
                 </td>
@@ -8572,6 +8571,7 @@
                 <th class="role-properties-head" scope="row">Supported States and Properties:</th>
                 <td class="role-properties">
                   <ul>
+                    <li><pref>aria-controls</pref></li>
                     <li><sref>aria-disabled</sref></li>
                     <li><pref>aria-orientation</pref></li>
                     <li><pref>aria-valuemax</pref></li>
@@ -16653,11 +16653,6 @@ button.ariaPressed; // null</pre
               <td><rref>radio</rref></td>
               <td><sref>aria-checked</sref></td>
               <td><code>false</code></td>
-            </tr>
-            <tr>
-              <td><rref>scrollbar</rref></td>
-              <td><pref>aria-controls</pref></td>
-              <td>no mapping</td>
             </tr>
             <tr>
               <td><rref>scrollbar</rref></td>


### PR DESCRIPTION
Closes #2580

Removed aria-controls from the required properties for scrollbar role.

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [x] "author MUST" tests: N/A (from MUST to MAY)
* [x] "user agent MUST" tests: N/A
* [x] Browser implementations (link to issue or commit): N/A
* [x] ACT review: Needed (already discussed https://github.com/act-rules/act-rules.github.io/issues/2337)
* [x] Does this need AT implementations? N/A
* [x] Related APG Issue/PR: N/A
* [ ] MDN Issue/PR: yes, since aria-controls is currently required for scrollbar role in MDN doc


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2581.html" title="Last updated on Aug 18, 2025, 6:21 AM UTC (422a6a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2581/0a5f5f3...422a6a6.html" title="Last updated on Aug 18, 2025, 6:21 AM UTC (422a6a6)">Diff</a>