### PR TITLE
Editorial: Add back accessibility subtree definition

### DIFF
--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -10771,7 +10771,7 @@
               </tr>
             </tbody>
           </table>
-          <p>Fire these events for node changes where the node in question is an element and has an <a class="termref">accessible object</a>:</p>
+          <p>Fire the following events for node changes where the node in question is an element and has an <a class="termref">accessible object</a>. The <dfn data-export="" data-lt="accessibility subtree">accessibility subtree</dfn> of a node is its <a class="termref">accessible object</a> in the <a>accessibility tree</a> and all of it's <a>accessibility descendants</a>. It does not include objects which have relationships other than parent-child in that tree. For example, it does not include objects linked via <a class="specref" href="#aria-flowto">aria-flowto</a> unless those objects are also descendants in the <a>accessibility tree</a>.
           <table class="data">
             <caption>
               Table of document change scenarios and events to be fired in each


### PR DESCRIPTION
In a rebase, I lost the part of the commit which moved the definition of subtree: https://github.com/w3c/aria/pull/2293 Then it got merged, now there is an error in the build about not finding the definition. I added it back in this PR.