### PR TITLE
Experiment with JSON to generate Core-AAM mapping tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,9 @@ pip-log.txt
 
 # Local Netlify folder
 .netlify
+
+#################
+## Node
+#################
+
+tools/node_modules/

--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -2193,19 +2193,19 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
+                  <p>Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</p>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
+                  <p>Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</p>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
+                  <p>Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</p>
                 </td>
               </tr>
               <tr>
@@ -2213,7 +2213,7 @@
                   <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
                 </th>
                 <td>
-                  <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
+                  <p>Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</p>
                 </td>
               </tr>
               <tr>
@@ -4342,19 +4342,19 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
+                  <p class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</p>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
+                  <p class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</p>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
+                  <p>Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</p>
                 </td>
               </tr>
               <tr>
@@ -4362,7 +4362,7 @@
                   <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
                 </th>
                 <td>
-                  <span class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</span>
+                  <p>Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</p>
                 </td>
               </tr>
               <tr>
@@ -5949,7 +5949,7 @@
                   ><br />
                   <span class="property">Localized Control Type: <code>time</code></span
                   ><br />
-                  <span>Note: create a separate UIA Control of type Text. This is different from most UIA text mappings, which only create ranges in the page text pattern.</span>
+                  <p>Note: create a separate UIA Control of type Text. This is different from most UIA text mappings, which only create ranges in the page text pattern.</p>
                 </td>
               </tr>
               <tr>
@@ -6656,7 +6656,7 @@
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: AXBrailleLabel</span>
+                  <span class="property">AXBrailleLabel: <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -6697,7 +6697,7 @@
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: AXBrailleRoleDescription</span>
+                  <span class="property">Property: AXBrailleRoleDescription: <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -10248,7 +10248,7 @@
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
                   <span class="property"
-                    >Localized Control Type is defined as that specified for the role of the element: based on the explicit role if the role attribute is provided; otherwise, based on the implicit
+                    >Localized Control Type</code>: Defined as that specified for the role of the element: based on the explicit role if the role attribute is provided; otherwise, based on the implicit
                     role for the host language.</span
                   >
                 </td>
@@ -10263,7 +10263,7 @@
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
                   <span class="property"
-                    >AXRoleDescription is defined as that specified for the role of the element: based on the explicit role if the role attribute is provided; otherwise, based on the implicit role for
+                    >AXRoleDescription: Defined as that specified for the role of the element: based on the explicit role if the role attribute is provided; otherwise, based on the implicit role for
                     the host language.</span
                   >
                 </td>

--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -596,6 +596,7 @@
         <section id="mapping_role_table">
           <h3>Role Mapping Tables</h3>
           <!-- GENERATION ROLE MAP START -->
+
           <h4 id="role-map-alert"><code>alert</code></h4>
           <table class="data" aria-labelledby="role-map-alert">
             <tbody>
@@ -614,41 +615,39 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_ALERT</code></span
+                  <span>Role: <code>ROLE_SYSTEM_ALERT</code></span
                   ><br />
-                  <span class="event">Event: The user agent SHOULD fire <code>EVENT_SYSTEM_ALERT</code>.</span>
+                  <span>Event: <code>EVENT_SYSTEM_ALERT</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>alert</code></span
+                  <span>Localized Control Type: <code>alert</code></span
                   ><br />
-                  <span class="property">LiveSetting: <code>Assertive (2)</code></span
+                  <span>LiveSetting: <code>Assertive (2)</code></span
                   ><br />
-                  <span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span>
+                  <span>Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_NOTIFICATION</code></span
+                  <span>Role: <code>ROLE_NOTIFICATION</code></span
                   ><br />
-                  <span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span>
+                  <span>Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXApplicationAlert</code></span
+                  <span>AXSubrole: <code>AXApplicationAlert</code></span
                   ><br />
-                  <span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span>
+                  <span>Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span>
                 </td>
               </tr>
               <tr>
@@ -659,6 +658,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-alertdialog"><code>alertdialog</code></h4>
           <table class="data" aria-labelledby="role-map-alertdialog">
             <tbody>
@@ -677,39 +677,37 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_DIALOG</code></span
+                  <span>Role: <code>ROLE_SYSTEM_DIALOG</code></span
                   ><br />
-                  <span class="event">Event: The user agent SHOULD fire <code>EVENT_SYSTEM_ALERT</code>.</span>
+                  <span>Event: <code>EVENT_SYSTEM_ALERT</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Pane</code></span
+                  <span>Control Type: <code>Pane</code></span
                   ><br />
-                  <span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span>
+                  <span>Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_ALERT</code></span
+                  <span>Role: <code>ROLE_ALERT</code></span
                   ><br />
-                  <span class="property">Interface: <code>Window</code></span
+                  <span>Interface: <code>Window</code></span
                   ><br />
-                  <span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span>
+                  <span>Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXApplicationAlertDialog</code></span
+                  <span>AXSubrole: <code>AXApplicationAlertDialog</code></span
                   ><br />
-                  <span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span>
+                  <span>Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span>
                 </td>
               </tr>
               <tr>
@@ -720,6 +718,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-application"><code>application</code></h4>
           <table class="data" aria-labelledby="role-map-application">
             <tbody>
@@ -738,32 +737,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_APPLICATION</code></span>
+                  <span>Role: <code>ROLE_SYSTEM_APPLICATION</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Pane</code></span
+                  <span>Control Type: <code>Pane</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>application</code></span>
+                  <span>Localized Control Type: <code>application</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_EMBEDDED</code></span>
+                  <span>Role: <code>ROLE_EMBEDDED</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXWebApplication</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXWebApplication</code></span>
                 </td>
               </tr>
               <tr>
@@ -774,6 +770,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-article"><code>article</code></h4>
           <table class="data" aria-labelledby="role-map-article">
             <tbody>
@@ -792,38 +789,35 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_DOCUMENT</code></span
+                  <span>Role: <code>ROLE_SYSTEM_DOCUMENT</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_SYSTEM_READONLY</code></span
+                  <span>State: <code>STATE_SYSTEM_READONLY</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:article</code></span>
+                  <span>Object Attribute: <code>xml-roles:article</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>article</code></span>
+                  <span>Localized Control Type: <code>article</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_ARTICLE</code></span
+                  <span>Role: <code>ROLE_ARTICLE</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:article</code></span>
+                  <span>Object Attribute: <code>xml-roles:article</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXDocumentArticle</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXDocumentArticle</code></span>
                 </td>
               </tr>
               <tr>
@@ -834,6 +828,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-banner"><code>banner</code></h4>
           <table class="data" aria-labelledby="role-map-banner">
             <tbody>
@@ -852,40 +847,37 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span
+                  <span>Role: <code>IA2_ROLE_LANDMARK</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:banner</code></span>
+                  <span>Object Attribute: <code>xml-roles:banner</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>banner</code></span
+                  <span>Localized Control Type: <code>banner</code></span
                   ><br />
-                  <span class="property">Landmark Type: <code>Custom</code></span
+                  <span>Landmark Type: <code>Custom</code></span
                   ><br />
-                  <span class="property">Localized Landmark Type: <code>banner</code></span>
+                  <span>Localized Landmark Type: <code>banner</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_LANDMARK</code></span
+                  <span>Role: <code>ROLE_LANDMARK</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:banner</code></span>
+                  <span>Object Attribute: <code>xml-roles:banner</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXLandmarkBanner</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXLandmarkBanner</code></span>
                 </td>
               </tr>
               <tr>
@@ -896,6 +888,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-blockquote"><code>blockquote</code></h4>
           <table class="data" aria-labelledby="role-map-blockquote">
             <tbody>
@@ -914,35 +907,31 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  <span>Role: <code>ROLE_SYSTEM_GROUPING</code></span
                   ><br />
-                  <span class="property">Role: <code>IA2_ROLE_BLOCK_QUOTE</code></span>
+                  <span>Role: <code>IA2_ROLE_BLOCK_QUOTE</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>blockquote</code></span>
+                  <span>Localized Control Type: <code>blockquote</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_BLOCK_QUOTE</code></span
-                  ><br />
+                  <span>Role: <code>ROLE_BLOCK_QUOTE</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -953,6 +942,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-button"><code>button</code> with default values for <code>aria-pressed</code> and <code>aria-haspopup</code></h4>
           <table class="data" aria-labelledby="role-map-button">
             <tbody>
@@ -972,30 +962,27 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_PUSHBUTTON</code></span>
+                  <span>Role: <code>ROLE_SYSTEM_PUSHBUTTON</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Button</code></span>
+                  <span>Control Type: <code>Button</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_PUSH_BUTTON</code></span>
+                  <span>Role: <code>ROLE_PUSH_BUTTON</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXButton</code></span
+                  <span>AXRole: <code>AXButton</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -1006,6 +993,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-button-haspopup"><code>button</code> with non-<code>false</code> value for <code>aria-haspopup</code></h4>
           <table class="data" aria-labelledby="role-map-button-haspopup">
             <tbody>
@@ -1024,30 +1012,27 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_BUTTONMENU</code></span>
+                  <span>Role: <code>ROLE_SYSTEM_BUTTONMENU</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Button</code></span>
+                  <span>Control Type: <code>Button</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_PUSH_BUTTON</code></span>
+                  <span>Role: <code>ROLE_PUSH_BUTTON</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXPopUpButton</code></span
+                  <span>AXRole: <code>AXPopUpButton</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -1058,6 +1043,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></h4>
           <table class="data" aria-labelledby="role-map-button-pressed">
             <tbody>
@@ -1076,32 +1062,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_PUSHBUTTON</code></span
+                  <span>Role: <code>ROLE_SYSTEM_PUSHBUTTON</code></span
                   ><br />
-                  <span class="property">Role: <code>IA2_ROLE_TOGGLE_BUTTON</code></span>
+                  <span>Role: <code>IA2_ROLE_TOGGLE_BUTTON</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Button</code></span>
+                  <span>Control Type: <code>Button</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_TOGGLE_BUTTON</code></span>
+                  <span>Role: <code>ROLE_TOGGLE_BUTTON</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXCheckBox</code></span
+                  <span>AXRole: <code>AXCheckBox</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXToggle</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXToggle</code></span>
                 </td>
               </tr>
               <tr>
@@ -1112,6 +1095,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-caption"><code>caption</code></h4>
           <table class="data" aria-labelledby="role-map-caption">
             <tbody>
@@ -1130,32 +1114,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  <span>Role: <code>ROLE_SYSTEM_GROUPING</code></span
                   ><br />
-                  <span class="property">Role: <code>IA2_ROLE_CAPTION</code></span>
+                  <span>Role: <code>IA2_ROLE_CAPTION</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Text</code></span>
+                  <span>Control Type: <code>Text</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_CAPTION</code></span>
+                  <span>Role: <code>ROLE_CAPTION</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -1166,6 +1147,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-cell"><code>cell</code></h4>
           <table class="data" aria-labelledby="role-map-cell">
             <tbody>
@@ -1184,40 +1166,37 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_CELL</code></span
+                  <span>Role: <code>ROLE_SYSTEM_CELL</code></span
                   ><br />
-                  <span class="property">Interface: <code>IAccessibleTableCell</code></span>
+                  <span>Interface: <code>IAccessibleTableCell</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>DataItem</code></span
+                  <span>Control Type: <code>DataItem</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>item</code></span
+                  <span>Localized Control Type: <code>item</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>GridItem</code></span
+                  <span>Control Pattern: <code>GridItem</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>TableItem</code></span>
+                  <span>Control Pattern: <code>TableItem</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_TABLE_CELL</code></span
+                  <span>Role: <code>ROLE_TABLE_CELL</code></span
                   ><br />
-                  <span class="property">Interface: <code>TableCell</code></span>
+                  <span>Interface: <code>TableCell</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXCell</code></span
+                  <span>AXRole: <code>AXCell</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -1228,6 +1207,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-checkbox"><code>checkbox</code></h4>
           <table class="data" aria-labelledby="role-map-checkbox">
             <tbody>
@@ -1246,7 +1226,7 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_CHECKBUTTON</code></span
+                  <span>Role: <code>ROLE_SYSTEM_CHECKBUTTON</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -1254,7 +1234,7 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Checkbox</code></span
+                  <span>Control Type: <code>Checkbox</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -1262,19 +1242,17 @@
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_CHECK_BOX</code></span
+                  <span>Role: <code>ROLE_CHECK_BOX</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXCheckBox</code></span
+                  <span>AXRole: <code>AXCheckBox</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -1287,6 +1265,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-code"><code>code</code></h4>
           <table class="data" aria-labelledby="role-map-code">
             <tbody>
@@ -1305,36 +1284,33 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span
+                  <span>Role: <code>IA2_ROLE_TEXT_FRAME</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:code</code></span>
+                  <span>Object Attribute: <code>xml-roles:code</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Text</code></span
+                  <span>Control Type: <code>Text</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>code</code></span>
+                  <span>Localized Control Type: <code>code</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_STATIC</code></span
+                  <span>Role: <code>ROLE_STATIC</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:code</code></span>
+                  <span>Object Attribute: <code>xml-roles:code</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXCodeStyleGroup</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXCodeStyleGroup</code></span>
                 </td>
               </tr>
               <tr>
@@ -1345,6 +1321,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-columnheader"><code>columnheader</code></h4>
           <table class="data" aria-labelledby="role-map-columnheader">
             <tbody>
@@ -1363,40 +1340,37 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_COLUMNHEADER</code></span
+                  <span>Role: <code>ROLE_SYSTEM_COLUMNHEADER</code></span
                   ><br />
-                  <span class="property">Interface: <code>IAccessibleTableCell</code></span>
+                  <span>Interface: <code>IAccessibleTableCell</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>DataItem</code></span
+                  <span>Control Type: <code>DataItem</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>column header</code></span
+                  <span>Localized Control Type: <code>column header</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>GridItem</code></span
+                  <span>Control Pattern: <code>GridItem</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>TableItem</code></span>
+                  <span>Control Pattern: <code>TableItem</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_COLUMN_HEADER</code></span
+                  <span>Role: <code>ROLE_COLUMN_HEADER</code></span
                   ><br />
-                  <span class="property">Interface: <code>TableCell</code></span>
+                  <span>Interface: <code>TableCell</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXCell</code></span
+                  <span>AXRole: <code>AXCell</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -1407,6 +1381,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-combobox"><code>combobox</code></h4>
           <table class="data" aria-labelledby="role-map-combobox">
             <tbody>
@@ -1425,40 +1400,37 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_COMBOBOX</code></span
+                  <span>Role: <code>ROLE_SYSTEM_COMBOBOX</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span
+                  <span>State: <code>STATE_SYSTEM_HASPOPUP</code></span
                   ><br />
-                  <span class="property"
-                    >State: <code>STATE_SYSTEM_COLLAPSED</code> if <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a> is not <code>&quot;true&quot;</code></span
+                  <span
+                    >State: <code>STATE_SYSTEM_COLLAPSED</code> if <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a> is not <code>"true"</code></span
                   >
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Combobox</code></span>
+                  <span>Control Type: <code>Combobox</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_COMBO_BOX</code></span
+                  <span>Role: <code>ROLE_COMBO_BOX</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_EXPANDABLE</code></span
+                  <span>State: <code>STATE_EXPANDABLE</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_HAS_POPUP</code></span>
+                  <span>State: <code>STATE_HAS_POPUP</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXComboBox</code></span
+                  <span>AXRole: <code>AXComboBox</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -1469,6 +1441,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-comment"><code>comment</code></h4>
           <table class="data" aria-labelledby="role-map-comment">
             <tbody>
@@ -1487,35 +1460,31 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>IA2_ROLE_COMMENT</code></span
+                  <span>Role: <code>IA2_ROLE_COMMENT</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:comment</code></span>
+                  <span>Object Attribute: <code>xml-roles:comment</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>comment</code></span
-                  ><br />
+                  <span>Localized Control Type: <code>comment</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_COMMENT</code></span
+                  <span>Role: <code>ROLE_COMMENT</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:comment</code></span>
+                  <span>Object Attribute: <code>xml-roles:comment</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
-                  ><br />
+                  <span>AXRole: <code>AXGroup</code></span>
                 </td>
               </tr>
               <tr>
@@ -1526,6 +1495,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-complementary"><code>complementary</code></h4>
           <table class="data" aria-labelledby="role-map-complementary">
             <tbody>
@@ -1544,40 +1514,37 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span
+                  <span>Role: <code>IA2_ROLE_LANDMARK</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:complementary</code></span>
+                  <span>Object Attribute: <code>xml-roles:complementary</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>complementary</code></span
+                  <span>Localized Control Type: <code>complementary</code></span
                   ><br />
-                  <span class="property">Landmark Type: <code>Custom</code></span
+                  <span>Landmark Type: <code>Custom</code></span
                   ><br />
-                  <span class="property">Localized Landmark Type: <code>complementary</code></span>
+                  <span>Localized Landmark Type: <code>complementary</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_LANDMARK</code></span
+                  <span>Role: <code>ROLE_LANDMARK</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:complementary</code></span>
+                  <span>Object Attribute: <code>xml-roles:complementary</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXLandmarkComplementary</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXLandmarkComplementary</code></span>
                 </td>
               </tr>
               <tr>
@@ -1588,6 +1555,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-contentinfo"><code>contentinfo</code></h4>
           <table class="data" aria-labelledby="role-map-contentinfo">
             <tbody>
@@ -1606,40 +1574,37 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span
+                  <span>Role: <code>IA2_ROLE_LANDMARK</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:contentinfo</code></span>
+                  <span>Object Attribute: <code>xml-roles:contentinfo</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>content information</code></span
+                  <span>Localized Control Type: <code>content information</code></span
                   ><br />
-                  <span class="property">Landmark Type: <code>Custom</code></span
+                  <span>Landmark Type: <code>Custom</code></span
                   ><br />
-                  <span class="property">Localized Landmark Type: <code>content information</code></span>
+                  <span>Localized Landmark Type: <code>content information</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_LANDMARK</code></span
+                  <span>Role: <code>ROLE_LANDMARK</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:contentinfo</code></span>
+                  <span>Object Attribute: <code>xml-roles:contentinfo</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXLandmarkContentInfo</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXLandmarkContentInfo</code></span>
                 </td>
               </tr>
               <tr>
@@ -1650,6 +1615,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-definition"><code>definition</code></h4>
           <table class="data" aria-labelledby="role-map-definition">
             <tbody>
@@ -1668,34 +1634,31 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>xml-roles:definition</code></span>
+                  <span>Object Attribute: <code>xml-roles:definition</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>definition</code></span>
+                  <span>Localized Control Type: <code>definition</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_DESCRIPTION_VALUE</code></span
+                  <span>Role: <code>ROLE_DESCRIPTION_VALUE</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:definition</code></span>
+                  <span>Object Attribute: <code>xml-roles:definition</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXDefinition</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXDefinition</code></span>
                 </td>
               </tr>
               <tr>
@@ -1706,6 +1669,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-deletion"><code>deletion</code></h4>
           <table class="data" aria-labelledby="role-map-deletion">
             <tbody>
@@ -1724,35 +1688,33 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>IA2_ROLE_CONTENT_DELETION</code></span>
+                  <span>Role: <code>IA2_ROLE_CONTENT_DELETION</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Text</code></span
+                  <span>Control Type: <code>Text</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>deletion</code></span>
+                  <span>Localized Control Type: <code>deletion</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_CONTENT_DELETION</code></span
+                  <span>Role: <code>ROLE_CONTENT_DELETION</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:deletion</code></span>
+                  <span>Object Attribute: <code>xml-roles:deletion</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXDeleteStyleGroup</code></span
+                  <span>AXSubrole: <code>AXDeleteStyleGroup</code></span
                   ><br />
-                  <span class="property">AXAttributedStringForTextMarkerRange: contains <code>AXIsSuggestedDeletion = 1;</code> for all text contained in a <code>deletion</code></span>
+                  <span>AXAttributedStringForTextMarkerRange: <code>AXIsSuggestedDeletion = 1;</code> for all text contained in a <code>deletion</code></span>
                 </td>
               </tr>
               <tr>
@@ -1763,6 +1725,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-dialog"><code>dialog</code></h4>
           <table class="data" aria-labelledby="role-map-dialog">
             <tbody>
@@ -1781,32 +1744,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_DIALOG</code></span>
+                  <span>Role: <code>ROLE_SYSTEM_DIALOG</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Pane</code></span>
+                  <span>Control Type: <code>Pane</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_DIALOG</code></span
+                  <span>Role: <code>ROLE_DIALOG</code></span
                   ><br />
-                  <span class="property">Interface: <code>Window</code></span>
+                  <span>Interface: <code>Window</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXApplicationDialog</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXApplicationDialog</code></span>
                 </td>
               </tr>
               <tr>
@@ -1817,6 +1777,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-directory"><code>directory</code> (deprecated)</h4>
           <table class="data" aria-labelledby="role-map-directory">
             <tbody>
@@ -1829,36 +1790,33 @@
               <tr>
                 <th>Computed Role</th>
                 <td>
-                  <p>list</p>
+                  <p><code>list</code></p>
                 </td>
               </tr>
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span>
+                  <span>Role: <code>ROLE_SYSTEM_LIST</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>List</code></span>
+                  <span>Control Type: <code>List</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_LIST</code></span>
+                  <span>Role: <code>ROLE_LIST</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXList</code></span
+                  <span>AXRole: <code>AXList</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXContentList</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXContentList</code></span>
                 </td>
               </tr>
               <tr>
@@ -1869,6 +1827,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-document"><code>document</code></h4>
           <table class="data" aria-labelledby="role-map-document">
             <tbody>
@@ -1887,32 +1846,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_DOCUMENT</code></span
+                  <span>Role: <code>ROLE_SYSTEM_DOCUMENT</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_SYSTEM_READONLY</code></span>
+                  <span>State: <code>STATE_SYSTEM_READONLY</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Document</code></span>
+                  <span>Control Type: <code>Document</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_DOCUMENT_FRAME</code></span>
+                  <span>Role: <code>ROLE_DOCUMENT_FRAME</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXDocument</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXDocument</code></span>
                 </td>
               </tr>
               <tr>
@@ -1923,6 +1879,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-emphasis"><code>emphasis</code></h4>
           <table class="data" aria-labelledby="role-map-emphasis">
             <tbody>
@@ -1941,36 +1898,33 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span
+                  <span>Role: <code>IA2_ROLE_TEXT_FRAME</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:emphasis</code></span>
+                  <span>Object Attribute: <code>xml-roles:emphasis</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Text</code></span
+                  <span>Control Type: <code>Text</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>emphasis</code></span>
+                  <span>Localized Control Type: <code>emphasis</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_STATIC</code></span
+                  <span>Role: <code>ROLE_STATIC</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:emphasis</code></span>
+                  <span>Object Attribute: <code>xml-roles:emphasis</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXEmphasisStyleGroup</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXEmphasisStyleGroup</code></span>
                 </td>
               </tr>
               <tr>
@@ -1981,6 +1935,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-feed"><code>feed</code></h4>
           <table class="data" aria-labelledby="role-map-feed">
             <tbody>
@@ -1999,36 +1954,33 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  <span>Role: <code>ROLE_SYSTEM_GROUPING</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:feed</code></span>
+                  <span>Object Attribute: <code>xml-roles:feed</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>feed</code></span>
+                  <span>Localized Control Type: <code>feed</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_PANEL</code></span
+                  <span>Role: <code>ROLE_PANEL</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:feed</code></span>
+                  <span>Object Attribute: <code>xml-roles:feed</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXApplicationGroup</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXApplicationGroup</code></span>
                 </td>
               </tr>
               <tr>
@@ -2039,6 +1991,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-figure"><code>figure</code></h4>
           <table class="data" aria-labelledby="role-map-figure">
             <tbody>
@@ -2057,36 +2010,33 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  <span>Role: <code>ROLE_SYSTEM_GROUPING</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:figure</code></span>
+                  <span>Object Attribute: <code>xml-roles:figure</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>figure</code></span>
+                  <span>Localized Control Type: <code>figure</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_PANEL</code></span
+                  <span>Role: <code>ROLE_PANEL</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:figure</code></span>
+                  <span>Object Attribute: <code>xml-roles:figure</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -2097,6 +2047,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-form"><code>form</code> with an accessible name</h4>
           <table class="data" aria-labelledby="role-map-form">
             <tbody>
@@ -2115,38 +2066,35 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>IA2_ROLE_FORM</code></span
+                  <span>Role: <code>IA2_ROLE_FORM</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:form</code></span>
+                  <span>Object Attribute: <code>xml-roles:form</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>form</code></span
+                  <span>Localized Control Type: <code>form</code></span
                   ><br />
-                  <span class="property">Landmark Type: <code>Form</code></span>
+                  <span>Landmark Type: <code>Form</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_LANDMARK</code></span
+                  <span>Role: <code>ROLE_LANDMARK</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:form</code></span>
+                  <span>Object Attribute: <code>xml-roles:form</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXLandmarkForm</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXLandmarkForm</code></span>
                 </td>
               </tr>
               <tr>
@@ -2157,6 +2105,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-form-nameless"><code>form</code> without an accessible name</h4>
           <table class="data" aria-labelledby="role-map-form-nameless">
             <tbody>
@@ -2191,9 +2140,7 @@
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
                   <p>Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</p>
                 </td>
@@ -2206,6 +2153,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-generic"><code>generic</code></h4>
           <table class="data" aria-labelledby="role-map-generic">
             <tbody>
@@ -2224,33 +2172,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  <span>Role: <code>ROLE_SYSTEM_GROUPING</code></span
                   ><br />
-                  <span class="property">Role: <code>IA2_ROLE_SECTION</code></span>
+                  <span>Role: <code>IA2_ROLE_SECTION</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span>
+                  <span>Control Type: <code>Group</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SECTION</code></span
-                  ><br />
+                  <span>Role: <code>ROLE_SECTION</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -2261,6 +2205,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-grid"><code>grid</code></h4>
           <table class="data" aria-labelledby="role-map-grid">
             <tbody>
@@ -2279,39 +2224,39 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_TABLE</code></span
+                  <span>Role: <code>ROLE_SYSTEM_TABLE</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:grid</code></span
+                  <span>Object Attribute: <code>xml-roles:grid</code></span
                   ><br />
-                  <span class="property">Interface: <code>IAccessibleTable2</code></span
+                  <span>Interface: <code>IAccessibleTable2</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible::accSelect()</code></span
+                  <span>Method: <code>IAccessible::accSelect()</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+                  <span>Method: <code>IAccessible::get_accSelection()</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>DataGrid</code></span
+                  <span>Control Type: <code>DataGrid</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>Grid</code></span
+                  <span>Control Pattern: <code>Grid</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>Table</code></span
+                  <span>Control Pattern: <code>Table</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>Selection</code></span>
+                  <span>Control Pattern: <code>Selection</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_TABLE</code></span
+                  <span>Role: <code>ROLE_TABLE</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:grid</code></span
+                  <span>Object Attribute: <code>xml-roles:grid</code></span
                   ><br />
-                  <span class="property">Interface: <code>Table</code></span
+                  <span>Interface: <code>Table</code></span
                   ><br />
-                  <span class="property">Interface: <code>Selection</code></span>
+                  <span>Interface: <code>Selection</code></span>
                   <p>
                     Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return
                     <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.
@@ -2319,17 +2264,15 @@
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXTable</code></span
+                  <span>AXRole: <code>AXTable</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span
                   ><br />
-                  <span class="property">AXColumnHeaderUIElements: a list of pointers to the columnheader elements</span><br />
-                  <span class="property">AXHeader: a pointer to the row or group containing those columnheader elements</span><br />
-                  <span class="property">AXRowHeaderUIElements: a list of pointers to the rowheader elements</span>
+                  <span>AXColumnHeaderUIElements: a list of pointers to the columnheader elements</span><br />
+                  <span>AXHeader: a pointer to the row or group containing those columnheader elements</span><br />
+                  <span>AXRowHeaderUIElements: a list of pointers to the rowheader elements</span>
                 </td>
               </tr>
               <tr>
@@ -2340,6 +2283,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-gridcell"><code>gridcell</code></h4>
           <table class="data" aria-labelledby="role-map-gridcell">
             <tbody>
@@ -2358,44 +2302,41 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_CELL</code></span
+                  <span>Role: <code>ROLE_SYSTEM_CELL</code></span
                   ><br />
-                  <span class="property">Interface: <code>IAccessibleTableCell</code></span>
+                  <span>Interface: <code>IAccessibleTableCell</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>DataItem</code></span
+                  <span>Control Type: <code>DataItem</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>item</code></span
+                  <span>Localized Control Type: <code>item</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>SelectionItem</code></span
+                  <span>Control Pattern: <code>SelectionItem</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>GridItem</code></span
+                  <span>Control Pattern: <code>GridItem</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>TableItem</code></span
+                  <span>Control Pattern: <code>TableItem</code></span
                   ><br />
-                  <span class="property">SelectionItem.SelectionContainer: the containing <code>grid</code></span>
+                  <span>SelectionItem.SelectionContainer: <code>grid</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_TABLE_CELL</code></span
+                  <span>Role: <code>ROLE_TABLE_CELL</code></span
                   ><br />
-                  <span class="property">Interface: <code>TableCell</code></span>
+                  <span>Interface: <code>TableCell</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXCell</code></span
+                  <span>AXRole: <code>AXCell</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -2406,6 +2347,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-group"><code>group</code></h4>
           <table class="data" aria-labelledby="role-map-group">
             <tbody>
@@ -2424,30 +2366,27 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span>
+                  <span>Role: <code>ROLE_SYSTEM_GROUPING</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span>
+                  <span>Control Type: <code>Group</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_PANEL</code></span>
+                  <span>Role: <code>ROLE_PANEL</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXApplicationGroup</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXApplicationGroup</code></span>
                 </td>
               </tr>
               <tr>
@@ -2458,6 +2397,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-heading"><code>heading</code></h4>
           <table class="data" aria-labelledby="role-map-heading">
             <tbody>
@@ -2476,34 +2416,31 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>IA2_ROLE_HEADING</code></span
+                  <span>Role: <code>IA2_ROLE_HEADING</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:heading</code></span>
+                  <span>Object Attribute: <code>xml-roles:heading</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Text</code></span
+                  <span>Control Type: <code>Text</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>heading</code></span>
+                  <span>Localized Control Type: <code>heading</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_HEADING</code></span>
+                  <span>Role: <code>ROLE_HEADING</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXHeading</code></span
+                  <span>AXRole: <code>AXHeading</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -2514,6 +2451,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-image"><code>image</code></h4>
           <table class="data" aria-labelledby="role-map-image">
             <tbody>
@@ -2532,34 +2470,31 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_GRAPHIC</code></span
+                  <span>Role: <code>ROLE_SYSTEM_GRAPHIC</code></span
                   ><br />
-                  <span class="property">Interface: <code>IAccessibleImage</code></span>
+                  <span>Interface: <code>IAccessibleImage</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Image</code></span>
+                  <span>Control Type: <code>Image</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_IMAGE</code></span
+                  <span>Role: <code>ROLE_IMAGE</code></span
                   ><br />
-                  <span class="property">Interface: <code>Image</code></span>
+                  <span>Interface: <code>Image</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXImage</code></span
+                  <span>AXRole: <code>AXImage</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -2570,6 +2505,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-img"><code>img</code></h4>
           <table class="data" aria-labelledby="role-map-img">
             <tbody>
@@ -2588,34 +2524,31 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_GRAPHIC</code></span
+                  <span>Role: <code>ROLE_SYSTEM_GRAPHIC</code></span
                   ><br />
-                  <span class="property">Interface: <code>IAccessibleImage</code></span>
+                  <span>Interface: <code>IAccessibleImage</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Image</code></span>
+                  <span>Control Type: <code>Image</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_IMAGE</code></span
+                  <span>Role: <code>ROLE_IMAGE</code></span
                   ><br />
-                  <span class="property">Interface: <code>Image</code></span>
+                  <span>Interface: <code>Image</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXImage</code></span
+                  <span>AXRole: <code>AXImage</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -2626,6 +2559,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-insertion"><code>insertion</code></h4>
           <table class="data" aria-labelledby="role-map-insertion">
             <tbody>
@@ -2644,35 +2578,33 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>IA2_ROLE_CONTENT_INSERTION</code></span>
+                  <span>Role: <code>IA2_ROLE_CONTENT_INSERTION</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Text</code></span
+                  <span>Control Type: <code>Text</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>insertion</code></span>
+                  <span>Localized Control Type: <code>insertion</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_CONTENT_INSERTION</code></span
+                  <span>Role: <code>ROLE_CONTENT_INSERTION</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:insertion</code></span>
+                  <span>Object Attribute: <code>xml-roles:insertion</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXInsertStyleGroup</code></span
+                  <span>AXSubrole: <code>AXInsertStyleGroup</code></span
                   ><br />
-                  <span class="property">AXAttributedStringForTextMarkerRange: contains <code>AXIsSuggestedInsertion = 1;</code> for all text contained in a <code>insertion</code></span>
+                  <span>AXAttributedStringForTextMarkerRange: <code>AXIsSuggestedInsertion = 1;</code> for all text contained in a <code>insertion</code></span>
                 </td>
               </tr>
               <tr>
@@ -2683,6 +2615,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-link"><code>link</code></h4>
           <table class="data" aria-labelledby="role-map-link">
             <tbody>
@@ -2701,39 +2634,38 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_LINK</code></span
-                  ><br />
-                  <span class="property">State: <code>STATE_SYSTEM_LINKED</code></span
-                  ><br />
-                  <span class="property">State: <code>STATE_SYSTEM_LINKED</code></span> on its descendants<br />
-                  <span class="property">Interface: <code>IAccessibleHypertext</code></span>
+                  <p>
+                    <span class="property">Role: <code>ROLE_SYSTEM_LINK</code></span
+                    ><br />
+                    <span class="property">State: <code>STATE_SYSTEM_LINKED</code></span
+                    ><br />
+                    <span class="property">State: <code>STATE_SYSTEM_LINKED</code></span> on its descendants<br />
+                    <span class="property">Interface: <code>IAccessibleHypertext</code></span>
+                  </p>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>HyperLink</code></span
+                  <span>Control Type: <code>HyperLink</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>Value</code></span>
+                  <span>Control Pattern: <code>Value</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_LINK</code></span
+                  <span>Role: <code>ROLE_LINK</code></span
                   ><br />
-                  <span class="property">Interface: <code>HyperlinkImpl</code></span>
+                  <span>Interface: <code>HyperlinkImpl</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXLink</code></span
+                  <span>AXRole: <code>AXLink</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -2744,6 +2676,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-list"><code>list</code></h4>
           <table class="data" aria-labelledby="role-map-list">
             <tbody>
@@ -2762,32 +2695,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span
+                  <span>Role: <code>ROLE_SYSTEM_LIST</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_SYSTEM_READONLY</code></span>
+                  <span>State: <code>STATE_SYSTEM_READONLY</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>List</code></span>
+                  <span>Control Type: <code>List</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_LIST</code></span>
+                  <span>Role: <code>ROLE_LIST</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXList</code></span
+                  <span>AXRole: <code>AXList</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXContentList</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXContentList</code></span>
                 </td>
               </tr>
               <tr>
@@ -2798,6 +2728,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-listbox"><code>listbox</code> without an accessibility parent of <code>combobox</code></h4>
           <table class="data" aria-labelledby="role-map-listbox">
             <tbody>
@@ -2816,27 +2747,27 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span
+                  <span>Role: <code>ROLE_SYSTEM_LIST</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible::accSelect()</code></span
+                  <span>Method: <code>IAccessible::accSelect()</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+                  <span>Method: <code>IAccessible::get_accSelection()</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>List</code></span
+                  <span>Control Type: <code>List</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>Selection</code></span>
+                  <span>Control Pattern: <code>Selection</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_LIST_BOX</code></span
+                  <span>Role: <code>ROLE_LIST_BOX</code></span
                   ><br />
-                  <span class="property">Interface: <code>Selection</code></span>
+                  <span>Interface: <code>Selection</code></span>
                   <p>
                     Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return
                     <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.
@@ -2844,14 +2775,11 @@
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXList</code></span
+                  <span>AXRole: <code>AXList</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -2862,6 +2790,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-listbox-in-combobox"><code>listbox</code> with an accessibility parent of <code>combobox</code></h4>
           <table class="data" aria-labelledby="role-map-listbox-in-combobox">
             <tbody>
@@ -2880,27 +2809,27 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_LIST</code></span
+                  <span>Role: <code>ROLE_SYSTEM_LIST</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible::accSelect()</code></span
+                  <span>Method: <code>IAccessible::accSelect()</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+                  <span>Method: <code>IAccessible::get_accSelection()</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>List</code></span
+                  <span>Control Type: <code>List</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>Selection</code></span>
+                  <span>Control Pattern: <code>Selection</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_MENU</code></span
+                  <span>Role: <code>ROLE_MENU</code></span
                   ><br />
-                  <span class="property">Interface: <code>Selection</code></span>
+                  <span>Interface: <code>Selection</code></span>
                   <p>
                     Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return
                     <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.
@@ -2908,14 +2837,11 @@
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXList</code></span
+                  <span>AXRole: <code>AXList</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -2926,6 +2852,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-listitem"><code>listitem</code></h4>
           <table class="data" aria-labelledby="role-map-listitem">
             <tbody>
@@ -2944,36 +2871,33 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_LISTITEM</code></span
+                  <span>Role: <code>ROLE_SYSTEM_LISTITEM</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_SYSTEM_READONLY</code></span>
+                  <span>State: <code>STATE_SYSTEM_READONLY</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>ListItem</code></span
+                  <span>Control Type: <code>ListItem</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>SelectionItem</code></span
+                  <span>Control Pattern: <code>SelectionItem</code></span
                   ><br />
-                  <span class="property">SelectionItem.SelectionContainer: the containing <code>list</code></span>
+                  <span>SelectionItem.SelectionContainer: <code>list</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_LIST_ITEM</code></span>
+                  <span>Role: <code>ROLE_LIST_ITEM</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -2984,6 +2908,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-log"><code>log</code></h4>
           <table class="data" aria-labelledby="role-map-log">
             <tbody>
@@ -3002,48 +2927,45 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>xml-roles:log</code></span
+                  <span>Object Attribute: <code>xml-roles:log</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-live:polite</code></span
+                  <span>Object Attribute: <code>container-live:polite</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>live:polite</code></span
+                  <span>Object Attribute: <code>live:polite</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-live-role:log</code></span>
+                  <span>Object Attribute: <code>container-live-role:log</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>log</code></span
+                  <span>Localized Control Type: <code>log</code></span
                   ><br />
-                  <span class="property">LiveSetting: <code>Polite (1)</code></span>
+                  <span>LiveSetting: <code>Polite (1)</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_LOG</code></span
+                  <span>Role: <code>ROLE_LOG</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:log</code></span
+                  <span>Object Attribute: <code>xml-roles:log</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-live:polite</code></span
+                  <span>Object Attribute: <code>container-live:polite</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>live:polite</code></span
+                  <span>Object Attribute: <code>live:polite</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-live-role:log</code></span>
+                  <span>Object Attribute: <code>container-live-role:log</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXApplicationLog</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXApplicationLog</code></span>
                 </td>
               </tr>
               <tr>
@@ -3054,6 +2976,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-main"><code>main</code></h4>
           <table class="data" aria-labelledby="role-map-main">
             <tbody>
@@ -3072,38 +2995,35 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span
+                  <span>Role: <code>IA2_ROLE_LANDMARK</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:main</code></span>
+                  <span>Object Attribute: <code>xml-roles:main</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>main</code></span
+                  <span>Localized Control Type: <code>main</code></span
                   ><br />
-                  <span class="property">Landmark Type: <code>Main</code></span>
+                  <span>Landmark Type: <code>Main</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_LANDMARK</code></span
+                  <span>Role: <code>ROLE_LANDMARK</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:main</code></span>
+                  <span>Object Attribute: <code>xml-roles:main</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXLandmarkMain</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXLandmarkMain</code></span>
                 </td>
               </tr>
               <tr>
@@ -3114,6 +3034,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-mark"><code>mark</code></h4>
           <table class="data" aria-labelledby="role-map-mark">
             <tbody>
@@ -3132,37 +3053,35 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  <span>Role: <code>ROLE_SYSTEM_GROUPING</code></span
                   ><br />
-                  <span class="property">Role: <code>IA2_ROLE_MARK</code></span
+                  <span>Role: <code>IA2_ROLE_MARK</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:mark</code></span>
+                  <span>Object Attribute: <code>xml-roles:mark</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span>
+                  <span>Control Type: <code>Group</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_MARK</code></span
+                  <span>Role: <code>ROLE_MARK</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:mark</code></span>
+                  <span>Object Attribute: <code>xml-roles:mark</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXRoleDescription: <code>highlight</code></span
+                  <span>AXRoleDescription: <code>highlight</code></span
                   ><br />
-                  <span class="property">AXAttributedStringForTextMarkerRange: contains <code>AXHighlight = 1;</code> for all text contained in a <code>mark</code></span>
+                  <span>AXAttributedStringForTextMarkerRange: <code>AXHighlight = 1;</code> for all text contained in a <code>mark</code></span>
                 </td>
               </tr>
               <tr>
@@ -3173,6 +3092,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-marquee"><code>marquee</code></h4>
           <table class="data" aria-labelledby="role-map-marquee">
             <tbody>
@@ -3191,34 +3111,31 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_ANIMATION</code></span
+                  <span>Role: <code>ROLE_SYSTEM_ANIMATION</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:marquee</code></span>
+                  <span>Object Attribute: <code>xml-roles:marquee</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>marquee</code></span>
+                  <span>Localized Control Type: <code>marquee</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_MARQUEE</code></span>
+                  <span>Role: <code>ROLE_MARQUEE</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXApplicationMarquee</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXApplicationMarquee</code></span>
                 </td>
               </tr>
               <tr>
@@ -3229,6 +3146,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-math"><code>math</code></h4>
           <table class="data" aria-labelledby="role-map-math">
             <tbody>
@@ -3247,32 +3165,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_EQUATION</code></span>
+                  <span>Role: <code>ROLE_SYSTEM_EQUATION</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>math</code></span>
+                  <span>Localized Control Type: <code>math</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_MATH</code></span>
+                  <span>Role: <code>ROLE_MATH</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXDocumentMath</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXDocumentMath</code></span>
                 </td>
               </tr>
               <tr>
@@ -3283,6 +3198,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-menu"><code>menu</code></h4>
           <table class="data" aria-labelledby="role-map-menu">
             <tbody>
@@ -3301,25 +3217,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_MENUPOPUP</code></span
+                  <span>Role: <code>ROLE_SYSTEM_MENUPOPUP</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible::accSelect()</code></span
+                  <span>Method: <code>IAccessible::accSelect()</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+                  <span>Method: <code>IAccessible::get_accSelection()</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Menu</code></span>
+                  <span>Control Type: <code>Menu</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_MENU</code></span
+                  <span>Role: <code>ROLE_MENU</code></span
                   ><br />
-                  <span class="property">Interface: <code>Selection</code></span>
+                  <span>Interface: <code>Selection</code></span>
                   <p>
                     Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return
                     <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.
@@ -3327,14 +3243,11 @@
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXMenu</code></span
+                  <span>AXRole: <code>AXMenu</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -3345,6 +3258,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-menubar"><code>menubar</code></h4>
           <table class="data" aria-labelledby="role-map-menubar">
             <tbody>
@@ -3363,25 +3277,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_MENUBAR</code></span
+                  <span>Role: <code>ROLE_SYSTEM_MENUBAR</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible::accSelect()</code></span
+                  <span>Method: <code>IAccessible::accSelect()</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+                  <span>Method: <code>IAccessible::get_accSelection()</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>MenuBar</code></span>
+                  <span>Control Type: <code>MenuBar</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_MENU_BAR</code></span
+                  <span>Role: <code>ROLE_MENU_BAR</code></span
                   ><br />
-                  <span class="property">Interface: <code>Selection</code></span>
+                  <span>Interface: <code>Selection</code></span>
                   <p>
                     Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return
                     <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.
@@ -3389,14 +3303,11 @@
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXMenuBar</code></span
+                  <span>AXRole: <code>AXMenuBar</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -3407,6 +3318,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-menuitem"><code>menuitem</code></h4>
           <table class="data" aria-labelledby="role-map-menuitem">
             <tbody>
@@ -3425,30 +3337,27 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_MENUITEM</code></span>
+                  <span>Role: <code>ROLE_SYSTEM_MENUITEM</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>MenuItem</code></span>
+                  <span>Control Type: <code>MenuItem</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_MENU_ITEM</code></span>
+                  <span>Role: <code>ROLE_MENU_ITEM</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXMenuItem</code></span
+                  <span>AXRole: <code>AXMenuItem</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -3459,6 +3368,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-menuitemcheckbox"><code>menuitemcheckbox</code></h4>
           <table class="data" aria-labelledby="role-map-menuitemcheckbox">
             <tbody>
@@ -3477,9 +3387,9 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_CHECKBUTTON</code> or <code>ROLE_SYSTEM_MENUITEM</code></span
+                  <span>Role: <code>ROLE_SYSTEM_CHECKBUTTON</code> or <code>ROLE_SYSTEM_MENUITEM</code></span
                   ><br />
-                  <span class="property">Role: <code>IA2_ROLE_CHECK_MENU_ITEM</code></span
+                  <span>Role: <code>IA2_ROLE_CHECK_MENU_ITEM</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -3487,9 +3397,9 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>MenuItem</code></span
+                  <span>Control Type: <code>MenuItem</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>Toggle</code></span
+                  <span>Control Pattern: <code>Toggle</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -3497,19 +3407,17 @@
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_CHECK_MENU_ITEM</code></span
+                  <span>Role: <code>ROLE_CHECK_MENU_ITEM</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXMenuItem</code></span
+                  <span>AXRole: <code>AXMenuItem</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -3522,6 +3430,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-menuitemradio"><code>menuitemradio</code></h4>
           <table class="data" aria-labelledby="role-map-menuitemradio">
             <tbody>
@@ -3540,9 +3449,9 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_RADIOBUTTON</code> or <code>ROLE_SYSTEM_MENUITEM</code></span
+                  <span>Role: <code>ROLE_SYSTEM_RADIOBUTTON</code> or <code>ROLE_SYSTEM_MENUITEM</code></span
                   ><br />
-                  <span class="property">Role: <code>IA2_ROLE_RADIO_MENU_ITEM</code></span
+                  <span>Role: <code>IA2_ROLE_RADIO_MENU_ITEM</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -3550,11 +3459,11 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>MenuItem</code></span
+                  <span>Control Type: <code>MenuItem</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>Toggle</code></span
+                  <span>Control Pattern: <code>Toggle</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>SelectionItem</code></span
+                  <span>Control Pattern: <code>SelectionItem</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -3562,19 +3471,17 @@
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_RADIO_MENU_ITEM</code></span
+                  <span>Role: <code>ROLE_RADIO_MENU_ITEM</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXMenuItem</code></span
+                  <span>AXRole: <code>AXMenuItem</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -3587,6 +3494,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-meter"><code>meter</code></h4>
           <table class="data" aria-labelledby="role-map-meter">
             <tbody>
@@ -3605,38 +3513,35 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>IA2_ROLE_LEVEL_BAR</code></span
+                  <span>Role: <code>IA2_ROLE_LEVEL_BAR</code></span
                   ><br />
-                  <span class="property">Interface: <code>IAccessibleValue</code></span>
+                  <span>Interface: <code>IAccessibleValue</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>ProgressBar</code></span
+                  <span>Control Type: <code>ProgressBar</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>meter</code></span
+                  <span>Localized Control Type: <code>meter</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>RangeValue</code></span>
+                  <span>Control Pattern: <code>RangeValue</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_LEVEL_BAR</code></span
+                  <span>Role: <code>ROLE_LEVEL_BAR</code></span
                   ><br />
-                  <span class="property">Interface: <code>Value</code></span>
+                  <span>Interface: <code>Value</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXLevelIndicator</code></span
+                  <span>AXRole: <code>AXLevelIndicator</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXMeter</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXMeter</code></span>
                 </td>
               </tr>
               <tr>
@@ -3647,6 +3552,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-navigation"><code>navigation</code></h4>
           <table class="data" aria-labelledby="role-map-navigation">
             <tbody>
@@ -3665,38 +3571,35 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span
+                  <span>Role: <code>IA2_ROLE_LANDMARK</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:navigation</code></span>
+                  <span>Object Attribute: <code>xml-roles:navigation</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>navigation</code></span
+                  <span>Localized Control Type: <code>navigation</code></span
                   ><br />
-                  <span class="property">Landmark Type: <code>Navigation</code></span>
+                  <span>Landmark Type: <code>Navigation</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_LANDMARK</code></span
+                  <span>Role: <code>ROLE_LANDMARK</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:navigation</code></span>
+                  <span>Object Attribute: <code>xml-roles:navigation</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXLandmarkNavigation</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXLandmarkNavigation</code></span>
                 </td>
               </tr>
               <tr>
@@ -3707,6 +3610,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-none"><code>none</code></h4>
           <table class="data" aria-labelledby="role-map-none">
             <tbody>
@@ -3753,9 +3657,7 @@
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
                   <p>
                     For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the
@@ -3771,6 +3673,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-note"><code>note</code></h4>
           <table class="data" aria-labelledby="role-map-note">
             <tbody>
@@ -3789,32 +3692,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>IA2_ROLE_NOTE</code></span>
+                  <span>Role: <code>IA2_ROLE_NOTE</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>note</code></span>
+                  <span>Localized Control Type: <code>note</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_COMMENT</code></span>
+                  <span>Role: <code>ROLE_COMMENT</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXDocumentNote</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXDocumentNote</code></span>
                 </td>
               </tr>
               <tr>
@@ -3825,6 +3725,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-option"><code>option</code> not inside <code>combobox</code></h4>
           <table class="data" aria-labelledby="role-map-option">
             <tbody>
@@ -3843,7 +3744,7 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_LISTITEM</code></span
+                  <span>Role: <code>ROLE_SYSTEM_LISTITEM</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -3851,9 +3752,9 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>ListItem</code></span
+                  <span>Control Type: <code>ListItem</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>Invoke</code></span
+                  <span>Control Pattern: <code>Invoke</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -3861,19 +3762,17 @@
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_LIST_ITEM</code></span
+                  <span>Role: <code>ROLE_LIST_ITEM</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a><br /></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXStaticText</code></span
+                  <span>AXRole: <code>AXStaticText</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -3886,6 +3785,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-option-in-combobox"><code>option</code> inside <code>combobox</code></h4>
           <table class="data" aria-labelledby="role-map-option-in-combobox">
             <tbody>
@@ -3904,7 +3804,7 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_LISTITEM</code></span
+                  <span>Role: <code>ROLE_SYSTEM_LISTITEM</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -3912,9 +3812,9 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>ListItem</code></span
+                  <span>Control Type: <code>ListItem</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>Invoke</code></span
+                  <span>Control Pattern: <code>Invoke</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -3922,19 +3822,17 @@
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_MENU_ITEM</code></span
+                  <span>Role: <code>ROLE_MENU_ITEM</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a><br /></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXStaticText</code></span
+                  <span>AXRole: <code>AXStaticText</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -3947,6 +3845,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-paragraph"><code>paragraph</code></h4>
           <table class="data" aria-labelledby="role-map-paragraph">
             <tbody>
@@ -3965,32 +3864,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  <span>Role: <code>ROLE_SYSTEM_GROUPING</code></span
                   ><br />
-                  <span class="property">Role: <code>IA2_ROLE_PARAGRAPH</code></span>
+                  <span>Role: <code>IA2_ROLE_PARAGRAPH</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Text</code></span>
+                  <span>Control Type: <code>Text</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_PARAGRAPH</code></span>
+                  <span>Role: <code>ROLE_PARAGRAPH</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -4001,6 +3897,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-presentation"><code>presentation</code></h4>
           <table class="data" aria-labelledby="role-map-presentation">
             <tbody>
@@ -4047,9 +3944,7 @@
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
                   <p>
                     For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the
@@ -4065,6 +3960,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-progressbar"><code>progressbar</code></h4>
           <table class="data" aria-labelledby="role-map-progressbar">
             <tbody>
@@ -4083,27 +3979,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_PROGRESSBAR</code></span
+                  <span>Role: <code>ROLE_SYSTEM_PROGRESSBAR</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_SYSTEM_READONLY</code></span
+                  <span>State: <code>STATE_SYSTEM_READONLY</code></span
                   ><br />
-                  <span class="property">Interface: <code>IAccessibleValue</code></span>
+                  <span>Interface: <code>IAccessibleValue</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>ProgressBar</code></span
-                  ><br />
-                  <span class="property">Control Pattern: <code>RangeValue</code> if <code>aria-valuenow</code>, <code>aria-valuemax</code>, or <code>aria-valuemin</code></span> is present
+                  <p>
+                    <span class="property">Control Type: <code>ProgressBar</code></span
+                    ><br />
+                    <span class="property">Control Pattern: <code>RangeValue</code> if <code>aria-valuenow</code>, <code>aria-valuemax</code>, or <code>aria-valuemin</code></span> is present
+                  </p>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_PROGRESS_BAR</code></span
+                  <span>Role: <code>ROLE_PROGRESS_BAR</code></span
                   ><br />
-                  <span class="property">Interface: <code>Value</code></span>
+                  <span>Interface: <code>Value</code></span>
                   <p>
                     Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the value via the accessibility API, user agents MUST return
                     <code>false</code> for all <code>Value</code> methods that provide a means to modify the value.
@@ -4111,14 +4009,11 @@
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXProgressIndicator</code></span
+                  <span>AXRole: <code>AXProgressIndicator</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -4129,6 +4024,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-radio"><code>radio</code></h4>
           <table class="data" aria-labelledby="role-map-radio">
             <tbody>
@@ -4147,7 +4043,7 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_RADIOBUTTON</code></span
+                  <span>Role: <code>ROLE_SYSTEM_RADIOBUTTON</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -4155,11 +4051,11 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>RadioButton</code></span
+                  <span>Control Type: <code>RadioButton</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>Toggle</code></span
+                  <span>Control Pattern: <code>Toggle</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>SelectionItem</code></span
+                  <span>Control Pattern: <code>SelectionItem</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -4167,19 +4063,17 @@
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_RADIO_BUTTON</code></span
+                  <span>Role: <code>ROLE_RADIO_BUTTON</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXRadioButton</code></span
+                  <span>AXRole: <code>AXRadioButton</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -4192,6 +4086,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-radiogroup"><code>radiogroup</code></h4>
           <table class="data" aria-labelledby="role-map-radiogroup">
             <tbody>
@@ -4210,30 +4105,27 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span>
+                  <span>Role: <code>ROLE_SYSTEM_GROUPING</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>List</code></span>
+                  <span>Control Type: <code>List</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_PANEL</code></span>
+                  <span>Role: <code>ROLE_PANEL</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXRadioGroup</code></span
+                  <span>AXRole: <code>AXRadioGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -4244,6 +4136,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-region"><code>region</code> with an accessible name</h4>
           <table class="data" aria-labelledby="role-map-region">
             <tbody>
@@ -4262,40 +4155,37 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span
+                  <span>Role: <code>IA2_ROLE_LANDMARK</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:region</code></span>
+                  <span>Object Attribute: <code>xml-roles:region</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>region</code></span
+                  <span>Localized Control Type: <code>region</code></span
                   ><br />
-                  <span class="property">Landmark Type: <code>Custom</code></span
+                  <span>Landmark Type: <code>Custom</code></span
                   ><br />
-                  <span class="property">Localized Landmark Type: <code>region</code></span>
+                  <span>Localized Landmark Type: <code>region</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_LANDMARK</code></span
+                  <span>Role: <code>ROLE_LANDMARK</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:region</code></span>
+                  <span>Object Attribute: <code>xml-roles:region</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXLandmarkRegion</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXLandmarkRegion</code></span>
                 </td>
               </tr>
               <tr>
@@ -4306,6 +4196,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-region-nameless"><code>region</code> without an accessible name</h4>
           <table class="data" aria-labelledby="role-map-region-nameless">
             <tbody>
@@ -4318,19 +4209,19 @@
               <tr>
                 <th>Computed Role</th>
                 <td>
-                  <p>Use native host language role.</p>
+                  <p><code>Use native host language role.</code></p>
                 </td>
               </tr>
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <p class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</p>
+                  <p>Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</p>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <p class="property">Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</p>
+                  <p>Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</p>
                 </td>
               </tr>
               <tr>
@@ -4340,9 +4231,7 @@
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
                   <p>Do not expose the <a class="termref">element</a> as a landmark. Use the native host language role of the element instead.</p>
                 </td>
@@ -4355,6 +4244,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-row"><code>row</code> not inside <code>treegrid</code></h4>
           <table class="data" aria-labelledby="role-map-row">
             <tbody>
@@ -4373,34 +4263,31 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_ROW</code></span>
+                  <span>Role: <code>ROLE_SYSTEM_ROW</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>DataItem</code></span
+                  <span>Control Type: <code>DataItem</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>row</code></span
+                  <span>Localized Control Type: <code>row</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>SelectionItem</code></span>
+                  <span>Control Pattern: <code>SelectionItem</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_TABLE_ROW</code></span>
+                  <span>Role: <code>ROLE_TABLE_ROW</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXRow</code></span
+                  <span>AXRole: <code>AXRow</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -4411,6 +4298,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-row-in-treegrid"><code>row</code> inside <code>treegrid</code></h4>
           <table class="data" aria-labelledby="role-map-row-in-treegrid">
             <tbody>
@@ -4429,34 +4317,31 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_OUTLINEITEM</code></span>
+                  <span>Role: <code>ROLE_SYSTEM_OUTLINEITEM</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>DataItem</code></span
+                  <span>Control Type: <code>DataItem</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>row</code></span
+                  <span>Localized Control Type: <code>row</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>SelectionItem</code></span>
+                  <span>Control Pattern: <code>SelectionItem</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_TABLE_ROW</code></span>
+                  <span>Role: <code>ROLE_TABLE_ROW</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXRow</code></span
+                  <span>AXRole: <code>AXRow</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -4467,6 +4352,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-rowgroup"><code>rowgroup</code></h4>
           <table class="data" aria-labelledby="role-map-rowgroup">
             <tbody>
@@ -4485,27 +4371,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span>
+                  <span>Role: <code>ROLE_SYSTEM_GROUPING</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span>
+                  <span>Control Type: <code>Group</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_PANEL</code></span>
+                  <span>Role: <code>ROLE_PANEL</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
@@ -4516,6 +4400,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-rowheader"><code>rowheader</code></h4>
           <table class="data" aria-labelledby="role-map-rowheader">
             <tbody>
@@ -4534,34 +4419,31 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_ROWHEADER</code></span
+                  <span>Role: <code>ROLE_SYSTEM_ROWHEADER</code></span
                   ><br />
-                  <span class="property">Interface: <code>IAccessibleTableCell</code></span>
+                  <span>Interface: <code>IAccessibleTableCell</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>HeaderItem</code></span>
+                  <span>Control Type: <code>HeaderItem</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_ROW_HEADER</code></span
+                  <span>Role: <code>ROLE_ROW_HEADER</code></span
                   ><br />
-                  <span class="property">Interface: <code>TableCell</code></span>
+                  <span>Interface: <code>TableCell</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXCell</code></span
+                  <span>AXRole: <code>AXCell</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -4572,6 +4454,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-scrollbar"><code>scrollbar</code></h4>
           <table class="data" aria-labelledby="role-map-scrollbar">
             <tbody>
@@ -4590,25 +4473,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_SCROLLBAR</code></span
+                  <span>Role: <code>ROLE_SYSTEM_SCROLLBAR</code></span
                   ><br />
-                  <span class="property">Interface: <code>IAccessibleValue</code></span>
+                  <span>Interface: <code>IAccessibleValue</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>ScrollBar</code></span
+                  <span>Control Type: <code>ScrollBar</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>RangeValue</code></span>
+                  <span>Control Pattern: <code>RangeValue</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SCROLL_BAR</code></span
+                  <span>Role: <code>ROLE_SCROLL_BAR</code></span
                   ><br />
-                  <span class="property">Interface: <code>Value</code></span>
+                  <span>Interface: <code>Value</code></span>
                   <p>
                     Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the value via the accessibility API, user agents MUST return
                     <code>false</code> for all <code>Value</code> methods that provide a means to modify the value.
@@ -4616,14 +4499,11 @@
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXScrollBar</code></span
+                  <span>AXRole: <code>AXScrollBar</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -4634,6 +4514,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-search"><code>search</code></h4>
           <table class="data" aria-labelledby="role-map-search">
             <tbody>
@@ -4652,38 +4533,35 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>IA2_ROLE_LANDMARK</code></span
+                  <span>Role: <code>IA2_ROLE_LANDMARK</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:search</code></span>
+                  <span>Object Attribute: <code>xml-roles:search</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>search</code></span
+                  <span>Localized Control Type: <code>search</code></span
                   ><br />
-                  <span class="property">Landmark Type: <code>Search</code></span>
+                  <span>Landmark Type: <code>Search</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_LANDMARK</code></span
+                  <span>Role: <code>ROLE_LANDMARK</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:search</code></span>
+                  <span>Object Attribute: <code>xml-roles:search</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXLandmarkSearch</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXLandmarkSearch</code></span>
                 </td>
               </tr>
               <tr>
@@ -4694,6 +4572,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-searchbox"><code>searchbox</code></h4>
           <table class="data" aria-labelledby="role-map-searchbox">
             <tbody>
@@ -4712,42 +4591,39 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span
+                  <span>Role: <code>ROLE_SYSTEM_TEXT</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>text-input-type:search</code></span>
+                  <span>Object Attribute: <code>text-input-type:search</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Edit</code></span
+                  <span>Control Type: <code>Edit</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>search box</code></span>
+                  <span>Localized Control Type: <code>search box</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_ENTRY</code></span
+                  <span>Role: <code>ROLE_ENTRY</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:searchbox</code></span
+                  <span>Object Attribute: <code>xml-roles:searchbox</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>text-input-type:search</code> </span>
-                  <br />
-                  <span class="property"
-                    >Interface: <code>EditableText</code> if <a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a> is not <code>&quot;true&quot;</code></span
+                  <span>Object Attribute: <code>text-input-type:search</code></span
+                  ><br />
+                  <span
+                    >Interface: <code>EditableText</code> if <a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a> is not <code>"true"</code></span
                   >
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXTextField</code></span
+                  <span>AXRole: <code>AXTextField</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXSearchField</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXSearchField</code></span>
                 </td>
               </tr>
               <tr>
@@ -4758,6 +4634,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-sectionfooter"><code>sectionfooter</code></h4>
           <table class="data" aria-labelledby="role-map-sectionfooter">
             <tbody>
@@ -4776,36 +4653,33 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  <span>Role: <code>ROLE_SYSTEM_GROUPING</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:sectionfooter</code></span>
+                  <span>Object Attribute: <code>xml-roles:sectionfooter</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>section footer</code></span>
+                  <span>Localized Control Type: <code>section footer</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_FOOTER</code></span
-                  ><br />
+                  <span>Role: <code>ROLE_FOOTER</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXSectionFooter</code></span
+                  <span>AXSubrole: <code>AXSectionFooter</code></span
                   ><br />
-                  <span class="property">AXRoleDescription: <code>section footer</code></span>
+                  <span>AXRoleDescription: <code>section footer</code></span>
                 </td>
               </tr>
               <tr>
@@ -4816,6 +4690,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-sectionheader"><code>sectionheader</code></h4>
           <table class="data" aria-labelledby="role-map-sectionheader">
             <tbody>
@@ -4834,35 +4709,33 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  <span>Role: <code>ROLE_SYSTEM_GROUPING</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:sectionheader</code></span>
+                  <span>Object Attribute: <code>xml-roles:sectionheader</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>section header</code></span>
+                  <span>Localized Control Type: <code>section header</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_HEADER</code></span>
+                  <span>Role: <code>ROLE_HEADER</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXSectionHeader</code></span
+                  <span>AXSubrole: <code>AXSectionHeader</code></span
                   ><br />
-                  <span class="property">AXRoleDescription: <code>section header</code></span>
+                  <span>AXRoleDescription: <code>section header</code></span>
                 </td>
               </tr>
               <tr>
@@ -4873,6 +4746,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-separator"><code>separator</code> (non-focusable)</h4>
           <table class="data" aria-labelledby="role-map-separator">
             <tbody>
@@ -4891,30 +4765,27 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_SEPARATOR</code></span>
+                  <span>Role: <code>ROLE_SYSTEM_SEPARATOR</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Separator</code></span>
+                  <span>Control Type: <code>Separator</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SEPARATOR</code></span>
+                  <span>Role: <code>ROLE_SEPARATOR</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXSplitter</code></span
+                  <span>AXRole: <code>AXSplitter</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -4925,6 +4796,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-separator-focusable"><code>separator</code> (focusable)</h4>
           <table class="data" aria-labelledby="role-map-separator-focusable">
             <tbody>
@@ -4943,25 +4815,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_SEPARATOR</code></span
+                  <span>Role: <code>ROLE_SYSTEM_SEPARATOR</code></span
                   ><br />
-                  <span class="property">Interface: <code>IAccessibleValue</code></span>
+                  <span>Interface: <code>IAccessibleValue</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Thumb</code></span
+                  <span>Control Type: <code>Thumb</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>RangeValue</code></span>
+                  <span>Control Pattern: <code>RangeValue</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SEPARATOR</code></span
+                  <span>Role: <code>ROLE_SEPARATOR</code></span
                   ><br />
-                  <span class="property">Interface: <code>Value</code></span>
+                  <span>Interface: <code>Value</code></span>
                   <p>
                     Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the value via the accessibility API, user agents MUST return
                     <code>false</code> for all <code>Value</code> methods that provide a means to modify the value.
@@ -4969,14 +4841,11 @@
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXSplitter</code></span
+                  <span>AXRole: <code>AXSplitter</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -4987,6 +4856,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-slider"><code>slider</code></h4>
           <table class="data" aria-labelledby="role-map-slider">
             <tbody>
@@ -5005,25 +4875,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_SLIDER</code></span
+                  <span>Role: <code>ROLE_SYSTEM_SLIDER</code></span
                   ><br />
-                  <span class="property">Interface: <code>IAccessibleValue</code></span>
+                  <span>Interface: <code>IAccessibleValue</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Slider</code></span
+                  <span>Control Type: <code>Slider</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>RangeValue</code></span>
+                  <span>Control Pattern: <code>RangeValue</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SLIDER</code></span
+                  <span>Role: <code>ROLE_SLIDER</code></span
                   ><br />
-                  <span class="property">Interface: <code>Value</code></span>
+                  <span>Interface: <code>Value</code></span>
                   <p>
                     Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the value via the accessibility API, user agents MUST return
                     <code>false</code> for all <code>Value</code> methods that provide a means to modify the value.
@@ -5031,14 +4901,11 @@
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXSlider</code></span
+                  <span>AXRole: <code>AXSlider</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -5049,6 +4916,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-spinbutton"><code>spinbutton</code></h4>
           <table class="data" aria-labelledby="role-map-spinbutton">
             <tbody>
@@ -5067,25 +4935,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_SPINBUTTON</code></span
+                  <span>Role: <code>ROLE_SYSTEM_SPINBUTTON</code></span
                   ><br />
-                  <span class="property">Interface: <code>IAccessibleValue</code></span>
+                  <span>Interface: <code>IAccessibleValue</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Spinner</code></span
+                  <span>Control Type: <code>Spinner</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>RangeValue</code></span>
+                  <span>Control Pattern: <code>RangeValue</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SPIN_BUTTON</code></span
+                  <span>Role: <code>ROLE_SPIN_BUTTON</code></span
                   ><br />
-                  <span class="property">Interface: <code>Value</code></span>
+                  <span>Interface: <code>Value</code></span>
                   <p>
                     Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the value via the accessibility API, user agents MUST return
                     <code>false</code> for all <code>Value</code> methods that provide a means to modify the value.
@@ -5093,14 +4961,11 @@
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXIncrementor</code></span
+                  <span>AXRole: <code>AXIncrementor</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -5111,6 +4976,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-status"><code>status</code></h4>
           <table class="data" aria-labelledby="role-map-status">
             <tbody>
@@ -5129,46 +4995,43 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_STATUSBAR</code></span
+                  <span>Role: <code>ROLE_SYSTEM_STATUSBAR</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-live:polite</code></span
+                  <span>Object Attribute: <code>container-live:polite</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>live:polite</code></span
+                  <span>Object Attribute: <code>live:polite</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-live-role:status</code></span>
+                  <span>Object Attribute: <code>container-live-role:status</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>status</code></span
+                  <span>Localized Control Type: <code>status</code></span
                   ><br />
-                  <span class="property">LiveSetting: <code>Polite (1)</code></span>
+                  <span>LiveSetting: <code>Polite (1)</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_STATUSBAR</code></span
+                  <span>Role: <code>ROLE_STATUSBAR</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-live:polite</code></span
+                  <span>Object Attribute: <code>container-live:polite</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>live:polite</code></span
+                  <span>Object Attribute: <code>live:polite</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-live-role:status</code></span>
+                  <span>Object Attribute: <code>container-live-role:status</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXApplicationStatus</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXApplicationStatus</code></span>
                 </td>
               </tr>
               <tr>
@@ -5179,6 +5042,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-strong"><code>strong</code></h4>
           <table class="data" aria-labelledby="role-map-strong">
             <tbody>
@@ -5197,36 +5061,33 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span
+                  <span>Role: <code>IA2_ROLE_TEXT_FRAME</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:strong</code></span>
+                  <span>Object Attribute: <code>xml-roles:strong</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Text</code></span
+                  <span>Control Type: <code>Text</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>strong</code></span>
+                  <span>Localized Control Type: <code>strong</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_STATIC</code></span
+                  <span>Role: <code>ROLE_STATIC</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:strong</code></span>
+                  <span>Object Attribute: <code>xml-roles:strong</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXStrongStyleGroup</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXStrongStyleGroup</code></span>
                 </td>
               </tr>
               <tr>
@@ -5237,6 +5098,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-subscript"><code>subscript</code></h4>
           <table class="data" aria-labelledby="role-map-subscript">
             <tbody>
@@ -5255,36 +5117,36 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  <span>Role: <code>ROLE_SYSTEM_GROUPING</code></span
                   ><br />
-                  <span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span
+                  <span>Role: <code>IA2_ROLE_TEXT_FRAME</code></span
                   ><br />
-                  <span class="property">Text Attribute: <code>text-position:sub</code></span>
+                  <span>Text Attribute: <code>text-position:sub</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Text</code></span
+                  <span>Control Type: <code>Text</code></span
                   ><br />
-                  <span class="property">Styles used are exposed by <code>IsSubscript</code> attribute of the <code>TextRange</code> Control Pattern implemented on the accessible object.</span>
+                  <span
+                    >Styles used are exposed by IsSubscript attribute of the TextRange Control Pattern implemented on the accessible object.: <code>IsSubscript</code> attribute of the
+                    <code>TextRange</code> Control Pattern implemented on the accessible object.</span
+                  >
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SUBSCRIPT</code></span>
+                  <span>Role: <code>ROLE_SUBSCRIPT</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXSubscriptStyleGroup</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXSubscriptStyleGroup</code></span>
                 </td>
               </tr>
               <tr>
@@ -5295,6 +5157,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-suggestion"><code>suggestion</code></h4>
           <table class="data" aria-labelledby="role-map-suggestion">
             <tbody>
@@ -5313,36 +5176,33 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>IA2_ROLE_SUGGESTION</code></span
+                  <span>Role: <code>IA2_ROLE_SUGGESTION</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:suggestion</code></span>
+                  <span>Object Attribute: <code>xml-roles:suggestion</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>suggestion</code></span
-                  ><br />
+                  <span>Localized Control Type: <code>suggestion</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SUGGESTION</code></span
+                  <span>Role: <code>ROLE_SUGGESTION</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:suggestion</code></span>
+                  <span>Object Attribute: <code>xml-roles:suggestion</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXAttributedStringForTextMarkerRange: contains <code>AXIsSuggestion = 1;</code> for all text contained in a <code>suggestion</code></span>
+                  <span>AXAttributedStringForTextMarkerRange: <code>AXIsSuggestion = 1;</code> for all text contained in a <code>suggestion</code></span>
                 </td>
               </tr>
               <tr>
@@ -5353,6 +5213,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-superscript"><code>superscript</code></h4>
           <table class="data" aria-labelledby="role-map-superscript">
             <tbody>
@@ -5371,36 +5232,36 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  <span>Role: <code>ROLE_SYSTEM_GROUPING</code></span
                   ><br />
-                  <span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span
+                  <span>Role: <code>IA2_ROLE_TEXT_FRAME</code></span
                   ><br />
-                  <span class="property">Text Attribute: <code>text-position:super</code></span>
+                  <span>Text Attribute: <code>text-position:super</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Text</code></span
+                  <span>Control Type: <code>Text</code></span
                   ><br />
-                  <span class="property">Styles used are exposed by <code>IsSuperscript</code> attribute of the <code>TextRange</code> Control Pattern implemented on the accessible object.</span>
+                  <span
+                    >Styles used are exposed by IsSuperscript attribute of the TextRange Control Pattern implemented on the accessible object.: <code>IsSuperscript</code> attribute of the
+                    <code>TextRange</code> Control Pattern implemented on the accessible object.</span
+                  >
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SUPERSCRIPT</code></span>
+                  <span>Role: <code>ROLE_SUPERSCRIPT</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXSuperscriptStyleGroup</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXSuperscriptStyleGroup</code></span>
                 </td>
               </tr>
               <tr>
@@ -5411,6 +5272,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-switch"><code>switch</code></h4>
           <table class="data" aria-labelledby="role-map-switch">
             <tbody>
@@ -5429,11 +5291,11 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_CHECKBUTTON</code></span
+                  <span>Role: <code>ROLE_SYSTEM_CHECKBUTTON</code></span
                   ><br />
-                  <span class="property">Role: <code>IA2_ROLE_TOGGLE_BUTTON</code></span
+                  <span>Role: <code>IA2_ROLE_TOGGLE_BUTTON</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:switch</code></span
+                  <span>Object Attribute: <code>xml-roles:switch</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -5441,11 +5303,11 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Button</code></span
+                  <span>Control Type: <code>Button</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>toggleswitch</code></span
+                  <span>Localized Control Type: <code>toggleswitch</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>Toggle</code></span
+                  <span>Control Pattern: <code>Toggle</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -5453,21 +5315,19 @@
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_TOGGLE_BUTTON</code></span
+                  <span>Role: <code>ROLE_TOGGLE_BUTTON</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:switch</code></span
+                  <span>Object Attribute: <code>xml-roles:switch</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXCheckBox</code></span
+                  <span>AXRole: <code>AXCheckBox</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXSwitch</code></span
+                  <span>AXSubrole: <code>AXSwitch</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -5480,6 +5340,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-tab"><code>tab</code></h4>
           <table class="data" aria-labelledby="role-map-tab">
             <tbody>
@@ -5498,9 +5359,9 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_PAGETAB</code></span
+                  <span>Role: <code>ROLE_SYSTEM_PAGETAB</code></span
                   ><br />
-                  <span class="property"
+                  <span
                     >State: <code>STATE_SYSTEM_SELECTED</code> if focus is inside <a class="role-reference" href="#tabpanel"><code>tabpanel</code></a> associated with
                     <a class="property-reference" href="#aria-labelledby"><code>aria-labelledby</code></a></span
                   >
@@ -5509,29 +5370,26 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>TabItem</code></span>
+                  <span>Control Type: <code>TabItem</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_PAGE_TAB</code></span
+                  <span>Role: <code>ROLE_PAGE_TAB</code></span
                   ><br />
-                  <span class="property"
+                  <span
                     >State: <code>STATE_SELECTED</code> if focus is inside <a class="role-reference" href="#tabpanel"><code>tabpanel</code></a> associated with
                     <a class="property-reference" href="#aria-labelledby"><code>aria-labelledby</code></a></span
                   >
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXRadioButton</code></span
+                  <span>AXRole: <code>AXRadioButton</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXTabButton</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXTabButton</code></span>
                 </td>
               </tr>
               <tr>
@@ -5542,6 +5400,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-table"><code>table</code></h4>
           <table class="data" aria-labelledby="role-map-table">
             <tbody>
@@ -5560,45 +5419,43 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_TABLE</code></span
+                  <span>Role: <code>ROLE_SYSTEM_TABLE</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:table</code></span
+                  <span>Object Attribute: <code>xml-roles:table</code></span
                   ><br />
-                  <span class="property">Interface: <code>IAccessibleTable2</code></span>
+                  <span>Interface: <code>IAccessibleTable2</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Table</code></span
+                  <span>Control Type: <code>Table</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>Grid</code></span
+                  <span>Control Pattern: <code>Grid</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>Table</code></span>
+                  <span>Control Pattern: <code>Table</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_TABLE</code></span
+                  <span>Role: <code>ROLE_TABLE</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:table</code></span
+                  <span>Object Attribute: <code>xml-roles:table</code></span
                   ><br />
-                  <span class="property">Interface: <code>Table</code></span>
+                  <span>Interface: <code>Table</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXTable</code></span
+                  <span>AXRole: <code>AXTable</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span
                   ><br />
-                  <span class="property">AXColumnHeaderUIElements: a list of pointers to the columnheader elements</span><br />
-                  <span class="property">AXHeader: a pointer to the row or group containing those columnheader elements</span><br />
-                  <span class="property">AXRowHeaderUIElements: a list of pointers to the rowheader elements</span>
+                  <span>AXColumnHeaderUIElements: a list of pointers to the columnheader elements</span><br />
+                  <span>AXHeader: a pointer to the row or group containing those columnheader elements</span><br />
+                  <span>AXRowHeaderUIElements: a list of pointers to the rowheader elements</span>
                 </td>
               </tr>
               <tr>
@@ -5609,6 +5466,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-tablist"><code>tablist</code></h4>
           <table class="data" aria-labelledby="role-map-tablist">
             <tbody>
@@ -5627,27 +5485,27 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_PAGETABLIST</code></span
+                  <span>Role: <code>ROLE_SYSTEM_PAGETABLIST</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible::accSelect()</code></span
+                  <span>Method: <code>IAccessible::accSelect()</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+                  <span>Method: <code>IAccessible::get_accSelection()</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Tab</code></span
+                  <span>Control Type: <code>Tab</code></span
                   ><br />
-                  <span class="property">Control Pattern: <code>Selection</code></span>
+                  <span>Control Pattern: <code>Selection</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_PAGE_TAB_LIST</code></span
+                  <span>Role: <code>ROLE_PAGE_TAB_LIST</code></span
                   ><br />
-                  <span class="property">Interface: <code>Selection</code></span>
+                  <span>Interface: <code>Selection</code></span>
                   <p>
                     Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return
                     <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.
@@ -5655,14 +5513,11 @@
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXTabGroup</code></span
+                  <span>AXRole: <code>AXTabGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -5673,6 +5528,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-tabpanel"><code>tabpanel</code></h4>
           <table class="data" aria-labelledby="role-map-tabpanel">
             <tbody>
@@ -5691,30 +5547,27 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_PANE</code> or <code>ROLE_SYSTEM_PROPERTYPAGE</code></span>
+                  <span>Role: <code>ROLE_SYSTEM_PANE</code> or <code>ROLE_SYSTEM_PROPERTYPAGE</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Pane</code></span>
+                  <span>Control Type: <code>Pane</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SCROLL_PANE</code></span>
+                  <span>Role: <code>ROLE_SCROLL_PANE</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXTabPanel</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXTabPanel</code></span>
                 </td>
               </tr>
               <tr>
@@ -5725,6 +5578,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-term"><code>term</code></h4>
           <table class="data" aria-labelledby="role-map-term">
             <tbody>
@@ -5743,34 +5597,31 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>IA2_ROLE_TEXT_FRAME</code></span
+                  <span>Role: <code>IA2_ROLE_TEXT_FRAME</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:term</code></span>
+                  <span>Object Attribute: <code>xml-roles:term</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Text</code></span
+                  <span>Control Type: <code>Text</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>term</code></span>
+                  <span>Localized Control Type: <code>term</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_DESCRIPTION_TERM</code></span>
+                  <span>Role: <code>ROLE_DESCRIPTION_TERM</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXTerm</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXTerm</code></span>
                 </td>
               </tr>
               <tr>
@@ -5781,6 +5632,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-textbox"><code>textbox</code> when <code>aria-multiline</code> is <code>false</code></h4>
           <table class="data" aria-labelledby="role-map-textbox">
             <tbody>
@@ -5799,38 +5651,35 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span
+                  <span>Role: <code>ROLE_SYSTEM_TEXT</code></span
                   ><br />
-                  <span class="property">State: <code>IA2_STATE_SINGLE_LINE</code></span>
+                  <span>State: <code>IA2_STATE_SINGLE_LINE</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Edit</code></span>
+                  <span>Control Type: <code>Edit</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_ENTRY</code></span
+                  <span>Role: <code>ROLE_ENTRY</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_SINGLE_LINE</code></span
+                  <span>State: <code>STATE_SINGLE_LINE</code></span
                   ><br />
-                  <span class="property"
-                    >Interface: <code>EditableText</code> if <a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a> is not <code>&quot;true&quot;</code></span
+                  <span
+                    >Interface: <code>EditableText</code> if <a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a> is not <code>"true"</code></span
                   >
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXTextField</code></span
+                  <span>AXRole: <code>AXTextField</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -5841,6 +5690,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-textbox-multiline"><code>textbox</code> when <code>aria-multiline</code> is <code>true</code></h4>
           <table class="data" aria-labelledby="role-map-textbox-multiline">
             <tbody>
@@ -5859,38 +5709,35 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_TEXT</code></span
+                  <span>Role: <code>ROLE_SYSTEM_TEXT</code></span
                   ><br />
-                  <span class="property">State: <code>IA2_STATE_MULTI_LINE</code></span>
+                  <span>State: <code>IA2_STATE_MULTI_LINE</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Edit</code></span>
+                  <span>Control Type: <code>Edit</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_ENTRY</code></span
+                  <span>Role: <code>ROLE_ENTRY</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_MULTI_LINE</code></span
+                  <span>State: <code>STATE_MULTI_LINE</code></span
                   ><br />
-                  <span class="property"
-                    >Interface: <code>EditableText</code> if <a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a> is not <code>&quot;true&quot;</code></span
+                  <span
+                    >Interface: <code>EditableText</code> if <a class="property-reference" href="#aria-readonly"><code>aria-readonly</code></a> is not <code>"true"</code></span
                   >
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXTextArea</code></span
+                  <span>AXRole: <code>AXTextArea</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -5901,6 +5748,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-time"><code>time</code></h4>
           <table class="data" aria-labelledby="role-map-time">
             <tbody>
@@ -5919,38 +5767,34 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_GROUPING</code></span
+                  <span>Role: <code>ROLE_SYSTEM_GROUPING</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:time</code></span>
+                  <span>Object Attribute: <code>xml-roles:time</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Text</code></span
+                  <span>Control Type: <code>Text</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>time</code></span
-                  ><br />
+                  <span>Localized Control Type: <code>time</code></span>
                   <p>Note: create a separate UIA Control of type Text. This is different from most UIA text mappings, which only create ranges in the page text pattern.</p>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_STATIC</code></span
+                  <span>Role: <code>ROLE_STATIC</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>xml-roles:time</code></span>
+                  <span>Object Attribute: <code>xml-roles:time</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXTimeGroup</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXTimeGroup</code></span>
                 </td>
               </tr>
               <tr>
@@ -5961,6 +5805,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-timer"><code>timer</code></h4>
           <table class="data" aria-labelledby="role-map-timer">
             <tbody>
@@ -5979,32 +5824,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>xml-roles:timer</code></span>
+                  <span>Object Attribute: <code>xml-roles:timer</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Group</code></span
+                  <span>Control Type: <code>Group</code></span
                   ><br />
-                  <span class="property">Localized Control Type: <code>timer</code></span>
+                  <span>Localized Control Type: <code>timer</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_TIMER</code></span>
+                  <span>Role: <code>ROLE_TIMER</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXApplicationTimer</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXApplicationTimer</code></span>
                 </td>
               </tr>
               <tr>
@@ -6015,6 +5857,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-toolbar"><code>toolbar</code></h4>
           <table class="data" aria-labelledby="role-map-toolbar">
             <tbody>
@@ -6033,30 +5876,27 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_TOOLBAR</code></span>
+                  <span>Role: <code>ROLE_SYSTEM_TOOLBAR</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>ToolBar</code></span>
+                  <span>Control Type: <code>ToolBar</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_TOOL_BAR</code></span>
+                  <span>Role: <code>ROLE_TOOL_BAR</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXToolbar</code></span
+                  <span>AXRole: <code>AXToolbar</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -6067,6 +5907,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-tooltip"><code>tooltip</code></h4>
           <table class="data" aria-labelledby="role-map-tooltip">
             <tbody>
@@ -6085,30 +5926,27 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_TOOLTIP</code></span>
+                  <span>Role: <code>ROLE_SYSTEM_TOOLTIP</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>ToolTip</code></span>
+                  <span>Control Type: <code>ToolTip</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_TOOL_TIP</code></span>
+                  <span>Role: <code>ROLE_TOOL_TIP</code></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXGroup</code></span
+                  <span>AXRole: <code>AXGroup</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXUserInterfaceTooltip</code></span
-                  ><br />
+                  <span>AXSubrole: <code>AXUserInterfaceTooltip</code></span>
                 </td>
               </tr>
               <tr>
@@ -6119,6 +5957,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-tree"><code>tree</code></h4>
           <table class="data" aria-labelledby="role-map-tree">
             <tbody>
@@ -6137,25 +5976,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_OUTLINE</code></span
+                  <span>Role: <code>ROLE_SYSTEM_OUTLINE</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible::accSelect()</code></span
+                  <span>Method: <code>IAccessible::accSelect()</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+                  <span>Method: <code>IAccessible::get_accSelection()</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Tree</code></span>
+                  <span>Control Type: <code>Tree</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_TREE</code></span
+                  <span>Role: <code>ROLE_TREE</code></span
                   ><br />
-                  <span class="property">Interface: <code>Selection</code></span>
+                  <span>Interface: <code>Selection</code></span>
                   <p>
                     Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return
                     <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.
@@ -6163,14 +6002,11 @@
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXOutline</code></span
+                  <span>AXRole: <code>AXOutline</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -6181,6 +6017,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-treegrid"><code>treegrid</code></h4>
           <table class="data" aria-labelledby="role-map-treegrid">
             <tbody>
@@ -6199,29 +6036,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_OUTLINE</code></span
+                  <span>Role: <code>ROLE_SYSTEM_OUTLINE</code></span
                   ><br />
-                  <span class="property">Interface: <code>IAccessibleTable2</code></span
+                  <span>Interface: <code>IAccessibleTable2</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible::accSelect()</code></span
+                  <span>Method: <code>IAccessible::accSelect()</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible::get_accSelection()</code></span>
+                  <span>Method: <code>IAccessible::get_accSelection()</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>DataGrid</code></span>
+                  <span>Control Type: <code>DataGrid</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_TREE_TABLE</code></span
+                  <span>Role: <code>ROLE_TREE_TABLE</code></span
                   ><br />
-                  <span class="property">Interface: <code>Table</code></span
+                  <span>Interface: <code>Table</code></span
                   ><br />
-                  <span class="property">Interface: <code>Selection</code></span>
+                  <span>Interface: <code>Selection</code></span>
                   <p>
                     Because <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return
                     <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection.
@@ -6229,14 +6066,11 @@
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXTable</code></span
+                  <span>AXRole: <code>AXTable</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>&lt;nil&gt;</code></span
-                  ><br />
+                  <span>AXSubrole: <code>&lt;nil&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -6247,6 +6081,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="role-map-treeitem"><code>treeitem</code></h4>
           <table class="data" aria-labelledby="role-map-treeitem">
             <tbody>
@@ -6265,7 +6100,7 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Role: <code>ROLE_SYSTEM_OUTLINEITEM</code></span
+                  <span>Role: <code>ROLE_SYSTEM_OUTLINEITEM</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -6273,7 +6108,7 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>TreeItem</code></span
+                  <span>Control Type: <code>TreeItem</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -6281,19 +6116,17 @@
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Role: <code>ROLE_TREE_ITEM</code></span
+                  <span>Role: <code>ROLE_TREE_ITEM</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
               </tr>
               <tr>
-                <th>
-                  <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
-                </th>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXRole: <code>AXRow</code></span
+                  <span>AXRole: <code>AXRow</code></span
                   ><br />
-                  <span class="property">AXSubrole: <code>AXOutlineRow</code></span
+                  <span>AXSubrole: <code>AXOutlineRow</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -6366,6 +6199,7 @@
         <section id="mapping_state-property_table">
           <h3>State and Property Mapping Tables</h3>
           <!-- GENERATION ATTRIBUTE MAP START -->
+
           <h4 id="ariaActiveDescendant"><code>aria-activedescendant</code></h4>
           <table class="data" aria-labelledby="ariaActiveDescendant">
             <tbody>
@@ -6377,21 +6211,29 @@
               </tr>
               <tr>
                 <th>MSAA + IAccessible2</th>
-                <td>See <a href="#focus_state_event_table">Focus Changes</a>.</td>
+                <td>
+                  <p>See <a href="#focus_state_event_table">Focus Changes</a>.</p>
+                </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
-                <td>See <a href="#focus_state_event_table">Focus Changes</a>.</td>
+                <td>
+                  <p>See <a href="#focus_state_event_table">Focus Changes</a>.</p>
+                </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
-                <td>See <a href="#focus_state_event_table">Focus Changes</a>.</td>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>
+                  <p>See <a href="#focus_state_event_table">Focus Changes</a>.</p>
+                </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  See <a href="#focus_state_event_table">Focus Changes</a>.<br />
-                  <span class="property">Property: <code>AXSelectedRows</code>: pointer to active descendant node</span>
+                  <p>
+                    See <a href="#focus_state_event_table">Focus Changes</a>.<br />
+                    <span class="property">Property: <code>AXSelectedRows</code>: pointer to active descendant node</span>
+                  </p>
                 </td>
               </tr>
               <tr>
@@ -6402,6 +6244,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaAtomicTrue"><code>aria-atomic</code>=<code>true</code></h4>
           <table class="data" aria-labelledby="ariaAtomicTrue">
             <tbody>
@@ -6415,39 +6258,39 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>atomic:true</code></span
+                  <span>Object Attribute: <code>atomic:true</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-atomic:true</code></span
+                  <span>Object Attribute: <code>container-atomic:true</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-atomic:true</code> on all descendants</span><br />
-                  <span class="relation">Relation: <code>IA2_RELATION_MEMBER_OF</code> pointing to this element (the atomic root)</span><br />
+                  <span>Object Attribute: <code>container-atomic:true</code> on all descendants</span><br />
+                  <span>Relation: <code>IA2_RELATION_MEMBER_OF</code> pointing to this element (the atomic root)</span><br />
                   <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.atomic</code>: <code>true</code></span
+                  <span>Property: <code>AriaProperties.atomic</code> <code>true</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>atomic:true</code></span
+                  <span>Object Attribute: <code>atomic:true</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-atomic:true</code></span
+                  <span>Object Attribute: <code>container-atomic:true</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-atomic:true</code> on all descendants</span><br />
-                  <span class="relation">Relation: <code>RELATION_MEMBER_OF</code> pointing to this element (the atomic root)</span><br />
+                  <span>Object Attribute: <code>container-atomic:true</code> on all descendants</span><br />
+                  <span>Relation: <code>RELATION_MEMBER_OF</code> pointing to this element (the atomic root)</span><br />
                   <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXARIAAtomic</code>: <code>YES</code></span
+                  <span>Property: <code>AXARIAAtomic</code> <code>YES</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
                 </td>
@@ -6460,6 +6303,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaAtomicFalse"><code>aria-atomic</code>=<code>false</code></h4>
           <table class="data" aria-labelledby="ariaAtomicFalse">
             <tbody>
@@ -6473,41 +6317,41 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a>, but if mapped:</span><br />
-                  <span class="property">Object Attribute: <code>atomic:false</code></span
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a>, but if mapped:</span><br />
+                  <span>Object Attribute: <code>atomic:false</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-atomic:false</code></span
+                  <span>Object Attribute: <code>container-atomic:false</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-atomic:false</code> on all descendants</span><br />
-                  <span class="relation">Relation: <code>IA2_RELATION_MEMBER_OF</code> pointing to this element (the atomic root)</span><br />
+                  <span>Object Attribute: <code>container-atomic:false</code> on all descendants</span><br />
+                  <span>Relation: <code>IA2_RELATION_MEMBER_OF</code> pointing to this element (the atomic root)</span><br />
                   <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.atomic</code>: <code>false</code></span
+                  <span>Property: <code>AriaProperties.atomic</code> <code>false</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a>, but if mapped:</span><br />
-                  <span class="property">Object Attribute: <code>atomic:false</code></span
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a>, but if mapped:</span><br />
+                  <span>Object Attribute: <code>atomic:false</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-atomic:false</code></span
+                  <span>Object Attribute: <code>container-atomic:false</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-atomic:false</code> on all descendants</span><br />
-                  <span class="relation">Relation: <code>RELATION_MEMBER_OF</code> pointing to this element (the atomic root)</span><br />
+                  <span>Object Attribute: <code>container-atomic:false</code> on all descendants</span><br />
+                  <span>Relation: <code>RELATION_MEMBER_OF</code> pointing to this element (the atomic root)</span><br />
                   <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXARIAAtomic</code>: <code>NO</code></span
+                  <span>Property: <code>AXARIAAtomic</code> <code>NO</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
                 </td>
@@ -6520,6 +6364,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaAutocompleteInlineListBoth"><code>aria-autocomplete</code>=<code>inline</code>, <code>list</code>, or <code>both</code></h4>
           <table class="data" aria-labelledby="ariaAutocompleteInlineListBoth">
             <tbody>
@@ -6533,29 +6378,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>autocomplete:&lt;value&gt;</code></span
+                  <span>Object Attribute: <code>autocomplete:&lt;value&gt;</code></span
                   ><br />
-                  <span class="property">State: <code>IA2_STATE_SUPPORTS_AUTOCOMPLETION</code></span>
+                  <span>State: <code>IA2_STATE_SUPPORTS_AUTOCOMPLETION</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>autocomplete:&lt;value&gt;</code></span
+                  <span>Object Attribute: <code>autocomplete:&lt;value&gt;</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_SUPPORTS_AUTOCOMPLETION</code></span>
+                  <span>State: <code>STATE_SUPPORTS_AUTOCOMPLETION</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
@@ -6566,6 +6411,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaAutocompleteNone"><code>aria-autocomplete</code>=<code>none</code></h4>
           <table class="data" aria-labelledby="ariaAutocompleteNone">
             <tbody>
@@ -6579,25 +6425,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
@@ -6608,6 +6454,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaBraillelabel"><code>aria-braillelabel</code></h4>
           <table class="data" aria-labelledby="ariaBraillelabel">
             <tbody>
@@ -6620,25 +6467,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>braillelabel:&lt;value&gt;</code></span>
+                  <span>Object Attribute: <code>braillelabel:&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.braillelabel</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AriaProperties.braillelabel</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>braillelabel:&lt;value&gt;</code></span>
+                  <span>Object Attribute: <code>braillelabel:&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">AXBrailleLabel: <code>&lt;value&gt;</code></span>
+                  <span>AXBrailleLabel: <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -6649,6 +6496,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaBrailleroledescription"><code>aria-brailleroledescription</code></h4>
           <table class="data" aria-labelledby="ariaBrailleroledescription">
             <tbody>
@@ -6661,25 +6509,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>brailleroledescription:&lt;value&gt;</code></span>
+                  <span>Object Attribute: <code>brailleroledescription:&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.brailleroledescription</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AriaProperties.brailleroledescription</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>brailleroledescription:&lt;value&gt;</code></span>
+                  <span>Object Attribute: <code>brailleroledescription:&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: AXBrailleRoleDescription: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -6690,6 +6538,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaBrailleroledescriptionUndefined"><code>aria-brailleroledescription</code> is undefined or the empty string</h4>
           <table class="data" aria-labelledby="ariaBrailleroledescriptionUndefined">
             <tbody>
@@ -6702,25 +6551,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
@@ -6731,6 +6580,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaBusyTrue"><code>aria-busy</code>=<code>true</code></h4>
           <table class="data" aria-labelledby="ariaBusyTrue">
             <tbody>
@@ -6744,25 +6594,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_BUSY</code></span>
+                  <span>State: <code>STATE_SYSTEM_BUSY</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.busy</code>: <code>true</code></span>
+                  <span>Property: <code>AriaProperties.busy</code> <code>true</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_BUSY</code></span>
+                  <span>State: <code>STATE_BUSY</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXElementBusy</code>: <code>YES</code></span>
+                  <span>Property: <code>AXElementBusy</code> <code>YES</code></span>
                 </td>
               </tr>
               <tr>
@@ -6773,6 +6623,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaBusyFalse"><code>aria-busy</code>=<code>false</code></h4>
           <table class="data" aria-labelledby="ariaBusyFalse">
             <tbody>
@@ -6786,25 +6637,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_BUSY</code> not exposed</span>
+                  <span>State: <code>STATE_SYSTEM_BUSY</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.busy</code>: <code>false</code></span>
+                  <span>Property: <code>AriaProperties.busy</code> <code>false</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_BUSY</code> not exposed</span>
+                  <span>State: <code>STATE_BUSY</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXElementBusy</code>: <code>NO</code></span>
+                  <span>Property: <code>AXElementBusy</code> <code>NO</code></span>
                 </td>
               </tr>
               <tr>
@@ -6815,6 +6666,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaCheckedTrue"><code>aria-checked</code>=<code>true</code></h4>
           <table class="data" aria-labelledby="ariaCheckedTrue">
             <tbody>
@@ -6828,33 +6680,33 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_CHECKED</code></span
+                  <span>State: <code>STATE_SYSTEM_CHECKED</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>checkable:true</code></span>
+                  <span>Object Attribute: <code>checkable:true</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>Toggle.ToggleState</code>: <code>On (1)</code></span
+                  <span>Property: <code>Toggle.ToggleState</code> <code>On (1)</code></span
                   ><br />
-                  <span class="property">Property: <code>SelectionItem.IsSelected</code>: <code>True</code> for <code>radio</code> and <code>menuitemradio</code></span>
+                  <span>Property: <code>SelectionItem.IsSelected</code> <code>True</code> for <code>radio</code> and <code>menuitemradio</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_CHECKABLE</code></span
+                  <span>State: <code>STATE_CHECKABLE</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_CHECKED</code></span>
+                  <span>State: <code>STATE_CHECKED</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXValue</code>: <code>1</code></span
+                  <span>Property: <code>AXValue</code> <code>1</code></span
                   ><br />
-                  <span class="property">Property: <code>AXMenuItemMarkChar</code>: <code>&#x2713;</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code></span>
+                  <span>Property: <code>AXMenuItemMarkChar</code> <code>✓</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code></span>
                 </td>
               </tr>
               <tr>
@@ -6865,6 +6717,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaCheckedFalse"><code>aria-checked</code>=<code>false</code></h4>
           <table class="data" aria-labelledby="ariaCheckedFalse">
             <tbody>
@@ -6878,32 +6731,32 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_CHECKED</code> not exposed</span><br />
-                  <span class="property">Object Attribute: <code>checkable:true</code></span>
+                  <span>State: <code>STATE_SYSTEM_CHECKED</code> not exposed</span><br />
+                  <span>Object Attribute: <code>checkable:true</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>Toggle.ToggleState</code>: <code>Off (0)</code></span
+                  <span>Property: <code>Toggle.ToggleState</code> <code>Off (0)</code></span
                   ><br />
-                  <span class="property">Property: <code>SelectionItem.IsSelected</code>: <code>False</code> for <code>radio</code> and <code>menuitemradio</code></span>
+                  <span>Property: <code>SelectionItem.IsSelected</code> <code>False</code> for <code>radio</code> and <code>menuitemradio</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_CHECKABLE</code></span
+                  <span>State: <code>STATE_CHECKABLE</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_CHECKED</code> not exposed</span>
+                  <span>State: <code>STATE_CHECKED</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXValue</code>: <code>0</code></span
+                  <span>Property: <code>AXValue</code> <code>0</code></span
                   ><br />
-                  <span class="property">Property: <code>AXMenuItemMarkChar</code>: <code>&lt;nil&gt;</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code></span>
+                  <span>Property: <code>AXMenuItemMarkChar</code> <code>&lt;nil&gt;</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code></span>
                 </td>
               </tr>
               <tr>
@@ -6914,6 +6767,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaCheckedMixed"><code>aria-checked</code>=<code>mixed</code></h4>
           <table class="data" aria-labelledby="ariaCheckedMixed">
             <tbody>
@@ -6927,33 +6781,33 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_MIXED</code></span
+                  <span>State: <code>STATE_SYSTEM_MIXED</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>checkable:true</code></span>
+                  <span>Object Attribute: <code>checkable:true</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>Toggle.ToggleState</code>: <code>Indeterminate (2)</code></span>
+                  <span>Property: <code>Toggle.ToggleState</code> <code>Indeterminate (2)</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_INDETERMINATE</code></span
+                  <span>State: <code>STATE_INDETERMINATE</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_CHECKABLE</code></span
+                  <span>State: <code>STATE_CHECKABLE</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_CHECKED</code> not exposed</span>
+                  <span>State: <code>STATE_CHECKED</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXValue</code>: <code>2</code></span
+                  <span>Property: <code>AXValue</code> <code>2</code></span
                   ><br />
-                  <span class="property">Property: <code>AXMenuItemMarkChar</code>: <code>&lt;nil&gt;</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code></span>
+                  <span>Property: <code>AXMenuItemMarkChar</code> <code>&lt;nil&gt;</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code></span>
                 </td>
               </tr>
               <tr>
@@ -6964,6 +6818,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaCheckedUndefined"><code>aria-checked</code> is undefined</h4>
           <table class="data" aria-labelledby="ariaCheckedUndefined">
             <tbody>
@@ -6976,25 +6831,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
@@ -7005,6 +6860,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaColCount"><code>aria-colcount</code></h4>
           <table class="data" aria-labelledby="ariaColCount">
             <tbody>
@@ -7017,28 +6873,28 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>colcount:&lt;value&gt;</code></span
+                  <span>Object Attribute: <code>colcount:&lt;value&gt;</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible2::groupPosition()</code>: <code>similarItemsInGroup=&lt;value&gt;</code> on cells and headers</span>
+                  <span>Method: <code>IAccessible2::groupPosition()</code> <code>similarItemsInGroup=&lt;value&gt;</code> on cells and headers</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>Grid.ColumnCount</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>Grid.ColumnCount</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>colcount</code> should contain the author-provided value.</span><br />
-                  <span class="method">Method: <code>atk_table_get_n_columns()</code> should return the actual number of columns.</span>
+                  <span>Object Attribute: <code>colcount</code> should contain the author-provided value.</span><br />
+                  <span>Method: <code>atk_table_get_n_columns()</code> should return the actual number of columns.</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXARIAColumnCount</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AXARIAColumnCount</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -7049,6 +6905,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaColIndex"><code>aria-colindex</code></h4>
           <table class="data" aria-labelledby="ariaColIndex">
             <tbody>
@@ -7061,28 +6918,28 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>colindex:&lt;value&gt;</code></span
+                  <span>Object Attribute: <code>colindex:&lt;value&gt;</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible2::groupPosition()</code>: <code>positionInGroup=&lt;value&gt;</code> on cells and headers</span>
+                  <span>Method: <code>IAccessible2::groupPosition()</code> <code>positionInGroup=&lt;value&gt;</code> on cells and headers</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>GridItem.Column</code>: <code>&lt;value&gt;</code> (zero-based)</span>
+                  <span>Property: <code>GridItem.Column</code> <code>&lt;value&gt;</code> (zero-based)</span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>colindex</code> should contain the author-provided value.</span><br />
-                  <span class="method">Method: <code>atk_table_cell_get_position()</code> should return the actual (zero-based) column index.</span>
+                  <span>Object Attribute: <code>colindex</code> should contain the author-provided value.</span><br />
+                  <span>Method: <code>atk_table_cell_get_position()</code> should return the actual (zero-based) column index.</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXARIAColumnIndex</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AXARIAColumnIndex</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -7093,6 +6950,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaColIndexText"><code>aria-colindextext</code></h4>
           <table class="data" aria-labelledby="ariaColIndexText">
             <tbody>
@@ -7105,25 +6963,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>colindextext:&lt;value&gt;</code></span>
+                  <span>Object Attribute: <code>colindextext:&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.colindextext</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AriaProperties.colindextext</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>colindextext:&lt;value&gt;</code></span>
+                  <span>Object Attribute: <code>colindextext:&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXColumnIndexDescription</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AXColumnIndexDescription</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -7134,6 +6992,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaColSpan"><code>aria-colspan</code></h4>
           <table class="data" aria-labelledby="ariaColSpan">
             <tbody>
@@ -7146,28 +7005,28 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>colspan:&lt;value&gt;</code></span
+                  <span>Object Attribute: <code>colspan:&lt;value&gt;</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessibleTableCell::columnExtent()</code>: <code>&lt;value&gt;</code></span>
+                  <span>Method: <code>IAccessibleTableCell::columnExtent()</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>GridItem.ColumnSpan</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>GridItem.ColumnSpan</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>colspan</code> should contain the author-provided value.</span><br />
-                  <span class="method">Method: <code>atk_table_cell_get_row_column_span()</code> should return the actual column span.</span>
+                  <span>Object Attribute: <code>colspan</code> should contain the author-provided value.</span><br />
+                  <span>Method: <code>atk_table_cell_get_row_column_span()</code> should return the actual column span.</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXColumnIndexRange.length</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AXColumnIndexRange.length</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -7178,6 +7037,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaControls"><code>aria-controls</code></h4>
           <table class="data" aria-labelledby="ariaControls">
             <tbody>
@@ -7190,29 +7050,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="relation">Relation: <code>IA2_RELATION_CONTROLLER_FOR</code> points to accessible nodes matching IDREFs</span><br />
-                  <span class="relation">Reverse Relation: <code>IA2_RELATION_CONTROLLED_BY</code> points to element</span><br />
+                  <span>Relation: <code>IA2_RELATION_CONTROLLER_FOR</code> points to accessible nodes matching IDREFs</span><br />
+                  <span>Reverse Relation: <code>IA2_RELATION_CONTROLLED_BY</code> points to element</span><br />
                   <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>ControllerFor</code>: pointers to accessible nodes matching IDREFs</span>
+                  <span>Property: <code>ControllerFor</code> pointers to accessible nodes matching IDREFs</span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="relation">Relation: <code>RELATION_CONTROLLER_FOR</code> points to accessible nodes matching IDREFs</span><br />
-                  <span class="relation">Reverse Relation: <code>RELATION_CONTROLLED_BY</code> points to element</span><br />
+                  <span>Relation: <code>RELATION_CONTROLLER_FOR</code> points to accessible nodes matching IDREFs</span><br />
+                  <span>Reverse Relation: <code>RELATION_CONTROLLED_BY</code> points to element</span><br />
                   <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXLinkedUIElements</code>: pointers to accessible nodes matching IDREFs</span>
+                  <span>Property: <code>AXLinkedUIElements</code> pointers to accessible nodes matching IDREFs</span>
                 </td>
               </tr>
               <tr>
@@ -7223,6 +7083,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaCurrent"><code>aria-current</code> with non-<code>false</code> allowed value</h4>
           <table class="data" aria-labelledby="ariaCurrent">
             <tbody>
@@ -7235,27 +7096,27 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>current:&lt;value&gt;</code></span>
+                  <span>Object Attribute: <code>current:&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.current</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AriaProperties.current</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>current:&lt;value&gt;</code></span
+                  <span>Object Attribute: <code>current:&lt;value&gt;</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_ACTIVE</code></span>
+                  <span>State: <code>STATE_ACTIVE</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXARIACurrent</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AXARIACurrent</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -7266,6 +7127,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaCurrentUnrecognizedValue"><code>aria-current</code> with unrecognized value</h4>
           <table class="data" aria-labelledby="ariaCurrentUnrecognizedValue">
             <tbody>
@@ -7278,27 +7140,27 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>current:true</code></span>
+                  <span>Object Attribute: <code>current:true</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.current</code>: <code>true</code></span>
+                  <span>Property: <code>AriaProperties.current</code> <code>true</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>current:true</code></span
+                  <span>Object Attribute: <code>current:true</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_ACTIVE</code></span>
+                  <span>State: <code>STATE_ACTIVE</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXARIACurrent</code>: <code>true</code></span>
+                  <span>Property: <code>AXARIACurrent</code> <code>true</code></span>
                 </td>
               </tr>
               <tr>
@@ -7309,6 +7171,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaCurrentUndefined"><code>aria-current</code> is <code>false</code> or undefined</h4>
           <table class="data" aria-labelledby="ariaCurrentUndefined">
             <tbody>
@@ -7321,25 +7184,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
@@ -7350,6 +7213,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaDescribedBy"><code>aria-describedby</code></h4>
           <table class="data" aria-labelledby="ariaDescribedBy">
             <tbody>
@@ -7362,40 +7226,41 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Property: <code>accDescription</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>accDescription</code> <code>&lt;value&gt;</code></span
                   ><br />
-                  <span class="relation">Relation: <code>IA2_RELATION_DESCRIBED_BY</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span
-                  ><br />
-                  <span class="relation">Reverse Relation: <code>IA2_RELATION_DESCRIPTION_FOR</code> points to element</span><br />
+                  <span>Relation: <code>IA2_RELATION_DESCRIBED_BY</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
+                  <span>Reverse Relation: <code>IA2_RELATION_DESCRIPTION_FOR</code> points to element</span><br />
                   <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a> and <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>FullDescription</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>FullDescription</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Property: <code>Description</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>Description</code> <code>&lt;value&gt;</code></span
                   ><br />
-                  <span class="relation">Relation: <code>RELATION_DESCRIBED_BY</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
-                  <span class="relation">Reverse Relation: <code>RELATION_DESCRIPTION_FOR</code> points to element</span><br />
+                  <span>Relation: <code>RELATION_DESCRIBED_BY</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
+                  <span>Reverse Relation: <code>RELATION_DESCRIPTION_FOR</code> points to element</span><br />
                   <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a> and <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="api"
-                    >In the accessibilityCustomContent API, expose as an <code>AXCustomContent</code> object with <code>{ label: "description" }</code> and `<code>value</code>` set to the description
-                    string.</span
-                  ><br />
-                  - <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+                  <p>
+                    <span class="api"
+                      >In the accessibilityCustomContent API, expose as an <code>AXCustomContent</code> object with <code>{ label: "description" }</code> and `<code>value</code>` set to the
+                      description string.</span
+                    ><br />
+                    - <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
+                  </p>
                 </td>
               </tr>
               <tr>
@@ -7406,6 +7271,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaDescription"><code>aria-description</code></h4>
           <table class="data" aria-labelledby="ariaDescription">
             <tbody>
@@ -7418,7 +7284,7 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Property: <code>accDescription</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>accDescription</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
                 </td>
@@ -7426,15 +7292,15 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>FullDescription</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>FullDescription</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Property: <code>Description</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>Description</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
                 </td>
@@ -7442,9 +7308,9 @@
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="api"
-                    >In the accessibilityCustomContent API, expose as an <code>AXCustomContent</code> object with <code>{ label: "description" }</code> and `<code>value</code>` set to the description
-                    string.</span
+                  <span
+                    >In the accessibilityCustomContent API, expose as an AXCustomContent object with { label: <code>AXCustomContent</code> object with <code>{ label: "description" }</code> and
+                    `<code>value</code>` set to the description string.</span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
                 </td>
@@ -7457,6 +7323,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaDetails"><code>aria-details</code></h4>
           <table class="data" aria-labelledby="ariaDetails">
             <tbody>
@@ -7469,29 +7336,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="relation">Relation: <code>IA2_RELATION_DETAILS</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
-                  <span class="relation">Reverse Relation: <code>IA2_RELATION_DETAILS_FOR</code> points to element</span><br />
+                  <span>Relation: <code>IA2_RELATION_DETAILS</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
+                  <span>Reverse Relation: <code>IA2_RELATION_DETAILS_FOR</code> points to element</span><br />
                   <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>DescribedBy</code>: points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span>
+                  <span>Property: <code>DescribedBy</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="relation">Relation: <code>RELATION_DETAILS</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
-                  <span class="relation">Reverse Relation: <code>RELATION_DETAILS_FOR</code> points to element</span><br />
+                  <span>Relation: <code>RELATION_DETAILS</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
+                  <span>Reverse Relation: <code>RELATION_DETAILS_FOR</code> points to element</span><br />
                   <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
@@ -7502,6 +7369,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaDisabledTrue"><code>aria-disabled</code>=<code>true</code></h4>
           <table class="data" aria-labelledby="ariaDisabledTrue">
             <tbody>
@@ -7515,27 +7383,27 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_UNAVAILABLE</code></span
+                  <span>State: <code>STATE_SYSTEM_UNAVAILABLE</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_SYSTEM_UNAVAILABLE</code> on all descendants with <code>STATE_SYSTEM_FOCUSABLE</code></span>
+                  <span>State: <code>STATE_SYSTEM_UNAVAILABLE</code> on all descendants with <code>STATE_SYSTEM_FOCUSABLE</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>IsEnabled</code>: <code>false</code></span>
+                  <span>Property: <code>IsEnabled</code> <code>false</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_ENABLED</code> not exposed</span>
+                  <span>State: <code>STATE_ENABLED</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXEnabled</code>: <code>NO</code></span>
+                  <span>Property: <code>AXEnabled</code> <code>NO</code></span>
                 </td>
               </tr>
               <tr>
@@ -7546,6 +7414,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaDisabledFalse"><code>aria-disabled</code>=<code>false</code></h4>
           <table class="data" aria-labelledby="ariaDisabledFalse">
             <tbody>
@@ -7559,25 +7428,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_UNAVAILABLE</code> not exposed</span>
+                  <span>State: <code>STATE_SYSTEM_UNAVAILABLE</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>IsEnabled</code>: <code>true</code></span>
+                  <span>Property: <code>IsEnabled</code> <code>true</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_ENABLED</code></span>
+                  <span>State: <code>STATE_ENABLED</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXEnabled</code>: <code>YES</code></span>
+                  <span>Property: <code>AXEnabled</code> <code>YES</code></span>
                 </td>
               </tr>
               <tr>
@@ -7588,6 +7457,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaDropeffectMoveLinkExecutePopup">
             <code>aria-dropeffect</code>=<code>copy</code>, <code>move</code>, <code>link</code>, <code>execute</code>, or <code>popup</code> (deprecated)
           </h4>
@@ -7603,25 +7473,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>dropeffect:&lt;value&gt;</code></span>
+                  <span>Object Attribute: <code>dropeffect:&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.dropeffect</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AriaProperties.dropeffect</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>dropeffect:&lt;value&gt;</code></span>
+                  <span>Object Attribute: <code>dropeffect:&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <code>array AXDropEffects</code>
+                  <p><code>array AXDropEffects</code></p>
                 </td>
               </tr>
               <tr>
@@ -7632,6 +7502,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaDropeffectNone"><code>aria-dropeffect</code>=<code>none</code> (deprecated)</h4>
           <table class="data" aria-labelledby="ariaDropeffectNone">
             <tbody>
@@ -7645,27 +7516,27 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>dropeffect:none</code> if there are no other valid tokens</span><br />
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a> if not specified by the author</span>
+                  <span>Object Attribute: <code>dropeffect:none</code> if there are no other valid tokens</span><br />
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a> if not specified by the author</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>dropeffect:none</code> if there are no other valid tokens</span><br />
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a> if not specified by the author</span>
+                  <span>Object Attribute: <code>dropeffect:none</code> if there are no other valid tokens</span><br />
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a> if not specified by the author</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
@@ -7676,6 +7547,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaErrorMessage"><code>aria-errormessage</code></h4>
           <table class="data" aria-labelledby="ariaErrorMessage">
             <tbody>
@@ -7688,29 +7560,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="relation">Relation: <code>IA2_RELATION_ERROR</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
-                  <span class="relation">Reverse Relation: <code>IA2_RELATION_ERROR_FOR</code> points to element</span><br />
+                  <span>Relation: <code>IA2_RELATION_ERROR</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
+                  <span>Reverse Relation: <code>IA2_RELATION_ERROR_FOR</code> points to element</span><br />
                   <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>ControllerFor</code>: pointer to the target accessible object</span>
+                  <span>Property: <code>ControllerFor</code> pointer to the target accessible object</span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="relation">Relation: <code>RELATION_ERROR_MESSAGE</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
-                  <span class="relation">Reverse Relation: <code>RELATION_ERROR_FOR</code> points to element</span><br />
+                  <span>Relation: <code>RELATION_ERROR_MESSAGE</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
+                  <span>Reverse Relation: <code>RELATION_ERROR_FOR</code> points to element</span><br />
                   <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXErrorMessageElements</code>: pointers to accessible nodes matching IDREFs</span>
+                  <span>Property: <code>AXErrorMessageElements</code> pointers to accessible nodes matching IDREFs</span>
                 </td>
               </tr>
               <tr>
@@ -7721,6 +7593,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaExpandedTrue"><code>aria-expanded</code>=<code>true</code></h4>
           <table class="data" aria-labelledby="ariaExpandedTrue">
             <tbody>
@@ -7734,27 +7607,27 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_EXPANDED</code></span>
+                  <span>State: <code>STATE_SYSTEM_EXPANDED</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>ExpandCollapse.ExpandCollapseState</code>: <code>Expanded</code></span>
+                  <span>Property: <code>ExpandCollapse.ExpandCollapseState</code> <code>Expanded</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_EXPANDABLE</code></span
+                  <span>State: <code>STATE_EXPANDABLE</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_EXPANDED</code></span>
+                  <span>State: <code>STATE_EXPANDED</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXExpanded</code>: <code>YES</code></span>
+                  <span>Property: <code>AXExpanded</code> <code>YES</code></span>
                 </td>
               </tr>
               <tr>
@@ -7765,6 +7638,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaExpandedFalse"><code>aria-expanded</code>=<code>false</code></h4>
           <table class="data" aria-labelledby="ariaExpandedFalse">
             <tbody>
@@ -7778,27 +7652,27 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_COLLAPSED</code></span>
+                  <span>State: <code>STATE_SYSTEM_COLLAPSED</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>ExpandCollapse.ExpandCollapseState</code>: <code>Collapsed</code></span>
+                  <span>Property: <code>ExpandCollapse.ExpandCollapseState</code> <code>Collapsed</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_EXPANDABLE</code></span
+                  <span>State: <code>STATE_EXPANDABLE</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_EXPANDED</code> not exposed</span>
+                  <span>State: <code>STATE_EXPANDED</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXExpanded</code>: <code>NO</code></span>
+                  <span>Property: <code>AXExpanded</code> <code>NO</code></span>
                 </td>
               </tr>
               <tr>
@@ -7809,6 +7683,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaExpandedUndefined"><code>aria-expanded</code> is undefined</h4>
           <table class="data" aria-labelledby="ariaExpandedUndefined">
             <tbody>
@@ -7821,25 +7696,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
@@ -7850,6 +7725,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaFlowto"><code>aria-flowto</code></h4>
           <table class="data" aria-labelledby="ariaFlowto">
             <tbody>
@@ -7862,29 +7738,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="relation">Relation: <code>IA2_RELATION_FLOW_TO</code> points to accessible nodes matching IDREFs</span><br />
-                  <span class="relation">Reverse Relation: <code>IA2_RELATION_FLOW_FROM</code> points to element</span><br />
+                  <span>Relation: <code>IA2_RELATION_FLOW_TO</code> points to accessible nodes matching IDREFs</span><br />
+                  <span>Reverse Relation: <code>IA2_RELATION_FLOW_FROM</code> points to element</span><br />
                   <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>FlowsTo</code>: pointers to accessible nodes matching IDREFs</span>
+                  <span>Property: <code>FlowsTo</code> pointers to accessible nodes matching IDREFs</span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="relation">Relation: <code>RELATION_FLOWS_TO</code> points to accessible nodes matching IDREFs</span><br />
-                  <span class="relation">Reverse Relation: <code>RELATION_FLOWS_FROM</code> points to element</span><br />
+                  <span>Relation: <code>RELATION_FLOWS_TO</code> points to accessible nodes matching IDREFs</span><br />
+                  <span>Reverse Relation: <code>RELATION_FLOWS_FROM</code> points to element</span><br />
                   <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXLinkedUIElements</code>: pointers to accessible nodes matching IDREFs</span>
+                  <span>Property: <code>AXLinkedUIElements</code> pointers to accessible nodes matching IDREFs</span>
                 </td>
               </tr>
               <tr>
@@ -7895,6 +7771,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaGrabbedTrue"><code>aria-grabbed</code>=<code>true</code></h4>
           <table class="data" aria-labelledby="ariaGrabbedTrue">
             <tbody>
@@ -7908,25 +7785,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>grabbed:true</code></span>
+                  <span>Object Attribute: <code>grabbed:true</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.grabbed</code>: <code>true</code></span>
+                  <span>Property: <code>AriaProperties.grabbed</code> <code>true</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>grabbed:true</code></span>
+                  <span>Object Attribute: <code>grabbed:true</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXGrabbed</code>: <code>YES</code></span>
+                  <span>Property: <code>AXGrabbed</code> <code>YES</code></span>
                 </td>
               </tr>
               <tr>
@@ -7937,6 +7814,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaGrabbedFalse"><code>aria-grabbed</code>=<code>false</code></h4>
           <table class="data" aria-labelledby="ariaGrabbedFalse">
             <tbody>
@@ -7950,25 +7828,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>grabbed:false</code></span>
+                  <span>Object Attribute: <code>grabbed:false</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.grabbed</code>: <code>false</code></span>
+                  <span>Property: <code>AriaProperties.grabbed</code> <code>false</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>grabbed:false</code></span>
+                  <span>Object Attribute: <code>grabbed:false</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXGrabbed</code>: <code>NO</code></span>
+                  <span>Property: <code>AXGrabbed</code> <code>NO</code></span>
                 </td>
               </tr>
               <tr>
@@ -7979,6 +7857,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaGrabbedUndefined"><code>aria-grabbed</code> is undefined</h4>
           <table class="data" aria-labelledby="ariaGrabbedUndefined">
             <tbody>
@@ -7991,25 +7870,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
@@ -8020,6 +7899,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaHaspopupTrue"><code>aria-haspopup</code>=<code>true</code></h4>
           <table class="data" aria-labelledby="ariaHaspopupTrue">
             <tbody>
@@ -8033,34 +7913,35 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span
+                  <span>State: <code>STATE_SYSTEM_HASPOPUP</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>haspopup:menu</code></span>
+                  <span>Object Attribute: <code>haspopup:menu</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Pattern: <code>ExpandCollapse</code></span>
+                  <span>Control Pattern: <code>ExpandCollapse</code></span
+                  ><br />
                   <span class="seealso"
                     >See also: <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a></span
                   >
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_HAS_POPUP</code></span
+                  <span>State: <code>STATE_HAS_POPUP</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>haspopup:menu</code></span>
+                  <span>Object Attribute: <code>haspopup:menu</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXPopupValue:menu</code></span
+                  <span>Property: <code>AXPopupValue:menu</code></span
                   ><br />
-                  <span class="property">Action: <code>AXShowMenu</code></span>
+                  <span>Action: <code>AXShowMenu</code></span>
                 </td>
               </tr>
               <tr>
@@ -8071,6 +7952,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaHaspopupFalse"><code>aria-haspopup</code>=<code>false</code></h4>
           <table class="data" aria-labelledby="ariaHaspopupFalse">
             <tbody>
@@ -8084,26 +7966,26 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code> not exposed</span><br />
-                  <span class="property">Object Attribute: <code>haspopup:false</code></span>
+                  <span>State: <code>STATE_SYSTEM_HASPOPUP</code> not exposed</span><br />
+                  <span>Object Attribute: <code>haspopup:false</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
@@ -8114,6 +7996,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaHaspopupDialog"><code>aria-haspopup</code>=<code>dialog</code></h4>
           <table class="data" aria-labelledby="ariaHaspopupDialog">
             <tbody>
@@ -8127,15 +8010,15 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span
+                  <span>State: <code>STATE_SYSTEM_HASPOPUP</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>haspopup:dialog</code></span>
+                  <span>Object Attribute: <code>haspopup:dialog</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Pattern: <code>ExpandCollapse</code></span
+                  <span>Control Pattern: <code>ExpandCollapse</code></span
                   ><br />
                   <span class="seealso"
                     >See also: <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a></span
@@ -8143,19 +8026,19 @@
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_HAS_POPUP</code></span
+                  <span>State: <code>STATE_HAS_POPUP</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>haspopup:dialog</code></span>
+                  <span>Object Attribute: <code>haspopup:dialog</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXPopupValue:dialog</code></span
+                  <span>Property: <code>AXPopupValue:dialog</code></span
                   ><br />
-                  <span class="action">Action: <code>AXShowMenu</code></span>
+                  <span>Action: <code>AXShowMenu</code></span>
                 </td>
               </tr>
               <tr>
@@ -8166,6 +8049,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaHaspopupGrid"><code>aria-haspopup</code>=<code>grid</code></h4>
           <table class="data" aria-labelledby="ariaHaspopupGrid">
             <tbody>
@@ -8179,15 +8063,15 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span
+                  <span>State: <code>STATE_SYSTEM_HASPOPUP</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>haspopup:grid</code></span>
+                  <span>Object Attribute: <code>haspopup:grid</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Pattern: <code>ExpandCollapse</code></span
+                  <span>Control Pattern: <code>ExpandCollapse</code></span
                   ><br />
                   <span class="seealso"
                     >See also: <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a></span
@@ -8195,19 +8079,19 @@
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_HAS_POPUP</code></span
+                  <span>State: <code>STATE_HAS_POPUP</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>haspopup:grid</code></span>
+                  <span>Object Attribute: <code>haspopup:grid</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXPopupValue:grid</code></span
+                  <span>Property: <code>AXPopupValue:grid</code></span
                   ><br />
-                  <span class="action">Action: <code>AXShowMenu</code></span>
+                  <span>Action: <code>AXShowMenu</code></span>
                 </td>
               </tr>
               <tr>
@@ -8218,6 +8102,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaHaspopupListbox"><code>aria-haspopup</code>=<code>listbox</code></h4>
           <table class="data" aria-labelledby="ariaHaspopupListbox">
             <tbody>
@@ -8231,15 +8116,15 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span
+                  <span>State: <code>STATE_SYSTEM_HASPOPUP</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>haspopup:listbox</code></span>
+                  <span>Object Attribute: <code>haspopup:listbox</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Pattern: <code>ExpandCollapse</code></span
+                  <span>Control Pattern: <code>ExpandCollapse</code></span
                   ><br />
                   <span class="seealso"
                     >See also: <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a></span
@@ -8247,19 +8132,19 @@
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_HAS_POPUP</code></span
+                  <span>State: <code>STATE_HAS_POPUP</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>haspopup:listbox</code></span>
+                  <span>Object Attribute: <code>haspopup:listbox</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXPopupValue:listbox</code></span
+                  <span>Property: <code>AXPopupValue:listbox</code></span
                   ><br />
-                  <span class="action">Action: <code>AXShowMenu</code></span>
+                  <span>Action: <code>AXShowMenu</code></span>
                 </td>
               </tr>
               <tr>
@@ -8270,6 +8155,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaHaspopupMenu"><code>aria-haspopup</code>=<code>menu</code></h4>
           <table class="data" aria-labelledby="ariaHaspopupMenu">
             <tbody>
@@ -8283,15 +8169,15 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span
+                  <span>State: <code>STATE_SYSTEM_HASPOPUP</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>haspopup:menu</code></span>
+                  <span>Object Attribute: <code>haspopup:menu</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Pattern: <code>ExpandCollapse</code></span
+                  <span>Control Pattern: <code>ExpandCollapse</code></span
                   ><br />
                   <span class="seealso"
                     >See also: <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a></span
@@ -8299,19 +8185,19 @@
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_HAS_POPUP</code></span
+                  <span>State: <code>STATE_HAS_POPUP</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>haspopup:menu</code></span>
+                  <span>Object Attribute: <code>haspopup:menu</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXPopupValue:menu</code></span
+                  <span>Property: <code>AXPopupValue:menu</code></span
                   ><br />
-                  <span class="action">Action: <code>AXShowMenu</code></span>
+                  <span>Action: <code>AXShowMenu</code></span>
                 </td>
               </tr>
               <tr>
@@ -8322,6 +8208,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaHaspopupTree"><code>aria-haspopup</code>=<code>tree</code></h4>
           <table class="data" aria-labelledby="ariaHaspopupTree">
             <tbody>
@@ -8335,15 +8222,15 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_HASPOPUP</code></span
+                  <span>State: <code>STATE_SYSTEM_HASPOPUP</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>haspopup:tree</code></span>
+                  <span>Object Attribute: <code>haspopup:tree</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Pattern: <code>ExpandCollapse</code></span
+                  <span>Control Pattern: <code>ExpandCollapse</code></span
                   ><br />
                   <span class="seealso"
                     >See also: <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a></span
@@ -8351,19 +8238,19 @@
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_HAS_POPUP</code></span
+                  <span>State: <code>STATE_HAS_POPUP</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>haspopup:tree</code></span>
+                  <span>Object Attribute: <code>haspopup:tree</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXPopupValue:tree</code></span
+                  <span>Property: <code>AXPopupValue:tree</code></span
                   ><br />
-                  <span class="action">Action: <code>AXShowMenu</code></span>
+                  <span>Action: <code>AXShowMenu</code></span>
                 </td>
               </tr>
               <tr>
@@ -8374,6 +8261,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaHiddenTrue"><code>aria-hidden</code>=<code>true</code> on unfocused element</h4>
           <table class="data" aria-labelledby="ariaHiddenTrue">
             <tbody>
@@ -8387,28 +8275,28 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property not-in-tree">Element SHOULD NOT be exposed</span><br />
+                  <span class="not-in-tree">Element SHOULD NOT be exposed</span><br />
                   <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property not-in-tree">Element SHOULD NOT be exposed</span><br />
+                  <span class="not-in-tree">Element SHOULD NOT be exposed</span><br />
                   <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property not-in-tree">Element SHOULD NOT be exposed</span><br />
+                  <span class="not-in-tree">Element SHOULD NOT be exposed</span><br />
                   <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-in-tree">Element SHOULD NOT be exposed</span><br />
+                  <span class="not-in-tree">Element SHOULD NOT be exposed</span><br />
                   <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
                 </td>
               </tr>
@@ -8420,6 +8308,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaHiddenTrueElementExposed"><code>aria-hidden</code>=<code>true</code> when element is focused or fires an accessibility event</h4>
           <table class="data" aria-labelledby="ariaHiddenTrueElementExposed">
             <tbody>
@@ -8433,7 +8322,7 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>hidden:true</code></span
+                  <span>Object Attribute: <code>hidden:true</code></span
                   ><br />
                   <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
                 </td>
@@ -8441,15 +8330,15 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.hidden</code>: <code>true</code></span
+                  <span>Property: <code>AriaProperties.hidden</code> <code>true</code></span
                   ><br />
                   <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>hidden:true</code></span
+                  <span>Object Attribute: <code>hidden:true</code></span
                   ><br />
                   <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
                 </td>
@@ -8457,7 +8346,7 @@
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span
                   ><br />
                   <span class="seealso">See also: <a class="specref" href="#tree_inclusion">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a></span>
                 </td>
@@ -8470,6 +8359,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaHiddenFalse"><code>aria-hidden</code>=<code>false</code></h4>
           <table class="data" aria-labelledby="ariaHiddenFalse">
             <tbody>
@@ -8483,25 +8373,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
@@ -8512,6 +8402,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaInvalidTrue"><code>aria-invalid</code>=<code>true</code></h4>
           <table class="data" aria-labelledby="ariaInvalidTrue">
             <tbody>
@@ -8525,29 +8416,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>IA2_STATE_INVALID_ENTRY</code></span
+                  <span>State: <code>IA2_STATE_INVALID_ENTRY</code></span
                   ><br />
-                  <span class="property">Text Attribute: <code>invalid:true</code></span>
+                  <span>Text Attribute: <code>invalid:true</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>IsDataValidForForm</code>: <code>false</code></span>
+                  <span>Property: <code>IsDataValidForForm</code> <code>false</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_INVALID_ENTRY</code></span
+                  <span>State: <code>STATE_INVALID_ENTRY</code></span
                   ><br />
-                  <span class="property">Text Attribute: <code>invalid:true</code></span>
+                  <span>Text Attribute: <code>invalid:true</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXInvalid</code>: <code>true</code></span>
+                  <span>Property: <code>AXInvalid</code> <code>true</code></span>
                 </td>
               </tr>
               <tr>
@@ -8558,6 +8449,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaInvalidFalse"><code>aria-invalid</code>=<code>false</code></h4>
           <table class="data" aria-labelledby="ariaInvalidFalse">
             <tbody>
@@ -8571,25 +8463,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>IA2_STATE_INVALID_ENTRY</code> not exposed</span>
+                  <span>State: <code>IA2_STATE_INVALID_ENTRY</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>IsDataValidForForm</code>: <code>true</code></span>
+                  <span>Property: <code>IsDataValidForForm</code> <code>true</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_INVALID_ENTRY</code> not exposed</span>
+                  <span>State: <code>STATE_INVALID_ENTRY</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXInvalid</code>: <code>false</code></span>
+                  <span>Property: <code>AXInvalid</code> <code>false</code></span>
                 </td>
               </tr>
               <tr>
@@ -8600,6 +8492,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaInvalidSpellingGrammar"><code>aria-invalid</code>=<code>spelling</code> or <code>grammar</code></h4>
           <table class="data" aria-labelledby="ariaInvalidSpellingGrammar">
             <tbody>
@@ -8613,29 +8506,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>IA2_STATE_INVALID_ENTRY</code></span
+                  <span>State: <code>IA2_STATE_INVALID_ENTRY</code></span
                   ><br />
-                  <span class="property">Text Attribute: <code>invalid:&lt;value&gt;</code></span>
+                  <span>Text Attribute: <code>invalid:&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>IsDataValidForForm</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>IsDataValidForForm</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_INVALID_ENTRY</code></span
+                  <span>State: <code>STATE_INVALID_ENTRY</code></span
                   ><br />
-                  <span class="property">Text Attribute: <code>invalid:&lt;value&gt;</code></span>
+                  <span>Text Attribute: <code>invalid:&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXInvalid</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AXInvalid</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -8646,6 +8539,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaInvalidUnrecognizedValue"><code>aria-invalid</code> with unrecognized value</h4>
           <table class="data" aria-labelledby="ariaInvalidUnrecognizedValue">
             <tbody>
@@ -8658,29 +8552,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>IA2_STATE_INVALID_ENTRY</code></span
+                  <span>State: <code>IA2_STATE_INVALID_ENTRY</code></span
                   ><br />
-                  <span class="property">Text Attribute: <code>invalid:true</code></span>
+                  <span>Text Attribute: <code>invalid:true</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>IsDataValidForForm</code>: <code>false</code></span>
+                  <span>Property: <code>IsDataValidForForm</code> <code>false</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_INVALID_ENTRY</code></span
+                  <span>State: <code>STATE_INVALID_ENTRY</code></span
                   ><br />
-                  <span class="property">Text Attribute: <code>invalid:true</code></span>
+                  <span>Text Attribute: <code>invalid:true</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXInvalid</code>: <code>true</code></span>
+                  <span>Property: <code>AXInvalid</code> <code>true</code></span>
                 </td>
               </tr>
               <tr>
@@ -8691,6 +8585,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaKeyshortcuts"><code>aria-keyshortcuts</code></h4>
           <table class="data" aria-labelledby="ariaKeyshortcuts">
             <tbody>
@@ -8703,25 +8598,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Property: <code>accKeyboardShortcut</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>accKeyboardShortcut</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AcceleratorKey</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AcceleratorKey</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>keyshortcuts:&lt;value&gt;</code></span>
+                  <span>Object Attribute: <code>keyshortcuts:&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXKeyShortcutsValue</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AXKeyShortcutsValue</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -8732,6 +8627,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaLabel"><code>aria-label</code></h4>
           <table class="data" aria-labelledby="ariaLabel">
             <tbody>
@@ -8744,7 +8640,7 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Property: <code>accName</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>accName</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
                 </td>
@@ -8752,15 +8648,15 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>Name</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>Name</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Property: <code>Name</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>Name</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
                 </td>
@@ -8768,7 +8664,7 @@
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXTitle</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>AXTitle</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
                 </td>
@@ -8781,6 +8677,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaLabelledBy"><code>aria-labelledby</code></h4>
           <table class="data" aria-labelledby="ariaLabelledBy">
             <tbody>
@@ -8793,41 +8690,38 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Property: <code>accName</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>accName</code> <code>&lt;value&gt;</code></span
                   ><br />
-                  <span class="relation">Relation: <code>IA2_RELATION_LABELLED_BY</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span
-                  ><br />
-                  <span class="relation">Reverse Relation: <code>IA2_RELATION_LABEL_FOR</code> points to element</span><br />
+                  <span>Relation: <code>IA2_RELATION_LABELLED_BY</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
+                  <span>Reverse Relation: <code>IA2_RELATION_LABEL_FOR</code> points to element</span><br />
                   <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a> and <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>Name</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>Name</code> <code>&lt;value&gt;</code></span
                   ><br />
-                  <span class="property">Property: <code>LabeledBy</code>: points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
+                  <span>Property: <code>LabeledBy</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
                   <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Property: <code>Name</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>Name</code> <code>&lt;value&gt;</code></span
                   ><br />
-                  <span class="relation">Relation: <code>RELATION_LABELLED_BY</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
-                  <span class="relation">Reverse Relation: <code>RELATION_LABEL_FOR</code> points to element</span><br />
+                  <span>Relation: <code>RELATION_LABELLED_BY</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
+                  <span>Reverse Relation: <code>RELATION_LABEL_FOR</code> points to element</span><br />
                   <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a> and <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXTitle</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>AXTitle</code> <code>&lt;value&gt;</code></span
                   ><br />
-                  <span class="property"
-                    >Property: <code>AXTitleUIElement</code> points to accessible node matching IDREF, if there is a single referenced element that is in the accessibility tree</span
-                  ><br />
+                  <span>Property: <code>AXTitleUIElement</code> points to accessible node matching IDREF, if there is a single referenced element that is in the accessibility tree</span><br />
                   <span class="seealso">See also: <a href="#mapping_additional_nd">Name Computation</a></span>
                 </td>
               </tr>
@@ -8839,6 +8733,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaLevel"><code>aria-level</code> on non-<code>heading</code></h4>
           <table class="data" aria-labelledby="ariaLevel">
             <tbody>
@@ -8851,10 +8746,9 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>level:&lt;value&gt;</code></span
+                  <span>Object Attribute: <code>level:&lt;value&gt;</code></span
                   ><br />
-                  <span class="method"
-                    >Method: <code>IAccessible2::groupPosition()</code>: <code>groupLevel=&lt;value&gt;</code> on roles that support <code>aria-posinset</code> and <code>aria-setsize</code></span
+                  <span>Method: <code>IAccessible2::groupPosition()</code> <code>groupLevel=&lt;value&gt;</code> on roles that support <code>aria-posinset</code> and <code>aria-setsize</code></span
                   ><br />
                   <span class="seealso"
                     >See also: <a href="#mapping_group_position"><code>groupPosition()</code></a></span
@@ -8864,20 +8758,20 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.level</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AriaProperties.level</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>level:&lt;value&gt;</code></span>
+                  <span>Object Attribute: <code>level:&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property"
-                    >Property: <code>AXDisclosureLevel</code>: <code>&lt;value&gt;</code> (zero-based), when used on an outline row (like a
+                  <span
+                    >Property: <code>AXDisclosureLevel</code> <code>&lt;value&gt;</code> (zero-based), when used on an outline row (like a
                     <a class="role-reference" href="#treeitem"><code>treeitem</code></a> or <a class="role-reference" href="#group"><code>group</code></a
                     >)</span
                   >
@@ -8891,6 +8785,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaLevelHeading"><code>aria-level</code> on <code>heading</code></h4>
           <table class="data" aria-labelledby="ariaLevelHeading">
             <tbody>
@@ -8903,27 +8798,27 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>level:&lt;value&gt;</code></span>
+                  <span>Object Attribute: <code>level:&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.level</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>AriaProperties.level</code> <code>&lt;value&gt;</code></span
                   ><br />
-                  <span class="property">Property: <code>StyleId_Heading</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>StyleId_Heading</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>level:&lt;value&gt;</code></span>
+                  <span>Object Attribute: <code>level:&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXValue</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AXValue</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -8934,6 +8829,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaLiveAssertive"><code>aria-live</code>=<code>assertive</code></h4>
           <table class="data" aria-labelledby="ariaLiveAssertive">
             <tbody>
@@ -8947,39 +8843,37 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>live:assertive</code></span
+                  <span>Object Attribute: <code>live:assertive</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-live:assertive</code></span
+                  <span>Object Attribute: <code>container-live:assertive</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-live:assertive</code> on all descendants</span><br />
+                  <span>Object Attribute: <code>container-live:assertive</code> on all descendants</span><br />
                   <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property"
-                    >Property: <code><code>LiveSetting</code></code
-                    >: <code>&quot;assertive&quot;</code></span
+                  <span>Property: <code>LiveSetting</code> <code>"assertive"</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>live:assertive</code></span
+                  <span>Object Attribute: <code>live:assertive</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-live:assertive</code></span
+                  <span>Object Attribute: <code>container-live:assertive</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-live:assertive</code> on all descendants</span><br />
+                  <span>Object Attribute: <code>container-live:assertive</code> on all descendants</span><br />
                   <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXARIALive</code>: <code>&quot;assertive&quot;</code></span
+                  <span>Property: <code>AXARIALive</code> <code>"assertive"</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
                 </td>
@@ -8992,6 +8886,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaLivePolite"><code>aria-live</code>=<code>polite</code></h4>
           <table class="data" aria-labelledby="ariaLivePolite">
             <tbody>
@@ -9005,39 +8900,37 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>live:polite</code></span
+                  <span>Object Attribute: <code>live:polite</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-live:polite</code></span
+                  <span>Object Attribute: <code>container-live:polite</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-live:polite</code> on all descendants</span><br />
+                  <span>Object Attribute: <code>container-live:polite</code> on all descendants</span><br />
                   <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property"
-                    >Property: <code><code>LiveSetting</code></code
-                    >: <code>&quot;polite&quot;</code></span
+                  <span>Property: <code>LiveSetting</code> <code>"polite"</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>live:polite</code></span
+                  <span>Object Attribute: <code>live:polite</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-live:polite</code></span
+                  <span>Object Attribute: <code>container-live:polite</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-live:polite</code> on all descendants</span><br />
+                  <span>Object Attribute: <code>container-live:polite</code> on all descendants</span><br />
                   <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXARIALive</code>: <code>&quot;polite&quot;</code></span
+                  <span>Property: <code>AXARIALive</code> <code>"polite"</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
                 </td>
@@ -9050,6 +8943,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaLiveOff"><code>aria-live</code>=<code>off</code></h4>
           <table class="data" aria-labelledby="ariaLiveOff">
             <tbody>
@@ -9063,36 +8957,33 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>live:off</code></span
+                  <span>Object Attribute: <code>live:off</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-live:off</code></span
+                  <span>Object Attribute: <code>container-live:off</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-live:off</code> on all descendants</span>
+                  <span>Object Attribute: <code>container-live:off</code> on all descendants</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property"
-                    >Property: <code><code>LiveSetting</code></code
-                    >: <code>&quot;off&quot;</code></span
-                  >
+                  <span>Property: <code>LiveSetting</code> <code>"off"</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>live:off</code></span
+                  <span>Object Attribute: <code>live:off</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-live:off</code></span
+                  <span>Object Attribute: <code>container-live:off</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-live:off</code> on all descendants</span><br />
+                  <span>Object Attribute: <code>container-live:off</code> on all descendants</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXARIALive</code>: <code>&quot;off&quot;</code></span>
+                  <span>Property: <code>AXARIALive</code> <code>"off"</code></span>
                 </td>
               </tr>
               <tr>
@@ -9103,6 +8994,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaModalTrue"><code>aria-modal</code>=<code>true</code></h4>
           <table class="data" aria-labelledby="ariaModalTrue">
             <tbody>
@@ -9116,27 +9008,28 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>IA2_STATE_MODAL</code></span>
+                  <span>State: <code>IA2_STATE_MODAL</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>Window.IsModal</code>: <code>true</code></span
-                  ><br />
+                  <span>Property: <code>Window.IsModal</code> <code>true</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_MODAL</code></span>
+                  <span>State: <code>STATE_MODAL</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  Prune the accessibility tree such that the background content is no longer exposed. No specific property is set on the <a class="termref">accessible object</a> that corresponds to
-                  the <a class="termref">element</a> with <code>aria-modal="true"</code>. Only the tree whose root is that modal accessible object is exposed.
+                  <p>
+                    Prune the accessibility tree such that the background content is no longer exposed. No specific property is set on the <a class="termref">accessible object</a> that corresponds to
+                    the <a class="termref">element</a> with <code>aria-modal="true"</code>. Only the tree whose root is that modal accessible object is exposed.
+                  </p>
                 </td>
               </tr>
               <tr>
@@ -9147,6 +9040,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaModalFalse"><code>aria-modal</code>=<code>false</code></h4>
           <table class="data" aria-labelledby="ariaModalFalse">
             <tbody>
@@ -9160,27 +9054,28 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>IA2_STATE_MODAL</code> not exposed</span>
+                  <span>State: <code>IA2_STATE_MODAL</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>Window.IsModal</code>: <code>false</code></span
-                  ><br />
+                  <span>Property: <code>Window.IsModal</code> <code>false</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_MODAL</code> not exposed</span>
+                  <span>State: <code>STATE_MODAL</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  Grow the accessibility tree such that the background content is exposed. No specific property is set on the <a class="termref">accessible object</a> that corresponds to the
-                  <a class="termref">element</a> with <code>aria-modal="false"</code>.
+                  <p>
+                    Grow the accessibility tree such that the background content is exposed. No specific property is set on the <a class="termref">accessible object</a> that corresponds to the
+                    <a class="termref">element</a> with <code>aria-modal="false"</code>.
+                  </p>
                 </td>
               </tr>
               <tr>
@@ -9191,6 +9086,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaMultilineTrue"><code>aria-multiline</code>=<code>true</code></h4>
           <table class="data" aria-labelledby="ariaMultilineTrue">
             <tbody>
@@ -9204,29 +9100,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>IA2_STATE_MULTI_LINE</code></span
+                  <span>State: <code>IA2_STATE_MULTI_LINE</code></span
                   ><br />
-                  <span class="property">State: <code>IA2_STATE_SINGLE_LINE</code> not exposed</span>
+                  <span>State: <code>IA2_STATE_SINGLE_LINE</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.multiline</code>: <code>true</code></span>
+                  <span>Property: <code>AriaProperties.multiline</code> <code>true</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_MULTI_LINE</code></span
+                  <span>State: <code>STATE_MULTI_LINE</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_SINGLE_LINE</code> not exposed</span>
+                  <span>State: <code>STATE_SINGLE_LINE</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span
                   ><br />
                   <span class="seealso"
                     >See also: <a href="#role-map-textbox"><code>textbox</code></a> in the Role Mapping Tables</span
@@ -9241,6 +9137,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaMultilineFalse"><code>aria-multiline</code>=<code>false</code></h4>
           <table class="data" aria-labelledby="ariaMultilineFalse">
             <tbody>
@@ -9254,29 +9151,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>IA2_STATE_SINGLE_LINE</code></span
+                  <span>State: <code>IA2_STATE_SINGLE_LINE</code></span
                   ><br />
-                  <span class="property">State: <code>IA2_STATE_MULTI_LINE</code> not exposed</span>
+                  <span>State: <code>IA2_STATE_MULTI_LINE</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_SINGLE_LINE</code></span
+                  <span>State: <code>STATE_SINGLE_LINE</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_MULTI_LINE</code> not exposed</span>
+                  <span>State: <code>STATE_MULTI_LINE</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span
                   ><br />
                   <span class="seealso"
                     >See also: <a href="#role-map-textbox"><code>textbox</code></a> in the Role Mapping Tables</span
@@ -9291,6 +9188,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaMultiselectableTrue"><code>aria-multiselectable</code>=<code>true</code></h4>
           <table class="data" aria-labelledby="ariaMultiselectableTrue">
             <tbody>
@@ -9304,9 +9202,9 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_MULTISELECTABLE</code></span
+                  <span>State: <code>STATE_SYSTEM_MULTISELECTABLE</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_SYSTEM_EXTSELECTABLE</code></span
+                  <span>State: <code>STATE_SYSTEM_EXTSELECTABLE</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
                 </td>
@@ -9314,15 +9212,15 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>Selection.CanSelectMultiple</code>: <code>true</code></span
+                  <span>Property: <code>Selection.CanSelectMultiple</code> <code>true</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_MULTISELECTABLE</code></span
+                  <span>State: <code>STATE_MULTISELECTABLE</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
                 </td>
@@ -9330,7 +9228,7 @@
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXIsMultiSelectable</code>: <code>YES</code></span
+                  <span>Property: <code>AXIsMultiSelectable</code> <code>YES</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
                 </td>
@@ -9343,6 +9241,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaMultiselectableFalse"><code>aria-multiselectable</code>=<code>false</code></h4>
           <table class="data" aria-labelledby="ariaMultiselectableFalse">
             <tbody>
@@ -9356,27 +9255,27 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_MULTISELECTABLE</code> not exposed</span><br />
-                  <span class="property">State: <code>STATE_SYSTEM_EXTSELECTABLE</code> not exposed</span><br />
+                  <span>State: <code>STATE_SYSTEM_MULTISELECTABLE</code> not exposed</span><br />
+                  <span>State: <code>STATE_SYSTEM_EXTSELECTABLE</code> not exposed</span><br />
                   <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_MULTISELECTABLE</code> not exposed</span>
+                  <span>State: <code>STATE_MULTISELECTABLE</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
@@ -9387,6 +9286,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaOrientationHorizontal"><code>aria-orientation</code>=<code>horizontal</code></h4>
           <table class="data" aria-labelledby="ariaOrientationHorizontal">
             <tbody>
@@ -9400,29 +9300,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>IA2_STATE_HORIZONTAL</code></span
+                  <span>State: <code>IA2_STATE_HORIZONTAL</code></span
                   ><br />
-                  <span class="property">State: <code>IA2_STATE_VERTICAL</code> not exposed</span>
+                  <span>State: <code>IA2_STATE_VERTICAL</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>Orientation</code>: <code>horizontal</code></span>
+                  <span>Property: <code>Orientation</code> <code>horizontal</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_HORIZONTAL</code></span
+                  <span>State: <code>STATE_HORIZONTAL</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_VERTICAL</code> not exposed</span>
+                  <span>State: <code>STATE_VERTICAL</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXOrientation</code>: <code>AXHorizontalOrientation</code></span>
+                  <span>Property: <code>AXOrientation</code> <code>AXHorizontalOrientation</code></span>
                 </td>
               </tr>
               <tr>
@@ -9433,6 +9333,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaOrientationVertical"><code>aria-orientation</code>=<code>vertical</code></h4>
           <table class="data" aria-labelledby="ariaOrientationVertical">
             <tbody>
@@ -9446,29 +9347,29 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>IA2_STATE_VERTICAL</code></span
+                  <span>State: <code>IA2_STATE_VERTICAL</code></span
                   ><br />
-                  <span class="property">State: <code>IA2_STATE_HORIZONTAL</code> not exposed</span>
+                  <span>State: <code>IA2_STATE_HORIZONTAL</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>Orientation</code>: <code>vertical</code></span>
+                  <span>Property: <code>Orientation</code> <code>vertical</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_VERTICAL</code></span
+                  <span>State: <code>STATE_VERTICAL</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_HORIZONTAL</code> not exposed</span>
+                  <span>State: <code>STATE_HORIZONTAL</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXOrientation</code>: <code>AXVerticalOrientation</code></span>
+                  <span>Property: <code>AXOrientation</code> <code>AXVerticalOrientation</code></span>
                 </td>
               </tr>
               <tr>
@@ -9479,6 +9380,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaOrientationUndefined"><code>aria-orientation</code> is undefined</h4>
           <table class="data" aria-labelledby="ariaOrientationUndefined">
             <tbody>
@@ -9491,26 +9393,26 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_VERTICAL</code> not exposed</span><br />
-                  <span class="property">State: <code>STATE_HORIZONTAL</code> not exposed</span>
+                  <span>State: <code>STATE_VERTICAL</code> not exposed</span><br />
+                  <span>State: <code>STATE_HORIZONTAL</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXOrientation</code>: <code>AXUnknownOrientation</code></span>
+                  <span>Property: <code>AXOrientation</code> <code>AXUnknownOrientation</code></span>
                 </td>
               </tr>
               <tr>
@@ -9521,6 +9423,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaOwns"><code>aria-owns</code></h4>
           <table class="data" aria-labelledby="ariaOwns">
             <tbody>
@@ -9533,39 +9436,40 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
+                  <span>Relation: <code>IA2_RELATION_NODE_PARENT_OF</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
+                  <span>Reverse Relation: <code>IA2_RELATION_NODE_CHILD_OF</code> points to element</span><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
                   <p>
                     User agents MAY expose the elements that are referenced by this property as children of the current element. In which case, if multiple
                     <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a> relationships are found, use only the first one. If the accessibility tree is not modified, expose as:
                   </p>
-                  <span class="relation">Relation: <code>IA2_RELATION_NODE_PARENT_OF</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span
-                  ><br />
-                  <span class="relation">Reverse Relation: <code>IA2_RELATION_NODE_CHILD_OF</code> points to element</span><br />
-                  <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  Expose the elements that are referenced by this property as children of the current element. If multiple
-                  <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a> relationships are found, use only the first one.
+                  <p>
+                    Expose the elements that are referenced by this property as children of the current element. If multiple
+                    <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a> relationships are found, use only the first one.
+                  </p>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
+                  <span>Relation: <code>RELATION_NODE_PARENT_OF</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
+                  <span>Reverse Relation: <code>RELATION_NODE_CHILD_OF</code> points to element</span><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
                   <p>
                     User agents MAY expose the elements that are referenced by this property as children of the current element. In which case, if multiple
                     <a class="property-reference" href="#aria-owns"><code>aria-owns</code></a> relationships are found, use only the first one. If the accessibility tree is not modified, expose as:
                   </p>
-                  <span class="relation">Relation: <code>RELATION_NODE_PARENT_OF</code> points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree</span><br />
-                  <span class="relation">Reverse Relation: <code>RELATION_NODE_CHILD_OF</code> points to element</span><br />
-                  <span class="seealso">See also: <a href="#mapping_additional_relations">Mapping Additional Relations</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXOwns</code>: pointers to accessible nodes matching IDREFs</span>
+                  <span>Property: <code>AXOwns</code> pointers to accessible nodes matching IDREFs</span>
                 </td>
               </tr>
               <tr>
@@ -9576,6 +9480,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaPlaceholder"><code>aria-placeholder</code></h4>
           <table class="data" aria-labelledby="ariaPlaceholder">
             <tbody>
@@ -9588,25 +9493,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>placeholder-text:&lt;value&gt;</code></span>
+                  <span>Object Attribute: <code>placeholder-text:&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>HelpText</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>HelpText</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>placeholder-text:&lt;value&gt;</code></span>
+                  <span>Object Attribute: <code>placeholder-text:&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXPlaceholderValue</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AXPlaceholderValue</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -9617,6 +9522,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaPosinset"><code>aria-posinset</code></h4>
           <table class="data" aria-labelledby="ariaPosinset">
             <tbody>
@@ -9629,7 +9535,7 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>posinset:&lt;value&gt;</code></span
+                  <span>Object Attribute: <code>posinset:&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
                 </td>
@@ -9637,15 +9543,15 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.posinset</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>AriaProperties.posinset</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>posinset:&lt;value&gt;</code></span
+                  <span>Object Attribute: <code>posinset:&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
                 </td>
@@ -9653,7 +9559,7 @@
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXARIAPosInSet</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>AXARIAPosInSet</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
                 </td>
@@ -9666,6 +9572,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaPressedTrue"><code>aria-pressed</code>=<code>true</code></h4>
           <table class="data" aria-labelledby="ariaPressedTrue">
             <tbody>
@@ -9679,7 +9586,7 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_PRESSED</code></span
+                  <span>State: <code>STATE_SYSTEM_PRESSED</code></span
                   ><br />
                   <span class="seealso"
                     >See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span
@@ -9689,13 +9596,13 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>Toggle.ToggleState</code>: <code>On (1)</code></span>
+                  <span>Property: <code>Toggle.ToggleState</code> <code>On (1)</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_PRESSED</code></span
+                  <span>State: <code>STATE_PRESSED</code></span
                   ><br />
                   <span class="seealso"
                     >See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span
@@ -9705,7 +9612,7 @@
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXValue</code>: <code>1</code></span
+                  <span>Property: <code>AXValue</code> <code>1</code></span
                   ><br />
                   <span class="seealso"
                     >See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span
@@ -9720,6 +9627,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaPressedMixed"><code>aria-pressed</code>=<code>mixed</code></h4>
           <table class="data" aria-labelledby="ariaPressedMixed">
             <tbody>
@@ -9733,7 +9641,7 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_MIXED</code></span
+                  <span>State: <code>STATE_SYSTEM_MIXED</code></span
                   ><br />
                   <span class="seealso"
                     >See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span
@@ -9743,13 +9651,13 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>Toggle.ToggleState</code>: <code>Indeterminate (2)</code></span>
+                  <span>Property: <code>Toggle.ToggleState</code> <code>Indeterminate (2)</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_INDETERMINATE</code></span
+                  <span>State: <code>STATE_INDETERMINATE</code></span
                   ><br />
                   <span class="seealso"
                     >See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span
@@ -9759,7 +9667,7 @@
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXValue</code>: <code>2</code></span
+                  <span>Property: <code>AXValue</code> <code>2</code></span
                   ><br />
                   <span class="seealso"
                     >See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span
@@ -9774,6 +9682,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaPressedFalse"><code>aria-pressed</code>=<code>false</code></h4>
           <table class="data" aria-labelledby="ariaPressedFalse">
             <tbody>
@@ -9787,7 +9696,7 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_PRESSED</code> not exposed</span><br />
+                  <span>State: <code>STATE_SYSTEM_PRESSED</code> not exposed</span><br />
                   <span class="seealso"
                     >See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span
                   >
@@ -9796,13 +9705,13 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>Toggle.ToggleState</code>: <code>Off (3)</code></span>
+                  <span>Property: <code>Toggle.ToggleState</code> <code>Off (3)</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_PRESSED</code> not exposed</span><br />
+                  <span>State: <code>STATE_PRESSED</code> not exposed</span><br />
                   <span class="seealso"
                     >See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span
                   >
@@ -9811,7 +9720,7 @@
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXValue</code>: <code>0</code></span
+                  <span>Property: <code>AXValue</code> <code>0</code></span
                   ><br />
                   <span class="seealso"
                     >See also: <a href="#role-map-button-pressed"><code>button</code> with defined value for <code>aria-pressed</code></a></span
@@ -9826,6 +9735,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaPressedUndefined"><code>aria-pressed</code> is undefined</h4>
           <table class="data" aria-labelledby="ariaPressedUndefined">
             <tbody>
@@ -9838,25 +9748,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
@@ -9867,6 +9777,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaReadonlyTrue"><code>aria-readonly</code>=<code>true</code></h4>
           <table class="data" aria-labelledby="ariaReadonlyTrue">
             <tbody>
@@ -9880,41 +9791,41 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_READONLY</code></span>
+                  <span>State: <code>STATE_SYSTEM_READONLY</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property"
-                    >Property: <code>Value.IsReadOnly</code>: <code>true</code>, if the element implements
+                  <span
+                    >Property: <code>Value.IsReadOnly</code> <code>true</code>, if the element implements
                     <a href="https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.ivalueprovider"><code>IValueProvider</code></a
                     >.</span
                   ><br />
-                  <span class="property"
-                    >Property: <code>RangeValue.IsReadOnly</code>: <code>true</code>, if the element implements
+                  <span
+                    >Property: <code>RangeValue.IsReadOnly</code> <code>true</code>, if the element implements
                     <a href="https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.irangevalueprovider"><code>IRangeValueProvider</code></a
                     >.</span
                   ><br />
-                  <span class="property">Property: <code>AriaProperties.readonly</code>: <code>true</code></span>
+                  <span>Property: <code>AriaProperties.readonly</code> <code>true</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_READ_ONLY</code></span
+                  <span>State: <code>STATE_READ_ONLY</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_EDITABLE</code> not exposed on text input roles</span><br />
-                  <span class="property"
+                  <span>State: <code>STATE_EDITABLE</code> not exposed on text input roles</span><br />
+                  <span
                     >State: <code>STATE_CHECKABLE</code> not exposed on roles supporting <a class="state-reference" href="#aria-checked"><code>aria-checked</code></a></span
                   ><br />
-                  <span class="property">State: <code>STATE_CHECKABLE</code> not exposed on <a class="role-reference" href="#radio">radio</a> descendants when used on a <code>radiogroup</code></span>
+                  <span>State: <code>STATE_CHECKABLE</code> not exposed on <a class="role-reference" href="#radio">radio</a> descendants when used on a <code>radiogroup</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="method">Method: <code>AXUIElementIsAttributeSettable(AXValue)</code>: <code>NO</code></span>
+                  <span>Method: <code>AXUIElementIsAttributeSettable(AXValue)</code> <code>NO</code></span>
                 </td>
               </tr>
               <tr>
@@ -9925,6 +9836,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaReadonlyFalse"><code>aria-readonly</code>=<code>false</code></h4>
           <table class="data" aria-labelledby="ariaReadonlyFalse">
             <tbody>
@@ -9938,36 +9850,36 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_READONLY</code> not exposed</span><br />
-                  <span class="property">State: <code>IA2_STATE_EDITABLE</code></span>
+                  <span>State: <code>STATE_SYSTEM_READONLY</code> not exposed</span><br />
+                  <span>State: <code>IA2_STATE_EDITABLE</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property"
-                    >Property: <code>Value.IsReadOnly</code>: <code>false</code>, if the element implements
+                  <span
+                    >Property: <code>Value.IsReadOnly</code> <code>false</code>, if the element implements
                     <a href="https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.ivalueprovider"><code>IValueProvider</code></a
                     >.</span
                   ><br />
-                  <span class="property"
-                    >Property: <code>RangeValue.IsReadOnly</code>: <code>false</code>, if the element implements
+                  <span
+                    >Property: <code>RangeValue.IsReadOnly</code> <code>false</code>, if the element implements
                     <a href="https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.irangevalueprovider"><code>IRangeValueProvider</code></a
                     >.</span
                   ><br />
-                  <span class="property">Property: <code>AriaProperties.readonly</code>: <code>false</code></span>
+                  <span>Property: <code>AriaProperties.readonly</code> <code>false</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_READ_ONLY</code> not exposed</span>
+                  <span>State: <code>STATE_READ_ONLY</code> not exposed</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="method">Method: <code>AXUIElementIsAttributeSettable(AXValue)</code>: <code>YES</code></span>
+                  <span>Method: <code>AXUIElementIsAttributeSettable(AXValue)</code> <code>YES</code></span>
                 </td>
               </tr>
               <tr>
@@ -9978,6 +9890,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaReadonlyUnspecifiedOnGridcell"><code>aria-readonly</code> is unspecified on <code>gridcell</code></h4>
           <table class="data" aria-labelledby="ariaReadonlyUnspecifiedOnGridcell">
             <tbody>
@@ -9990,37 +9903,45 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited
-                  value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and
-                  <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a
-                  >.
+                  <p>
+                    The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited
+                    value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and
+                    <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a
+                    >.
+                  </p>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited
-                  value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and
-                  <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a
-                  >.
+                  <p>
+                    The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited
+                    value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and
+                    <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a
+                    >.
+                  </p>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited
-                  value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and
-                  <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a
-                  >.
+                  <p>
+                    The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited
+                    value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and
+                    <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a
+                    >.
+                  </p>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited
-                  value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and
-                  <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a
-                  >.
+                  <p>
+                    The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited
+                    value on the <code>gridcell</code> as described for <a href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a> and
+                    <a href="#ariaReadonlyFalse"><code>aria-readonly="false"</code></a
+                    >.
+                  </p>
                 </td>
               </tr>
               <tr>
@@ -10031,6 +9952,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaRelevant"><code>aria-relevant</code></h4>
           <table class="data" aria-labelledby="ariaRelevant">
             <tbody>
@@ -10043,37 +9965,37 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>relevant:&lt;value&gt;</code></span
+                  <span>Object Attribute: <code>relevant:&lt;value&gt;</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-relevant:&lt;value&gt;</code></span
+                  <span>Object Attribute: <code>container-relevant:&lt;value&gt;</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-relevant:&lt;value&gt;</code> on all descendants</span><br />
+                  <span>Object Attribute: <code>container-relevant:&lt;value&gt;</code> on all descendants</span><br />
                   <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.relevant</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>AriaProperties.relevant</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>relevant:&lt;value&gt;</code></span
+                  <span>Object Attribute: <code>relevant:&lt;value&gt;</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-relevant:&lt;value&gt;</code></span
+                  <span>Object Attribute: <code>container-relevant:&lt;value&gt;</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>container-relevant:&lt;value&gt;</code> on all descendants</span><br />
+                  <span>Object Attribute: <code>container-relevant:&lt;value&gt;</code> on all descendants</span><br />
                   <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXARIARelevant</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>AXARIARelevant</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_events_visibility">Changes to document content or node visibility</a></span>
                 </td>
@@ -10086,6 +10008,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaRequiredTrue"><code>aria-required</code>=<code>true</code></h4>
           <table class="data" aria-labelledby="ariaRequiredTrue">
             <tbody>
@@ -10099,25 +10022,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>IA2_STATE_REQUIRED</code></span>
+                  <span>State: <code>IA2_STATE_REQUIRED</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>IsRequiredForForm</code>: <code>true</code></span>
+                  <span>Property: <code>IsRequiredForForm</code> <code>true</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_REQUIRED</code></span>
+                  <span>State: <code>STATE_REQUIRED</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXRequired</code>: <code>YES</code></span>
+                  <span>Property: <code>AXRequired</code> <code>YES</code></span>
                 </td>
               </tr>
               <tr>
@@ -10128,6 +10051,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaRequiredFalse"><code>aria-required</code>=<code>false</code></h4>
           <table class="data" aria-labelledby="ariaRequiredFalse">
             <tbody>
@@ -10141,25 +10065,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
@@ -10170,6 +10094,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaRoleDescription"><code>aria-roledescription</code></h4>
           <table class="data" aria-labelledby="ariaRoleDescription">
             <tbody>
@@ -10182,25 +10107,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="method">Method: <code>localizedExtendedRole()</code>: <code>&lt;value&gt;</code></span>
+                  <span>Method: <code>localizedExtendedRole()</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Localized Control Type: <code>&lt;value&gt;</code></span>
+                  <span>Localized Control Type: <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>roledescription:&lt;value&gt;</code></span>
+                  <span>Object Attribute: <code>roledescription:&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXRoleDescription</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AXRoleDescription</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -10211,6 +10136,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaRoleDescriptionEmptyString"><code>aria-roledescription</code> is undefined or the empty string</h4>
           <table class="data" aria-labelledby="ariaRoleDescriptionEmptyString">
             <tbody>
@@ -10223,28 +10149,28 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">
-                    Localized Control Type: Defined as that specified for the role of the element: based on the explicit role if the role attribute is provided; otherwise, based on the implicit role
+                  <span
+                    >Localized Control Type: Defined as that specified for the role of the element: based on the explicit role if the role attribute is provided; otherwise, based on the implicit role
                     for the host language.</span
                   >
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property"
+                  <span
                     >AXRoleDescription: Defined as that specified for the role of the element: based on the explicit role if the role attribute is provided; otherwise, based on the implicit role for
                     the host language.</span
                   >
@@ -10258,6 +10184,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaRowCount"><code>aria-rowcount</code></h4>
           <table class="data" aria-labelledby="ariaRowCount">
             <tbody>
@@ -10270,28 +10197,28 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>rowcount:&lt;value&gt;</code></span
+                  <span>Object Attribute: <code>rowcount:&lt;value&gt;</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible2::groupPosition()</code>: <code>similarItemsInGroup=&lt;value&gt;</code> on rows</span>
+                  <span>Method: <code>IAccessible2::groupPosition()</code> <code>similarItemsInGroup=&lt;value&gt;</code> on rows</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>Grid.RowCount</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>Grid.RowCount</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>rowcount</code> should contain the author-provided value.</span><br />
-                  <span class="method">Method: <code>atk_table_get_n_rows()</code> should return the actual number of rows.</span>
+                  <span>Object Attribute: <code>rowcount</code> should contain the author-provided value.</span><br />
+                  <span>Method: <code>atk_table_get_n_rows()</code> should return the actual number of rows.</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXARIARowCount</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AXARIARowCount</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -10302,6 +10229,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaRowIndex"><code>aria-rowindex</code></h4>
           <table class="data" aria-labelledby="ariaRowIndex">
             <tbody>
@@ -10314,28 +10242,28 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>rowindex:&lt;value&gt;</code></span
+                  <span>Object Attribute: <code>rowindex:&lt;value&gt;</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible2::groupPosition()</code>: <code>positionInGroup=&lt;value&gt;</code> on rows</span>
+                  <span>Method: <code>IAccessible2::groupPosition()</code> <code>positionInGroup=&lt;value&gt;</code> on rows</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>GridItem.Row</code>: <code>&lt;value&gt;</code> (zero-based)</span>
+                  <span>Property: <code>GridItem.Row</code> <code>&lt;value&gt;</code> (zero-based)</span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>rowindex</code> should contain the author-provided value.</span><br />
-                  <span class="method">Method: <code>atk_table_cell_get_position()</code> should return the actual (zero-based) row index.</span>
+                  <span>Object Attribute: <code>rowindex</code> should contain the author-provided value.</span><br />
+                  <span>Method: <code>atk_table_cell_get_position()</code> should return the actual (zero-based) row index.</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXARIARowIndex</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AXARIARowIndex</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -10346,6 +10274,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaRowIndexText"><code>aria-rowindextext</code></h4>
           <table class="data" aria-labelledby="ariaRowIndexText">
             <tbody>
@@ -10358,25 +10287,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>rowindextext:&lt;value&gt;</code></span>
+                  <span>Object Attribute: <code>rowindextext:&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.rowindextext</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AriaProperties.rowindextext</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>rowindextext:&lt;value&gt;</code></span>
+                  <span>Object Attribute: <code>rowindextext:&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXRowIndexDescription</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AXRowIndexDescription</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -10387,6 +10316,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaRowSpan"><code>aria-rowspan</code></h4>
           <table class="data" aria-labelledby="ariaRowSpan">
             <tbody>
@@ -10399,28 +10329,28 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>rowspan:&lt;value&gt;</code></span
+                  <span>Object Attribute: <code>rowspan:&lt;value&gt;</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessibleTableCell::rowExtent()</code>: <code>column=&lt;value&gt;</code></span>
+                  <span>Method: <code>IAccessibleTableCell::rowExtent()</code> <code>column=&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>GridItem.RowSpan</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>GridItem.RowSpan</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>rowspan</code> should contain the author-provided value.</span><br />
-                  <span class="method">Method: <code>atk_table_cell_get_row_column_span()</code> should return the actual row span.</span>
+                  <span>Object Attribute: <code>rowspan</code> should contain the author-provided value.</span><br />
+                  <span>Method: <code>atk_table_cell_get_row_column_span()</code> should return the actual row span.</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXRowIndexRange.length</code>: <code>&lt;value&gt;</code></span>
+                  <span>Property: <code>AXRowIndexRange.length</code> <code>&lt;value&gt;</code></span>
                 </td>
               </tr>
               <tr>
@@ -10431,6 +10361,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaSelectedTrue"><code>aria-selected</code>=<code>true</code></h4>
           <table class="data" aria-labelledby="ariaSelectedTrue">
             <tbody>
@@ -10444,9 +10375,9 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_SELECTABLE</code></span
+                  <span>State: <code>STATE_SYSTEM_SELECTABLE</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_SYSTEM_SELECTED</code></span
+                  <span>State: <code>STATE_SYSTEM_SELECTED</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
                 </td>
@@ -10454,15 +10385,15 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>SelectionItem.IsSelected</code>: <code>true</code></span>
+                  <span>Property: <code>SelectionItem.IsSelected</code> <code>true</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_SELECTABLE</code></span
+                  <span>State: <code>STATE_SELECTABLE</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_SELECTED</code></span
+                  <span>State: <code>STATE_SELECTED</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
                 </td>
@@ -10470,7 +10401,7 @@
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXSelected</code>: <code>YES</code></span>
+                  <span>Property: <code>AXSelected</code> <code>YES</code></span>
                 </td>
               </tr>
               <tr>
@@ -10481,6 +10412,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaSelectedFalse"><code>aria-selected</code>=<code>false</code></h4>
           <table class="data" aria-labelledby="ariaSelectedFalse">
             <tbody>
@@ -10494,31 +10426,31 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">State: <code>STATE_SYSTEM_SELECTABLE</code></span
+                  <span>State: <code>STATE_SYSTEM_SELECTABLE</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_SYSTEM_SELECTED</code> not exposed</span><br />
+                  <span>State: <code>STATE_SYSTEM_SELECTED</code> not exposed</span><br />
                   <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>SelectionItem.IsSelected</code>: <code>false</code></span>
+                  <span>Property: <code>SelectionItem.IsSelected</code> <code>false</code></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">State: <code>STATE_SELECTABLE</code></span
+                  <span>State: <code>STATE_SELECTABLE</code></span
                   ><br />
-                  <span class="property">State: <code>STATE_SELECTED</code> not exposed</span><br />
+                  <span>State: <code>STATE_SELECTED</code> not exposed</span><br />
                   <span class="seealso">See also: <a href="#mapping_events_selection">Selection</a> for details on accessibility events</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXSelected</code>: <code>NO</code></span>
+                  <span>Property: <code>AXSelected</code> <code>NO</code></span>
                 </td>
               </tr>
               <tr>
@@ -10529,6 +10461,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaSelectedUndefined"><code>aria-selected</code> is undefined</h4>
           <table class="data" aria-labelledby="ariaSelectedUndefined">
             <tbody>
@@ -10541,25 +10474,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped</a></span>
                 </td>
               </tr>
               <tr>
@@ -10570,6 +10503,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaSetsize"><code>aria-setsize</code></h4>
           <table class="data" aria-labelledby="ariaSetsize">
             <tbody>
@@ -10582,7 +10516,7 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>setsize:&lt;value&gt;</code></span
+                  <span>Object Attribute: <code>setsize:&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
                 </td>
@@ -10590,29 +10524,29 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.setsize</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>AriaProperties.setsize</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
+                  <span>Object Attribute: <code>setsize:&lt;value&gt;</code></span
+                  ><br />
+                  <span>State: <code>STATE_INDETERMINATE</code> if the author-provided value is <code>-1</code></span
+                  ><br />
+                  <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
                   <p>
                     If the author-provided value of <code>aria-setsize</code> is <code>-1</code>, the exposed value should be based on the number of objects in the
                     <abbr title="Document Object Model">DOM</abbr>.
                   </p>
-                  <span class="property">Object Attribute: <code>setsize:&lt;value&gt;</code></span
-                  ><br />
-                  <span class="property">State: <code>STATE_INDETERMINATE</code> if the author-provided value is <code>-1</code></span
-                  ><br />
-                  <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXARIASetSize</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>AXARIASetSize</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#mapping_additional_position">Group Position</a></span>
                 </td>
@@ -10625,6 +10559,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaSortAscending"><code>aria-sort</code>=<code>ascending</code></h4>
           <table class="data" aria-labelledby="ariaSortAscending">
             <tbody>
@@ -10638,30 +10573,30 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>sort:ascending</code></span>
+                  <span>Object Attribute: <code>sort:ascending</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.sort</code>: <code>ascending</code></span
+                  <span>Property: <code>AriaProperties.sort</code> <code>ascending</code></span
                   ><br />
-                  <span class="property"
-                    >Property: <code>ItemStatus</code>: <code>ascending</code> if the element maps to
+                  <span
+                    >Property: <code>ItemStatus</code> <code>ascending</code> if the element maps to
                     <a href="https://msdn.microsoft.com/en-us/library/windows/apps/ee671630.aspx"><code>HeaderItem</code></a> Control Type</span
                   >
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>sort:ascending</code></span>
+                  <span>Object Attribute: <code>sort:ascending</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXSortDirection</code>: <code>AXAscendingSortDirection</code></span>
+                  <span>Property: <code>AXSortDirection</code> <code>AXAscendingSortDirection</code></span>
                 </td>
               </tr>
               <tr>
@@ -10672,6 +10607,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaSortDescending"><code>aria-sort</code>=<code>descending</code></h4>
           <table class="data" aria-labelledby="ariaSortDescending">
             <tbody>
@@ -10685,30 +10621,30 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>sort:descending</code></span>
+                  <span>Object Attribute: <code>sort:descending</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.sort</code>: <code>descending</code></span
+                  <span>Property: <code>AriaProperties.sort</code> <code>descending</code></span
                   ><br />
-                  <span class="property"
-                    >Property: <code>ItemStatus</code>: <code>descending</code> if the element maps to
+                  <span
+                    >Property: <code>ItemStatus</code> <code>descending</code> if the element maps to
                     <a href="https://msdn.microsoft.com/en-us/library/windows/apps/ee671630.aspx"><code>HeaderItem</code></a> Control Type</span
                   >
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>sort:descending</code></span>
+                  <span>Object Attribute: <code>sort:descending</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXSortDirection</code>: <code>AXDescendingSortDirection</code></span>
+                  <span>Property: <code>AXSortDirection</code> <code>AXDescendingSortDirection</code></span>
                 </td>
               </tr>
               <tr>
@@ -10719,6 +10655,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaSortOther"><code>aria-sort</code>=<code>other</code></h4>
           <table class="data" aria-labelledby="ariaSortOther">
             <tbody>
@@ -10732,30 +10669,30 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>sort:other</code></span>
+                  <span>Object Attribute: <code>sort:other</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AriaProperties.sort</code>: <code>other</code></span
+                  <span>Property: <code>AriaProperties.sort</code> <code>other</code></span
                   ><br />
-                  <span class="property"
-                    >Property: <code>ItemStatus</code>: <code>other</code> if the element maps to
+                  <span
+                    >Property: <code>ItemStatus</code> <code>other</code> if the element maps to
                     <a href="https://msdn.microsoft.com/en-us/library/windows/apps/ee671630.aspx"><code>HeaderItem</code></a> Control Type</span
                   >
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>sort:other</code></span>
+                  <span>Object Attribute: <code>sort:other</code></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXSortDirection</code>: <code>AXUnknownSortDirection</code></span>
+                  <span>Property: <code>AXSortDirection</code> <code>AXUnknownSortDirection</code></span>
                 </td>
               </tr>
               <tr>
@@ -10766,6 +10703,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaSortNone"><code>aria-sort</code>=<code>none</code></h4>
           <table class="data" aria-labelledby="ariaSortNone">
             <tbody>
@@ -10779,25 +10717,25 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="property">Object Attribute: <code>sort:none</code>, if the value is not unspecified</span>
+                  <span>Object Attribute: <code>sort:none</code> if the value is not unspecified</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>sort:none</code>, if the value is not unspecified</span>
+                  <span>Object Attribute: <code>sort:none</code> if the value is not unspecified</span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="not-mapped"><a href="#not_mapped">Not mapped*</a></span>
                 </td>
               </tr>
               <tr>
@@ -10808,6 +10746,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaValueMax"><code>aria-valuemax</code></h4>
           <table class="data" aria-labelledby="ariaValueMax">
             <tbody>
@@ -10820,7 +10759,7 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="method">Method: <code>IAccessibleValue::maximumValue()</code>: <code>&lt;value&gt;</code></span
+                  <span>Method: <code>IAccessibleValue::maximumValue()</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
                 </td>
@@ -10828,15 +10767,15 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>RangeValue.Maximum</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>RangeValue.Maximum</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="method">Method: <code>atk_value_get_maximum_value()</code>: <code>&lt;value&gt;</code></span
+                  <span>Method: <code>atk_value_get_maximum_value()</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
                 </td>
@@ -10844,7 +10783,7 @@
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXMaxValue</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>AXMaxValue</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
                 </td>
@@ -10857,6 +10796,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaValueMin"><code>aria-valuemin</code></h4>
           <table class="data" aria-labelledby="ariaValueMin">
             <tbody>
@@ -10869,7 +10809,7 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="method">Method: <code>IAccessibleValue::minimumValue()</code>: <code>&lt;value&gt;</code></span
+                  <span>Method: <code>IAccessibleValue::minimumValue()</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
                 </td>
@@ -10877,15 +10817,15 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>RangeValue.Minimum</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>RangeValue.Minimum</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="method">Method: <code>atk_value_get_minimum_value()</code>: <code>&lt;value&gt;</code></span
+                  <span>Method: <code>atk_value_get_minimum_value()</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
                 </td>
@@ -10893,7 +10833,7 @@
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXMinValue</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>AXMinValue</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
                 </td>
@@ -10906,6 +10846,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaValueNow"><code>aria-valuenow</code></h4>
           <table class="data" aria-labelledby="ariaValueNow">
             <tbody>
@@ -10918,24 +10859,24 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="method">Method: <code>IAccessibleValue::currentValue()</code>: <code>&lt;value&gt;</code></span
+                  <span>Method: <code>IAccessibleValue::currentValue()</code> <code>&lt;value&gt;</code></span
                   ><br />
-                  <span class="method">Method: <code>IAccessible::get_accValue()</code>: <code>&lt;value&gt;</code> if <code>aria-valuetext</code> is not defined</span><br />
+                  <span>Method: <code>IAccessible::get_accValue()</code> <code>&lt;value&gt;</code> if <code>aria-valuetext</code> is not defined</span><br />
                   <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
                 </td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>RangeValue.Value</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>RangeValue.Value</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="method">Method: <code>atk_value_get_current_value()</code>: <code>&lt;value&gt;</code></span
+                  <span>Method: <code>atk_value_get_current_value()</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
                 </td>
@@ -10943,7 +10884,7 @@
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXValue</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>AXValue</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
                 </td>
@@ -10956,6 +10897,7 @@
               </tr>
             </tbody>
           </table>
+
           <h4 id="ariaValueText"><code>aria-valuetext</code></h4>
           <table class="data" aria-labelledby="ariaValueText">
             <tbody>
@@ -10968,9 +10910,9 @@
               <tr>
                 <th>MSAA + IAccessible2</th>
                 <td>
-                  <span class="method">Method: <code>IAccessible::get_accValue()</code>: <code>&lt;value&gt;</code></span
+                  <span>Method: <code>IAccessible::get_accValue()</code> <code>&lt;value&gt;</code></span
                   ><br />
-                  <span class="property">Object Attribute: <code>valuetext:&lt;value&gt;</code></span
+                  <span>Object Attribute: <code>valuetext:&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
                 </td>
@@ -10978,15 +10920,15 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Property: <code>Value.Value</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>Value.Value</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
                 </td>
               </tr>
               <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology-Service Provider Interface">AT-SPI</abbr></th>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
                 <td>
-                  <span class="property">Object Attribute: <code>valuetext:&lt;value&gt;</code></span
+                  <span>Object Attribute: <code>valuetext:&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
                 </td>
@@ -10994,7 +10936,7 @@
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property">Property: <code>AXValueDescription</code>: <code>&lt;value&gt;</code></span
+                  <span>Property: <code>AXValueDescription</code> <code>&lt;value&gt;</code></span
                   ><br />
                   <span class="seealso">See also: <a href="#document-handling_author-errors_states-properties" class="specref">Handling Author Errors for States and Properties</a></span>
                 </td>

--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -597,6 +597,7 @@
         </section>
         <section id="mapping_role_table">
           <h3>Role Mapping Tables</h3>
+          <!-- GENERATION ROLE MAP START -->
           <h4 id="role-map-alert"><code>alert</code></h4>
           <table class="data" aria-labelledby="role-map-alert">
             <tbody>
@@ -6323,6 +6324,7 @@
               </tr>
             </tbody>
           </table>
+          <!-- GENERATION ROLE MAP END -->
         </section>
       </section>
 
@@ -6381,6 +6383,7 @@
         </section>
         <section id="mapping_state-property_table">
           <h3>State and Property Mapping Tables</h3>
+          <!-- GENERATION ATTRIBUTE MAP START -->
           <h4 id="ariaActiveDescendant"><code>aria-activedescendant</code></h4>
           <table class="data" aria-labelledby="ariaActiveDescendant">
             <tbody>
@@ -11022,6 +11025,7 @@
               </tr>
             </tbody>
           </table>
+          <!-- GENERATION ATTRIBUTE MAP END -->
         </section>
       </section>
       <section id="mapping_additional">

--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -6374,11 +6374,8 @@
               <cite><a class="specref" href="">Accessible Rich Internet Applications (WAI-ARIA) 1.2</a></cite> [[!WAI-ARIA-1.2]]].
             </li>
           </ol>
-        </section>
-        <section id="mapping_state-property_table">
-          <h3>State and Property Mapping Tables</h3>
           <section id="not_mapped">
-            <h4>Not Mapped</h4>
+            <h2>Not Mapped</h2>
             <p>
               There are a number of occurrences in the table where a given state or property is declared "Not mapped". In some cases, this occurs for the default value of the state/property, and is
               equivalent to its absence. User agents might find it quicker to map the value than check to see if it is the default. For computational efficiency, user agents MAY expose the state or
@@ -6390,6 +6387,9 @@
               >. Its absence not only indicates that the accessible object is not grabbed, but further defines it as not grab-able. These cases are marked as "Not mapped" without an asterisk.
             </p>
           </section>
+        </section>
+        <section id="mapping_state-property_table">
+          <h3>State and Property Mapping Tables</h3>
           <h4 id="ariaActiveDescendant"><code>aria-activedescendant</code></h4>
           <table class="data" aria-labelledby="ariaActiveDescendant">
             <tbody>

--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -541,9 +541,7 @@
               <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>: expose as an object attribute pair
               (<code>xml-roles:&quot;string&quot;</code>)
             </li>
-            <li>
-              <abbr title="macOS Accessibility Protocol">AX API</abbr>: User agent should return a user-presentable, localized string value for the AXRoleDescription.
-            </li>
+            <li><abbr title="macOS Accessibility Protocol">AX API</abbr>: User agent should return a user-presentable, localized string value for the AXRoleDescription.</li>
           </ul>
         </section>
         <section id="roleMappingComputedRole">
@@ -618,9 +616,7 @@
                 <td>
                   <span class="property">Role: <code>ROLE_SYSTEM_ALERT</code></span
                   ><br />
-                  <span class="event"
-                    >Event: The user agent SHOULD fire <code>EVENT_SYSTEM_ALERT</code>.</span
-                  >
+                  <span class="event">Event: The user agent SHOULD fire <code>EVENT_SYSTEM_ALERT</code>.</span>
                 </td>
               </tr>
               <tr>
@@ -632,9 +628,7 @@
                   ><br />
                   <span class="property">LiveSetting: <code>Assertive (2)</code></span
                   ><br />
-                  <span class="event"
-                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span
-                  >
+                  <span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span>
                 </td>
               </tr>
               <tr>
@@ -642,9 +636,7 @@
                 <td>
                   <span class="property">Role: <code>ROLE_NOTIFICATION</code></span
                   ><br />
-                  <span class="event"
-                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span
-                  >
+                  <span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span>
                 </td>
               </tr>
               <tr>
@@ -656,9 +648,7 @@
                   ><br />
                   <span class="property">AXSubrole: <code>AXApplicationAlert</code></span
                   ><br />
-                  <span class="event"
-                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span
-                  >
+                  <span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span>
                 </td>
               </tr>
               <tr>
@@ -689,9 +679,7 @@
                 <td>
                   <span class="property">Role: <code>ROLE_SYSTEM_DIALOG</code></span
                   ><br />
-                  <span class="event"
-                    >Event: The user agent SHOULD fire <code>EVENT_SYSTEM_ALERT</code>.</span
-                  >
+                  <span class="event">Event: The user agent SHOULD fire <code>EVENT_SYSTEM_ALERT</code>.</span>
                 </td>
               </tr>
               <tr>
@@ -699,9 +687,7 @@
                 <td>
                   <span class="property">Control Type: <code>Pane</code></span
                   ><br />
-                  <span class="event"
-                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span
-                  >
+                  <span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span>
                 </td>
               </tr>
               <tr>
@@ -711,9 +697,7 @@
                   ><br />
                   <span class="property">Interface: <code>Window</code></span
                   ><br />
-                  <span class="event"
-                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span
-                  >
+                  <span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span>
                 </td>
               </tr>
               <tr>
@@ -725,9 +709,7 @@
                   ><br />
                   <span class="property">AXSubrole: <code>AXApplicationAlertDialog</code></span
                   ><br />
-                  <span class="event"
-                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span
-                  >
+                  <span class="event">Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span>
                 </td>
               </tr>
               <tr>
@@ -10247,9 +10229,9 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property"
-                    >Localized Control Type</code>: Defined as that specified for the role of the element: based on the explicit role if the role attribute is provided; otherwise, based on the implicit
-                    role for the host language.</span
+                  <span class="property">
+                    Localized Control Type: Defined as that specified for the role of the element: based on the explicit role if the role attribute is provided; otherwise, based on the implicit role
+                    for the host language.</span
                   >
                 </td>
               </tr>
@@ -12437,14 +12419,13 @@
           </table>
         </section>
 
-
         <section id="mapping_events_alerts">
           <h3>alerts and alertdialogs</h3>
-            <p>
-              This specification does not currently contain guidance for when user agents should fire system alert events for `alert` and `alertdialogs`. Some guidance may be added to the specification at a later date but it will be a recommendation (SHOULD), not a requirement (MUST).
-            </p>
+          <p>
+            This specification does not currently contain guidance for when user agents should fire system alert events for `alert` and `alertdialogs`. Some guidance may be added to the specification
+            at a later date but it will be a recommendation (SHOULD), not a requirement (MUST).
+          </p>
         </section>
-
       </section>
     </section>
 

--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -619,7 +619,7 @@
                   <span class="property">Role: <code>ROLE_SYSTEM_ALERT</code></span
                   ><br />
                   <span class="event"
-                    >Event: The user agent SHOULD fire <code>EVENT_SYSTEM_ALERT</code>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span
+                    >Event: The user agent SHOULD fire <code>EVENT_SYSTEM_ALERT</code>.</span
                   >
                 </td>
               </tr>
@@ -633,7 +633,7 @@
                   <span class="property">LiveSetting: <code>Assertive (2)</code></span
                   ><br />
                   <span class="event"
-                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span
+                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span
                   >
                 </td>
               </tr>
@@ -643,7 +643,7 @@
                   <span class="property">Role: <code>ROLE_NOTIFICATION</code></span
                   ><br />
                   <span class="event"
-                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span
+                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span
                   >
                 </td>
               </tr>
@@ -657,7 +657,7 @@
                   <span class="property">AXSubrole: <code>AXApplicationAlert</code></span
                   ><br />
                   <span class="event"
-                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span
+                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span
                   >
                 </td>
               </tr>
@@ -690,7 +690,7 @@
                   <span class="property">Role: <code>ROLE_SYSTEM_DIALOG</code></span
                   ><br />
                   <span class="event"
-                    >Event: The user agent SHOULD fire <code>EVENT_SYSTEM_ALERT</code>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span
+                    >Event: The user agent SHOULD fire <code>EVENT_SYSTEM_ALERT</code>.</span
                   >
                 </td>
               </tr>
@@ -700,7 +700,7 @@
                   <span class="property">Control Type: <code>Pane</code></span
                   ><br />
                   <span class="event"
-                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span
+                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span
                   >
                 </td>
               </tr>
@@ -712,7 +712,7 @@
                   <span class="property">Interface: <code>Window</code></span
                   ><br />
                   <span class="event"
-                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span
+                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span
                   >
                 </td>
               </tr>
@@ -726,7 +726,7 @@
                   <span class="property">AXSubrole: <code>AXApplicationAlertDialog</code></span
                   ><br />
                   <span class="event"
-                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>. <sup>[<a href="#ftn.note2">Note 2</a>]</sup></span
+                    >Event: The user agent SHOULD fire a system alert <a class="termref">event</a>.</span
                   >
                 </td>
               </tr>

--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -541,6 +541,9 @@
               <abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>: expose as an object attribute pair
               (<code>xml-roles:&quot;string&quot;</code>)
             </li>
+            <li>
+              <abbr title="macOS Accessibility Protocol">AX API</abbr>: User agent should return a user-presentable, localized string value for the AXRoleDescription.
+            </li>
           </ul>
         </section>
         <section id="roleMappingComputedRole">
@@ -6320,18 +6323,6 @@
               </tr>
             </tbody>
           </table>
-          <div class="note" id="ftn.note1">
-            <p>
-              <sup>[Note 1]</sup>
-              User agent should return a user-presentable, localized string value for the AXRoleDescription.
-            </p>
-          </div>
-          <div class="note" id="ftn.note2">
-            <p>
-              <sup>[Note 2]</sup> This specification does not currently contain guidance for when user agents should fire system alert events. Some guidance may be added to the specification at a
-              later date but it will be a recommendation (SHOULD), not a requirement (MUST).
-            </p>
-          </div>
         </section>
       </section>
 
@@ -12441,6 +12432,15 @@
             </tbody>
           </table>
         </section>
+
+
+        <section id="mapping_events_alerts">
+          <h3>alerts and alertdialogs</h3>
+            <p>
+              This specification does not currently contain guidance for when user agents should fire system alert events for `alert` and `alertdialogs`. Some guidance may be added to the specification at a later date but it will be a recommendation (SHOULD), not a requirement (MUST).
+            </p>
+        </section>
+
       </section>
     </section>
 

--- a/tools/extract-mappings.js
+++ b/tools/extract-mappings.js
@@ -1,0 +1,169 @@
+import { readFileSync, writeFileSync } from 'fs';
+import * as cheerio from 'cheerio';
+
+const html = readFileSync('../core-aam/index.html', 'utf8');
+const $ = cheerio.load(html);
+
+// Maps normalised <th> text to JSON field names.
+const PLATFORM_KEYS = {
+  'MSAA + IAccessible2': 'msaaIA2',
+  'UIA':                 'uia',
+  'ATK/AT-SPI':          'atkAtSpi',
+  'AX API':              'axApi',
+  'Android':             'android',
+};
+
+// Collapse whitespace and strip footnote markers like "[Note 1]" from <th> text.
+function normalizeHeader(th) {
+  return $(th).text().replace(/\s+/g, ' ').replace(/\[Note \d+\]/g, '').trim();
+}
+
+// Parse the ARIA Specification cell.
+// Returns the raw inner HTML of the <td> as a string.
+function parseAriaSpec(td) {
+  return $(td).html().trim();
+}
+
+// Returns true when the cell contains content that cannot be represented as a
+// structured items array — i.e. it has non-whitespace text nodes or elements
+// other than <span>, <br>, or <p> as direct children.
+function isNotStructuredCell(td) {
+  let complex = false;
+  $(td).contents().each((_, node) => {
+    if (complex) return false;
+    if (node.type === 'text') {
+      if (node.data.trim() !== '') complex = true;
+    } else if (node.type === 'tag' && !['span', 'br', 'p'].includes(node.name)) {
+      complex = true;
+    }
+  });
+  return complex;
+}
+
+// Parse a single <span> into a mapping item object { type, value?, description? }.
+// Returns null for spans that should be skipped.
+function parseSpan(span) {
+  const classes = ($(span).attr('class') || '').split(/\s+/).filter(Boolean);
+
+  if (!classes.length) return null;
+
+  // For not-mapped, not-in-tree, and seealso spans, save the type and the
+  // full inner HTML of the span as the description.
+  const sentinelClass = classes.find(c => ['not-mapped', 'not-in-tree', 'seealso'].includes(c));
+  if (sentinelClass) {
+    return { type: sentinelClass, description: $(span).html().trim() };
+  }
+
+  // type: plain text before the first colon.
+  const fullText = $(span).text().trim();
+  const colonIdx = fullText.indexOf(':');
+  const type = colonIdx !== -1 ? fullText.slice(0, colonIdx).trim() : fullText;
+
+  const codeEl = $(span).find('code').first();
+
+  if (!codeEl.length) {
+    // No <code> element: everything after the first colon in the span HTML is
+    // the description. The type label is always plain text at the start of the
+    // span, so the first ':' in the HTML is the delimiter.
+    const spanHtml = $(span).html().trim();
+    const htmlColonIdx = spanHtml.indexOf(':');
+    const descHtml = htmlColonIdx !== -1 ? spanHtml.slice(htmlColonIdx + 1).trim() : '';
+    const item = { type };
+    if (descHtml) item.description = descHtml;
+    return item;
+  }
+
+  const value = codeEl.text().trim();
+
+  // description: the HTML content of the span after the first <code> element,
+  // with leading punctuation stripped.
+  const contents = $(span).contents().toArray();
+  const codeIdx = contents.findIndex(n => n.type === 'tag' && n.name === 'code');
+  const descHtml = contents
+    .slice(codeIdx + 1)
+    .map(n => $.html(n))
+    .join('')
+    .trim()
+    .replace(/^[:,.]\s*/, '')
+    .trim();
+
+  const item = { type, value };
+  if (descHtml) item.description = descHtml;
+  return item;
+}
+
+// Parse a mapping cell (<td>) into an item-list object.
+// Falls back to { rawHtml } for cells that contain bare text or unexpected
+// elements (e.g. "See <a href="...">Focus Changes</a>.").
+function parseCell(td) {
+  const result = { items: [] };
+
+  if (isNotStructuredCell(td)) {
+    result.note = $(td).html().trim();
+    return result;
+  }
+
+  $(td).contents().each((_, node) => {
+    if (node.name == 'br' ||
+        node.type === 'text') {
+      return;
+    }
+    if (node.name == 'span') {
+      const item = parseSpan(node);
+      if (item) result.items.push(item);
+      return;
+    }
+
+    result.note = ($(node).html().trim());
+  });
+
+  return result;
+}
+
+const output = { roles: {}, attributes: {} };
+
+$('h4[id]').each((_, h4) => {
+  const id = $(h4).attr('id');
+  const table = $(h4).next('table');
+  if (!table.length) return;
+
+  const isRole = id.startsWith('role-map-');
+  const isAttr = !isRole && id.startsWith('aria');
+  if (!isRole && !isAttr) return;
+
+  // Store the raw inner HTML of the <h4> so the generation script can
+  // faithfully recreate headings that contain extra content (e.g. "button
+  // with default values for aria-pressed and aria-haspopup").
+  const entry = {
+    headingHtml: $(h4).html().trim(),
+  };
+
+  table.find('tr').each((_, tr) => {
+    const th = $(tr).find('th').first();
+    const td = $(tr).find('td').first();
+    if (!th.length || !td.length) return;
+
+    const header = normalizeHeader(th);
+
+    if (header === 'ARIA Specification') {
+      entry.ariaSpec = parseAriaSpec(td);
+    } else if (header === 'Computed Role') {
+      entry.computedRole = $(td).text().trim();
+    } else {
+      const key = PLATFORM_KEYS[header];
+      if (key) entry[key] = parseCell(td);
+    }
+  });
+
+  if (isRole) {
+    output.roles[id] = entry;
+  } else {
+    output.attributes[id] = entry;
+  }
+});
+
+writeFileSync('mappings.json', JSON.stringify(output, null, 2));
+console.log(
+  `Wrote ${Object.keys(output.roles).length} roles and ` +
+  `${Object.keys(output.attributes).length} attributes to mappings.json.`
+);

--- a/tools/generate-mappings.js
+++ b/tools/generate-mappings.js
@@ -1,0 +1,136 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { execSync } from 'child_process';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const htmlPath = resolve(repoRoot, 'core-aam/index.html');
+
+const mappings = JSON.parse(readFileSync('mappings.json', 'utf8'));
+
+function escapeHtml(str) {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+// Full <abbr>-wrapped markup for each platform's <th> cell.
+const TH = {
+  ariaSpec: 'ARIA Specification',
+  computedRole: 'Computed Role',
+  msaaIA2: 'MSAA + IAccessible2',
+  uia: '<abbr title="User Interface Automation">UIA</abbr>',
+  atkAtSpi:
+    '<abbr title="Accessibility Toolkit">ATK</abbr>' +
+    '/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>',
+  axApi: '<abbr title="macOS Accessibility Protocol">AX API</abbr>',
+  android: 'Android',
+};
+
+// Build a <td> element from an item-list object.
+function buildCell(platform) {
+  if (!platform) return '<td></td>';
+
+  // Cells that could not be parsed structurally are stored as raw HTML.
+  if (platform.rawHtml !== undefined) {
+    return `<td>\n              ${platform.rawHtml}\n            </td>`;
+  }
+
+  const parts = platform.items.map(item => {
+    if (['not-mapped', 'not-in-tree', 'seealso'].includes(item.type)) {
+      return `<span class="${item.type}">${item.description}</span>`;
+    }
+    if (item.value === undefined) {
+      const desc = item.description ? `: ${item.description}` : '';
+      return `<span>${item.type}${desc}</span>`;
+    }
+    const desc = item.description ? ` ${item.description}` : '';
+    return `<span>${item.type}: <code>${escapeHtml(item.value)}</code>${desc}</span>`;
+  });
+
+  let content = parts.join('<br />\n              ');
+  if (platform.note) content += `\n              <p>${platform.note}</p>`;
+
+  if (!content) return '<td></td>';
+  return `<td>\n              ${content}\n            </td>`;
+}
+
+// Build a complete <h4> + <table> block for one mapping entry.
+// id is the key from the JSON (e.g. "role-map-blockquote", "ariaErrorMessage").
+function buildEntryHtml(id, entry) {
+  const isRole = 'computedRole' in entry;
+
+  const computedRoleRow = isRole
+    ? `
+            <tr>
+              <th>${TH.computedRole}</th>
+              <td>
+                <p><code>${entry.computedRole}</code></p>
+              </td>
+            </tr>`
+    : '';
+
+  return `
+          <h4 id="${id}">${entry.headingHtml}</h4>
+          <table class="data" aria-labelledby="${id}">
+            <tbody>
+              <tr>
+                <th>${TH.ariaSpec}</th>
+                <td>
+                  ${entry.ariaSpec}
+                </td>
+              </tr>${computedRoleRow}
+              <tr>
+                <th>${TH.msaaIA2}</th>
+                ${buildCell(entry.msaaIA2)}
+              </tr>
+              <tr>
+                <th>${TH.uia}</th>
+                ${buildCell(entry.uia)}
+              </tr>
+              <tr>
+                <th>${TH.atkAtSpi}</th>
+                ${buildCell(entry.atkAtSpi)}
+              </tr>
+              <tr>
+                <th>${TH.axApi}</th>
+                ${buildCell(entry.axApi)}
+              </tr>
+              <tr>
+                <th>${TH.android}</th>
+                ${buildCell(entry.android)}
+              </tr>
+            </tbody>
+          </table>`;
+}
+
+// Replace everything between startMarker and endMarker in the file content.
+// The markers themselves are preserved.
+function replaceBetweenMarkers(content, startMarker, endMarker, replacement) {
+  const startIdx = content.indexOf(startMarker);
+  const endIdx = content.indexOf(endMarker);
+  if (startIdx === -1) throw new Error(`Marker not found: ${startMarker}`);
+  if (endIdx === -1) throw new Error(`Marker not found: ${endMarker}`);
+  if (endIdx <= startIdx) throw new Error(`End marker appears before start marker`);
+  return (
+    content.slice(0, startIdx + startMarker.length) +
+    '\n' +
+    replacement +
+    '\n          ' +
+    content.slice(endIdx)
+  );
+}
+
+const roleBlocks = Object.entries(mappings.roles).map(([id, entry]) => buildEntryHtml(id, entry)).join('\n');
+const attrBlocks = Object.entries(mappings.attributes).map(([id, entry]) => buildEntryHtml(id, entry)).join('\n');
+
+let content = readFileSync(htmlPath, 'utf8');
+content = replaceBetweenMarkers(content, '<!-- GENERATION ROLE MAP START -->', '<!-- GENERATION ROLE MAP END -->', roleBlocks);
+content = replaceBetweenMarkers(content, '<!-- GENERATION ATTRIBUTE MAP START -->', '<!-- GENERATION ATTRIBUTE MAP END -->', attrBlocks);
+writeFileSync(htmlPath, content);
+
+execSync('npx prettier --write core-aam/index.html', { cwd: repoRoot, stdio: 'inherit' });
+
+console.log(
+  `Updated ${Object.keys(mappings.roles).length} role tables and ` +
+  `${Object.keys(mappings.attributes).length} attribute tables in core-aam/index.html.`
+);

--- a/tools/mappings.json
+++ b/tools/mappings.json
@@ -1,0 +1,10646 @@
+{
+  "roles": {
+    "role-map-alert": {
+      "headingHtml": "<code>alert</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#alert\"><code>alert</code></a>",
+      "computedRole": "alert",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_ALERT"
+          },
+          {
+            "type": "Event",
+            "value": "EVENT_SYSTEM_ALERT"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "alert"
+          },
+          {
+            "type": "LiveSetting",
+            "value": "Assertive (2)"
+          },
+          {
+            "type": "Event",
+            "description": "The user agent SHOULD fire a system alert <a class=\"termref\">event</a>."
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_NOTIFICATION"
+          },
+          {
+            "type": "Event",
+            "description": "The user agent SHOULD fire a system alert <a class=\"termref\">event</a>."
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXApplicationAlert"
+          },
+          {
+            "type": "Event",
+            "description": "The user agent SHOULD fire a system alert <a class=\"termref\">event</a>."
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-alertdialog": {
+      "headingHtml": "<code>alertdialog</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#alertdialog\"><code>alertdialog</code></a>",
+      "computedRole": "alertdialog",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_DIALOG"
+          },
+          {
+            "type": "Event",
+            "value": "EVENT_SYSTEM_ALERT"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Pane"
+          },
+          {
+            "type": "Event",
+            "description": "The user agent SHOULD fire a system alert <a class=\"termref\">event</a>."
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_ALERT"
+          },
+          {
+            "type": "Interface",
+            "value": "Window"
+          },
+          {
+            "type": "Event",
+            "description": "The user agent SHOULD fire a system alert <a class=\"termref\">event</a>."
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXApplicationAlertDialog"
+          },
+          {
+            "type": "Event",
+            "description": "The user agent SHOULD fire a system alert <a class=\"termref\">event</a>."
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-application": {
+      "headingHtml": "<code>application</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#application\"><code>application</code></a>",
+      "computedRole": "application",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_APPLICATION"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Pane"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "application"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_EMBEDDED"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXWebApplication"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-article": {
+      "headingHtml": "<code>article</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#article\"><code>article</code></a>",
+      "computedRole": "article",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_DOCUMENT"
+          },
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_READONLY"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:article"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "article"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_ARTICLE"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:article"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXDocumentArticle"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-banner": {
+      "headingHtml": "<code>banner</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#banner\"><code>banner</code></a>",
+      "computedRole": "banner",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_LANDMARK"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:banner"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "banner"
+          },
+          {
+            "type": "Landmark Type",
+            "value": "Custom"
+          },
+          {
+            "type": "Localized Landmark Type",
+            "value": "banner"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_LANDMARK"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:banner"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXLandmarkBanner"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-blockquote": {
+      "headingHtml": "<code>blockquote</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#blockquote\"><code>blockquote</code></a>",
+      "computedRole": "blockquote",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_GROUPING"
+          },
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_BLOCK_QUOTE"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "blockquote"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_BLOCK_QUOTE"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-button": {
+      "headingHtml": "<code>button</code> with default values for <code>aria-pressed</code> and <code>aria-haspopup</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#button\"><code>button</code></a> with default values for <a class=\"property-reference\" href=\"#aria-pressed\"><code>aria-pressed</code></a> and\n                  <a class=\"property-reference\" href=\"#aria-haspopup\"><code>aria-haspopup</code></a>",
+      "computedRole": "button",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_PUSHBUTTON"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Button"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_PUSH_BUTTON"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXButton"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-button-haspopup": {
+      "headingHtml": "<code>button</code> with non-<code>false</code> value for <code>aria-haspopup</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#button\"><code>button</code></a> with non-<code>false</code> value for <code>aria-haspopup</code>",
+      "computedRole": "button",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_BUTTONMENU"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Button"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_PUSH_BUTTON"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXPopUpButton"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-button-pressed": {
+      "headingHtml": "<code>button</code> with defined value for <code>aria-pressed</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#button\"><code>button</code></a> with defined value for <a class=\"property-reference\" href=\"#aria-pressed\"><code>aria-pressed</code></a>",
+      "computedRole": "button",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_PUSHBUTTON"
+          },
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_TOGGLE_BUTTON"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Button"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_TOGGLE_BUTTON"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXCheckBox"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXToggle"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-caption": {
+      "headingHtml": "<code>caption</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#caption\"><code>caption</code></a>",
+      "computedRole": "caption",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_GROUPING"
+          },
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_CAPTION"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Text"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_CAPTION"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-cell": {
+      "headingHtml": "<code>cell</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#cell\"><code>cell</code></a>",
+      "computedRole": "cell",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_CELL"
+          },
+          {
+            "type": "Interface",
+            "value": "IAccessibleTableCell"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "DataItem"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "item"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "GridItem"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "TableItem"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_TABLE_CELL"
+          },
+          {
+            "type": "Interface",
+            "value": "TableCell"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXCell"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-checkbox": {
+      "headingHtml": "<code>checkbox</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#checkbox\"><code>checkbox</code></a>",
+      "computedRole": "checkbox",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_CHECKBUTTON"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Checkbox"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_CHECK_BOX"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXCheckBox"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-code": {
+      "headingHtml": "<code>code</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#code\"><code>code</code></a>",
+      "computedRole": "code",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_TEXT_FRAME"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:code"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Text"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "code"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_STATIC"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:code"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXCodeStyleGroup"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-columnheader": {
+      "headingHtml": "<code>columnheader</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#columnheader\"><code>columnheader</code></a>",
+      "computedRole": "columnheader",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_COLUMNHEADER"
+          },
+          {
+            "type": "Interface",
+            "value": "IAccessibleTableCell"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "DataItem"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "column header"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "GridItem"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "TableItem"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_COLUMN_HEADER"
+          },
+          {
+            "type": "Interface",
+            "value": "TableCell"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXCell"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-combobox": {
+      "headingHtml": "<code>combobox</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#combobox\"><code>combobox</code></a>",
+      "computedRole": "combobox",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_COMBOBOX"
+          },
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_HASPOPUP"
+          },
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_COLLAPSED",
+            "description": "if <a class=\"state-reference\" href=\"#aria-expanded\"><code>aria-expanded</code></a> is not <code>\"true\"</code>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Combobox"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_COMBO_BOX"
+          },
+          {
+            "type": "State",
+            "value": "STATE_EXPANDABLE"
+          },
+          {
+            "type": "State",
+            "value": "STATE_HAS_POPUP"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXComboBox"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-comment": {
+      "headingHtml": "<code>comment</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#comment\"><code>comment</code></a>",
+      "computedRole": "comment",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_COMMENT"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:comment"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "comment"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_COMMENT"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:comment"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-complementary": {
+      "headingHtml": "<code>complementary</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#complementary\"><code>complementary</code></a>",
+      "computedRole": "complementary",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_LANDMARK"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:complementary"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "complementary"
+          },
+          {
+            "type": "Landmark Type",
+            "value": "Custom"
+          },
+          {
+            "type": "Localized Landmark Type",
+            "value": "complementary"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_LANDMARK"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:complementary"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXLandmarkComplementary"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-contentinfo": {
+      "headingHtml": "<code>contentinfo</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#contentinfo\"><code>contentinfo</code></a>",
+      "computedRole": "contentinfo",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_LANDMARK"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:contentinfo"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "content information"
+          },
+          {
+            "type": "Landmark Type",
+            "value": "Custom"
+          },
+          {
+            "type": "Localized Landmark Type",
+            "value": "content information"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_LANDMARK"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:contentinfo"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXLandmarkContentInfo"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-definition": {
+      "headingHtml": "<code>definition</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#definition\"><code>definition</code></a>",
+      "computedRole": "definition",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:definition"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "definition"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_DESCRIPTION_VALUE"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:definition"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXDefinition"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-deletion": {
+      "headingHtml": "<code>deletion</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#deletion\"><code>deletion</code></a>",
+      "computedRole": "deletion",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_CONTENT_DELETION"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Text"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "deletion"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_CONTENT_DELETION"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:deletion"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXDeleteStyleGroup"
+          },
+          {
+            "type": "AXAttributedStringForTextMarkerRange",
+            "value": "AXIsSuggestedDeletion = 1;",
+            "description": "for all text contained in a <code>deletion</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-dialog": {
+      "headingHtml": "<code>dialog</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#dialog\"><code>dialog</code></a>",
+      "computedRole": "dialog",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_DIALOG"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Pane"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_DIALOG"
+          },
+          {
+            "type": "Interface",
+            "value": "Window"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXApplicationDialog"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-directory": {
+      "headingHtml": "<code>directory</code> (deprecated)",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#directory\"><code>directory</code></a>",
+      "computedRole": "list",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_LIST"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "List"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_LIST"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXList"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXContentList"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-document": {
+      "headingHtml": "<code>document</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#document\"><code>document</code></a>",
+      "computedRole": "document",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_DOCUMENT"
+          },
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_READONLY"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Document"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_DOCUMENT_FRAME"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXDocument"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-emphasis": {
+      "headingHtml": "<code>emphasis</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#emphasis\"><code>emphasis</code></a>",
+      "computedRole": "emphasis",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_TEXT_FRAME"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:emphasis"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Text"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "emphasis"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_STATIC"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:emphasis"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXEmphasisStyleGroup"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-feed": {
+      "headingHtml": "<code>feed</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#feed\"><code>feed</code></a>",
+      "computedRole": "feed",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_GROUPING"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:feed"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "feed"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_PANEL"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:feed"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXApplicationGroup"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-figure": {
+      "headingHtml": "<code>figure</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#figure\"><code>figure</code></a>",
+      "computedRole": "figure",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_GROUPING"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:figure"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "figure"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_PANEL"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:figure"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-form": {
+      "headingHtml": "<code>form</code> with an accessible name",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#form\"><code>form</code></a> with an accessible name",
+      "computedRole": "form",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_FORM"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:form"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "form"
+          },
+          {
+            "type": "Landmark Type",
+            "value": "Form"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_LANDMARK"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:form"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXLandmarkForm"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-form-nameless": {
+      "headingHtml": "<code>form</code> without an accessible name",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#form\"><code>form</code></a> without an accessible name",
+      "computedRole": "form",
+      "msaaIA2": {
+        "items": [],
+        "note": "Do not expose the <a class=\"termref\">element</a> as a landmark. Use the native host language role of the element instead."
+      },
+      "uia": {
+        "items": [],
+        "note": "Do not expose the <a class=\"termref\">element</a> as a landmark. Use the native host language role of the element instead."
+      },
+      "atkAtSpi": {
+        "items": [],
+        "note": "Do not expose the <a class=\"termref\">element</a> as a landmark. Use the native host language role of the element instead."
+      },
+      "axApi": {
+        "items": [],
+        "note": "Do not expose the <a class=\"termref\">element</a> as a landmark. Use the native host language role of the element instead."
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-generic": {
+      "headingHtml": "<code>generic</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#generic\"><code>generic</code></a>",
+      "computedRole": "generic",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_GROUPING"
+          },
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_SECTION"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SECTION"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-grid": {
+      "headingHtml": "<code>grid</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#grid\"><code>grid</code></a>",
+      "computedRole": "grid",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_TABLE"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:grid"
+          },
+          {
+            "type": "Interface",
+            "value": "IAccessibleTable2"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible::accSelect()"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible::get_accSelection()"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "DataGrid"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "Grid"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "Table"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "Selection"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_TABLE"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:grid"
+          },
+          {
+            "type": "Interface",
+            "value": "Table"
+          },
+          {
+            "type": "Interface",
+            "value": "Selection"
+          }
+        ],
+        "note": "Because <abbr title=\"Accessible Rich Internet Applications\">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return\n                    <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection."
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXTable"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          },
+          {
+            "type": "AXColumnHeaderUIElements",
+            "description": "a list of pointers to the columnheader elements"
+          },
+          {
+            "type": "AXHeader",
+            "description": "a pointer to the row or group containing those columnheader elements"
+          },
+          {
+            "type": "AXRowHeaderUIElements",
+            "description": "a list of pointers to the rowheader elements"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-gridcell": {
+      "headingHtml": "<code>gridcell</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#gridcell\"><code>gridcell</code></a>",
+      "computedRole": "gridcell",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_CELL"
+          },
+          {
+            "type": "Interface",
+            "value": "IAccessibleTableCell"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "DataItem"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "item"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "SelectionItem"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "GridItem"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "TableItem"
+          },
+          {
+            "type": "SelectionItem.SelectionContainer",
+            "value": "grid"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_TABLE_CELL"
+          },
+          {
+            "type": "Interface",
+            "value": "TableCell"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXCell"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-group": {
+      "headingHtml": "<code>group</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#group\"><code>group</code></a>",
+      "computedRole": "group",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_GROUPING"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_PANEL"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXApplicationGroup"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-heading": {
+      "headingHtml": "<code>heading</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#heading\"><code>heading</code></a>",
+      "computedRole": "heading",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_HEADING"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:heading"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Text"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "heading"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_HEADING"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXHeading"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-image": {
+      "headingHtml": "<code>image</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#image\"><code>image</code></a>",
+      "computedRole": "image",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_GRAPHIC"
+          },
+          {
+            "type": "Interface",
+            "value": "IAccessibleImage"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Image"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_IMAGE"
+          },
+          {
+            "type": "Interface",
+            "value": "Image"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXImage"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-img": {
+      "headingHtml": "<code>img</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#img\"><code>img</code></a>",
+      "computedRole": "image",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_GRAPHIC"
+          },
+          {
+            "type": "Interface",
+            "value": "IAccessibleImage"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Image"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_IMAGE"
+          },
+          {
+            "type": "Interface",
+            "value": "Image"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXImage"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-insertion": {
+      "headingHtml": "<code>insertion</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#insertion\"><code>insertion</code></a>",
+      "computedRole": "insertion",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_CONTENT_INSERTION"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Text"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "insertion"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_CONTENT_INSERTION"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:insertion"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXInsertStyleGroup"
+          },
+          {
+            "type": "AXAttributedStringForTextMarkerRange",
+            "value": "AXIsSuggestedInsertion = 1;",
+            "description": "for all text contained in a <code>insertion</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-link": {
+      "headingHtml": "<code>link</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#link\"><code>link</code></a>",
+      "computedRole": "link",
+      "msaaIA2": {
+        "items": [],
+        "note": "<span class=\"property\">Role: <code>ROLE_SYSTEM_LINK</code></span><br>\n                  <span class=\"property\">State: <code>STATE_SYSTEM_LINKED</code></span><br>\n                  <span class=\"property\">State: <code>STATE_SYSTEM_LINKED</code></span> on its descendants<br>\n                  <span class=\"property\">Interface: <code>IAccessibleHypertext</code></span>"
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "HyperLink"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "Value"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_LINK"
+          },
+          {
+            "type": "Interface",
+            "value": "HyperlinkImpl"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXLink"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-list": {
+      "headingHtml": "<code>list</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#list\"><code>list</code></a>",
+      "computedRole": "list",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_LIST"
+          },
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_READONLY"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "List"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_LIST"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXList"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXContentList"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-listbox": {
+      "headingHtml": "<code>listbox</code> without an accessibility parent of <code>combobox</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#listbox\"><code>listbox</code></a>",
+      "computedRole": "listbox",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_LIST"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible::accSelect()"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible::get_accSelection()"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "List"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "Selection"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_LIST_BOX"
+          },
+          {
+            "type": "Interface",
+            "value": "Selection"
+          }
+        ],
+        "note": "Because <abbr title=\"Accessible Rich Internet Applications\">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return\n                    <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection."
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXList"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-listbox-in-combobox": {
+      "headingHtml": "<code>listbox</code> with an accessibility parent of <code>combobox</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#listbox\"><code>listbox</code></a>",
+      "computedRole": "listbox",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_LIST"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible::accSelect()"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible::get_accSelection()"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "List"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "Selection"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_MENU"
+          },
+          {
+            "type": "Interface",
+            "value": "Selection"
+          }
+        ],
+        "note": "Because <abbr title=\"Accessible Rich Internet Applications\">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return\n                    <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection."
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXList"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-listitem": {
+      "headingHtml": "<code>listitem</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#listitem\"><code>listitem</code></a>",
+      "computedRole": "listitem",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_LISTITEM"
+          },
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_READONLY"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "ListItem"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "SelectionItem"
+          },
+          {
+            "type": "SelectionItem.SelectionContainer",
+            "value": "list"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_LIST_ITEM"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-log": {
+      "headingHtml": "<code>log</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#log\"><code>log</code></a>",
+      "computedRole": "log",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:log"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-live:polite"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "live:polite"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-live-role:log"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "log"
+          },
+          {
+            "type": "LiveSetting",
+            "value": "Polite (1)"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_LOG"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:log"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-live:polite"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "live:polite"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-live-role:log"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXApplicationLog"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-main": {
+      "headingHtml": "<code>main</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#main\"><code>main</code></a>",
+      "computedRole": "main",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_LANDMARK"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:main"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "main"
+          },
+          {
+            "type": "Landmark Type",
+            "value": "Main"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_LANDMARK"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:main"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXLandmarkMain"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-mark": {
+      "headingHtml": "<code>mark</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#mark\"><code>mark</code></a>",
+      "computedRole": "mark",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_GROUPING"
+          },
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_MARK"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:mark"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_MARK"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:mark"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXRoleDescription",
+            "value": "highlight"
+          },
+          {
+            "type": "AXAttributedStringForTextMarkerRange",
+            "value": "AXHighlight = 1;",
+            "description": "for all text contained in a <code>mark</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-marquee": {
+      "headingHtml": "<code>marquee</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#marquee\"><code>marquee</code></a>",
+      "computedRole": "marquee",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_ANIMATION"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:marquee"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "marquee"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_MARQUEE"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXApplicationMarquee"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-math": {
+      "headingHtml": "<code>math</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#math\"><code>math</code></a>",
+      "computedRole": "math",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_EQUATION"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "math"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_MATH"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXDocumentMath"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-menu": {
+      "headingHtml": "<code>menu</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#menu\"><code>menu</code></a>",
+      "computedRole": "menu",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_MENUPOPUP"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible::accSelect()"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible::get_accSelection()"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Menu"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_MENU"
+          },
+          {
+            "type": "Interface",
+            "value": "Selection"
+          }
+        ],
+        "note": "Because <abbr title=\"Accessible Rich Internet Applications\">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return\n                    <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection."
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXMenu"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-menubar": {
+      "headingHtml": "<code>menubar</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#menubar\"><code>menubar</code></a>",
+      "computedRole": "menubar",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_MENUBAR"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible::accSelect()"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible::get_accSelection()"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "MenuBar"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_MENU_BAR"
+          },
+          {
+            "type": "Interface",
+            "value": "Selection"
+          }
+        ],
+        "note": "Because <abbr title=\"Accessible Rich Internet Applications\">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return\n                    <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection."
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXMenuBar"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-menuitem": {
+      "headingHtml": "<code>menuitem</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#menuitem\"><code>menuitem</code></a>",
+      "computedRole": "menuitem",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_MENUITEM"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "MenuItem"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_MENU_ITEM"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXMenuItem"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-menuitemcheckbox": {
+      "headingHtml": "<code>menuitemcheckbox</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#menuitemcheckbox\"><code>menuitemcheckbox</code></a>",
+      "computedRole": "menuitemcheckbox",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_CHECKBUTTON",
+            "description": "or <code>ROLE_SYSTEM_MENUITEM</code>"
+          },
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_CHECK_MENU_ITEM"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "MenuItem"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "Toggle"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_CHECK_MENU_ITEM"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXMenuItem"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-menuitemradio": {
+      "headingHtml": "<code>menuitemradio</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#menuitemradio\"><code>menuitemradio</code></a>",
+      "computedRole": "menuitemradio",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_RADIOBUTTON",
+            "description": "or <code>ROLE_SYSTEM_MENUITEM</code>"
+          },
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_RADIO_MENU_ITEM"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "MenuItem"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "Toggle"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "SelectionItem"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_RADIO_MENU_ITEM"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXMenuItem"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-meter": {
+      "headingHtml": "<code>meter</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#meter\"><code>meter</code></a>",
+      "computedRole": "meter",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_LEVEL_BAR"
+          },
+          {
+            "type": "Interface",
+            "value": "IAccessibleValue"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "ProgressBar"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "meter"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "RangeValue"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_LEVEL_BAR"
+          },
+          {
+            "type": "Interface",
+            "value": "Value"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXLevelIndicator"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXMeter"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-navigation": {
+      "headingHtml": "<code>navigation</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#navigation\"><code>navigation</code></a>",
+      "computedRole": "navigation",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_LANDMARK"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:navigation"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "navigation"
+          },
+          {
+            "type": "Landmark Type",
+            "value": "Navigation"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_LANDMARK"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:navigation"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXLandmarkNavigation"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-none": {
+      "headingHtml": "<code>none</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#none\"><code>none</code></a>",
+      "computedRole": "none",
+      "msaaIA2": {
+        "items": [],
+        "note": "For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the\n                    <a class=\"termref\">accessibility tree</a>, expose it as <code>IA2_ROLE_TEXT_FRAME</code>. [=user agents=] SHOULD prune empty descendants from the\n                    <a class=\"termref\">accessibility tree</a>."
+      },
+      "uia": {
+        "items": [],
+        "note": "For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the\n                    <a class=\"termref\">accessibility tree</a>, expose it using the <code>text</code> pattern. [=user agents=] SHOULD prune empty descendants from the\n                    <a class=\"termref\">accessibility tree</a>."
+      },
+      "atkAtSpi": {
+        "items": [],
+        "note": "For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the\n                    <a class=\"termref\">accessibility tree</a>, expose it as <code>ROLE_SECTION</code>. [=user agents=] SHOULD prune empty descendants from the\n                    <a class=\"termref\">accessibility tree</a>."
+      },
+      "axApi": {
+        "items": [],
+        "note": "For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the\n                    <a class=\"termref\">accessibility tree</a>, expose it as <code>AXGroup</code>. [=user agents=] SHOULD prune empty descendants from the <a class=\"termref\">accessibility tree</a>."
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-note": {
+      "headingHtml": "<code>note</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#note\"><code>note</code></a>",
+      "computedRole": "note",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_NOTE"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "note"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_COMMENT"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXDocumentNote"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-option": {
+      "headingHtml": "<code>option</code> not inside <code>combobox</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#option\"><code>option</code></a> not inside <code>combobox</code>",
+      "computedRole": "option",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_LISTITEM"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "ListItem"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "Invoke"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_LIST_ITEM"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a><br>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXStaticText"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-option-in-combobox": {
+      "headingHtml": "<code>option</code> inside <code>combobox</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#option\"><code>option</code></a> inside <code>combobox</code>",
+      "computedRole": "option",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_LISTITEM"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "ListItem"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "Invoke"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_MENU_ITEM"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a><br>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXStaticText"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-paragraph": {
+      "headingHtml": "<code>paragraph</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#paragraph\"><code>paragraph</code></a>",
+      "computedRole": "paragraph",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_GROUPING"
+          },
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_PARAGRAPH"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Text"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_PARAGRAPH"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-presentation": {
+      "headingHtml": "<code>presentation</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#presentation\"><code>presentation</code></a>",
+      "computedRole": "none",
+      "msaaIA2": {
+        "items": [],
+        "note": "For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the\n                    <a class=\"termref\">accessibility tree</a>, expose it as <code>IA2_ROLE_TEXT_FRAME</code>. [=user agents=] SHOULD prune empty descendants from the\n                    <a class=\"termref\">accessibility tree</a>."
+      },
+      "uia": {
+        "items": [],
+        "note": "For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the\n                    <a class=\"termref\">accessibility tree</a>, expose it using the <code>text</code> pattern. [=user agents=] SHOULD prune empty descendants from the\n                    <a class=\"termref\">accessibility tree</a>."
+      },
+      "atkAtSpi": {
+        "items": [],
+        "note": "For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the\n                    <a class=\"termref\">accessibility tree</a>, expose it as <code>ROLE_SECTION</code>. [=user agents=] SHOULD prune empty descendants from the\n                    <a class=\"termref\">accessibility tree</a>."
+      },
+      "axApi": {
+        "items": [],
+        "note": "For objects that have specified allowed accessibility children (e.g., a grid with gridcell children, a list with listitem children), and the descendant is in the\n                    <a class=\"termref\">accessibility tree</a>, expose it as <code>AXGroup</code>. [=user agents=] SHOULD prune empty descendants from the <a class=\"termref\">accessibility tree</a>."
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-progressbar": {
+      "headingHtml": "<code>progressbar</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#progressbar\"><code>progressbar</code></a>",
+      "computedRole": "progressbar",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_PROGRESSBAR"
+          },
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_READONLY"
+          },
+          {
+            "type": "Interface",
+            "value": "IAccessibleValue"
+          }
+        ]
+      },
+      "uia": {
+        "items": [],
+        "note": "<span class=\"property\">Control Type: <code>ProgressBar</code></span><br>\n                  <span class=\"property\">Control Pattern: <code>RangeValue</code> if <code>aria-valuenow</code>, <code>aria-valuemax</code>, or <code>aria-valuemin</code></span> is present"
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_PROGRESS_BAR"
+          },
+          {
+            "type": "Interface",
+            "value": "Value"
+          }
+        ],
+        "note": "Because <abbr title=\"Accessible Rich Internet Applications\">WAI-ARIA</abbr> does not support modifying the value via the accessibility API, user agents MUST return\n                    <code>false</code> for all <code>Value</code> methods that provide a means to modify the value."
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXProgressIndicator"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-radio": {
+      "headingHtml": "<code>radio</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#radio\"><code>radio</code></a>",
+      "computedRole": "radio",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_RADIOBUTTON"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "RadioButton"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "Toggle"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "SelectionItem"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_RADIO_BUTTON"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXRadioButton"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-radiogroup": {
+      "headingHtml": "<code>radiogroup</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#radiogroup\"><code>radiogroup</code></a>",
+      "computedRole": "radiogroup",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_GROUPING"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "List"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_PANEL"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXRadioGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-region": {
+      "headingHtml": "<code>region</code> with an accessible name",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#region\"><code>region</code></a> with an accessible name",
+      "computedRole": "region",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_LANDMARK"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:region"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "region"
+          },
+          {
+            "type": "Landmark Type",
+            "value": "Custom"
+          },
+          {
+            "type": "Localized Landmark Type",
+            "value": "region"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_LANDMARK"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:region"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXLandmarkRegion"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-region-nameless": {
+      "headingHtml": "<code>region</code> without an accessible name",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#region\"><code>region</code></a> without an accessible name",
+      "computedRole": "Use native host language role.",
+      "msaaIA2": {
+        "items": [],
+        "note": "Do not expose the <a class=\"termref\">element</a> as a landmark. Use the native host language role of the element instead."
+      },
+      "uia": {
+        "items": [],
+        "note": "Do not expose the <a class=\"termref\">element</a> as a landmark. Use the native host language role of the element instead."
+      },
+      "atkAtSpi": {
+        "items": [],
+        "note": "Do not expose the <a class=\"termref\">element</a> as a landmark. Use the native host language role of the element instead."
+      },
+      "axApi": {
+        "items": [],
+        "note": "Do not expose the <a class=\"termref\">element</a> as a landmark. Use the native host language role of the element instead."
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-row": {
+      "headingHtml": "<code>row</code> not inside <code>treegrid</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#row\"><code>row</code></a> not inside <code>treegrid</code>",
+      "computedRole": "row",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_ROW"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "DataItem"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "row"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "SelectionItem"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_TABLE_ROW"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXRow"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-row-in-treegrid": {
+      "headingHtml": "<code>row</code> inside <code>treegrid</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#row\"><code>row</code></a> inside <code>treegrid</code>",
+      "computedRole": "row",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_OUTLINEITEM"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "DataItem"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "row"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "SelectionItem"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_TABLE_ROW"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXRow"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-rowgroup": {
+      "headingHtml": "<code>rowgroup</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#rowgroup\"><code>rowgroup</code></a>",
+      "computedRole": "rowgroup",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_GROUPING"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_PANEL"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-rowheader": {
+      "headingHtml": "<code>rowheader</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#rowheader\"><code>rowheader</code></a>",
+      "computedRole": "rowheader",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_ROWHEADER"
+          },
+          {
+            "type": "Interface",
+            "value": "IAccessibleTableCell"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "HeaderItem"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_ROW_HEADER"
+          },
+          {
+            "type": "Interface",
+            "value": "TableCell"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXCell"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-scrollbar": {
+      "headingHtml": "<code>scrollbar</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#scrollbar\"><code>scrollbar</code></a>",
+      "computedRole": "scrollbar",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_SCROLLBAR"
+          },
+          {
+            "type": "Interface",
+            "value": "IAccessibleValue"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "ScrollBar"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "RangeValue"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SCROLL_BAR"
+          },
+          {
+            "type": "Interface",
+            "value": "Value"
+          }
+        ],
+        "note": "Because <abbr title=\"Accessible Rich Internet Applications\">WAI-ARIA</abbr> does not support modifying the value via the accessibility API, user agents MUST return\n                    <code>false</code> for all <code>Value</code> methods that provide a means to modify the value."
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXScrollBar"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-search": {
+      "headingHtml": "<code>search</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#search\"><code>search</code></a>",
+      "computedRole": "search",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_LANDMARK"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:search"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "search"
+          },
+          {
+            "type": "Landmark Type",
+            "value": "Search"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_LANDMARK"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:search"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXLandmarkSearch"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-searchbox": {
+      "headingHtml": "<code>searchbox</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#searchbox\"><code>searchbox</code></a>",
+      "computedRole": "searchbox",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_TEXT"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "text-input-type:search"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Edit"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "search box"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_ENTRY"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:searchbox"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "text-input-type:search"
+          },
+          {
+            "type": "Interface",
+            "value": "EditableText",
+            "description": "if <a class=\"property-reference\" href=\"#aria-readonly\"><code>aria-readonly</code></a> is not <code>\"true\"</code>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXTextField"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXSearchField"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-sectionfooter": {
+      "headingHtml": "<code>sectionfooter</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#sectionfooter\"><code>sectionfooter</code></a>",
+      "computedRole": "sectionfooter",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_GROUPING"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:sectionfooter"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "section footer"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_FOOTER"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXSectionFooter"
+          },
+          {
+            "type": "AXRoleDescription",
+            "value": "section footer"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-sectionheader": {
+      "headingHtml": "<code>sectionheader</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#sectionheader\"><code>sectionheader</code></a>",
+      "computedRole": "sectionheader",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_GROUPING"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:sectionheader"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "section header"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_HEADER"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXSectionHeader"
+          },
+          {
+            "type": "AXRoleDescription",
+            "value": "section header"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-separator": {
+      "headingHtml": "<code>separator</code> (non-focusable)",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#separator\"><code>separator</code></a> (non-focusable)",
+      "computedRole": "seperator",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_SEPARATOR"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Separator"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SEPARATOR"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXSplitter"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-separator-focusable": {
+      "headingHtml": "<code>separator</code> (focusable)",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#separator\"><code>separator</code></a> (focusable)",
+      "computedRole": "seperator",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_SEPARATOR"
+          },
+          {
+            "type": "Interface",
+            "value": "IAccessibleValue"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Thumb"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "RangeValue"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SEPARATOR"
+          },
+          {
+            "type": "Interface",
+            "value": "Value"
+          }
+        ],
+        "note": "Because <abbr title=\"Accessible Rich Internet Applications\">WAI-ARIA</abbr> does not support modifying the value via the accessibility API, user agents MUST return\n                    <code>false</code> for all <code>Value</code> methods that provide a means to modify the value."
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXSplitter"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-slider": {
+      "headingHtml": "<code>slider</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#slider\"><code>slider</code></a>",
+      "computedRole": "slider",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_SLIDER"
+          },
+          {
+            "type": "Interface",
+            "value": "IAccessibleValue"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Slider"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "RangeValue"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SLIDER"
+          },
+          {
+            "type": "Interface",
+            "value": "Value"
+          }
+        ],
+        "note": "Because <abbr title=\"Accessible Rich Internet Applications\">WAI-ARIA</abbr> does not support modifying the value via the accessibility API, user agents MUST return\n                    <code>false</code> for all <code>Value</code> methods that provide a means to modify the value."
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXSlider"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-spinbutton": {
+      "headingHtml": "<code>spinbutton</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#spinbutton\"><code>spinbutton</code></a>",
+      "computedRole": "spinbutton",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_SPINBUTTON"
+          },
+          {
+            "type": "Interface",
+            "value": "IAccessibleValue"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Spinner"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "RangeValue"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SPIN_BUTTON"
+          },
+          {
+            "type": "Interface",
+            "value": "Value"
+          }
+        ],
+        "note": "Because <abbr title=\"Accessible Rich Internet Applications\">WAI-ARIA</abbr> does not support modifying the value via the accessibility API, user agents MUST return\n                    <code>false</code> for all <code>Value</code> methods that provide a means to modify the value."
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXIncrementor"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-status": {
+      "headingHtml": "<code>status</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#status\"><code>status</code></a>",
+      "computedRole": "status",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_STATUSBAR"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-live:polite"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "live:polite"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-live-role:status"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "status"
+          },
+          {
+            "type": "LiveSetting",
+            "value": "Polite (1)"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_STATUSBAR"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-live:polite"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "live:polite"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-live-role:status"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXApplicationStatus"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-strong": {
+      "headingHtml": "<code>strong</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#strong\"><code>strong</code></a>",
+      "computedRole": "strong",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_TEXT_FRAME"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:strong"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Text"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "strong"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_STATIC"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:strong"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXStrongStyleGroup"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-subscript": {
+      "headingHtml": "<code>subscript</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#subscript\"><code>subscript</code></a>",
+      "computedRole": "subscript",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_GROUPING"
+          },
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_TEXT_FRAME"
+          },
+          {
+            "type": "Text Attribute",
+            "value": "text-position:sub"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Text"
+          },
+          {
+            "type": "Styles used are exposed by IsSubscript attribute of the TextRange Control Pattern implemented on the accessible object.",
+            "value": "IsSubscript",
+            "description": "attribute of the <code>TextRange</code> Control Pattern implemented on the accessible object."
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SUBSCRIPT"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXSubscriptStyleGroup"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-suggestion": {
+      "headingHtml": "<code>suggestion</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#suggestion\"><code>suggestion</code></a>",
+      "computedRole": "suggestion",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_SUGGESTION"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:suggestion"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "suggestion"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SUGGESTION"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:suggestion"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXAttributedStringForTextMarkerRange",
+            "value": "AXIsSuggestion = 1;",
+            "description": "for all text contained in a <code>suggestion</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-superscript": {
+      "headingHtml": "<code>superscript</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#superscript\"><code>superscript</code></a>",
+      "computedRole": "superscript",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_GROUPING"
+          },
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_TEXT_FRAME"
+          },
+          {
+            "type": "Text Attribute",
+            "value": "text-position:super"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Text"
+          },
+          {
+            "type": "Styles used are exposed by IsSuperscript attribute of the TextRange Control Pattern implemented on the accessible object.",
+            "value": "IsSuperscript",
+            "description": "attribute of the <code>TextRange</code> Control Pattern implemented on the accessible object."
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SUPERSCRIPT"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXSuperscriptStyleGroup"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-switch": {
+      "headingHtml": "<code>switch</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#switch\"><code>switch</code></a>",
+      "computedRole": "switch",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_CHECKBUTTON"
+          },
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_TOGGLE_BUTTON"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:switch"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Button"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "toggleswitch"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "Toggle"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_TOGGLE_BUTTON"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:switch"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXCheckBox"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXSwitch"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-tab": {
+      "headingHtml": "<code>tab</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#tab\"><code>tab</code></a>",
+      "computedRole": "tab",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_PAGETAB"
+          },
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_SELECTED",
+            "description": "if focus is inside <a class=\"role-reference\" href=\"#tabpanel\"><code>tabpanel</code></a> associated with\n                    <a class=\"property-reference\" href=\"#aria-labelledby\"><code>aria-labelledby</code></a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "TabItem"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_PAGE_TAB"
+          },
+          {
+            "type": "State",
+            "value": "STATE_SELECTED",
+            "description": "if focus is inside <a class=\"role-reference\" href=\"#tabpanel\"><code>tabpanel</code></a> associated with\n                    <a class=\"property-reference\" href=\"#aria-labelledby\"><code>aria-labelledby</code></a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXRadioButton"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXTabButton"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-table": {
+      "headingHtml": "<code>table</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#table\"><code>table</code></a>",
+      "computedRole": "table",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_TABLE"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:table"
+          },
+          {
+            "type": "Interface",
+            "value": "IAccessibleTable2"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Table"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "Grid"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "Table"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_TABLE"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:table"
+          },
+          {
+            "type": "Interface",
+            "value": "Table"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXTable"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          },
+          {
+            "type": "AXColumnHeaderUIElements",
+            "description": "a list of pointers to the columnheader elements"
+          },
+          {
+            "type": "AXHeader",
+            "description": "a pointer to the row or group containing those columnheader elements"
+          },
+          {
+            "type": "AXRowHeaderUIElements",
+            "description": "a list of pointers to the rowheader elements"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-tablist": {
+      "headingHtml": "<code>tablist</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#tablist\"><code>tablist</code></a>",
+      "computedRole": "tablist",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_PAGETABLIST"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible::accSelect()"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible::get_accSelection()"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Tab"
+          },
+          {
+            "type": "Control Pattern",
+            "value": "Selection"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_PAGE_TAB_LIST"
+          },
+          {
+            "type": "Interface",
+            "value": "Selection"
+          }
+        ],
+        "note": "Because <abbr title=\"Accessible Rich Internet Applications\">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return\n                    <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection."
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXTabGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-tabpanel": {
+      "headingHtml": "<code>tabpanel</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#tabpanel\"><code>tabpanel</code></a>",
+      "computedRole": "tabpanel",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_PANE",
+            "description": "or <code>ROLE_SYSTEM_PROPERTYPAGE</code>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Pane"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SCROLL_PANE"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXTabPanel"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-term": {
+      "headingHtml": "<code>term</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#term\"><code>term</code></a>",
+      "computedRole": "term",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "IA2_ROLE_TEXT_FRAME"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:term"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Text"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "term"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_DESCRIPTION_TERM"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXTerm"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-textbox": {
+      "headingHtml": "<code>textbox</code> when <code>aria-multiline</code> is <code>false</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#textbox\"><code>textbox</code></a> when <code>aria-multiline</code> is <code>false</code>",
+      "computedRole": "textbox",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_TEXT"
+          },
+          {
+            "type": "State",
+            "value": "IA2_STATE_SINGLE_LINE"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Edit"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_ENTRY"
+          },
+          {
+            "type": "State",
+            "value": "STATE_SINGLE_LINE"
+          },
+          {
+            "type": "Interface",
+            "value": "EditableText",
+            "description": "if <a class=\"property-reference\" href=\"#aria-readonly\"><code>aria-readonly</code></a> is not <code>\"true\"</code>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXTextField"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-textbox-multiline": {
+      "headingHtml": "<code>textbox</code> when <code>aria-multiline</code> is <code>true</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#textbox\"><code>textbox</code></a> when <code>aria-multiline</code> is <code>true</code>",
+      "computedRole": "textbox",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_TEXT"
+          },
+          {
+            "type": "State",
+            "value": "IA2_STATE_MULTI_LINE"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Edit"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_ENTRY"
+          },
+          {
+            "type": "State",
+            "value": "STATE_MULTI_LINE"
+          },
+          {
+            "type": "Interface",
+            "value": "EditableText",
+            "description": "if <a class=\"property-reference\" href=\"#aria-readonly\"><code>aria-readonly</code></a> is not <code>\"true\"</code>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXTextArea"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-time": {
+      "headingHtml": "<code>time</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#time\"><code>time</code></a>",
+      "computedRole": "time",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_GROUPING"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:time"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Text"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "time"
+          }
+        ],
+        "note": "Note: create a separate UIA Control of type Text. This is different from most UIA text mappings, which only create ranges in the page text pattern."
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_STATIC"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:time"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXTimeGroup"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-timer": {
+      "headingHtml": "<code>timer</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#timer\"><code>timer</code></a>",
+      "computedRole": "timer",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "xml-roles:timer"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Group"
+          },
+          {
+            "type": "Localized Control Type",
+            "value": "timer"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_TIMER"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXApplicationTimer"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-toolbar": {
+      "headingHtml": "<code>toolbar</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#toolbar\"><code>toolbar</code></a>",
+      "computedRole": "toolbar",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_TOOLBAR"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "ToolBar"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_TOOL_BAR"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXToolbar"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-tooltip": {
+      "headingHtml": "<code>tooltip</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#tooltip\"><code>tooltip</code></a>",
+      "computedRole": "tooltip",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_TOOLTIP"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "ToolTip"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_TOOL_TIP"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXGroup"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXUserInterfaceTooltip"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-tree": {
+      "headingHtml": "<code>tree</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#tree\"><code>tree</code></a>",
+      "computedRole": "tree",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_OUTLINE"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible::accSelect()"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible::get_accSelection()"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "Tree"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_TREE"
+          },
+          {
+            "type": "Interface",
+            "value": "Selection"
+          }
+        ],
+        "note": "Because <abbr title=\"Accessible Rich Internet Applications\">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return\n                    <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection."
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXOutline"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-treegrid": {
+      "headingHtml": "<code>treegrid</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#treegrid\"><code>treegrid</code></a>",
+      "computedRole": "treegrid",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_OUTLINE"
+          },
+          {
+            "type": "Interface",
+            "value": "IAccessibleTable2"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible::accSelect()"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible::get_accSelection()"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "DataGrid"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_TREE_TABLE"
+          },
+          {
+            "type": "Interface",
+            "value": "Table"
+          },
+          {
+            "type": "Interface",
+            "value": "Selection"
+          }
+        ],
+        "note": "Because <abbr title=\"Accessible Rich Internet Applications\">WAI-ARIA</abbr> does not support modifying the selection via the accessibility API, user agents MUST return\n                    <code>false</code> for all <code>Selection</code> methods that provide a means to modify the selection."
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXTable"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "<nil>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "role-map-treeitem": {
+      "headingHtml": "<code>treeitem</code>",
+      "ariaSpec": "<a class=\"role-reference\" href=\"#treeitem\"><code>treeitem</code></a>",
+      "computedRole": "treeitem",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_SYSTEM_OUTLINEITEM"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Type",
+            "value": "TreeItem"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Role",
+            "value": "ROLE_TREE_ITEM"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRole",
+            "value": "AXRow"
+          },
+          {
+            "type": "AXSubrole",
+            "value": "AXOutlineRow"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <code>aria-checked</code> in the <a href=\"#mapping_state-property_table\">State and Property Mapping Tables</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    }
+  },
+  "attributes": {
+    "ariaActiveDescendant": {
+      "headingHtml": "<code>aria-activedescendant</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-activedescendant\"><code>aria-activedescendant</code></a>",
+      "msaaIA2": {
+        "items": [],
+        "note": "See <a href=\"#focus_state_event_table\">Focus Changes</a>."
+      },
+      "uia": {
+        "items": [],
+        "note": "See <a href=\"#focus_state_event_table\">Focus Changes</a>."
+      },
+      "atkAtSpi": {
+        "items": [],
+        "note": "See <a href=\"#focus_state_event_table\">Focus Changes</a>."
+      },
+      "axApi": {
+        "items": [],
+        "note": "See <a href=\"#focus_state_event_table\">Focus Changes</a>.<br>\n                  <span class=\"property\">Property: <code>AXSelectedRows</code>: pointer to active descendant node</span>"
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaAtomicTrue": {
+      "headingHtml": "<code>aria-atomic</code>=<code>true</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-atomic\"><code>aria-atomic</code></a>=<code>true</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "atomic:true"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-atomic:true"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-atomic:true",
+            "description": "on all descendants"
+          },
+          {
+            "type": "Relation",
+            "value": "IA2_RELATION_MEMBER_OF",
+            "description": "pointing to this element (the atomic root)"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_visibility\">Changes to document content or node visibility</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.atomic",
+            "description": "<code>true</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_visibility\">Changes to document content or node visibility</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "atomic:true"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-atomic:true"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-atomic:true",
+            "description": "on all descendants"
+          },
+          {
+            "type": "Relation",
+            "value": "RELATION_MEMBER_OF",
+            "description": "pointing to this element (the atomic root)"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_visibility\">Changes to document content or node visibility</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXARIAAtomic",
+            "description": "<code>YES</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_visibility\">Changes to document content or node visibility</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaAtomicFalse": {
+      "headingHtml": "<code>aria-atomic</code>=<code>false</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-atomic\"><code>aria-atomic</code></a>=<code>false</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>, but if mapped:"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "atomic:false"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-atomic:false"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-atomic:false",
+            "description": "on all descendants"
+          },
+          {
+            "type": "Relation",
+            "value": "IA2_RELATION_MEMBER_OF",
+            "description": "pointing to this element (the atomic root)"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_visibility\">Changes to document content or node visibility</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.atomic",
+            "description": "<code>false</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_visibility\">Changes to document content or node visibility</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>, but if mapped:"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "atomic:false"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-atomic:false"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-atomic:false",
+            "description": "on all descendants"
+          },
+          {
+            "type": "Relation",
+            "value": "RELATION_MEMBER_OF",
+            "description": "pointing to this element (the atomic root)"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_visibility\">Changes to document content or node visibility</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXARIAAtomic",
+            "description": "<code>NO</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_visibility\">Changes to document content or node visibility</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaAutocompleteInlineListBoth": {
+      "headingHtml": "<code>aria-autocomplete</code>=<code>inline</code>, <code>list</code>, or <code>both</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-autocomplete\"><code>aria-autocomplete</code></a>=<code>inline</code>, <code>list</code>, or <code>both</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "autocomplete:<value>"
+          },
+          {
+            "type": "State",
+            "value": "IA2_STATE_SUPPORTS_AUTOCOMPLETION"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "autocomplete:<value>"
+          },
+          {
+            "type": "State",
+            "value": "STATE_SUPPORTS_AUTOCOMPLETION"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaAutocompleteNone": {
+      "headingHtml": "<code>aria-autocomplete</code>=<code>none</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-autocomplete\"><code>aria-autocomplete</code></a>=<code>none</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaBraillelabel": {
+      "headingHtml": "<code>aria-braillelabel</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-braillelabel\"><code>aria-braillelabel</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "braillelabel:<value>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.braillelabel",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "braillelabel:<value>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXBrailleLabel",
+            "value": "<value>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaBrailleroledescription": {
+      "headingHtml": "<code>aria-brailleroledescription</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-brailleroledescription\"><code>aria-brailleroledescription</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "brailleroledescription:<value>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.brailleroledescription",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "brailleroledescription:<value>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "<value>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaBrailleroledescriptionUndefined": {
+      "headingHtml": "<code>aria-brailleroledescription</code> is undefined or the empty string",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-brailleroledescription\"><code>aria-brailleroledescription</code></a> is undefined or the empty string",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaBusyTrue": {
+      "headingHtml": "<code>aria-busy</code>=<code>true</code>",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-busy\"><code>aria-busy</code></a>=<code>true</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_BUSY"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.busy",
+            "description": "<code>true</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_BUSY"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXElementBusy",
+            "description": "<code>YES</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaBusyFalse": {
+      "headingHtml": "<code>aria-busy</code>=<code>false</code>",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-busy\"><code>aria-busy</code></a>=<code>false</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_BUSY",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.busy",
+            "description": "<code>false</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_BUSY",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXElementBusy",
+            "description": "<code>NO</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaCheckedTrue": {
+      "headingHtml": "<code>aria-checked</code>=<code>true</code>",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-checked\"><code>aria-checked</code></a>=<code>true</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_CHECKED"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "checkable:true"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Toggle.ToggleState",
+            "description": "<code>On (1)</code>"
+          },
+          {
+            "type": "Property",
+            "value": "SelectionItem.IsSelected",
+            "description": "<code>True</code> for <code>radio</code> and <code>menuitemradio</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_CHECKABLE"
+          },
+          {
+            "type": "State",
+            "value": "STATE_CHECKED"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXValue",
+            "description": "<code>1</code>"
+          },
+          {
+            "type": "Property",
+            "value": "AXMenuItemMarkChar",
+            "description": "<code>✓</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaCheckedFalse": {
+      "headingHtml": "<code>aria-checked</code>=<code>false</code>",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-checked\"><code>aria-checked</code></a>=<code>false</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_CHECKED",
+            "description": "not exposed"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "checkable:true"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Toggle.ToggleState",
+            "description": "<code>Off (0)</code>"
+          },
+          {
+            "type": "Property",
+            "value": "SelectionItem.IsSelected",
+            "description": "<code>False</code> for <code>radio</code> and <code>menuitemradio</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_CHECKABLE"
+          },
+          {
+            "type": "State",
+            "value": "STATE_CHECKED",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXValue",
+            "description": "<code>0</code>"
+          },
+          {
+            "type": "Property",
+            "value": "AXMenuItemMarkChar",
+            "description": "<code>&lt;nil&gt;</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaCheckedMixed": {
+      "headingHtml": "<code>aria-checked</code>=<code>mixed</code>",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-checked\"><code>aria-checked</code></a>=<code>mixed</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_MIXED"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "checkable:true"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Toggle.ToggleState",
+            "description": "<code>Indeterminate (2)</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_INDETERMINATE"
+          },
+          {
+            "type": "State",
+            "value": "STATE_CHECKABLE"
+          },
+          {
+            "type": "State",
+            "value": "STATE_CHECKED",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXValue",
+            "description": "<code>2</code>"
+          },
+          {
+            "type": "Property",
+            "value": "AXMenuItemMarkChar",
+            "description": "<code>&lt;nil&gt;</code> for <code>menuitemcheckbox</code> and <code>menuitemradio</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaCheckedUndefined": {
+      "headingHtml": "<code>aria-checked</code> is undefined",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-checked\"><code>aria-checked</code></a> is undefined",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaColCount": {
+      "headingHtml": "<code>aria-colcount</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-colcount\"><code>aria-colcount</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "colcount:<value>"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible2::groupPosition()",
+            "description": "<code>similarItemsInGroup=&lt;value&gt;</code> on cells and headers"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Grid.ColumnCount",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "colcount",
+            "description": "should contain the author-provided value."
+          },
+          {
+            "type": "Method",
+            "value": "atk_table_get_n_columns()",
+            "description": "should return the actual number of columns."
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXARIAColumnCount",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaColIndex": {
+      "headingHtml": "<code>aria-colindex</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-colindex\"><code>aria-colindex</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "colindex:<value>"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible2::groupPosition()",
+            "description": "<code>positionInGroup=&lt;value&gt;</code> on cells and headers"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "GridItem.Column",
+            "description": "<code>&lt;value&gt;</code> (zero-based)"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "colindex",
+            "description": "should contain the author-provided value."
+          },
+          {
+            "type": "Method",
+            "value": "atk_table_cell_get_position()",
+            "description": "should return the actual (zero-based) column index."
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXARIAColumnIndex",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaColIndexText": {
+      "headingHtml": "<code>aria-colindextext</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-colindextext\"><code>aria-colindextext</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "colindextext:<value>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.colindextext",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "colindextext:<value>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXColumnIndexDescription",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaColSpan": {
+      "headingHtml": "<code>aria-colspan</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-colspan\"><code>aria-colspan</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "colspan:<value>"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessibleTableCell::columnExtent()",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "GridItem.ColumnSpan",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "colspan",
+            "description": "should contain the author-provided value."
+          },
+          {
+            "type": "Method",
+            "value": "atk_table_cell_get_row_column_span()",
+            "description": "should return the actual column span."
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXColumnIndexRange.length",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaControls": {
+      "headingHtml": "<code>aria-controls</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-controls\"><code>aria-controls</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Relation",
+            "value": "IA2_RELATION_CONTROLLER_FOR",
+            "description": "points to accessible nodes matching IDREFs"
+          },
+          {
+            "type": "Reverse Relation",
+            "value": "IA2_RELATION_CONTROLLED_BY",
+            "description": "points to element"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_relations\">Mapping Additional Relations</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "ControllerFor",
+            "description": "pointers to accessible nodes matching IDREFs"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Relation",
+            "value": "RELATION_CONTROLLER_FOR",
+            "description": "points to accessible nodes matching IDREFs"
+          },
+          {
+            "type": "Reverse Relation",
+            "value": "RELATION_CONTROLLED_BY",
+            "description": "points to element"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_relations\">Mapping Additional Relations</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXLinkedUIElements",
+            "description": "pointers to accessible nodes matching IDREFs"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaCurrent": {
+      "headingHtml": "<code>aria-current</code> with non-<code>false</code> allowed value",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-current\"><code>aria-current</code></a> with non-<code>false</code> allowed value",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "current:<value>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.current",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "current:<value>"
+          },
+          {
+            "type": "State",
+            "value": "STATE_ACTIVE"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXARIACurrent",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaCurrentUnrecognizedValue": {
+      "headingHtml": "<code>aria-current</code> with unrecognized value",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-current\"><code>aria-current</code></a> with unrecognized value",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "current:true"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.current",
+            "description": "<code>true</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "current:true"
+          },
+          {
+            "type": "State",
+            "value": "STATE_ACTIVE"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXARIACurrent",
+            "description": "<code>true</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaCurrentUndefined": {
+      "headingHtml": "<code>aria-current</code> is <code>false</code> or undefined",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-current\"><code>aria-current</code></a> is <code>false</code> or undefined",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaDescribedBy": {
+      "headingHtml": "<code>aria-describedby</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-describedby\"><code>aria-describedby</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "accDescription",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "Relation",
+            "value": "IA2_RELATION_DESCRIBED_BY",
+            "description": "points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree"
+          },
+          {
+            "type": "Reverse Relation",
+            "value": "IA2_RELATION_DESCRIPTION_FOR",
+            "description": "points to element"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_nd\">Name Computation</a> and <a href=\"#mapping_additional_relations\">Mapping Additional Relations</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "FullDescription",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_nd\">Name Computation</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Description",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "Relation",
+            "value": "RELATION_DESCRIBED_BY",
+            "description": "points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree"
+          },
+          {
+            "type": "Reverse Relation",
+            "value": "RELATION_DESCRIPTION_FOR",
+            "description": "points to element"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_nd\">Name Computation</a> and <a href=\"#mapping_additional_relations\">Mapping Additional Relations</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [],
+        "note": "<span class=\"api\">In the accessibilityCustomContent API, expose as an <code>AXCustomContent</code> object with <code>{ label: \"description\" }</code> and `<code>value</code>` set to the description\n                    string.</span><br>\n                  - <span class=\"seealso\">See also: <a href=\"#mapping_additional_nd\">Name Computation</a></span>"
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaDescription": {
+      "headingHtml": "<code>aria-description</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-description\"><code>aria-description</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "accDescription",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_nd\">Name Computation</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "FullDescription",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_nd\">Name Computation</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Description",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_nd\">Name Computation</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "In the accessibilityCustomContent API, expose as an AXCustomContent object with { label",
+            "value": "AXCustomContent",
+            "description": "object with <code>{ label: \"description\" }</code> and `<code>value</code>` set to the description\n                    string."
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_nd\">Name Computation</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaDetails": {
+      "headingHtml": "<code>aria-details</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-details\"><code>aria-details</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Relation",
+            "value": "IA2_RELATION_DETAILS",
+            "description": "points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree"
+          },
+          {
+            "type": "Reverse Relation",
+            "value": "IA2_RELATION_DETAILS_FOR",
+            "description": "points to element"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_relations\">Mapping Additional Relations</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "DescribedBy",
+            "description": "points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Relation",
+            "value": "RELATION_DETAILS",
+            "description": "points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree"
+          },
+          {
+            "type": "Reverse Relation",
+            "value": "RELATION_DETAILS_FOR",
+            "description": "points to element"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_relations\">Mapping Additional Relations</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaDisabledTrue": {
+      "headingHtml": "<code>aria-disabled</code>=<code>true</code>",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-disabled\"><code>aria-disabled</code></a>=<code>true</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_UNAVAILABLE"
+          },
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_UNAVAILABLE",
+            "description": "on all descendants with <code>STATE_SYSTEM_FOCUSABLE</code>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "IsEnabled",
+            "description": "<code>false</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_ENABLED",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXEnabled",
+            "description": "<code>NO</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaDisabledFalse": {
+      "headingHtml": "<code>aria-disabled</code>=<code>false</code>",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-disabled\"><code>aria-disabled</code></a>=<code>false</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_UNAVAILABLE",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "IsEnabled",
+            "description": "<code>true</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_ENABLED"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXEnabled",
+            "description": "<code>YES</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaDropeffectMoveLinkExecutePopup": {
+      "headingHtml": "<code>aria-dropeffect</code>=<code>copy</code>, <code>move</code>, <code>link</code>, <code>execute</code>, or <code>popup</code> (deprecated)",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-dropeffect\"><code>aria-dropeffect</code></a>=<code>copy</code>, <code>move</code>, <code>link</code>, <code>execute</code>, or <code>popup</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "dropeffect:<value>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.dropeffect",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "dropeffect:<value>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [],
+        "note": "<code>array AXDropEffects</code>"
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaDropeffectNone": {
+      "headingHtml": "<code>aria-dropeffect</code>=<code>none</code> (deprecated)",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-dropeffect\"><code>aria-dropeffect</code></a>=<code>none</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "dropeffect:none",
+            "description": "if there are no other valid tokens"
+          },
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a> if not specified by the author"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "dropeffect:none",
+            "description": "if there are no other valid tokens"
+          },
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a> if not specified by the author"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaErrorMessage": {
+      "headingHtml": "<code>aria-errormessage</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-errormessage\"><code>aria-errormessage</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Relation",
+            "value": "IA2_RELATION_ERROR",
+            "description": "points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree"
+          },
+          {
+            "type": "Reverse Relation",
+            "value": "IA2_RELATION_ERROR_FOR",
+            "description": "points to element"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_relations\">Mapping Additional Relations</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "ControllerFor",
+            "description": "pointer to the target accessible object"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Relation",
+            "value": "RELATION_ERROR_MESSAGE",
+            "description": "points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree"
+          },
+          {
+            "type": "Reverse Relation",
+            "value": "RELATION_ERROR_FOR",
+            "description": "points to element"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_relations\">Mapping Additional Relations</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXErrorMessageElements",
+            "description": "pointers to accessible nodes matching IDREFs"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaExpandedTrue": {
+      "headingHtml": "<code>aria-expanded</code>=<code>true</code>",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-expanded\"><code>aria-expanded</code></a>=<code>true</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_EXPANDED"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "ExpandCollapse.ExpandCollapseState",
+            "description": "<code>Expanded</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_EXPANDABLE"
+          },
+          {
+            "type": "State",
+            "value": "STATE_EXPANDED"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXExpanded",
+            "description": "<code>YES</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaExpandedFalse": {
+      "headingHtml": "<code>aria-expanded</code>=<code>false</code>",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-expanded\"><code>aria-expanded</code></a>=<code>false</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_COLLAPSED"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "ExpandCollapse.ExpandCollapseState",
+            "description": "<code>Collapsed</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_EXPANDABLE"
+          },
+          {
+            "type": "State",
+            "value": "STATE_EXPANDED",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXExpanded",
+            "description": "<code>NO</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaExpandedUndefined": {
+      "headingHtml": "<code>aria-expanded</code> is undefined",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-expanded\"><code>aria-expanded</code></a> is undefined",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaFlowto": {
+      "headingHtml": "<code>aria-flowto</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-flowto\"><code>aria-flowto</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Relation",
+            "value": "IA2_RELATION_FLOW_TO",
+            "description": "points to accessible nodes matching IDREFs"
+          },
+          {
+            "type": "Reverse Relation",
+            "value": "IA2_RELATION_FLOW_FROM",
+            "description": "points to element"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_relations\">Mapping Additional Relations</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "FlowsTo",
+            "description": "pointers to accessible nodes matching IDREFs"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Relation",
+            "value": "RELATION_FLOWS_TO",
+            "description": "points to accessible nodes matching IDREFs"
+          },
+          {
+            "type": "Reverse Relation",
+            "value": "RELATION_FLOWS_FROM",
+            "description": "points to element"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_relations\">Mapping Additional Relations</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXLinkedUIElements",
+            "description": "pointers to accessible nodes matching IDREFs"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaGrabbedTrue": {
+      "headingHtml": "<code>aria-grabbed</code>=<code>true</code>",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-grabbed\"><code>aria-grabbed</code></a>=<code>true</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "grabbed:true"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.grabbed",
+            "description": "<code>true</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "grabbed:true"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXGrabbed",
+            "description": "<code>YES</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaGrabbedFalse": {
+      "headingHtml": "<code>aria-grabbed</code>=<code>false</code>",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-grabbed\"><code>aria-grabbed</code></a>=<code>false</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "grabbed:false"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.grabbed",
+            "description": "<code>false</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "grabbed:false"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXGrabbed",
+            "description": "<code>NO</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaGrabbedUndefined": {
+      "headingHtml": "<code>aria-grabbed</code> is undefined",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-grabbed\"><code>aria-grabbed</code></a> is undefined",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaHaspopupTrue": {
+      "headingHtml": "<code>aria-haspopup</code>=<code>true</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-haspopup\"><code>aria-haspopup</code></a>=<code>true</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_HASPOPUP"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "haspopup:menu"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Pattern",
+            "value": "ExpandCollapse"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a class=\"state-reference\" href=\"#aria-expanded\"><code>aria-expanded</code></a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_HAS_POPUP"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "haspopup:menu"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXPopupValue:menu"
+          },
+          {
+            "type": "Action",
+            "value": "AXShowMenu"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaHaspopupFalse": {
+      "headingHtml": "<code>aria-haspopup</code>=<code>false</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-haspopup\"><code>aria-haspopup</code></a>=<code>false</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_HASPOPUP",
+            "description": "not exposed"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "haspopup:false"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaHaspopupDialog": {
+      "headingHtml": "<code>aria-haspopup</code>=<code>dialog</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-haspopup\"><code>aria-haspopup</code></a>=<code>dialog</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_HASPOPUP"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "haspopup:dialog"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Pattern",
+            "value": "ExpandCollapse"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a class=\"state-reference\" href=\"#aria-expanded\"><code>aria-expanded</code></a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_HAS_POPUP"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "haspopup:dialog"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXPopupValue:dialog"
+          },
+          {
+            "type": "Action",
+            "value": "AXShowMenu"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaHaspopupGrid": {
+      "headingHtml": "<code>aria-haspopup</code>=<code>grid</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-haspopup\"><code>aria-haspopup</code></a>=<code>grid</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_HASPOPUP"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "haspopup:grid"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Pattern",
+            "value": "ExpandCollapse"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a class=\"state-reference\" href=\"#aria-expanded\"><code>aria-expanded</code></a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_HAS_POPUP"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "haspopup:grid"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXPopupValue:grid"
+          },
+          {
+            "type": "Action",
+            "value": "AXShowMenu"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaHaspopupListbox": {
+      "headingHtml": "<code>aria-haspopup</code>=<code>listbox</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-haspopup\"><code>aria-haspopup</code></a>=<code>listbox</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_HASPOPUP"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "haspopup:listbox"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Pattern",
+            "value": "ExpandCollapse"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a class=\"state-reference\" href=\"#aria-expanded\"><code>aria-expanded</code></a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_HAS_POPUP"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "haspopup:listbox"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXPopupValue:listbox"
+          },
+          {
+            "type": "Action",
+            "value": "AXShowMenu"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaHaspopupMenu": {
+      "headingHtml": "<code>aria-haspopup</code>=<code>menu</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-haspopup\"><code>aria-haspopup</code></a>=<code>menu</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_HASPOPUP"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "haspopup:menu"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Pattern",
+            "value": "ExpandCollapse"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a class=\"state-reference\" href=\"#aria-expanded\"><code>aria-expanded</code></a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_HAS_POPUP"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "haspopup:menu"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXPopupValue:menu"
+          },
+          {
+            "type": "Action",
+            "value": "AXShowMenu"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaHaspopupTree": {
+      "headingHtml": "<code>aria-haspopup</code>=<code>tree</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-haspopup\"><code>aria-haspopup</code></a>=<code>tree</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_HASPOPUP"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "haspopup:tree"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Control Pattern",
+            "value": "ExpandCollapse"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a class=\"state-reference\" href=\"#aria-expanded\"><code>aria-expanded</code></a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_HAS_POPUP"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "haspopup:tree"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXPopupValue:tree"
+          },
+          {
+            "type": "Action",
+            "value": "AXShowMenu"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaHiddenTrue": {
+      "headingHtml": "<code>aria-hidden</code>=<code>true</code> on unfocused element",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-hidden\"><code>aria-hidden</code></a>=<code>true</code> on unfocused element",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "not-in-tree",
+            "description": "Element SHOULD NOT be exposed"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a class=\"specref\" href=\"#tree_inclusion\">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "not-in-tree",
+            "description": "Element SHOULD NOT be exposed"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a class=\"specref\" href=\"#tree_inclusion\">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "not-in-tree",
+            "description": "Element SHOULD NOT be exposed"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a class=\"specref\" href=\"#tree_inclusion\">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-in-tree",
+            "description": "Element SHOULD NOT be exposed"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a class=\"specref\" href=\"#tree_inclusion\">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaHiddenTrueElementExposed": {
+      "headingHtml": "<code>aria-hidden</code>=<code>true</code> when element is focused or fires an accessibility event",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-hidden\"><code>aria-hidden</code></a>=<code>true</code> when element is focused or fires an accessibility event",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "hidden:true"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a class=\"specref\" href=\"#tree_inclusion\">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.hidden",
+            "description": "<code>true</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a class=\"specref\" href=\"#tree_inclusion\">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "hidden:true"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a class=\"specref\" href=\"#tree_inclusion\">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a class=\"specref\" href=\"#tree_inclusion\">Including Elements in the Accessibility Tree in the WAI-ARIA specification</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaHiddenFalse": {
+      "headingHtml": "<code>aria-hidden</code>=<code>false</code>",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-hidden\"><code>aria-hidden</code></a>=<code>false</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaInvalidTrue": {
+      "headingHtml": "<code>aria-invalid</code>=<code>true</code>",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-invalid\"><code>aria-invalid</code></a>=<code>true</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "IA2_STATE_INVALID_ENTRY"
+          },
+          {
+            "type": "Text Attribute",
+            "value": "invalid:true"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "IsDataValidForForm",
+            "description": "<code>false</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_INVALID_ENTRY"
+          },
+          {
+            "type": "Text Attribute",
+            "value": "invalid:true"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXInvalid",
+            "description": "<code>true</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaInvalidFalse": {
+      "headingHtml": "<code>aria-invalid</code>=<code>false</code>",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-invalid\"><code>aria-invalid</code></a>=<code>false</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "IA2_STATE_INVALID_ENTRY",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "IsDataValidForForm",
+            "description": "<code>true</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_INVALID_ENTRY",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXInvalid",
+            "description": "<code>false</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaInvalidSpellingGrammar": {
+      "headingHtml": "<code>aria-invalid</code>=<code>spelling</code> or <code>grammar</code>",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-invalid\"><code>aria-invalid</code></a>=<code>spelling</code> or <code>grammar</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "IA2_STATE_INVALID_ENTRY"
+          },
+          {
+            "type": "Text Attribute",
+            "value": "invalid:<value>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "IsDataValidForForm",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_INVALID_ENTRY"
+          },
+          {
+            "type": "Text Attribute",
+            "value": "invalid:<value>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXInvalid",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaInvalidUnrecognizedValue": {
+      "headingHtml": "<code>aria-invalid</code> with unrecognized value",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-invalid\"><code>aria-invalid</code></a> with unrecognized value",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "IA2_STATE_INVALID_ENTRY"
+          },
+          {
+            "type": "Text Attribute",
+            "value": "invalid:true"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "IsDataValidForForm",
+            "description": "<code>false</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_INVALID_ENTRY"
+          },
+          {
+            "type": "Text Attribute",
+            "value": "invalid:true"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXInvalid",
+            "description": "<code>true</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaKeyshortcuts": {
+      "headingHtml": "<code>aria-keyshortcuts</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-keyshortcuts\"><code>aria-keyshortcuts</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "accKeyboardShortcut",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AcceleratorKey",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "keyshortcuts:<value>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXKeyShortcutsValue",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaLabel": {
+      "headingHtml": "<code>aria-label</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-label\"><code>aria-label</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "accName",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_nd\">Name Computation</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Name",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_nd\">Name Computation</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Name",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_nd\">Name Computation</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXTitle",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_nd\">Name Computation</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaLabelledBy": {
+      "headingHtml": "<code>aria-labelledby</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-labelledby\"><code>aria-labelledby</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "accName",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "Relation",
+            "value": "IA2_RELATION_LABELLED_BY",
+            "description": "points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree"
+          },
+          {
+            "type": "Reverse Relation",
+            "value": "IA2_RELATION_LABEL_FOR",
+            "description": "points to element"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_nd\">Name Computation</a> and <a href=\"#mapping_additional_relations\">Mapping Additional Relations</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Name",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "Property",
+            "value": "LabeledBy",
+            "description": "points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_nd\">Name Computation</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Name",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "Relation",
+            "value": "RELATION_LABELLED_BY",
+            "description": "points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree"
+          },
+          {
+            "type": "Reverse Relation",
+            "value": "RELATION_LABEL_FOR",
+            "description": "points to element"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_nd\">Name Computation</a> and <a href=\"#mapping_additional_relations\">Mapping Additional Relations</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXTitle",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "Property",
+            "value": "AXTitleUIElement",
+            "description": "points to accessible node matching IDREF, if there is a single referenced element that is in the accessibility tree"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_nd\">Name Computation</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaLevel": {
+      "headingHtml": "<code>aria-level</code> on non-<code>heading</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-level\"><code>aria-level</code></a> on non-<code>heading</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "level:<value>"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible2::groupPosition()",
+            "description": "<code>groupLevel=&lt;value&gt;</code> on roles that support <code>aria-posinset</code> and <code>aria-setsize</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_group_position\"><code>groupPosition()</code></a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.level",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "level:<value>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXDisclosureLevel",
+            "description": "<code>&lt;value&gt;</code> (zero-based), when used on an outline row (like a\n                    <a class=\"role-reference\" href=\"#treeitem\"><code>treeitem</code></a> or <a class=\"role-reference\" href=\"#group\"><code>group</code></a>)"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaLevelHeading": {
+      "headingHtml": "<code>aria-level</code> on <code>heading</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-level\"><code>aria-level</code></a> on <code>heading</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "level:<value>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.level",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "Property",
+            "value": "StyleId_Heading",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "level:<value>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXValue",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaLiveAssertive": {
+      "headingHtml": "<code>aria-live</code>=<code>assertive</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-live\"><code>aria-live</code></a>=<code>assertive</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "live:assertive"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-live:assertive"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-live:assertive",
+            "description": "on all descendants"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_visibility\">Changes to document content or node visibility</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "LiveSetting",
+            "description": "<code>\"assertive\"</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_visibility\">Changes to document content or node visibility</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "live:assertive"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-live:assertive"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-live:assertive",
+            "description": "on all descendants"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_visibility\">Changes to document content or node visibility</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXARIALive",
+            "description": "<code>\"assertive\"</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_visibility\">Changes to document content or node visibility</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaLivePolite": {
+      "headingHtml": "<code>aria-live</code>=<code>polite</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-live\"><code>aria-live</code></a>=<code>polite</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "live:polite"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-live:polite"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-live:polite",
+            "description": "on all descendants"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_visibility\">Changes to document content or node visibility</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "LiveSetting",
+            "description": "<code>\"polite\"</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_visibility\">Changes to document content or node visibility</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "live:polite"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-live:polite"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-live:polite",
+            "description": "on all descendants"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_visibility\">Changes to document content or node visibility</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXARIALive",
+            "description": "<code>\"polite\"</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_visibility\">Changes to document content or node visibility</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaLiveOff": {
+      "headingHtml": "<code>aria-live</code>=<code>off</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-live\"><code>aria-live</code></a>=<code>off</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "live:off"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-live:off"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-live:off",
+            "description": "on all descendants"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "LiveSetting",
+            "description": "<code>\"off\"</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "live:off"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-live:off"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-live:off",
+            "description": "on all descendants"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXARIALive",
+            "description": "<code>\"off\"</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaModalTrue": {
+      "headingHtml": "<code>aria-modal</code>=<code>true</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-modal\"><code>aria-modal</code></a>=<code>true</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "IA2_STATE_MODAL"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Window.IsModal",
+            "description": "<code>true</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_MODAL"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [],
+        "note": "Prune the accessibility tree such that the background content is no longer exposed. No specific property is set on the <a class=\"termref\">accessible object</a> that corresponds to\n                  the <a class=\"termref\">element</a> with <code>aria-modal=\"true\"</code>. Only the tree whose root is that modal accessible object is exposed."
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaModalFalse": {
+      "headingHtml": "<code>aria-modal</code>=<code>false</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-modal\"><code>aria-modal</code></a>=<code>false</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "IA2_STATE_MODAL",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Window.IsModal",
+            "description": "<code>false</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_MODAL",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [],
+        "note": "Grow the accessibility tree such that the background content is exposed. No specific property is set on the <a class=\"termref\">accessible object</a> that corresponds to the\n                  <a class=\"termref\">element</a> with <code>aria-modal=\"false\"</code>."
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaMultilineTrue": {
+      "headingHtml": "<code>aria-multiline</code>=<code>true</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-multiline\"><code>aria-multiline</code></a>=<code>true</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "IA2_STATE_MULTI_LINE"
+          },
+          {
+            "type": "State",
+            "value": "IA2_STATE_SINGLE_LINE",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.multiline",
+            "description": "<code>true</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_MULTI_LINE"
+          },
+          {
+            "type": "State",
+            "value": "STATE_SINGLE_LINE",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#role-map-textbox\"><code>textbox</code></a> in the Role Mapping Tables"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaMultilineFalse": {
+      "headingHtml": "<code>aria-multiline</code>=<code>false</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-multiline\"><code>aria-multiline</code></a>=<code>false</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "IA2_STATE_SINGLE_LINE"
+          },
+          {
+            "type": "State",
+            "value": "IA2_STATE_MULTI_LINE",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SINGLE_LINE"
+          },
+          {
+            "type": "State",
+            "value": "STATE_MULTI_LINE",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#role-map-textbox\"><code>textbox</code></a> in the Role Mapping Tables"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaMultiselectableTrue": {
+      "headingHtml": "<code>aria-multiselectable</code>=<code>true</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-multiselectable\"><code>aria-multiselectable</code></a>=<code>true</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_MULTISELECTABLE"
+          },
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_EXTSELECTABLE"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_selection\">Selection</a> for details on accessibility events"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Selection.CanSelectMultiple",
+            "description": "<code>true</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_selection\">Selection</a> for details on accessibility events"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_MULTISELECTABLE"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_selection\">Selection</a> for details on accessibility events"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXIsMultiSelectable",
+            "description": "<code>YES</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_selection\">Selection</a> for details on accessibility events"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaMultiselectableFalse": {
+      "headingHtml": "<code>aria-multiselectable</code>=<code>false</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-multiselectable\"><code>aria-multiselectable</code></a>=<code>false</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_MULTISELECTABLE",
+            "description": "not exposed"
+          },
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_EXTSELECTABLE",
+            "description": "not exposed"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_selection\">Selection</a> for details on accessibility events"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_MULTISELECTABLE",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaOrientationHorizontal": {
+      "headingHtml": "<code>aria-orientation</code>=<code>horizontal</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-orientation\"><code>aria-orientation</code></a>=<code>horizontal</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "IA2_STATE_HORIZONTAL"
+          },
+          {
+            "type": "State",
+            "value": "IA2_STATE_VERTICAL",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Orientation",
+            "description": "<code>horizontal</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_HORIZONTAL"
+          },
+          {
+            "type": "State",
+            "value": "STATE_VERTICAL",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXOrientation",
+            "description": "<code>AXHorizontalOrientation</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaOrientationVertical": {
+      "headingHtml": "<code>aria-orientation</code>=<code>vertical</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-orientation\"><code>aria-orientation</code></a>=<code>vertical</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "IA2_STATE_VERTICAL"
+          },
+          {
+            "type": "State",
+            "value": "IA2_STATE_HORIZONTAL",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Orientation",
+            "description": "<code>vertical</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_VERTICAL"
+          },
+          {
+            "type": "State",
+            "value": "STATE_HORIZONTAL",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXOrientation",
+            "description": "<code>AXVerticalOrientation</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaOrientationUndefined": {
+      "headingHtml": "<code>aria-orientation</code> is undefined",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-orientation\"><code>aria-orientation</code></a> is undefined",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_VERTICAL",
+            "description": "not exposed"
+          },
+          {
+            "type": "State",
+            "value": "STATE_HORIZONTAL",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXOrientation",
+            "description": "<code>AXUnknownOrientation</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaOwns": {
+      "headingHtml": "<code>aria-owns</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-owns\"><code>aria-owns</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Relation",
+            "value": "IA2_RELATION_NODE_PARENT_OF",
+            "description": "points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree"
+          },
+          {
+            "type": "Reverse Relation",
+            "value": "IA2_RELATION_NODE_CHILD_OF",
+            "description": "points to element"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_relations\">Mapping Additional Relations</a>"
+          }
+        ],
+        "note": "User agents MAY expose the elements that are referenced by this property as children of the current element. In which case, if multiple\n                    <a class=\"property-reference\" href=\"#aria-owns\"><code>aria-owns</code></a> relationships are found, use only the first one. If the accessibility tree is not modified, expose as:"
+      },
+      "uia": {
+        "items": [],
+        "note": "Expose the elements that are referenced by this property as children of the current element. If multiple\n                  <a class=\"property-reference\" href=\"#aria-owns\"><code>aria-owns</code></a> relationships are found, use only the first one."
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Relation",
+            "value": "RELATION_NODE_PARENT_OF",
+            "description": "points to accessible nodes matching IDREFs, if the referenced objects are in the accessibility tree"
+          },
+          {
+            "type": "Reverse Relation",
+            "value": "RELATION_NODE_CHILD_OF",
+            "description": "points to element"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_relations\">Mapping Additional Relations</a>"
+          }
+        ],
+        "note": "User agents MAY expose the elements that are referenced by this property as children of the current element. In which case, if multiple\n                    <a class=\"property-reference\" href=\"#aria-owns\"><code>aria-owns</code></a> relationships are found, use only the first one. If the accessibility tree is not modified, expose as:"
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXOwns",
+            "description": "pointers to accessible nodes matching IDREFs"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaPlaceholder": {
+      "headingHtml": "<code>aria-placeholder</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-placeholder\"><code>aria-placeholder</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "placeholder-text:<value>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "HelpText",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "placeholder-text:<value>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXPlaceholderValue",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaPosinset": {
+      "headingHtml": "<code>aria-posinset</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-posinset\"><code>aria-posinset</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "posinset:<value>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_position\">Group Position</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.posinset",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_position\">Group Position</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "posinset:<value>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_position\">Group Position</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXARIAPosInSet",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_position\">Group Position</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaPressedTrue": {
+      "headingHtml": "<code>aria-pressed</code>=<code>true</code>",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-pressed\"><code>aria-pressed</code></a>=<code>true</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_PRESSED"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#role-map-button-pressed\"><code>button</code> with defined value for <code>aria-pressed</code></a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Toggle.ToggleState",
+            "description": "<code>On (1)</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_PRESSED"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#role-map-button-pressed\"><code>button</code> with defined value for <code>aria-pressed</code></a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXValue",
+            "description": "<code>1</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#role-map-button-pressed\"><code>button</code> with defined value for <code>aria-pressed</code></a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaPressedMixed": {
+      "headingHtml": "<code>aria-pressed</code>=<code>mixed</code>",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-pressed\"><code>aria-pressed</code></a>=<code>mixed</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_MIXED"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#role-map-button-pressed\"><code>button</code> with defined value for <code>aria-pressed</code></a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Toggle.ToggleState",
+            "description": "<code>Indeterminate (2)</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_INDETERMINATE"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#role-map-button-pressed\"><code>button</code> with defined value for <code>aria-pressed</code></a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXValue",
+            "description": "<code>2</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#role-map-button-pressed\"><code>button</code> with defined value for <code>aria-pressed</code></a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaPressedFalse": {
+      "headingHtml": "<code>aria-pressed</code>=<code>false</code>",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-pressed\"><code>aria-pressed</code></a>=<code>false</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_PRESSED",
+            "description": "not exposed"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#role-map-button-pressed\"><code>button</code> with defined value for <code>aria-pressed</code></a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Toggle.ToggleState",
+            "description": "<code>Off (3)</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_PRESSED",
+            "description": "not exposed"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#role-map-button-pressed\"><code>button</code> with defined value for <code>aria-pressed</code></a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXValue",
+            "description": "<code>0</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#role-map-button-pressed\"><code>button</code> with defined value for <code>aria-pressed</code></a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaPressedUndefined": {
+      "headingHtml": "<code>aria-pressed</code> is undefined",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-pressed\"><code>aria-pressed</code></a> is undefined",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaReadonlyTrue": {
+      "headingHtml": "<code>aria-readonly</code>=<code>true</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-readonly\"><code>aria-readonly</code></a>=<code>true</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_READONLY"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Value.IsReadOnly",
+            "description": "<code>true</code>, if the element implements\n                    <a href=\"https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.ivalueprovider\"><code>IValueProvider</code></a>."
+          },
+          {
+            "type": "Property",
+            "value": "RangeValue.IsReadOnly",
+            "description": "<code>true</code>, if the element implements\n                    <a href=\"https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.irangevalueprovider\"><code>IRangeValueProvider</code></a>."
+          },
+          {
+            "type": "Property",
+            "value": "AriaProperties.readonly",
+            "description": "<code>true</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_READ_ONLY"
+          },
+          {
+            "type": "State",
+            "value": "STATE_EDITABLE",
+            "description": "not exposed on text input roles"
+          },
+          {
+            "type": "State",
+            "value": "STATE_CHECKABLE",
+            "description": "not exposed on roles supporting <a class=\"state-reference\" href=\"#aria-checked\"><code>aria-checked</code></a>"
+          },
+          {
+            "type": "State",
+            "value": "STATE_CHECKABLE",
+            "description": "not exposed on <a class=\"role-reference\" href=\"#radio\">radio</a> descendants when used on a <code>radiogroup</code>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Method",
+            "value": "AXUIElementIsAttributeSettable(AXValue)",
+            "description": "<code>NO</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaReadonlyFalse": {
+      "headingHtml": "<code>aria-readonly</code>=<code>false</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-readonly\"><code>aria-readonly</code></a>=<code>false</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_READONLY",
+            "description": "not exposed"
+          },
+          {
+            "type": "State",
+            "value": "IA2_STATE_EDITABLE"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Value.IsReadOnly",
+            "description": "<code>false</code>, if the element implements\n                    <a href=\"https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.ivalueprovider\"><code>IValueProvider</code></a>."
+          },
+          {
+            "type": "Property",
+            "value": "RangeValue.IsReadOnly",
+            "description": "<code>false</code>, if the element implements\n                    <a href=\"https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.provider.irangevalueprovider\"><code>IRangeValueProvider</code></a>."
+          },
+          {
+            "type": "Property",
+            "value": "AriaProperties.readonly",
+            "description": "<code>false</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_READ_ONLY",
+            "description": "not exposed"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Method",
+            "value": "AXUIElementIsAttributeSettable(AXValue)",
+            "description": "<code>YES</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaReadonlyUnspecifiedOnGridcell": {
+      "headingHtml": "<code>aria-readonly</code> is unspecified on <code>gridcell</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-readonly\"><code>aria-readonly</code></a> is unspecified on <code>gridcell</code>",
+      "msaaIA2": {
+        "items": [],
+        "note": "The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited\n                  value on the <code>gridcell</code> as described for <a href=\"#ariaReadonlyTrue\"><code>aria-readonly=\"true\"</code></a> and\n                  <a href=\"#ariaReadonlyFalse\"><code>aria-readonly=\"false\"</code></a>."
+      },
+      "uia": {
+        "items": [],
+        "note": "The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited\n                  value on the <code>gridcell</code> as described for <a href=\"#ariaReadonlyTrue\"><code>aria-readonly=\"true\"</code></a> and\n                  <a href=\"#ariaReadonlyFalse\"><code>aria-readonly=\"false\"</code></a>."
+      },
+      "atkAtSpi": {
+        "items": [],
+        "note": "The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited\n                  value on the <code>gridcell</code> as described for <a href=\"#ariaReadonlyTrue\"><code>aria-readonly=\"true\"</code></a> and\n                  <a href=\"#ariaReadonlyFalse\"><code>aria-readonly=\"false\"</code></a>."
+      },
+      "axApi": {
+        "items": [],
+        "note": "The <code>gridcell</code> MUST inherit any author-provided value for <code>aria-readonly</code> from the containing <code>grid</code> or <code>treegrid</code>. Expose the inherited\n                  value on the <code>gridcell</code> as described for <a href=\"#ariaReadonlyTrue\"><code>aria-readonly=\"true\"</code></a> and\n                  <a href=\"#ariaReadonlyFalse\"><code>aria-readonly=\"false\"</code></a>."
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaRelevant": {
+      "headingHtml": "<code>aria-relevant</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-relevant\"><code>aria-relevant</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "relevant:<value>"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-relevant:<value>"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-relevant:<value>",
+            "description": "on all descendants"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_visibility\">Changes to document content or node visibility</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.relevant",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_visibility\">Changes to document content or node visibility</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "relevant:<value>"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-relevant:<value>"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "container-relevant:<value>",
+            "description": "on all descendants"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_visibility\">Changes to document content or node visibility</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXARIARelevant",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_visibility\">Changes to document content or node visibility</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaRequiredTrue": {
+      "headingHtml": "<code>aria-required</code>=<code>true</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-required\"><code>aria-required</code></a>=<code>true</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "IA2_STATE_REQUIRED"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "IsRequiredForForm",
+            "description": "<code>true</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_REQUIRED"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXRequired",
+            "description": "<code>YES</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaRequiredFalse": {
+      "headingHtml": "<code>aria-required</code>=<code>false</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-required\"><code>aria-required</code></a>=<code>false</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaRoleDescription": {
+      "headingHtml": "<code>aria-roledescription</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-roledescription\"><code>aria-roledescription</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Method",
+            "value": "localizedExtendedRole()",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Localized Control Type",
+            "value": "<value>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "roledescription:<value>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXRoleDescription",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaRoleDescriptionEmptyString": {
+      "headingHtml": "<code>aria-roledescription</code> is undefined or the empty string",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-roledescription\"><code>aria-roledescription</code></a> is undefined or the empty string",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Localized Control Type",
+            "description": "Defined as that specified for the role of the element: based on the explicit role if the role attribute is provided; otherwise, based on the implicit\n                    role for the host language."
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "AXRoleDescription",
+            "description": "Defined as that specified for the role of the element: based on the explicit role if the role attribute is provided; otherwise, based on the implicit role for\n                    the host language."
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaRowCount": {
+      "headingHtml": "<code>aria-rowcount</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-rowcount\"><code>aria-rowcount</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "rowcount:<value>"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible2::groupPosition()",
+            "description": "<code>similarItemsInGroup=&lt;value&gt;</code> on rows"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Grid.RowCount",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "rowcount",
+            "description": "should contain the author-provided value."
+          },
+          {
+            "type": "Method",
+            "value": "atk_table_get_n_rows()",
+            "description": "should return the actual number of rows."
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXARIARowCount",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaRowIndex": {
+      "headingHtml": "<code>aria-rowindex</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-rowindex\"><code>aria-rowindex</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "rowindex:<value>"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible2::groupPosition()",
+            "description": "<code>positionInGroup=&lt;value&gt;</code> on rows"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "GridItem.Row",
+            "description": "<code>&lt;value&gt;</code> (zero-based)"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "rowindex",
+            "description": "should contain the author-provided value."
+          },
+          {
+            "type": "Method",
+            "value": "atk_table_cell_get_position()",
+            "description": "should return the actual (zero-based) row index."
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXARIARowIndex",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaRowIndexText": {
+      "headingHtml": "<code>aria-rowindextext</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-rowindextext\"><code>aria-rowindextext</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "rowindextext:<value>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.rowindextext",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "rowindextext:<value>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXRowIndexDescription",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaRowSpan": {
+      "headingHtml": "<code>aria-rowspan</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-rowspan\"><code>aria-rowspan</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "rowspan:<value>"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessibleTableCell::rowExtent()",
+            "description": "<code>column=&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "GridItem.RowSpan",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "rowspan",
+            "description": "should contain the author-provided value."
+          },
+          {
+            "type": "Method",
+            "value": "atk_table_cell_get_row_column_span()",
+            "description": "should return the actual row span."
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXRowIndexRange.length",
+            "description": "<code>&lt;value&gt;</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaSelectedTrue": {
+      "headingHtml": "<code>aria-selected</code>=<code>true</code>",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-selected\"><code>aria-selected</code></a>=<code>true</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_SELECTABLE"
+          },
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_SELECTED"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_selection\">Selection</a> for details on accessibility events"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "SelectionItem.IsSelected",
+            "description": "<code>true</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SELECTABLE"
+          },
+          {
+            "type": "State",
+            "value": "STATE_SELECTED"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_selection\">Selection</a> for details on accessibility events"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXSelected",
+            "description": "<code>YES</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaSelectedFalse": {
+      "headingHtml": "<code>aria-selected</code>=<code>false</code>",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-selected\"><code>aria-selected</code></a>=<code>false</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_SELECTABLE"
+          },
+          {
+            "type": "State",
+            "value": "STATE_SYSTEM_SELECTED",
+            "description": "not exposed"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_selection\">Selection</a> for details on accessibility events"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "SelectionItem.IsSelected",
+            "description": "<code>false</code>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "State",
+            "value": "STATE_SELECTABLE"
+          },
+          {
+            "type": "State",
+            "value": "STATE_SELECTED",
+            "description": "not exposed"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_events_selection\">Selection</a> for details on accessibility events"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXSelected",
+            "description": "<code>NO</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaSelectedUndefined": {
+      "headingHtml": "<code>aria-selected</code> is undefined",
+      "ariaSpec": "<a class=\"state-reference\" href=\"#aria-selected\"><code>aria-selected</code></a> is undefined",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaSetsize": {
+      "headingHtml": "<code>aria-setsize</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-setsize\"><code>aria-setsize</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "setsize:<value>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_position\">Group Position</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.setsize",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_position\">Group Position</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "setsize:<value>"
+          },
+          {
+            "type": "State",
+            "value": "STATE_INDETERMINATE",
+            "description": "if the author-provided value is <code>-1</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_position\">Group Position</a>"
+          }
+        ],
+        "note": "If the author-provided value of <code>aria-setsize</code> is <code>-1</code>, the exposed value should be based on the number of objects in the\n                    <abbr title=\"Document Object Model\">DOM</abbr>."
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXARIASetSize",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#mapping_additional_position\">Group Position</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaSortAscending": {
+      "headingHtml": "<code>aria-sort</code>=<code>ascending</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-sort\"><code>aria-sort</code></a>=<code>ascending</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "sort:ascending"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.sort",
+            "description": "<code>ascending</code>"
+          },
+          {
+            "type": "Property",
+            "value": "ItemStatus",
+            "description": "<code>ascending</code> if the element maps to\n                    <a href=\"https://msdn.microsoft.com/en-us/library/windows/apps/ee671630.aspx\"><code>HeaderItem</code></a> Control Type"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "sort:ascending"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXSortDirection",
+            "description": "<code>AXAscendingSortDirection</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaSortDescending": {
+      "headingHtml": "<code>aria-sort</code>=<code>descending</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-sort\"><code>aria-sort</code></a>=<code>descending</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "sort:descending"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.sort",
+            "description": "<code>descending</code>"
+          },
+          {
+            "type": "Property",
+            "value": "ItemStatus",
+            "description": "<code>descending</code> if the element maps to\n                    <a href=\"https://msdn.microsoft.com/en-us/library/windows/apps/ee671630.aspx\"><code>HeaderItem</code></a> Control Type"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "sort:descending"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXSortDirection",
+            "description": "<code>AXDescendingSortDirection</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaSortOther": {
+      "headingHtml": "<code>aria-sort</code>=<code>other</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-sort\"><code>aria-sort</code></a>=<code>other</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "sort:other"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AriaProperties.sort",
+            "description": "<code>other</code>"
+          },
+          {
+            "type": "Property",
+            "value": "ItemStatus",
+            "description": "<code>other</code> if the element maps to\n                    <a href=\"https://msdn.microsoft.com/en-us/library/windows/apps/ee671630.aspx\"><code>HeaderItem</code></a> Control Type"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "sort:other"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXSortDirection",
+            "description": "<code>AXUnknownSortDirection</code>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaSortNone": {
+      "headingHtml": "<code>aria-sort</code>=<code>none</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-sort\"><code>aria-sort</code></a>=<code>none</code>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "sort:none",
+            "description": "if the value is not unspecified"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "sort:none",
+            "description": "if the value is not unspecified"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "not-mapped",
+            "description": "<a href=\"#not_mapped\">Not mapped*</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaValueMax": {
+      "headingHtml": "<code>aria-valuemax</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-valuemax\"><code>aria-valuemax</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Method",
+            "value": "IAccessibleValue::maximumValue()",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#document-handling_author-errors_states-properties\" class=\"specref\">Handling Author Errors for States and Properties</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "RangeValue.Maximum",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#document-handling_author-errors_states-properties\" class=\"specref\">Handling Author Errors for States and Properties</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Method",
+            "value": "atk_value_get_maximum_value()",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#document-handling_author-errors_states-properties\" class=\"specref\">Handling Author Errors for States and Properties</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXMaxValue",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#document-handling_author-errors_states-properties\" class=\"specref\">Handling Author Errors for States and Properties</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaValueMin": {
+      "headingHtml": "<code>aria-valuemin</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-valuemin\"><code>aria-valuemin</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Method",
+            "value": "IAccessibleValue::minimumValue()",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#document-handling_author-errors_states-properties\" class=\"specref\">Handling Author Errors for States and Properties</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "RangeValue.Minimum",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#document-handling_author-errors_states-properties\" class=\"specref\">Handling Author Errors for States and Properties</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Method",
+            "value": "atk_value_get_minimum_value()",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#document-handling_author-errors_states-properties\" class=\"specref\">Handling Author Errors for States and Properties</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXMinValue",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#document-handling_author-errors_states-properties\" class=\"specref\">Handling Author Errors for States and Properties</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaValueNow": {
+      "headingHtml": "<code>aria-valuenow</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-valuenow\"><code>aria-valuenow</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Method",
+            "value": "IAccessibleValue::currentValue()",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "Method",
+            "value": "IAccessible::get_accValue()",
+            "description": "<code>&lt;value&gt;</code> if <code>aria-valuetext</code> is not defined"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#document-handling_author-errors_states-properties\" class=\"specref\">Handling Author Errors for States and Properties</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "RangeValue.Value",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#document-handling_author-errors_states-properties\" class=\"specref\">Handling Author Errors for States and Properties</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Method",
+            "value": "atk_value_get_current_value()",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#document-handling_author-errors_states-properties\" class=\"specref\">Handling Author Errors for States and Properties</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXValue",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#document-handling_author-errors_states-properties\" class=\"specref\">Handling Author Errors for States and Properties</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    },
+    "ariaValueText": {
+      "headingHtml": "<code>aria-valuetext</code>",
+      "ariaSpec": "<a class=\"property-reference\" href=\"#aria-valuetext\"><code>aria-valuetext</code></a>",
+      "msaaIA2": {
+        "items": [
+          {
+            "type": "Method",
+            "value": "IAccessible::get_accValue()",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "Object Attribute",
+            "value": "valuetext:<value>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#document-handling_author-errors_states-properties\" class=\"specref\">Handling Author Errors for States and Properties</a>"
+          }
+        ]
+      },
+      "uia": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "Value.Value",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#document-handling_author-errors_states-properties\" class=\"specref\">Handling Author Errors for States and Properties</a>"
+          }
+        ]
+      },
+      "atkAtSpi": {
+        "items": [
+          {
+            "type": "Object Attribute",
+            "value": "valuetext:<value>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#document-handling_author-errors_states-properties\" class=\"specref\">Handling Author Errors for States and Properties</a>"
+          }
+        ]
+      },
+      "axApi": {
+        "items": [
+          {
+            "type": "Property",
+            "value": "AXValueDescription",
+            "description": "<code>&lt;value&gt;</code>"
+          },
+          {
+            "type": "seealso",
+            "description": "See also: <a href=\"#document-handling_author-errors_states-properties\" class=\"specref\">Handling Author Errors for States and Properties</a>"
+          }
+        ]
+      },
+      "android": {
+        "items": [],
+        "note": "TBD"
+      }
+    }
+  }
+}

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -1,0 +1,313 @@
+{
+  "name": "extract-aam-data",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "extract-aam-data",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "cheerio": "^1.2.0"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "extract-aam-data",
+  "private": true,
+  "type": "module",
+  "main": "extract-mappings.js",
+  "scripts": {
+    "extract": "node extract-mappings.js",
+    "generate": "node generate-mappings.js"
+  },
+  "dependencies": {
+    "cheerio": "^1.2.0"
+  }
+}


### PR DESCRIPTION
🚀 **Netlify Preview**:
🔄 **this PR updates the following sspecs**:
- [core-aam preview](https://deploy-preview-2744--wai-aria.netlify.app/core-aam/index.html) &mdash; [core-aam diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fcore-aam%2F&doc2=https%3A%2F%2Fdeploy-preview-2744--wai-aria.netlify.app%2Fcore-aam%2Findex.html)

Closes: https://github.com/w3c/core-aam/issues/258

Extracting the data wasn't too hard -- especially with the help of generative AI to write the extraction and generation scripts. I added the extraction script but in the long run I don't think anything like that would be checked in.

Some questions are:
* Is editing a JSON like this better than editing tables?
* Can we actually use this JSON to write tests?

About test writing:
* We would need to add more metadata in order to to this. For example, the "test" html, like `<div id="test" role="blockquote"></div>`. Sometimes we will want to test variations in the markup as well. 
* Also, not everything will be so easy to programmatically write tests from the prose alone, so we would have to mark/know which things could auto generate tests and which can't?