### PR TITLE
[html-aam] Set heading level based on HTML computed heading level

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -2667,7 +2667,7 @@
               <th>[[wai-aria-1.2]]</th>
               <td>
                 <a class="core-mapping" href="#role-map-heading">`heading`</a> role, with the <a class="core-mapping" href="#ariaLevel">`aria-level`</a> property set to
-                <a data-cite="html/sections.html#get-an-element's-computed-heading-offset">the computed heading level</a>; this is the number from the element's tag name (e.g., 2 for `h2`), adjusted
+                 <a data-cite="html/sections.html#get-an-element's-computed-heading-level">the computed heading level</a>; this is the number from the element's tag name (e.g., 2 for `h2`), adjusted
                 by any <a href="#att-headingoffset">`headingoffset`</a> or <a href="#att-headingreset">`headingreset`</a> attributes in scope.
                 <p>If an explicit <a class="core-mapping" href="#ariaLevel">`aria-level`</a> attribute is specified on the element, user agents MUST use that value instead of the implicit `aria-level` value derived from
                  the computed heading level.</p>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -2671,6 +2671,7 @@
                 by any <a href="#att-headingoffset">`headingoffset`</a> or <a href="#att-headingreset">`headingreset`</a> attributes in scope.
                 <p>If an explicit <a class="core-mapping" href="#ariaLevel">`aria-level`</a> attribute is specified on the element, user agents MUST use that value instead of the implicit `aria-level` value derived from
                  the computed heading level.</p>
+                 <p class="note">The <a data-cite="html/sections.html#get-an-element's-computed-heading-level">computed heading level algorithm</a> caps the implicit `aria-level` value at 9.</p>
               </td>
             </tr>
             <tr>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -11169,7 +11169,7 @@
             <tr>
               <th>Element(s)</th>
               <td>
-                <a data-cite="html/dom.html#global-attributes">Global attribute</a>
+                <a data-cite="html/infrastructure.html#html-elements">HTML elements</a>
               </td>
             </tr>
             <tr>
@@ -11218,7 +11218,7 @@
             <tr>
               <th>Element(s)</th>
               <td>
-                <a data-cite="html/dom.html#global-attributes">Global attribute</a>
+                <a data-cite="html/infrastructure.html#html-elements">HTML elements</a>
               </td>
             </tr>
             <tr>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -2669,10 +2669,8 @@
                 <a class="core-mapping" href="#role-map-heading">`heading`</a> role, with the <a class="core-mapping" href="#ariaLevel">`aria-level`</a> property set to
                 <a data-cite="html/sections.html#get-an-element's-computed-heading-offset">the computed heading level</a>; this is the number from the element's tag name (e.g., 2 for `h2`), adjusted
                 by any <a href="#att-headingoffset">`headingoffset`</a> or <a href="#att-headingreset">`headingreset`</a> attributes in scope.
-                <div class="note">
-                  If an explicit <a class="core-mapping" href="#ariaLevel">`aria-level`</a> attribute is specified on the element, it takes priority over the implicit `aria-level` value derived from
-                  the computed heading level.
-                </div>
+                <p>If an explicit <a class="core-mapping" href="#ariaLevel">`aria-level`</a> attribute is specified on the element, user agents MUST use that value instead of the implicit `aria-level` value derived from
+                 the computed heading level.</p>
               </td>
             </tr>
             <tr>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -2666,8 +2666,13 @@
             <tr>
               <th>[[wai-aria-1.2]]</th>
               <td>
-                <a class="core-mapping" href="#role-map-heading">`heading`</a> role, with the <a class="core-mapping" href="#ariaLevel">`aria-level`</a> property set to the number in the element's tag
-                name.
+                <a class="core-mapping" href="#role-map-heading">`heading`</a> role, with the <a class="core-mapping" href="#ariaLevel">`aria-level`</a> property set to
+                <a data-cite="html/sections.html#get-an-element's-computed-heading-offset">the computed heading level</a>; this is the number from the element's tag name (e.g., 2 for `h2`), adjusted
+                by any <a href="#att-headingoffset">`headingoffset`</a> or <a href="#att-headingreset">`headingreset`</a> attributes in scope.
+                <div class="note">
+                  If an explicit <a class="core-mapping" href="#ariaLevel">`aria-level`</a> attribute is specified on the element, it takes priority over the implicit `aria-level` value derived from
+                  the computed heading level.
+                </div>
               </td>
             </tr>
             <tr>
@@ -11147,6 +11152,107 @@
             <tr>
               <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
               <td>Expose via `AXColumnHeaderUIElements` and `AXRowHeaderUIElements`</td>
+            </tr>
+            <tr>
+              <th>Comments</th>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+        <h4 id="att-headingoffset">`headingoffset`</h4>
+        <table class="data" aria-labelledby="att-headingoffset">
+          <tbody>
+            <tr>
+              <th>HTML Specification</th>
+              <td><a data-cite="html/sections.html#attr-headingoffset">`headingoffset`</a></td>
+            </tr>
+            <tr>
+              <th>Element(s)</th>
+              <td>
+                <a data-cite="html/dom.html#global-attributes">Global attribute</a>
+              </td>
+            </tr>
+            <tr>
+              <th>[[WAI-ARIA-1.2]]</th>
+              <td>Adjusts the <a class="core-mapping" href="#ariaLevel">`aria-level`</a> property of in-scope <a href="#el-h1-h6">heading elements</a> by the specified offset value.</td>
+            </tr>
+            <tr>
+              <th>
+                <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
+              </th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
+            </tr>
+            <tr>
+              <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
+            </tr>
+            <tr>
+              <th><span class="informative">[[ATK]]</span></th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
+            </tr>
+            <tr>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
+            </tr>
+            <tr>
+              <th>Comments</th>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+        <h4 id="att-headingreset">`headingreset`</h4>
+        <table class="data" aria-labelledby="att-headingreset">
+          <tbody>
+            <tr>
+              <th>HTML Specification</th>
+              <td><a data-cite="html/sections.html#attr-headingreset">`headingreset`</a></td>
+            </tr>
+            <tr>
+              <th>Element(s)</th>
+              <td>
+                <a data-cite="html/dom.html#global-attributes">Global attribute</a>
+              </td>
+            </tr>
+            <tr>
+              <th>[[WAI-ARIA-1.2]]</th>
+              <td>
+                Resets the <a class="core-mapping" href="#ariaLevel">`aria-level`</a> property of in-scope <a href="#el-h1-h6">heading elements</a> to the specified base level before applying any
+                offset.
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
+              </th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
+            </tr>
+            <tr>
+              <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
+            </tr>
+            <tr>
+              <th><span class="informative">[[ATK]]</span></th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
+            </tr>
+            <tr>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
             </tr>
             <tr>
               <th>Comments</th>


### PR DESCRIPTION
🚀 **Netlify Preview**:
🔄 **this PR updates the following sspecs**:
- [html-aam preview](https://deploy-preview-2720--wai-aria.netlify.app/html-aam/index.html) &mdash; [html-aam diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fhtml-aam%2F&doc2=https%3A%2F%2Fdeploy-preview-2720--wai-aria.netlify.app%2Fhtml-aam%2Findex.html)

Refs https://github.com/whatwg/html/pull/11086.

This wires up HTML-AAM to the `headingoffset` feature of the html spec which defines an algorithm for computing a heading level.

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

(Supersedes https://github.com/w3c/aria/pull/2598)

* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests:
* [x] Browser implementations (link to issue or commit):
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=295092
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1974383
   * Blink: https://issues.chromium.org/issues/333628468
* [ ] ACT review?
* [ ] Does this need AT implementations?
* [ ] Related APG Issue/PR:
* [ ] MDN Issue/PR: