### PR TITLE
editorial: add "focusable" to terms and reference it

### DIFF
--- a/index.html
+++ b/index.html
@@ -592,6 +592,10 @@
           <dd>
             <p>Translated to platform-specific <a class="termref">accessibility APIs</a> as defined in the <a href="" class="core-mapping">Core Accessibility API Mappings</a>.</p>
           </dd>
+          <dt><dfn>Focusable</dfn></dt>
+          <dd>
+            <p>An element or area matching the definition of <a href="https://html.spec.whatwg.org/multipage/interaction.html#focusable-area">focusable area</a> in the HTML Specification.</p>
+          </dd>
           <dt><dfn>Graphical Document</dfn></dt>
           <dd>
             <p>
@@ -966,7 +970,7 @@
             performed a scrolling action.
           </p>
           <p>
-            Authors SHOULD ensure that all interactive [=elements=] are focusable and that all parts of composite widgets are either focusable or have a documented alternative method to achieve their
+            Authors SHOULD ensure that all interactive [=elements=] are <a>focusable</a> and that all parts of composite widgets are either focusable or have a documented alternative method to achieve their
             function.
           </p>
           <p>Authors MUST manage focus on the following container roles:</p>
@@ -1025,7 +1029,7 @@
               <pref>aria-activedescendant</pref> attribute:
               <ol>
                 <li>
-                  Focusable, if the element also has a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref">role</a>. The element needs to be focusable because it
+                  <a>Focusable</a>, if the element also has a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> <a class="termref">role</a>. The element needs to be focusable because it
                   could be referenced by the <pref>aria-activedescendant</pref> attribute. Native elements that have no <a class="termref">role</a> attribute do not need to be checked; their native
                   semantics determine the focusable state.
                 </li>
@@ -1696,7 +1700,7 @@
           <rdef>application</rdef>
           <div class="role-description">
             <p>
-              A <rref>structure</rref> containing one or more focusable elements requiring user input, such as keyboard or gesture events, that do not follow a standard interaction pattern supported
+              A <rref>structure</rref> containing one or more <a>focusable</a> elements requiring user input, such as keyboard or gesture events, that do not follow a standard interaction pattern supported
               by a <rref>widget</rref> role.
             </p>
             <p>
@@ -2819,7 +2823,7 @@
             </p>
             <p>
               If the user interface includes an additional icon that allows the visibility of the popup to be controlled via pointer and touch events, authors SHOULD ensure that element has role
-              <rref>button</rref>, that it is focusable but not included in the page <kbd>Tab</kbd> sequence, and that it is not a descendant of the element with role <code>combobox</code>. In
+              <rref>button</rref>, that it is <a>focusable</a> but not included in the page <kbd>Tab</kbd> sequence, and that it is not a descendant of the element with role <code>combobox</code>. In
               addition, to be keyboard accessible, authors SHOULD provide keyboard mechanisms for moving focus between the <code>combobox</code> element and elements contained in the popup. For
               example, one common convention is that <kbd>Down Arrow</kbd> moves focus from the input to the first focusable descendant of the popup element. If the popup element supports
               <pref>aria-activedescendant</pref>, in lieu of moving focus, such keyboard mechanisms can control the value of <pref>aria-activedescendant</pref> on the <code>combobox</code> element.
@@ -3634,7 +3638,7 @@
             </p>
             <p>Authors SHOULD provide an accessible name for a dialog, which can be done with the <pref>aria-label</pref> or <pref>aria-labelledby</pref> attribute.</p>
             <p>
-              Authors SHOULD ensure that all dialogs (both modal and non-modal) have at least one focusable descendant element. Authors SHOULD focus an element in the modal dialog when it is
+              Authors SHOULD ensure that all dialogs (both modal and non-modal) have at least one <a>focusable</a> descendant element. Authors SHOULD focus an element in the modal dialog when it is
               displayed, and authors SHOULD constrain keyboard focus to focusable elements within a modal dialog, until dismissed.
             </p>
             <p>
@@ -3841,7 +3845,7 @@
             </p>
             <p>
               Because <a>assistive technologies</a> that have a reading mode default to that mode for all elements except for those with either a <rref>widget</rref> or <rref>application</rref> role,
-              the only circumstance where the <code>document</code> role is useful for changing assistive technology behavior is when the element with role <code>document</code> is a focusable child
+              the only circumstance where the <code>document</code> role is useful for changing assistive technology behavior is when the element with role <code>document</code> is a <a>focusable</a> child
               element of a <rref>widget</rref> or <rref>application</rref>. For example, given an <rref>application</rref> element which contains some static rich text, the author can apply role
               <code>document</code> to the element containing the text and give it a <code>tabindex</code> of <code>0</code>. When a screen reader user presses the Tab key and places focus on the
               <code>document</code> element, the user will be able to read the text with the screen reader's reading cursor.
@@ -4042,7 +4046,7 @@
               <code>feed</code>.
             </p>
             <p>
-              Authors SHOULD make each <rref>article</rref> in a <code>feed</code> focusable and ensure that the application scrolls an <rref>article</rref> into view when <a>user agent</a> focus is
+              Authors SHOULD make each <rref>article</rref> in a <code>feed</code> <a>focusable</a> and ensure that the application scrolls an <rref>article</rref> into view when <a>user agent</a> focus is
               set on the <rref>article</rref> or one of its descendant elements. For example, in HTML, each <rref>article</rref> element should have a <code>tabindex</code> value of either
               <code>-1</code> or <code>0</code>.
             </p>
@@ -4450,7 +4454,7 @@
           <rdef>grid</rdef>
           <div class="role-description">
             <p>
-              A composite <rref>widget</rref> containing a collection of one or more rows with one or more cells where some or all cells in the grid are focusable by using methods of two-dimensional
+              A composite <rref>widget</rref> containing a collection of one or more rows with one or more cells where some or all cells in the grid are <a>focusable</a> by using methods of two-dimensional
               navigation, such as directional arrow keys.
             </p>
             <p>
@@ -4629,7 +4633,7 @@
           <div class="role-description">
             <p>A <rref>cell</rref> in a <rref>grid</rref> or <rref>treegrid</rref>.</p>
             <p>
-              A <code>gridcell</code> can be focusable, editable, and selectable. A <code>gridcell</code> can have <a>relationships</a> such as <pref>aria-controls</pref> to address the application of
+              A <code>gridcell</code> can be <a>focusable</a>, editable, and selectable. A <code>gridcell</code> can have <a>relationships</a> such as <pref>aria-controls</pref> to address the application of
               functional relationships.
             </p>
             <p>
@@ -6943,7 +6947,7 @@
               <li>A layout table and/or any of its associated rows, cells, etc.</li>
             </ul>
             <p>
-              For any element with a role of <rref>none</rref>/<rref>presentation</rref> and which is not focusable, the user agent MUST NOT expose the implicit native semantics of the element (the
+              For any element with a role of <rref>none</rref>/<rref>presentation</rref> and which is not <a>focusable</a>, the user agent MUST NOT expose the implicit native semantics of the element (the
               role and its states and properties) to accessibility <abbr title="Application Programming Interfaces">APIs</abbr>. However, the user agent MUST expose content and descendant elements
               that do not have an explicit or inherited role of <rref>none</rref>/<rref>presentation</rref>. Thus, the <rref>none</rref>/<rref>presentation</rref> role causes a given element to be
               treated as having no role or to be removed from the <a>accessibility tree</a>, but does not cause the content contained within the element to be removed from the accessibility tree.
@@ -9174,7 +9178,7 @@
           <div class="role-description">
             <p>A divider that separates and distinguishes sections of content or groups of menuitems.</p>
             <p>
-              There are two types of separators: a static <rref>structure</rref> that provides only a visible boundary and a focusable, interactive <rref>widget</rref> that is also moveable. If a
+              There are two types of separators: a static <rref>structure</rref> that provides only a visible boundary and a <a>focusable</a>, interactive <rref>widget</rref> that is also moveable. If a
               <code>separator</code> is not focusable, it is revealed to <a>assistive technologies</a> as a static structural element. For example, a static <code>separator</code> can be used to help
               visually divide two groups of menu items in a menu or to provide a horizontal rule between two sections of a page.
             </p>
@@ -11455,7 +11459,7 @@
               an individual <rref>gridcell</rref> element.
             </p>
             <p>
-              When the <pref>aria-readonly</pref> attribute is applied to a focusable <rref>gridcell</rref>, it indicates whether the content contained in the <rref>gridcell</rref> is editable. The
+              When the <pref>aria-readonly</pref> attribute is applied to a <a>focusable</a> <rref>gridcell</rref>, it indicates whether the content contained in the <rref>gridcell</rref> is editable. The
               <pref>aria-readonly</pref> attribute does not represent availability of functions for navigating or manipulating the <code>treegrid</code> itself.
             </p>
             <p>
@@ -12174,7 +12178,7 @@ button.ariaPressed; // null</pre
               <rref>application</rref>.
             </p>
             <p>
-              The <code>aria-activedescendant</code> property provides an alternative method of managing focus for interactive elements that might contain multiple focusable descendants, such as
+              The <code>aria-activedescendant</code> property provides an alternative method of managing focus for interactive elements that might contain multiple <a>focusable</a> descendants, such as
               menus, grids, and toolbars. Instead of moving DOM focus among <a>accessibility descendants</a>, authors MAY set DOM focus on a container <a>element</a> that supports
               <code>aria-activedescendant</code> and then use <code>aria-activedescendant</code> to refer to the element that is active.
             </p>
@@ -13479,7 +13483,7 @@ button.ariaPressed; // null</pre
               has been disabled.
             </p>
             <p>
-              The <a>state</a> of being disabled applies to the element with aria-disabled and all focusable descendant elements of the element on which the <sref>aria-disabled</sref>
+              The <a>state</a> of being disabled applies to the element with aria-disabled and all <a>focusable</a> descendant elements of the element on which the <sref>aria-disabled</sref>
               <a>attribute</a> is applied.
             </p>
             <p class="note">
@@ -13717,7 +13721,7 @@ button.ariaPressed; // null</pre
           <div class="state-description">
             <p><a>Indicates</a> whether a related element is expanded (shown) or collapsed (hidden).</p>
             <p>
-              The <sref>aria-expanded</sref> attribute is applied to a focusable, interactive element that toggles visibility of content of a different element. If the element with
+              The <sref>aria-expanded</sref> attribute is applied to a <a>focusable</a>, interactive element that toggles visibility of content of a different element. If the element with
               <sref>aria-expanded</sref> is also a <rref>treeitem</rref> in a <rref>tree</rref> or a <rref>row</rref> in a <rref>treegrid</rref>, then it SHOULD also be the
               <a>accessibility parent</a> of the content it expands and collapses. Otherwise, the element with <sref>aria-expanded</sref> SHOULD NOT be the <a>accessibility parent</a> of the content
               that is expanding or collapsing. Rather, identify that relationship between the interactive element and the element being controlled using <pref>aria-controls</pref>.
@@ -13933,7 +13937,7 @@ button.ariaPressed; // null</pre
               container.
             </p>
             <p>
-              For the popup element to be keyboard accessible, authors SHOULD ensure that the element that can trigger the popup is focusable, that there is a keyboard mechanism for opening the popup,
+              For the popup element to be keyboard accessible, authors SHOULD ensure that the element that can trigger the popup is <a>focusable</a>, that there is a keyboard mechanism for opening the popup,
               and that the popup element manages focus of all its descendants as described in <a href="#managingfocus">Managing Focus</a>.
             </p>
             <p>
@@ -15092,7 +15096,7 @@ button.ariaPressed; // null</pre
             <p>Indicates that the <a>element</a> is not editable, but is otherwise <a>operable</a>. See related <sref>aria-disabled</sref>.</p>
             <p>
               This means the user can read but not set the value of the <a>widget</a>. Readonly elements are relevant to the user, and authors SHOULD NOT restrict navigation to the element or its
-              focusable descendants. Other actions such as copying the value of the element are also supported. This is in contrast to disabled elements, to which applications might not allow user
+              <a>focusable</a> descendants. Other actions such as copying the value of the element are also supported. This is in contrast to disabled elements, to which applications might not allow user
               navigation to descendants.
             </p>
             <p>Examples include:</p>
@@ -16348,7 +16352,7 @@ button.ariaPressed; // null</pre
       <section id="host_general_focus">
         <h2>Focus Navigation</h2>
         <p>
-          An implementing host language MUST provide support for the author to make all interactive elements focusable, that is, any renderable or event-receiving elements. An implementing host
+          An implementing host language MUST provide support for the author to make all interactive elements <a>focusable</a>, that is, any renderable or event-receiving elements. An implementing host
           language MUST provide a facility to allow authors to define whether these focusable, interactive elements appear in the default tab navigation order. The <code>tabindex</code>
           <a>attribute</a> in HTML is an example of one implementation.
         </p>
@@ -16704,7 +16708,7 @@ button.ariaPressed; // null</pre
         <p>User agents MUST NOT expose [=elements=] having explicit or inherited presentational role in the accessibility tree, with these exceptions:</p>
         <ul>
           <li>
-            If an element is focusable, user agents MUST ignore the <rref>none</rref>/<rref>presentation</rref> role and expose the element with its implicit role, in order to ensure that the element
+            If an element is <a>focusable</a>, user agents MUST ignore the <rref>none</rref>/<rref>presentation</rref> role and expose the element with its implicit role, in order to ensure that the element
             is <a>operable</a>.
           </li>
           <li>


### PR DESCRIPTION
Matches #2066 and adds several references across the spec; roughly the first use of focusable in a section is linked.

Closes #1936; also closes #2066


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2605.html" title="Last updated on Aug 21, 2025, 10:30 AM UTC (2797006)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2605/5b53575...2797006.html" title="Last updated on Aug 21, 2025, 10:30 AM UTC (2797006)">Diff</a>