### PR TITLE
editorial: remove extra closing tags

### DIFF
--- a/graphics-aria/img/figure-graphics-doc.html
+++ b/graphics-aria/img/figure-graphics-doc.html
@@ -138,7 +138,6 @@
                     as do the arrows that emphasize the pattern.
                 </desc>
                 <rect y="50%" width="100%" height="50%" fill="url(#reflect)" />
-                </rect>
                 <use y="70%" xlink:href="#gradient-vector" >
                     <title>1st cycle</title>
                     <desc>left-to-right arrow, starting from x="0"</desc>

--- a/validator-tests/errormessage-hidden-removed.html
+++ b/validator-tests/errormessage-hidden-removed.html
@@ -9,27 +9,27 @@ RULE: " Authors MUST use aria-invalid in conjunction with aria-errormessage and 
 
 <!-- inputs with aria-errormessage that should fail -->
 
-<input type="text" id="error-message-hidden-1" aria-invalid="true" aria-errormessage="id-message-1" class="fail"></div>
+<input type="text" id="error-message-hidden-1" aria-invalid="true" aria-errormessage="id-message-1" class="fail">
 <div id="id-message-1" hidden>Error message 1</div>
 
-<input type="text" id="error-message-hidden-2" aria-invalid="true" aria-errormessage="id-message-2" class="fail"></div>
+<input type="text" id="error-message-hidden-2" aria-invalid="true" aria-errormessage="id-message-2" class="fail">
 <div id="id-message-2" style="display: none">Error message 2</div>
 
-<input type="text" id="error-message-hidden-3" aria-invalid="true" aria-errormessage="id-message-3" class="fail"></div>
+<input type="text" id="error-message-hidden-3" aria-invalid="true" aria-errormessage="id-message-3" class="fail">
 <div id="id-message-3" style="visibility: hidden">Error message 3</div>
 
 <!-- inputs with aria-errormessage that should pass -->
 
-<input type="text" id="aria-invalid-value-false-1" aria-invalid="false" aria-errormessage="id-message-4" class="pass"></div>
+<input type="text" id="aria-invalid-value-false-1" aria-invalid="false" aria-errormessage="id-message-4" class="pass">
 <div id="id-message-4" hidden>Error message 4</div>
 
-<input type="text" id="aria-invalid-value-false-2" aria-invalid="false" aria-errormessage="id-message-5" class="pass"></div>
+<input type="text" id="aria-invalid-value-false-2" aria-invalid="false" aria-errormessage="id-message-5" class="pass">
 <div id="id-message-5" style="display: none">Error message 5</div>
 
-<input type="text" id="aria-invalid-value-false-3" aria-invalid="false" aria-errormessage="id-message-6" class="pass"></div>
+<input type="text" id="aria-invalid-value-false-3" aria-invalid="false" aria-errormessage="id-message-6" class="pass">
 <div id="id-message-6"  style="visibility: hidden">Error message 6</div>
 
-<input type="text" id="aria-invalid-visible-1" aria-invalid="true" aria-errormessage="id-message-7" class="pass"></div>
+<input type="text" id="aria-invalid-visible-1" aria-invalid="true" aria-errormessage="id-message-7" class="pass">
 <div id="id-message-7">Error message 7</div>
 
 </body>


### PR DESCRIPTION
Just ran `npx prettier -c .` and fixed a few of the  issues that their parse choked on.