### PR TITLE
Removed aria-controls from the states and properties table for the combobox role to align with the combobox role definition.

### DIFF
--- a/index.html
+++ b/index.html
@@ -16626,7 +16626,6 @@ button.ariaPressed; // null</pre
             </tr>
             <tr>
               <td><rref>combobox</rref></td>
-              <td><sref>aria-controls</sref></td>
               <td>no mapping</td>
             </tr>
             <tr>


### PR DESCRIPTION
Closes #2582

Removed aria-controls from the states and properties table for the combobox role to align with the combobox role definition.