### PR TITLE
Fix `::marker` accname instruction

### DIFF
--- a/accname/index.html
+++ b/accname/index.html
@@ -669,7 +669,7 @@
                       <a href="https://www.w3.org/TR/css-pseudo-4/#selectordef-marker"><code>::marker</code></a> pseudo element.
                       <ol class="acc-ol">
                         <li id="comp_name_from_content_pseudo_element_marker">
-                          For <code>::marker</code> pseudo elements, <a class="termref">User agents</a> MUST append <abbr title="Cascading Style Sheets">CSS</abbr> textual content, without a space, to
+                          For <code>::marker</code> pseudo elements, <a class="termref">User agents</a> MUST prepend <abbr title="Cascading Style Sheets">CSS</abbr> textual content, without a space, to
                           the textual content of the <code>current node</code> if the <code>current node</code> supports <code>::marker</code>.
                         </li>
                         <li id="comp_name_from_content_pseudo_element_before">


### PR DESCRIPTION
Closes #2596

Fixes a small but normative typo. Accname currently says `::marker` content should be appended, but it should be _prepended_.

# Test, Documentation and Implementation tracking

* [X] "author MUST" tests: N/A
* [X] "user agent MUST" tests: web-platform-tests/wpt#54222
* [ ] Browser implementations (link to issue or commit):
   * WebKit:
   * Gecko:
   * Blink:
* [ ] ACT review?
* [X] Does this need AT implementations? No
* [X] Related APG Issue/PR: N/A
* [X] MDN Issue/PR: N/A
