### PR TITLE
Editorial: Fix id value references and add h2s where appropriate

### DIFF
--- a/pdf-aam/index.html
+++ b/pdf-aam/index.html
@@ -201,7 +201,7 @@
       </div>
     </section>
 
-    <section id="mapping-pdf-object to be named">
+    <section id="mapping-pdf-object-to-be-named">
       <h2>Mapping PDF-object to be named to Accessibility APIs</h2>
 
       <h3>General Rules for Exposing PDF Semantics via HTML or WAI-ARIA Semantics</h3>

--- a/pdf-aam/index.html
+++ b/pdf-aam/index.html
@@ -146,6 +146,7 @@
   </head>
   <body>
     <section id="abstract">
+      <h2>Abstract</h2>
       <p>
         This document describes how [=user agents=] should expose semantics of PDF content to <a class="termref">accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a
         >. This helps users with disabilities to obtain and interact with information using <a class="termref">assistive technologies</a>. Documenting these mappings promotes interoperable exposure of
@@ -153,6 +154,7 @@
       </p>
     </section>
     <section id="sotd">
+      <h2>Status of This Document</h2>
       <p>
         The Accessible Rich Internet Applications Working Group seeks feedback on any aspect of the specification. When submitting feedback, please consider issues in the context of the companion
         documents. To comment, <a href="https://github.com/w3c/pdf-aam/issues/new">file an issue in the <abbr title="World Wide Web Consortium">W3C</abbr> pdf-aam GitHub repository</a>. If this is not
@@ -162,6 +164,7 @@
       </p>
     </section>
     <section id="Introduction">
+      <h2>Introduction</h2>
       <p>This section is non-normative.</p>
 
       <p>


### PR DESCRIPTION
Fix some markup issues for the PDF-AAM spec to build. Others need to be fixed via scripts