### PR TITLE
editorial: [aria.js] switch high-traffic innerText usage to textContent

### DIFF
--- a/common/script/aria.js
+++ b/common/script/aria.js
@@ -50,7 +50,7 @@ const rewriteDef = function (node) {
   let type = "";
   if (node.tagName === "RDEF") type = "role";
   const abstract = node.parentNode.querySelector(".role-abstract");
-  if (abstract?.innerText === "True") {
+  if (abstract?.textContent === "True") {
     //NOTE: optional chaining because synonym roles and sdef/pdef won't have .role-abstract anywhere
     type = "abstract role";
   }
@@ -287,8 +287,8 @@ const pruneUnusedRows = () => {
       ".role-abstract, .role-parent, .role-base, .role-related, .role-scope, .role-mustcontain, .role-required-properties, .role-properties, .role-namefrom, .role-namerequired, .role-namerequired-inherited, .role-childpresentational, .role-presentational-inherited, .state-related, .property-related,.role-inherited, .role-children, .property-descendants, .state-descendants, .implicit-values",
     )
     .forEach(function (item) {
-      var content = item.innerText;
-      if (content.length === 1 || content.length === 0) {
+      const content = item.textContent.trim();
+      if (!content) {
         // there is no item - remove the row
         item.parentNode.parentNode.removeChild(item.parentNode);
       } else if (

--- a/common/script/resolveReferences.js
+++ b/common/script/resolveReferences.js
@@ -255,7 +255,7 @@ function updateReferences(base) {
         .call(base.querySelectorAll("pref, sref, rref"))
         .forEach(function (item) {
             // what are we referencing?
-            var content = item.innerText;
+            var content = item.textContent;
             var usedTitle = false;
             var ref = item.getAttribute("title");
             if (!ref) {


### PR DESCRIPTION
🚀 **Netlify Preview**:
🔄 **this PR updates the following sspecs**:
- [ARIA preview](https://deploy-preview-2792--wai-aria.netlify.app/index.html) &mdash; [ARIA diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Faria%2F&doc2=https%3A%2F%2Fdeploy-preview-2792--wai-aria.netlify.app%2Findex.html)

This resolves performance regressions observed when running the ARIA ED in Chromium, which caused it to take several minutes to render, thus timing out in CI.

In local testing, I had observed the following in Vivaldi (Chromium-based):

- `rdefs.forEach(rewriteDef)` took 5 seconds
- `pruneUnusedRows` took 70 seconds (over a minute)
- `updateReferences` took 370 seconds (over 6 minutes)

This was caused by a CSS change in ReSpec 37.0.0 introduced in https://github.com/speced/respec/pull/5204, which apparently had a significant impact on the cost of reading `innerText` in Chromium. This impact is greatly compounded when it is read hundreds of times.

In 2 out of 3 affected cases, `innerText` can be directly replaced with `textContent`. In the other case, additional trimming of whitespace is necessary to achieve identical results.

`textContent` is more performant than `innerText`, because the latter takes how the text is visually displayed into account.

I verified that the aria, dpub-aria, and graphics-aria EDs all export identical HTML before and after this change. (I checked the latter two in addition because they also invoke `updateReferences`.) I also verified that individual results of each `innerText` vs. `textContent` access were identical as I was developing each fix.