### PR TITLE
[html-aam] Add focusgroup attribute mapping

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -11103,6 +11103,119 @@
             </tr>
           </tbody>
         </table>
+        <h4 id="att-focusgroup">`focusgroup`</h4>
+        <table class="data" aria-labelledby="att-focusgroup">
+          <tbody>
+            <tr>
+              <th>HTML Specification</th>
+              <td>`focusgroup`</td>
+            </tr>
+            <tr>
+              <th>Element(s)</th>
+              <td>
+                <a data-cite="html/interaction.html#attr-focusgroup">HTML elements</a>
+              </td>
+            </tr>
+            <tr>
+              <th>[[WAI-ARIA-1.2]]</th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
+              </th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
+            </tr>
+            <tr>
+              <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
+            </tr>
+            <tr>
+              <th><span class="informative">[[ATK]]</span></th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
+            </tr>
+            <tr>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
+            </tr>
+            <tr>
+              <th id="att-focusgroup-comments">Comments</th>
+              <td>
+                <p>
+                  The `focusgroup` attribute enables <a data-cite="html/interaction.html#directional-navigation">directional navigation</a> among its focusable descendants and has no direct
+                  accessibility API mapping of its own. However, per <a data-cite="html/interaction.html#focusgroup-aria-role-inference">[HTML] §ARIA Role Inference</a>, when a behavior token is
+                  specified the user agent infers an ARIA role for the <a data-cite="html/interaction.html#focus-group-owner">focus group owner</a>, and for `button` elements or elements that would
+                  otherwise have a <a class="core-mapping" href="#role-map-generic">`generic`</a> role (such as `div` or `span`) participating in the focus group as
+                  <a data-cite="html/interaction.html#focus-group-item">focus group items</a>, as summarized below. Owner role inference applies only when the element would otherwise have an implicit
+                  role of <a class="core-mapping" href="#role-map-generic">`generic`</a>, has no explicit <a data-cite="wai-aria-1.2/#host_general_role">`role`</a> attribute, and has no non-generic
+                  native semantics (such as `nav`, `ul`, or `table`). Item role inference applies to `button` elements without an explicit `role`, and to elements that would otherwise have a
+                  <a class="core-mapping" href="#role-map-generic">`generic`</a> role participating as focus group items; other native interactive elements (links, form controls, etc.) retain their
+                  native semantics.
+                </p>
+                <table class="simple">
+                  <thead>
+                    <tr>
+                      <th>`focusgroup` behavior token</th>
+                      <th>Inferred owner role</th>
+                      <th>Inferred item role (on `button` elements or elements that would otherwise be generic, participating as focus group items)</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>`toolbar`</td>
+                      <td><a class="core-mapping" href="#role-map-toolbar">`toolbar`</a></td>
+                      <td>(none — items keep their native role)</td>
+                    </tr>
+                    <tr>
+                      <td>`tablist`</td>
+                      <td><a class="core-mapping" href="#role-map-tablist">`tablist`</a></td>
+                      <td><a class="core-mapping" href="#role-map-tab">`tab`</a></td>
+                    </tr>
+                    <tr>
+                      <td>`radiogroup`</td>
+                      <td><a class="core-mapping" href="#role-map-radiogroup">`radiogroup`</a></td>
+                      <td><a class="core-mapping" href="#role-map-radio">`radio`</a></td>
+                    </tr>
+                    <tr>
+                      <td>`listbox`</td>
+                      <td><a class="core-mapping" href="#role-map-listbox">`listbox`</a></td>
+                      <td><a class="core-mapping" href="#role-map-option">`option`</a></td>
+                    </tr>
+                    <tr>
+                      <td>`menu`</td>
+                      <td><a class="core-mapping" href="#role-map-menu">`menu`</a></td>
+                      <td><a class="core-mapping" href="#role-map-menuitem">`menuitem`</a></td>
+                    </tr>
+                    <tr>
+                      <td>`menubar`</td>
+                      <td><a class="core-mapping" href="#role-map-menubar">`menubar`</a></td>
+                      <td><a class="core-mapping" href="#role-map-menuitem">`menuitem`</a></td>
+                    </tr>
+                  </tbody>
+                </table>
+                <p class="note">
+                  Role inference never overrides an explicit author-defined `role` attribute or non-generic native-element semantics, and does not infer variant roles such as
+                  <a class="core-mapping" href="#role-map-menuitemcheckbox">`menuitemcheckbox`</a> or <a class="core-mapping" href="#role-map-menuitemradio">`menuitemradio`</a>.
+                </p>
+                <p class="note">
+                  The `inline` and `block` axis modifiers do not cause user agents to infer or expose
+                  <a data-cite="wai-aria-1.2/#aria-orientation">`aria-orientation`</a>; they only restrict the axis along which
+                  <a data-cite="html/interaction.html#directional-navigation">directional navigation</a> may move focus.
+                </p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
         <h4 id="att-headers">`headers`</h4>
         <table class="data" aria-labelledby="att-headers">
           <tbody>


### PR DESCRIPTION
Companion to whatwg/html#11723.

Closes #2602

Adds an `att-focusgroup` entry to html-aam documenting the mapping for the `focusgroup` content attribute being specified in [whatwg/html#11723](https://github.com/whatwg/html/pull/11723). The attribute itself has no direct accessibility API mapping, so all six platform rows are `Not mapped`. The Comments cell explains the details.

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [ ] "author MUST" tests:
* [x] "user agent MUST" tests: https://wpt.live/html/interaction/focus/focusgroup/tentative/
* [ ] Browser implementations (link to issue or commit):
   * WebKit: No Implementation, [Standards Position](https://github.com/WebKit/standards-positions/issues/171)
   * Gecko: No Implementation, [Standards Position](https://github.com/mozilla/standards-positions/issues/1348)
   * Blink: https://issues.chromium.org/issues/40210717
* [ ] ACT review?
* [ ] Does this need AT implementations? No, the feature is designed to match existing patterns on the web today, moving authors away from a javascript-based implementation towards a user-agent provided one.
* [ ] Related APG Issue/PR:
* [ ] MDN Issue/PR:
