### PR TITLE
Editorial: Living spec prose

### DIFF
--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -196,6 +196,7 @@
           >comment archive</a
         >). In-progress updates to the document may be viewed in the <a href="http://w3c.github.io/core-aam/">publicly visible editors' draft</a>.
       </p>
+      <p><strong>Living specification</strong> &mdash; This document is maintained as a living specification. For the latest normative version, visit <a href="https://www.w3.org/TR/core-aam-1.2/">Core Accessibility API Mappings</a>.</p>
     </section>
     <section id="intro" class="informative">
       <h2>Introduction</h2>

--- a/dpub-aam/index.html
+++ b/dpub-aam/index.html
@@ -164,6 +164,7 @@
     </section>
     <section id="sotd">
       <p>Future updates to this specification may incorporate <a href="https://www.w3.org/policies/process/20231103/#allow-new-features">new features</a>.</p>
+      <p><strong>Living specification</strong> &mdash; This document is maintained as a living specification. For the latest normative version, visit <a href="https://www.w3.org/TR/dpub-aam/">Digital Publishing Accessibility API Mappings</a>.</p>
     </section>
     <section id="intro" class="informative">
       <h2>Introduction</h2>


### PR DESCRIPTION
Relates to #2514

Only add this prose to specs that have already reached the Candidate Recommendation status.

- Core-aam
- DPUB-AAM

I propose we add to others as they reach CR and leave #2514 open.
