### PR TITLE
Add interestfor attribute related mappings

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -11625,6 +11625,87 @@
             </tr>
           </tbody>
         </table>
+        <h4 id="att-interestfor-attribute">`interestfor`</h4>
+        <table class="data" aria-labelledby="att-interestfor-attribute">
+          <tbody>
+            <tr>
+              <th>HTML Specification</th>
+              <td>
+                <span class="el-context"> `interestfor` </span>
+              </td>
+            </tr>
+            <tr>
+              <th>Element(s)</th>
+              <td>
+                <a data-cite="html/form-elements.html#the-button-element">`button`</a>;
+                <a data-cite="html/text-level-semantics.html#the-a-element">`a`</a>;
+                <a data-cite="html/image-maps.html#the-area-element">`area`</a>
+              </td>
+            </tr>
+            <tr>
+              <th>[[WAI-ARIA-1.2]]</th>
+              <td>
+                <p>A popover is <dfn>"plain"</dfn> if it contains only elements with a computed role of generic, text and images.</p>
+                <p>A popover is <dfn>"rich"</dfn> if it is not "plain".</p>
+                <p>If the `interestfor`-associated element is invalid, or is not a not a popover: no `aria-expanded` mapping</p>
+                <p>
+                  If the `interestfor`-associated element is an accessibility ancestor of the interest invoker:
+                  <a class="core-mapping" href="#ariaExpandedUndefined">`aria-expanded=undefined`</a>
+                </p>
+                <p>If the `interestfor`-associated element is a <a>"plain"</a> popover:
+                  <ul>
+                    <li><p>Set <a class="core-mapping" href="#ariaHiddenTrue">`aria-hidden="true"`</a> on the target popover.</p></li>
+                    <li><p>If no other <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is available, use the popover's inner text for
+                      the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.</p></li>
+                    <li><p>If the popover is not used as the <a data-cite="accname-1.2/#dfn-accessible-name">name</a>, then use it to compute the
+                      <a data-cite="accname-1.2/#dfn-accessible-description">accessible description</a>, setting the
+                      <a data-cite="wai-aria-1.2/#aria-describedby">`aria-describedby`</a> relation to point from the interest invoker to the popover</p></li>
+                  </ul>
+                </p>
+                <p>If the `interestfor`-associated element is a <a>"rich"</a> popover:
+                  <ul>
+                    <li><p>If the popover is displayed: <a class="core-mapping" href="#ariaExpandedTrue">`aria-expanded=true`</a></p></li>
+                    <li><p>If the popover is hidden: <a class="core-mapping" href="#ariaExpandedFalse">`aria-expanded=false`</a></p></li>
+                    <li><p>Set a <a>minimum role</a> of <a class="core-mapping" href="#role-map-tooltip">`tooltip`</a> on the target popover</p></li>
+                    <li><p>Set `aria-details` pointing to the target popover</p></li>
+                  </ul>
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
+              </th>
+              <td>
+                <div class="general">Use WAI-ARIA mapping</div>
+                <div class="objattrs"><span class="type">Object attributes:</span> `details-roles:popover`</div>
+              </td>
+            </tr>
+            <tr>
+              <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+              <td>
+                <div class="general">Use WAI-ARIA mapping</div>
+              </td>
+            </tr>
+            <tr>
+              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <td>
+                <div class="general">Use WAI-ARIA mapping</div>
+                <div class="objattrs"><span class="type">Object attributes:</span> `details-roles:popover`</div>
+              </td>
+            </tr>
+            <tr>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <td>
+                <div class="general">Use WAI-ARIA mapping</div>
+              </td>
+            </tr>
+            <tr>
+              <th>Comments</th>
+              <td>
+              </td>
+            </tr>
+          </tbody>
+        </table>
         <h4 id="att-ismap">`ismap`</h4>
         <table class="data" aria-labelledby="att-ismap">
           <tbody>
@@ -16853,10 +16934,11 @@
         <section>
           <h4>Substantive changes since moving to the <a href="https://www.w3.org/WAI/ARIA/">Accessible Rich Internet Applications Working Group</a> (03-Nov-2019)</h4>
           <ul>
-            <li>2-April-2025: Add `command` and `commandfor` attribute mappings. See <a href="https://github.com/w3c/aria/pull/2354/">GitHub ARIA PR 2354</a>.</li>
-            <li>11-July-2024: User Agents ignore `aria-hidden=true` on `body` and `html` elements. See <a href="https://github.com/w3c/html-aam/pull/516">GitHub PR 516</a>.</li>
-            <li>06-June-2024: Add concept of Minimum Role. See <a href="https://github.com/w3c/html-aam/pull/454">GitHub PR 454</a>.</li>
-            <li>06-June-2024: Add `popover`, `popovertarget` and `popovertargetaction` mappings. See <a href="https://github.com/w3c/html-aam/pull/481">GitHub PR 481</a>.</li>
+            <li>2-Sep-2025: Add `interestfor` attribute mappings. See <a href="https://github.com/w3c/aria/pull/Xyz/">GitHub ARIA PR Xyz</a>.</li>
+            <li>2-Apr-2025: Add `command` and `commandfor` attribute mappings. See <a href="https://github.com/w3c/aria/pull/2354/">GitHub ARIA PR 2354</a>.</li>
+            <li>11-Jul-2024: User Agents ignore `aria-hidden=true` on `body` and `html` elements. See <a href="https://github.com/w3c/html-aam/pull/516">GitHub PR 516</a>.</li>
+            <li>06-Jun-2024: Add concept of Minimum Role. See <a href="https://github.com/w3c/html-aam/pull/454">GitHub PR 454</a>.</li>
+            <li>06-Jun-2024: Add `popover`, `popovertarget` and `popovertargetaction` mappings. See <a href="https://github.com/w3c/html-aam/pull/481">GitHub PR 481</a>.</li>
             <li>09-Oct-2023: Acknowledge use of `hr` element within `select` element. See <a href="https://github.com/w3c/html-aam/pull/504">GitHub PR 504</a>.</li>
             <li>03-Oct-2023: Update image mappings to reference the primary synonym roles (`image` and `none`). See <a href="https://github.com/w3c/html-aam/pull/498">GitHub PR 498</a>.</li>
             <li>03-Oct-2023: Clarify when to expose required field as invalid. See <a href="https://github.com/w3c/html-aam/pull/429">GitHub PR 429</a>.</li>


### PR DESCRIPTION
This adds the mapping for the `interestfor` attribute.

See [the explainer](https://open-ui.org/components/interest-invokers.explainer/) for the overall API description and use cases.


And a few other todo items (delete this section after performing them):
* [ ] For every spec that this PR edits, please add the appropriate `spec:<spec_name>` label. If you don't have privileges to do this, editors will do it for you.

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests:
* [X] Browser implementations (link to issue or commit):
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=297786
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1984699
   * Blink: https://crbug.com/326681249
* [ ] ACT review?
* [X] Does this need AT implementations? Yes
* [ ] Related APG Issue/PR:
* [X] MDN Issue/PR: https://github.com/mdn/mdn/issues/721
* [X] Other: https://github.com/w3c/a11y-request/issues/118