### PR TITLE
CORE-AAM: Map aria-details AX API to AXDetailsElements

### DIFF
--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -7585,7 +7585,7 @@
               <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                  <span class="property not-mapped"><a href="#not_mapped">Not mapped*</a></span>
+                  <span class="property">Property: <code>AXDetailsElements</code>: pointers to accessible nodes matching IDREFs</span>
                 </td>
               </tr>
               <tr>


### PR DESCRIPTION
🚀 **Netlify Preview**:
🔄 **this PR updates the following sspecs**:
- [core-aam preview](https://deploy-preview-2803--wai-aria.netlify.app/core-aam/index.html) &mdash; [core-aam diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fcore-aam%2F&doc2=https%3A%2F%2Fdeploy-preview-2803--wai-aria.netlify.app%2Fcore-aam%2Findex.html)

Map `aria-details` AX API to AXDetailsElements, which is already implemented in some UAs/ATs.

* [ ] Browser implementations:
   * [x] WebKit: existing implementation 
   * [ ] Gecko: [2043758](https://bugzilla.mozilla.org/show_bug.cgi?id=2043758)
   * [x] Blink: [517967199](https://issues.chromium.org/issues/517967199)
* [x] Does this need AT implementations? 
   * AXDetailsElements is exposed to users similarly to Custom Actions (labeled "Details") in Mac VO, but this may need adjustments in VO or other AT. (Note: rdar://178273498&178273484)