### PR TITLE
Editorial: Update link from #presentation (role) to instead point to #none (role)

### DIFF
--- a/index.html
+++ b/index.html
@@ -16136,7 +16136,7 @@ button.ariaPressed; // null</pre
           </li>
           <li>
             Elements with <rref>none</rref> or <rref>presentation</rref> as the first role in the role attribute. However, their exclusion is conditional. In addition, the element's descendants and
-            text content are generally included. These exceptions and conditions are documented in the <a href="#presentation">presentation (role)</a> section.
+            text content are generally included. These exceptions and conditions are documented in the <a href="#none">none (role)</a> section.
           </li>
         </ul>
         <p>If not already excluded from the accessibility tree per the above rules, user agents SHOULD NOT include the following elements in the accessibility tree:</p>


### PR DESCRIPTION
Closes #2696

Updates the link `<a href="#presentation">presentation (role)</a>` to instead point to `<a href="#none">none (role)</a>`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/janewman/aria/pull/2702.html" title="Last updated on Dec 18, 2025, 10:51 PM UTC (a09d798)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria/2702/55751aa...janewman:a09d798.html" title="Last updated on Dec 18, 2025, 10:51 PM UTC (a09d798)">Diff</a>