### PR TITLE
editorial: CI for roleInfo.js

### DIFF
--- a/.github/workflows/roleInfo.yml
+++ b/.github/workflows/roleInfo.yml
@@ -1,4 +1,4 @@
-name: roleInfo
+name: roleInfo update
 
 on:
   push:

--- a/.github/workflows/roleInfo.yml
+++ b/.github/workflows/roleInfo.yml
@@ -1,0 +1,26 @@
+name: roleInfo
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  roleInfo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "latest"
+      - run: npm i linkedom
+      - run: node ./common/script/buildRoleInfo.js > ./common/script/roleInfo.js
+      - run: git config user.name "github-actions[bot]"
+      - run: git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - run: git add ./common/script/roleInfo.js
+      - run: |
+         git commit -m'chore: update roleInfo.js'
+      - run: git push

--- a/.github/workflows/roleInfo.yml
+++ b/.github/workflows/roleInfo.yml
@@ -1,7 +1,7 @@
 name: roleInfo
 
 on:
-  pull_request:
+  push:
     branches:
       - main
 

--- a/.github/workflows/roleInfo.yml
+++ b/.github/workflows/roleInfo.yml
@@ -22,5 +22,5 @@ jobs:
       - run: git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - run: git add ./common/script/roleInfo.js
       - run: |
-         git commit -m'chore: update roleInfo.js'
+         git diff-index --quiet HEAD ./common/script/roleInfo.js || git commit -m'chore: update roleInfo.js'
       - run: git push

--- a/.github/workflows/roleInfoCheck.yml
+++ b/.github/workflows/roleInfoCheck.yml
@@ -18,5 +18,5 @@ jobs:
           node-version: "latest"
       - run: npm i linkedom prettier@3.6.0
       - run: node ./common/script/buildRoleInfo.js > ./common/script/roleInfo.js
-      - run: prettier --write --print-width 200 ./common/script/buildRoleInfo.js
+      - run: npx prettier --write --print-width 200 ./common/script/buildRoleInfo.js
       - run: git diff --exit-code

--- a/.github/workflows/roleInfoCheck.yml
+++ b/.github/workflows/roleInfoCheck.yml
@@ -1,0 +1,21 @@
+name: roleInfo
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  roleInfo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "latest"
+      - run: npm i linkedom
+      - run: node ./common/script/buildRoleInfo.js > ./common/script/roleInfo.js
+      - run: git diff --exit-code

--- a/.github/workflows/roleInfoCheck.yml
+++ b/.github/workflows/roleInfoCheck.yml
@@ -1,4 +1,4 @@
-name: roleInfo
+name: roleInfo PR check
 
 on:
   pull_request:

--- a/.github/workflows/roleInfoCheck.yml
+++ b/.github/workflows/roleInfoCheck.yml
@@ -18,5 +18,5 @@ jobs:
           node-version: "latest"
       - run: npm i linkedom prettier@3.6.0
       - run: node ./common/script/buildRoleInfo.js > ./common/script/roleInfo.js
-      - run: npx prettier --write --print-width 200 ./common/script/buildRoleInfo.js
+      - run: npx prettier --write --print-width 200 ./common/script/roleInfo.js
       - run: git diff --exit-code

--- a/.github/workflows/roleInfoCheck.yml
+++ b/.github/workflows/roleInfoCheck.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "latest"
-      - run: npm i linkedom
+      - run: npm i linkedom prettier@3.6.0
       - run: node ./common/script/buildRoleInfo.js > ./common/script/roleInfo.js
+      - run: prettier --write --print-width 200 ./common/script/buildRoleInfo.js
       - run: git diff --exit-code

--- a/common/script/buildRoleInfo.js
+++ b/common/script/buildRoleInfo.js
@@ -20,7 +20,3 @@ const scriptAddition =
 
 // HACK: eval!
 eval(scriptWithoutRespecUI + scriptAddition);
-
-//NOTEs & Questions:
-// * we can execute ariaAttributeReference but can't access roleInfo since it's currently const. We could make aria.js a module and import it properly here; or we could have ariaAttributeReference return it (or make it global again).
-// * can we match serialization of current output in browser? Right now, roleInfo.js doesn't escape all strings but this will. Also, do we want to generate JSON?

--- a/common/script/buildRoleInfo.js
+++ b/common/script/buildRoleInfo.js
@@ -1,0 +1,26 @@
+import * as fs from "node:fs";
+import { parseHTML } from 'linkedom';
+
+const { document } = parseHTML(
+    fs.readFileSync("../aria/index.html").toString()
+);
+
+// mock functions for aria.js
+let updateReferences = () => {};
+document.URL = "";
+
+const script = fs.readFileSync("./common/script/aria.js").toString();
+
+
+const scriptWithoutRespecUI = script.substring(0, script.indexOf("require(")); // TODO: HACK remove everything past "require(" (NOTE: if we went only with this SSG approach, we could remove that end of aria.js and this hack)
+
+// HACK call ariaAttributeReferences() and log out roleInfo with prefix
+const scriptAddition =
+    'ariaAttributeReferences();console.log("/* This file is generated - do not modify */ var roleInfo = "+JSON.stringify(roleInfo, null, 2));';
+
+// HACK: eval!
+eval(scriptWithoutRespecUI + scriptAddition);
+
+//NOTEs & Questions:
+// * we can execute ariaAttributeReference but can't access roleInfo since it's currently const. We could make aria.js a module and import it properly here; or we could have ariaAttributeReference return it (or make it global again).
+// * can we match serialization of current output in browser? Right now, roleInfo.js doesn't escape all strings but this will. Also, do we want to generate JSON?


### PR DESCRIPTION
Adds github actions and scripts to enable automatic checking and updating of roleInfo.js

- common/script/buildRoleInfo.js
  - currently very hacky way of running aria.js using linkedom (see #2501 for plans on removing hackery)
- roleInfo.yml: updates roleInfo.js on pushes to main
  - standard nodejs setup
  - installs linkedom and runs buildRoleInfo.js to update roleInfo
- roleInfoCheck.yml: checks PRs if they introduce changes to roleInfo.js
   - similar to roleInfo.yml but only reports on git diff (no commit)

Part of  #2501


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2625.html" title="Last updated on Sep 25, 2025, 10:19 AM UTC (fe811fa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2625/42350b4...fe811fa.html" title="Last updated on Sep 25, 2025, 10:19 AM UTC (fe811fa)">Diff</a>