### PR TITLE
Update aria-valuenow to use native value as the default instead of 0

### DIFF
--- a/index.html
+++ b/index.html
@@ -9443,7 +9443,10 @@
               <rref>button</rref> elements are <em>NOT</em> included in the primary navigation ring, e.g., the Tab ring in HTML.
             </p>
             <p>
-              Authors SHOULD set the <pref>aria-valuenow</pref> attribute when the <rref>spinbutton</rref> has a value. Authors SHOULD set the <pref>aria-valuemin</pref> attribute when there is a
+              On elements that have a native HTML <code>[^input/value^]</code> property such as an <code>&lt;input type="[^text^]"&gt;</code>, and that value is a decimal number, authors MAY set the <pref>aria-valuenow</pref> attribute if they wish to override it.
+            </p>
+            <p>
+              On elements that do not have a native HTML <code>[^input/value^]</code> property, or the value is something other than a decimal number, authors SHOULD set the <pref>aria-valuenow</pref> attribute when the <rref>spinbutton</rref> has a value. Authors SHOULD set the <pref>aria-valuemin</pref> attribute when there is a
               minimum value, and the <pref>aria-valuemax</pref> attribute when there is a maximum value.
             </p>
           </div>
@@ -16039,7 +16042,7 @@ button.ariaPressed; // null</pre
             <p>This property is used, for example, on a range widget such as a slider or progress bar.</p>
             <p>
               If the current value is not known (for example, an indeterminate progress bar), the author SHOULD NOT set the <pref>aria-valuenow</pref> <a>attribute</a>. If the
-              <pref>aria-valuenow</pref> attribute is absent, no information is implied about the current value. If the <pref>aria-valuenow</pref> has a known maximum and minimum, the author SHOULD
+              <pref>aria-valuenow</pref> attribute is absent and there is no HTML <code>[^input/value^]</code> attribute or the HTML <code>[^input/value^]</code> is not a decimal number, no information is implied about the current value. If the <pref>aria-valuenow</pref> has a known maximum and minimum, the author SHOULD
               provide properties for <pref>aria-valuemax</pref> and <pref>aria-valuemin</pref>.
             </p>
             <p>


### PR DESCRIPTION
Closes #2631

Right now, the spec says that `aria-valuenow` should default to 0 even if on an element like `<input type="text">` with a native `value`.

This PR updates the spec to specify that the native `value` should be used if it exists and `aria-valuenow` is undefined, falling back on 0 if both are absent.

A few questions to resolve include:
- should `element.ariaValueNow` be mapped to `value` if `aria-valuenow` is not present, or should it be an AAM thing?
- This came up because of `role=spinbutton`, but I think it's equally appropriate if less frequent on other `aria-valuenow`-supporting roles. Does that seem reasonable?

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests:
* [ ] Browser implementations (link to issue or commit):
   * WebKit:
   * Gecko:
   * Blink:
* [ ] ACT review?
* [ ] Does this need AT implementations?
* [ ] Related APG Issue/PR:
* [ ] MDN Issue/PR:
