### PR TITLE
Editorial: fix capitalisation of company name

### DIFF
--- a/svg-aam/index.html
+++ b/svg-aam/index.html
@@ -40,7 +40,7 @@
         // only "name" is required
         editors: [
           { name: "Cynthia Shelly", company: "Invited Expert", mailto: "buphie@gmail.com", w3cid: "11897" },
-          { name: "Mark Rogers", company: "powerMapper", mailto: "mark.rogers@powermapper.com", w3cid: "95601" },
+          { name: "Mark Rogers", company: "PowerMapper", mailto: "mark.rogers@powermapper.com", w3cid: "95601" },
         ],
         formerEditors: [
           { name: "Amelia Bellamy-Royds", company: "Invited Expert", mailto: "amelia.bellamy.royds@gmail.com", w3cid: 75809 },


### PR DESCRIPTION
This fixes capitalisation of my company name listed in svg-aam authors (was spelled powerMapper with a lowercase 'p', now changed to PowerMapper with an uppercase 'P')

Main purpose of this PR is testing svg-aam authoring workflow.

