### PR TITLE
editorial: [aria.js]  populate global states&props lists in pre-processing

### DIFF
--- a/common/script/aria.js
+++ b/common/script/aria.js
@@ -43,32 +43,6 @@ const buildPropList = function (propList, item) {
 };
 
 /**
- * Populates globalSP for given sdef/pdef
- * @param {Object} propList -
- * @param {Object} globalSP -
- * @param {HTMLElement} item - from nodeList.forEach
- */
-const buildGlobalStatesAndPropertiesList = function (propList, globalSP, item) {
-  const title = item.getAttribute("title") || item.innerHTML;
-  const container = item.parentElement;
-  const itemEntry = propList[title];
-
-  const applicabilityText = container.querySelector("." + itemEntry.is + "-applicability").innerText;
-  const isDefault = applicabilityText === "All elements of the base markup";
-  const isProhibited = applicabilityText === "All elements of the base markup except for some roles or elements that prohibit its use";
-  const isDeprecated = applicabilityText === "Use as a global deprecated in ARIA 1.2";
-  // NOTE: the only other value for applicabilityText appears to be "Placeholder"
-  if (isDefault || isProhibited || isDeprecated) {
-    globalSP.push(
-      Object.assign(itemEntry, {
-        prohibited: isProhibited,
-        deprecated: isDeprecated,
-      }),
-    );
-  }
-};
-
-/**
  *
  * @param {HTMLElement} node - rdef/sdef/pdef element
  */
@@ -97,34 +71,6 @@ const renderIndexStatesAndProperties = (propList) => {
     .map((item) => `<dt><a href="#${item.title}" class="${item.is}-reference">${item.name}</a></dt>\n<dd>${item.desc}</dd>\n`)
     .join("");
   indexStatePropPlaceholder.outerHTML = `<dl id="index_state_prop">${indexStatePropContent}</dl>`;
-};
-
-/**
- * Generate index of global states and properties
- * @param {Object} globalSP
- */
-const renderIndexGlobalStatesAndProperties = (globalSP) => {
-  const globalStatesPropertiesContent = globalSP
-    .map((item) => {
-      // TODO: This is the only use of globalSP - why does it not just consist of the markup we create here in this loop?
-      const isState = item.is === "state";
-      const tagName = isState ? "sref" : "pref";
-      return `<li><${tagName} ${item.prohibited ? "data-prohibited " : ""}${item.deprecated ? "data-deprecated " : ""}${
-        isState ? `title="${item.name}"` : ""
-      }>${item.name}${isState ? " (state)" : ""}</${tagName}>${
-        // TODO: consider moving "(state)" out of sref/pref tag; then maybe remove title attr for sref (after checking resolveReferences interference)
-        // TODO: cf. buildStatesProperties() and buildRoleInfoPropList() which have extra logic for title set here)
-
-        item.prohibited ? " (Except where prohibited)" : ""
-      }${item.deprecated ? " (Global use deprecated in ARIA 1.2)" : ""}</li>\n`;
-    })
-    .join("");
-  const globalStatesPropertiesPlaceholder = document.querySelector("#global_states .placeholder");
-  globalStatesPropertiesPlaceholder.outerHTML = `<ul>${globalStatesPropertiesContent}</ul>`;
-
-  // Populate role=roletype properties with global properties
-  const roletypePropsPlaceholder = document.querySelector("#roletype td.role-properties span.placeholder");
-  roletypePropsPlaceholder.outerHTML = `<ul>${globalStatesPropertiesContent}</ul>`;
 };
 
 /**
@@ -470,7 +416,6 @@ const renderRoleChildren = ([role, subroleSet]) => {
  */
 function ariaAttributeReferences() {
   const propList = {};
-  const globalSP = [];
 
   let skipIndex = 0;
   const myURL = document.URL;
@@ -483,15 +428,11 @@ function ariaAttributeReferences() {
   const pdefsAndsdefs = document.querySelectorAll("pdef, sdef");
 
   pdefsAndsdefs.forEach(buildPropList.bind(null, propList));
-  pdefsAndsdefs.forEach(buildGlobalStatesAndPropertiesList.bind(null, propList, globalSP));
   pdefsAndsdefs.forEach(rewriteDef);
 
   if (!skipIndex) {
     // Generate index of states and properties
     renderIndexStatesAndProperties(propList);
-
-    // Generate index of global states and properties
-    renderIndexGlobalStatesAndProperties(globalSP);
   }
 
   // what about roles?

--- a/common/script/ariaPreprocessing.js
+++ b/common/script/ariaPreprocessing.js
@@ -1,3 +1,33 @@
+/**
+ * Generates list items in lists that include the global states and properties
+ * @param {HTMLElement} globalStatesPlaceholder - placeholder in #global_states
+ * @param {HTMLElement} roletypePropsPlaceholder - placeholder in #roletype
+ * @param {HTMLElement} def - sdef or pdef element NOTE: from forEach loop
+ * @returns 
+ */
+const buildGlobalStatesAndPropertiesLists = (globalStatesPlaceholder, roletypePropsPlaceholder, def) => {
+  const container = def.parentElement;
+  const applicabilityText = container.querySelector(".state-applicability, .property-applicability").innerText;
+  const isDefault = applicabilityText === "All elements of the base markup";
+  const isProhibited = applicabilityText === "All elements of the base markup except for some roles or elements that prohibit its use";
+  const isDeprecated = applicabilityText === "Use as a global deprecated in ARIA 1.2";
+  // NOTE: the only other value for applicabilityText appears to be "Placeholder"
+  if (!(isDefault || isProhibited || isDeprecated)) return;
+  const isState = def.tagName === "SDEF";
+  const refTagName = isState ? "sref" : "pref";
+  const htmlString = `<li><${refTagName} ${isProhibited ? "data-prohibited " : ""}${isDeprecated ? "data-deprecated " : ""}${isState ? `title="${def.innerHTML}"` : ""
+    }>${def.innerHTML}${isState ? " (state)" : ""}</${refTagName}>${
+    // TODO: consider moving "(state)" out of sref/pref tag; then maybe remove title attr for sref (after checking resolveReferences interference)
+    isProhibited ? " (Except where prohibited)" : ""
+    }${isDeprecated ? " (Global use deprecated in ARIA 1.2)" : ""}</li>\n`;
+  globalStatesPlaceholder.insertAdjacentHTML('beforeend', htmlString);
+  roletypePropsPlaceholder.insertAdjacentHTML('beforeend', htmlString);
+}
+
+/**
+ * Rewrites rdef/sdef/pdef elements to valid HTML markup
+ * @param {HTMLElement} def - rdef, sdef, or pdef element NOTE: from forEach loop
+ */
 const rewriteDefContainer = (def) => {
   // dummy h4
   // TODO: move *def elements into this h4
@@ -15,4 +45,14 @@ const rewriteDefContainer = (def) => {
   sec.innerHTML = theContents;
   container.parentNode.replaceChild(sec, container);
 };
-var ariaPreprocessing = () => document.querySelectorAll("rdef, sdef, pdef").forEach(rewriteDefContainer);
+
+var ariaPreprocessing = () => {
+  // run buildGlobalStatesAndPropertiesLists()
+  const globalStatesPlaceholder = document.querySelector('#global_states ul[data-aria-preprocess="placeholder"]');
+  const roletypePropsPlaceholder = document.querySelector('#roletype ul[data-aria-preprocess="placeholder"]');
+  document.querySelectorAll("pdef, sdef").forEach(buildGlobalStatesAndPropertiesLists.bind(null, globalStatesPlaceholder, roletypePropsPlaceholder));
+  globalStatesPlaceholder.removeAttribute('data-aria-preprocess');
+  roletypePropsPlaceholder.removeAttribute('data-aria-preprocess');
+  // run rewriteDefContainer()
+  document.querySelectorAll("rdef, sdef, pdef").forEach(rewriteDefContainer);
+}

--- a/common/script/buildRoleInfo.js
+++ b/common/script/buildRoleInfo.js
@@ -8,9 +8,10 @@ let updateReferences = () => {};
 document.URL = "";
 
 const script = fs.readFileSync("./common/script/aria.js").toString();
+const prescript = fs.readFileSync("./common/script/ariaPreprocessing.js").toString();
 
-// HACK call ariaAttributeReferences() and log out roleInfo with prefix
-const scriptAddition = 'ariaAttributeReferences();console.log("/* This file is generated - do not modify */ var roleInfo = "+JSON.stringify(roleInfo, null, 2));';
+// HACK call ariaPreprocessing(), ariaAttributeReferences(), and log out roleInfo with prefix
+const scriptAddition = 'ariaPreprocessing();ariaAttributeReferences();console.log("/* This file is generated - do not modify */ var roleInfo = "+JSON.stringify(roleInfo, null, 2));';
 
 // HACK: eval!
-eval(script + scriptAddition);
+eval(prescript + script + scriptAddition);

--- a/index.html
+++ b/index.html
@@ -8116,7 +8116,7 @@
               </tr>
               <tr>
                 <th class="role-properties-head" scope="row">Supported States and Properties:</th>
-                <td class="role-properties"><span class="placeholder">Placeholder for global states and properties</span></td>
+                <td class="role-properties"><ul data-aria-preprocess="placeholder"></ul></td>
               </tr>
               <tr>
                 <th class="role-inherited-head" scope="row">Inherited States and Properties:</th>
@@ -12063,7 +12063,7 @@ button.ariaPressed; // null</pre
           supported by all roles and by all base markup elements unless otherwise prohibited. If a role prohibits use of any global states or properties, those states or properties are listed as
           prohibited in the characteristics table included in the section that defines the role.
         </p>
-        <p class="placeholder">Placeholder for global states and properties</p>
+        <ul data-aria-preprocess="placeholder"></ul>
       </section>
       <section id="state_prop_taxonomy">
         <h2>Taxonomy of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> States and Properties</h2>


### PR DESCRIPTION
🚀 **Netlify Preview**:
🔄 **this PR updates the following sspecs**:
- [ARIA preview](https://deploy-preview-2766--wai-aria.netlify.app/index.html) &mdash; [ARIA diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Faria%2F&doc2=https%3A%2F%2Fdeploy-preview-2766--wai-aria.netlify.app%2Findex.html)

- index.html
  - roletype role characteristics table
    - replace placeholder span with empty ul with data attribute
  - Global States and Properties section
    - replace placeholder p with empty ul with data attribute
- common/script/aria.js
  - remove buildGlobalStatesAndPropertiesList()
  - remove renderIndexGlobalStatesAndProperties()
  - ariaAttributeReferences()
    - remove calls to both of the above
- common/script/ariaPreprocessing.js
  - add buildGlobalStatesAndPropertiesLists()
    - a merger of the two functions from aria.js
    - uses HTML markup directly/only to generate list items
  - ariaPreprocessing()
    - call buildGlobalStatesAndPropertiesLists() with relevant placeholders
    - clean up placeholder markup

Part of #2501