### PR TITLE
Editorial: Fix typo in variable name 'chlidren' to 'children'

### DIFF
--- a/common/script/ariaChild.js
+++ b/common/script/ariaChild.js
@@ -440,7 +440,7 @@ function ariaAttributeReferences() {
                                 );
                             })
                             .forEach(function (subrole) {
-                                myList.push(chlidren);
+                                myList.push(children);
                             });
                     });
 


### PR DESCRIPTION
🚀 **Netlify Preview**:
🔄 **this PR updates the following sspecs**:
- [ARIA preview](https://deploy-preview-2779--wai-aria.netlify.app/index.html) &mdash; [ARIA diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Faria%2F&doc2=https%3A%2F%2Fdeploy-preview-2779--wai-aria.netlify.app%2Findex.html)

If merged, this PR fixes a typo in a variable name. It does not change any spec.