### PR TITLE
editorial: drag-and-drop content clean-up

### DIFF
--- a/index.html
+++ b/index.html
@@ -12056,7 +12056,6 @@ button.ariaPressed; // null</pre
         <ol>
           <li><a href="#attrs_widgets">Widget Attributes</a></li>
           <li><a href="#attrs_liveregions">Live Region Attributes</a></li>
-          <li><a href="#attrs_dragdrop">Drag-and-Drop Attributes</a></li>
           <li><a href="#attrs_relationships">Relationship Attributes</a></li>
         </ol>
         <section id="attrs_widgets">
@@ -12109,17 +12108,6 @@ button.ariaPressed; // null</pre
             <li><sref>aria-busy</sref></li>
             <li><pref>aria-live</pref></li>
             <li><pref>aria-relevant</pref></li>
-          </ul>
-        </section>
-        <section id="attrs_dragdrop">
-          <h3>Drag-and-Drop Attributes</h3>
-          <p>
-            This section lists [=attributes=] which indicate information about drag-and-drop interface [=elements=], such as draggable elements and their drop targets. Drop target information will be
-            rendered visually by the author and provided to <a>assistive technologies</a> through an alternate modality.
-          </p>
-          <ul>
-            <li><pref>aria-dropeffect</pref></li>
-            <li><sref>aria-grabbed</sref></li>
           </ul>
         </section>
         <section id="attrs_relationships">
@@ -16934,7 +16922,6 @@ button.ariaPressed; // null</pre
             <td><sref>aria-disabled</sref></td>
             <td><a href="#valuetype_true-false">true/false</a></td>
           </tr>
-          <!-- <tr><td><dfn>ariaDropeffect</dfn></td><td><pref>aria-dropeffect</pref></td></tr> -->
           <tr>
             <td><dfn>ariaErrorMessageElements</dfn></td>
             <td><pref>aria-errormessage</pref></td>
@@ -16950,7 +16937,6 @@ button.ariaPressed; // null</pre
             <td><pref>aria-flowto</pref></td>
             <td><a href="#valuetype_idref_list">ID reference list</a></td>
           </tr>
-          <!-- <tr><td><dfn>ariaGrabbed</dfn></td><td><pref>aria-grabbed</pref></td></tr> -->
           <tr>
             <td><dfn>ariaHasPopup</dfn></td>
             <td><pref>aria-haspopup</pref></td>


### PR DESCRIPTION
Additional cleanup following the deprecation of
aria-dropeffect and aria-grabbed.

- Section 6.6: remove link to subsection 6.6.3
- Section 6.6.3: remove subsection
- Section 10.2: remove commented-out table rows for these attributes

Resolves #2676


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria/pull/2692.html" title="Last updated on Dec 5, 2025, 3:50 PM UTC (cc57da6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2692/e366533...cc57da6.html" title="Last updated on Dec 5, 2025, 3:50 PM UTC (cc57da6)">Diff</a>