### PR TITLE
editorial: fix buildRoleInfo.js

### DIFF
--- a/common/script/buildRoleInfo.js
+++ b/common/script/buildRoleInfo.js
@@ -9,10 +9,8 @@ document.URL = "";
 
 const script = fs.readFileSync("./common/script/aria.js").toString();
 
-const scriptWithoutRespecUI = script.substring(0, script.indexOf("require(")); // TODO: HACK remove everything past "require(" (NOTE: if we went only with this SSG approach, we could remove that end of aria.js and this hack)
-
 // HACK call ariaAttributeReferences() and log out roleInfo with prefix
 const scriptAddition = 'ariaAttributeReferences();console.log("/* This file is generated - do not modify */ var roleInfo = "+JSON.stringify(roleInfo, null, 2));';
 
 // HACK: eval!
-eval(scriptWithoutRespecUI + scriptAddition);
+eval(script + scriptAddition);


### PR DESCRIPTION
Removes hack 1 of 3 (which is no longer needed after #2745)

Fixes a regression from #2745
