### PR TITLE
editorial: include example list in relevant note

### DIFF
--- a/index.html
+++ b/index.html
@@ -1193,49 +1193,51 @@
             <rref>row</rref> will not fulfill the requirement that <rref>listbox</rref> allows children with <rref>option</rref> or <rref>group</rref> roles.
           </p>
           <p class="note">An element with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> fulfills this requirement.</p>
-          <p class="note">Examples of valid ways to mark up allowed accessibility child roles include:</p>
-          <ol>
-            <li>
-              Direct DOM child:
-              <!-- ReSpec needs these examples to be unindented. -->
-              <pre class="example highlight html">
-&lt;div role="listbox"&gt;
-	&lt;div role="option"&gt;option text&lt;/div&gt;
-&lt;/div&gt;</pre
-              >
-            </li>
-            <li>
-              DOM child with generics intervening:
-              <!-- ReSpec needs these examples to be unindented. -->
-              <pre class="example highlight html">
-&lt;div role="listbox"&gt;
-	&lt;div&gt;
-		&lt;div role="option"&gt;option text&lt;/div&gt;
-	&lt;/div&gt;
-&lt;/div&gt;</pre
-              >
-            </li>
-            <li>
-              Direct <code>aria-owns</code> relationship:
-              <!-- ReSpec needs these examples to be unindented. -->
-              <pre class="example highlight html">
-&lt;div role="listbox" aria-owns="id1"&gt;&lt;/div&gt;
-&lt;div role="option" id="id1"&gt;option text&lt;/div&gt;</pre
-              >
-            </li>
-            <li>
-              <code>aria-owns</code> relationship with generics intervening:
-              <!-- ReSpec needs these examples to be unindented. -->
-              <pre class="example highlight html">
-&lt;div role="listbox" aria-owns="id1"&gt;&lt;/div&gt;
-&lt;div id="id1"&gt;
-	&lt;div&gt;
-		&lt;div role="option"&gt;option text&lt;/div&gt;
-	&lt;/div&gt;
-&lt;/div&gt;</pre
-              >
-            </li>
-          </ol>
+          <div class="note">
+            <p>Examples of valid ways to mark up allowed accessibility child roles include:</p>
+            <ol>
+              <li>
+                Direct DOM child:
+                <!-- ReSpec needs these examples to be unindented. -->
+                <pre class="example highlight html">
+  &lt;div role="listbox"&gt;
+    &lt;div role="option"&gt;option text&lt;/div&gt;
+  &lt;/div&gt;</pre
+                >
+              </li>
+              <li>
+                DOM child with generics intervening:
+                <!-- ReSpec needs these examples to be unindented. -->
+                <pre class="example highlight html">
+  &lt;div role="listbox"&gt;
+    &lt;div&gt;
+      &lt;div role="option"&gt;option text&lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;</pre
+                >
+              </li>
+              <li>
+                Direct <code>aria-owns</code> relationship:
+                <!-- ReSpec needs these examples to be unindented. -->
+                <pre class="example highlight html">
+  &lt;div role="listbox" aria-owns="id1"&gt;&lt;/div&gt;
+  &lt;div role="option" id="id1"&gt;option text&lt;/div&gt;</pre
+                >
+              </li>
+              <li>
+                <code>aria-owns</code> relationship with generics intervening:
+                <!-- ReSpec needs these examples to be unindented. -->
+                <pre class="example highlight html">
+  &lt;div role="listbox" aria-owns="id1"&gt;&lt;/div&gt;
+  &lt;div id="id1"&gt;
+    &lt;div&gt;
+      &lt;div role="option"&gt;option text&lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;</pre
+                >
+              </li>
+            </ol>
+          </div>
         </section>
         <section id="scope">
           <h3>Required Accessibility Parent Role</h3>


### PR DESCRIPTION
🚀 **Netlify Preview**:
🔄 **this PR updates the following sspecs**:
- [ARIA preview](https://deploy-preview-2712--wai-aria.netlify.app/index.html) &mdash; [ARIA diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Faria%2F&doc2=https%3A%2F%2Fdeploy-preview-2712--wai-aria.netlify.app%2Findex.html)

Adjusting markup to allow list in the note it belongs to.