### PR TITLE
Editorial: Update ARIAMixin to use new [Reflect] extended attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -16740,80 +16740,63 @@ button.ariaPressed; // null</pre
         <h2>Interface Mixin <dfn>ARIAMixin</dfn></h2>
         <pre class="idl" data-cite="webidl">
 			interface mixin ARIAMixin {
-				[CEReactions] attribute DOMString? role;
-				[CEReactions] attribute Element? ariaActiveDescendantElement;
-				[CEReactions] attribute DOMString? ariaAtomic;
-				[CEReactions] attribute DOMString? ariaAutoComplete;
-				[CEReactions] attribute DOMString? ariaBrailleLabel;
-				[CEReactions] attribute DOMString? ariaBrailleRoleDescription;
-				[CEReactions] attribute DOMString? ariaBusy;
-				[CEReactions] attribute DOMString? ariaChecked;
-				[CEReactions] attribute DOMString? ariaColCount;
-				[CEReactions] attribute DOMString? ariaColIndex;
-				[CEReactions] attribute DOMString? ariaColIndexText;
-				[CEReactions] attribute DOMString? ariaColSpan;
-				[CEReactions] attribute FrozenArray&lt;Element&gt;? ariaControlsElements;
-				[CEReactions] attribute DOMString? ariaCurrent;
-				[CEReactions] attribute FrozenArray&lt;Element&gt;? ariaDescribedByElements;
-				[CEReactions] attribute DOMString? ariaDescription;
-				[CEReactions] attribute FrozenArray&lt;Element&gt;? ariaDetailsElements;
-				[CEReactions] attribute DOMString? ariaDisabled;
-				[CEReactions] attribute FrozenArray&lt;Element&gt;? ariaErrorMessageElements;
-				[CEReactions] attribute DOMString? ariaExpanded;
-				[CEReactions] attribute FrozenArray&lt;Element&gt;? ariaFlowToElements;
-				[CEReactions] attribute DOMString? ariaHasPopup;
-				[CEReactions] attribute DOMString? ariaHidden;
-				[CEReactions] attribute DOMString? ariaInvalid;
-				[CEReactions] attribute DOMString? ariaKeyShortcuts;
-				[CEReactions] attribute DOMString? ariaLabel;
-				[CEReactions] attribute FrozenArray&lt;Element&gt;? ariaLabelledByElements;
-				[CEReactions] attribute DOMString? ariaLevel;
-				[CEReactions] attribute DOMString? ariaLive;
-				[CEReactions] attribute DOMString? ariaModal;
-				[CEReactions] attribute DOMString? ariaMultiLine;
-				[CEReactions] attribute DOMString? ariaMultiSelectable;
-				[CEReactions] attribute DOMString? ariaOrientation;
-				[CEReactions] attribute FrozenArray&lt;Element&gt;? ariaOwnsElements;
-				[CEReactions] attribute DOMString? ariaPlaceholder;
-				[CEReactions] attribute DOMString? ariaPosInSet;
-				[CEReactions] attribute DOMString? ariaPressed;
-				[CEReactions] attribute DOMString? ariaReadOnly;
-				[CEReactions] attribute DOMString? ariaRelevant;
-				[CEReactions] attribute DOMString? ariaRequired;
-				[CEReactions] attribute DOMString? ariaRoleDescription;
-				[CEReactions] attribute DOMString? ariaRowCount;
-				[CEReactions] attribute DOMString? ariaRowIndex;
-				[CEReactions] attribute DOMString? ariaRowIndexText;
-				[CEReactions] attribute DOMString? ariaRowSpan;
-				[CEReactions] attribute DOMString? ariaSelected;
-				[CEReactions] attribute DOMString? ariaSetSize;
-				[CEReactions] attribute DOMString? ariaSort;
-				[CEReactions] attribute DOMString? ariaValueMax;
-				[CEReactions] attribute DOMString? ariaValueMin;
-				[CEReactions] attribute DOMString? ariaValueNow;
-				[CEReactions] attribute DOMString? ariaValueText;
-			};
+				[CEReactions, Reflect] attribute DOMString? role;
+				[CEReactions, Reflect="aria-activedescendant"] attribute Element? ariaActiveDescendantElement;
+				[CEReactions, Reflect="aria-atomic"] attribute DOMString? ariaAtomic;
+				[CEReactions, Reflect="aria-autocomplete"] attribute DOMString? ariaAutoComplete;
+				[CEReactions, Reflect="aria-braillelabel"] attribute DOMString? ariaBrailleLabel;
+				[CEReactions, Reflect="aria-brailleroledescription"] attribute DOMString? ariaBrailleRoleDescription;
+				[CEReactions, Reflect="aria-busy"] attribute DOMString? ariaBusy;
+				[CEReactions, Reflect="aria-checked"] attribute DOMString? ariaChecked;
+				[CEReactions, Reflect="aria-colcount"] attribute DOMString? ariaColCount;
+				[CEReactions, Reflect="aria-colindex"] attribute DOMString? ariaColIndex;
+				[CEReactions, Reflect="aria-colindextext"] attribute DOMString? ariaColIndexText;
+				[CEReactions, Reflect="aria-colspan"] attribute DOMString? ariaColSpan;
+				[CEReactions, Reflect="aria-controls"] attribute FrozenArray&lt;Element&gt;? ariaControlsElements;
+				[CEReactions, Reflect="aria-current"] attribute DOMString? ariaCurrent;
+				[CEReactions, Reflect="aria-describedby"] attribute FrozenArray&lt;Element&gt;? ariaDescribedByElements;
+				[CEReactions, Reflect="aria-description"] attribute DOMString? ariaDescription;
+				[CEReactions, Reflect="aria-details"] attribute FrozenArray&lt;Element&gt;? ariaDetailsElements;
+				[CEReactions, Reflect="aria-disabled"] attribute DOMString? ariaDisabled;
+				[CEReactions, Reflect="aria-errormessage"] attribute FrozenArray&lt;Element&gt;? ariaErrorMessageElements;
+				[CEReactions, Reflect="aria-expanded"] attribute DOMString? ariaExpanded;
+				[CEReactions, Reflect="aria-flowto"] attribute FrozenArray&lt;Element&gt;? ariaFlowToElements;
+				[CEReactions, Reflect="aria-haspopup"] attribute DOMString? ariaHasPopup;
+				[CEReactions, Reflect="aria-hidden"] attribute DOMString? ariaHidden;
+				[CEReactions, Reflect="aria-invalid"] attribute DOMString? ariaInvalid;
+				[CEReactions, Reflect="aria-keyshortcuts"] attribute DOMString? ariaKeyShortcuts;
+				[CEReactions, Reflect="aria-label"] attribute DOMString? ariaLabel;
+				[CEReactions, Reflect="aria-labelledby"] attribute FrozenArray&lt;Element&gt;? ariaLabelledByElements;
+				[CEReactions, Reflect="aria-level"] attribute DOMString? ariaLevel;
+				[CEReactions, Reflect="aria-live"] attribute DOMString? ariaLive;
+				[CEReactions, Reflect="aria-modal"] attribute DOMString? ariaModal;
+				[CEReactions, Reflect="aria-multiline"] attribute DOMString? ariaMultiLine;
+				[CEReactions, Reflect="aria-multiselectable"] attribute DOMString? ariaMultiSelectable;
+				[CEReactions, Reflect="aria-orientation"] attribute DOMString? ariaOrientation;
+				[CEReactions, Reflect="aria-owns"] attribute FrozenArray&lt;Element&gt;? ariaOwnsElements;
+				[CEReactions, Reflect="aria-placeholder"] attribute DOMString? ariaPlaceholder;
+				[CEReactions, Reflect="aria-posinset"] attribute DOMString? ariaPosInSet;
+				[CEReactions, Reflect="aria-pressed"] attribute DOMString? ariaPressed;
+				[CEReactions, Reflect="aria-readonly"] attribute DOMString? ariaReadOnly;
+				[CEReactions, Reflect="aria-relevant"] attribute DOMString? ariaRelevant;
+				[CEReactions, Reflect="aria-required"] attribute DOMString? ariaRequired;
+				[CEReactions, Reflect="aria-roledescription"] attribute DOMString? ariaRoleDescription;
+				[CEReactions, Reflect="aria-rowcount"] attribute DOMString? ariaRowCount;
+				[CEReactions, Reflect="aria-rowindex"] attribute DOMString? ariaRowIndex;
+				[CEReactions, Reflect="aria-rowindextext"] attribute DOMString? ariaRowIndexText;
+				[CEReactions, Reflect="aria-rowspan"] attribute DOMString? ariaRowSpan;
+				[CEReactions, Reflect="aria-selected"] attribute DOMString? ariaSelected;
+				[CEReactions, Reflect="aria-setsize"] attribute DOMString? ariaSetSize;
+				[CEReactions, Reflect="aria-sort"] attribute DOMString? ariaSort;
+				[CEReactions, Reflect="aria-valuemax"] attribute DOMString? ariaValueMax;
+				[CEReactions, Reflect="aria-valuemin"] attribute DOMString? ariaValueMin;
+				[CEReactions, Reflect="aria-valuenow"] attribute DOMString? ariaValueNow;
+				[CEReactions, Reflect="aria-valuetext"] attribute DOMString? ariaValueText;
+      };
       Element includes ARIAMixin;
 		</pre
         >
 
-        <p>For every IDL attribute <var>idlAttribute</var> defined in <code>ARIAMixin</code> when included on an element:</p>
-
-        <ol>
-          <li>
-            <p>Let <var>contentAttributeName</var> be the local name of the ARIA content attribute determined by looking up <var>idlAttribute</var> in the ARIA Attribute Correspondence table.</p>
-          </li>
-
-          <li>
-            <p><var>idlAttribute</var> must [=reflect=] <var>contentAttributeName</var> and support {{ElementInternals}}.</p>
-          </li>
-        </ol>
-
-        <p class="note">
-          In practice, this means that, e.g., the <code>role</code> IDL attribute on <code>Element</code> reflects the <code>role</code> content attribute; the <code>ariaValueMin</code> IDL attribute
-          reflects the <pref>aria-valuemin</pref> content attribute; etc. Ambiguity clarifications (such as <code>ariaPosInSet</code>) are listed in
-          <a href="#idl_attr_exceptions">IDL Attribute Name Notes or Exceptions</a>.
-        </p>
       </section>
 
       <section id="accessibilityroleandproperties-correspondence" class="normative" data-dfn-for="ARIAMixin" data-link-for="ARIAMixin">


### PR DESCRIPTION
Uses the new [Reflect] extended attribute that was introduced to HTML in https://github.com/whatwg/html/pull/11450

And a few other todo items (delete this section after performing them):
* [ ] For every spec that this PR edits, please add the appropriate `spec:<spec_name>` label. If you don't have privileges to do this, editors will do it for you.
* [x] If the change is [editorial](https://github.com/w3c/aria/blob/main/documentation/process.md#editorial-changes), please add "Editorial:" at the start of your PR name, and delete the "Test, Documentation and Implementation tracking" section below.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/aria/pull/2587.html" title="Last updated on Jul 31, 2025, 3:20 PM UTC (92726ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2587/45ec98e...lukewarlow:92726ac.html" title="Last updated on Jul 31, 2025, 3:20 PM UTC (92726ac)">Diff</a>