### PR TITLE
html-aam: map new menu html elements to aria roles

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -5152,6 +5152,222 @@
             </tr>
           </tbody>
         </table>
+        <h4 id="el-menubar">`menubar`</h4>
+        <table class="data" aria-labelledby="el-menubar">
+          <tbody>
+            <tr>
+              <th>HTML Specification</th>
+              <td>
+                <!-- <a data-cite="html">`menubar`</a> -->
+                <a href="https://whatpr.org/html/12011/interactive-elements.html#the-menubar-element">`menubar`</a>
+              </td>
+            </tr>
+            <tr>
+              <th>[[wai-aria-1.2]]</th>
+              <td><a class="core-mapping" href="#role-map-menubar">`menubar`</a> role</td>
+            </tr>
+            <tr>
+              <th><a data-cite="core-aam-1.2/#roleMappingComputedRole">Computed Role</a></th>
+              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th>
+                <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
+              </th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th><span class="informative">[[ATK]]</span></th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th>Comments</th>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+        <h4 id="el-menuitem">`menuitem`</h4>
+        <table class="data" aria-labelledby="el-menuitem">
+          <tbody>
+            <tr>
+              <th>HTML Specification</th>
+              <td>
+                <!-- <a data-cite="html">`menuitem`</a> -->
+                <a href="https://whatpr.org/html/12011/interactive-elements.html#the-menuitem-element">`menuitem`</a>
+              </td>
+            </tr>
+            <tr>
+              <th>[[wai-aria-1.2]]</th>
+              <td><a class="core-mapping" href="#role-map-menuitem">`menuitem`</a> role</td>
+            </tr>
+            <tr>
+              <th><a data-cite="core-aam-1.2/#roleMappingComputedRole">Computed Role</a></th>
+              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th>
+                <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
+              </th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th><span class="informative">[[ATK]]</span></th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th>Comments</th>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+        <h4 id="el-menuitem-checkbox">`menuitem` <span class="el-context">(descendant of `fieldset` with `checkable="multiple"`)</span></h4>
+        <table class="data" aria-labelledby="el-menuitem-checkbox">
+          <tbody>
+            <tr>
+              <th>HTML Specification</th>
+              <td>
+                <!-- <a data-cite="html">`menuitem`</a> -->
+                <a href="https://whatpr.org/html/12011/interactive-elements.html#the-menuitem-element">`menuitem`</a>
+                <span class="el-context">(descendant of <a data-cite="html/form-elements.html#the-fieldset-element">`fieldset`</a> with <a data-cite="html/form-elements.html#attr-fieldset-checkable">`checkable`</a> attribute in the `multiple` state)</span>
+              </td>
+            </tr>
+            <tr>
+              <th>[[wai-aria-1.2]]</th>
+              <td>
+                <a class="core-mapping" href="#role-map-menuitemcheckbox">`menuitemcheckbox`</a> role, with the <a class="core-mapping" href="#ariaCheckedMixed">`aria-checked`</a> state set to "true" if the element's <a data-cite="html/form-control-infrastructure.html#concept-fe-checked">checkedness</a> is true, or "false" otherwise
+              </td>
+            </tr>
+            <tr>
+              <th><a data-cite="core-aam-1.2/#roleMappingComputedRole">Computed Role</a></th>
+              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th>
+                <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
+              </th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th><span class="informative">[[ATK]]</span></th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th>Comments</th>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+        <h4 id="el-menuitem-radio">`menuitem` <span class="el-context">(descendant of `fieldset` with `checkable="single"`)</span></h4>
+        <table class="data" aria-labelledby="el-menuitem-radio">
+          <tbody>
+            <tr>
+              <th>HTML Specification</th>
+              <td>
+                <!-- <a data-cite="html">`menuitem`</a> -->
+                <a href="https://whatpr.org/html/12011/interactive-elements.html#the-menuitem-element">`menuitem`</a>
+                <span class="el-context">(descendant of <a data-cite="html/form-elements.html#the-fieldset-element">`fieldset`</a> with <a data-cite="html/form-elements.html#attr-fieldset-checkable">`checkable`</a> attribute in the `single` state)</span>
+              </td>
+            </tr>
+            <tr>
+              <th>[[wai-aria-1.2]]</th>
+              <td>
+                <a class="core-mapping" href="#role-map-menuitemradio">`menuitemradio`</a> role, with the <a class="core-mapping" href="#ariaCheckedMixed">`aria-checked`</a> state set to "true" if the element's <a data-cite="html/form-control-infrastructure.html#concept-fe-checked">checkedness</a> is true, or "false" otherwise
+              </td>
+            </tr>
+            <tr>
+              <th><a data-cite="core-aam-1.2/#roleMappingComputedRole">Computed Role</a></th>
+              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th>
+                <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
+              </th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th><span class="informative">[[ATK]]</span></th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th>Comments</th>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+        <h4 id="el-menulist">`menulist`</h4>
+        <table class="data" aria-labelledby="el-menulist">
+          <tbody>
+            <tr>
+              <th>HTML Specification</th>
+              <td>
+                <!-- <a data-cite="html">`menulist`</a> -->
+                <a href="https://whatpr.org/html/12011/interactive-elements.html#the-menulist-element">`menulist`</a>
+              </td>
+            </tr>
+            <tr>
+              <th>[[wai-aria-1.2]]</th>
+              <td><a class="core-mapping" href="#role-map-menu">`menu`</a> role</td>
+            </tr>
+            <tr>
+              <th><a data-cite="core-aam-1.2/#roleMappingComputedRole">Computed Role</a></th>
+              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th>
+                <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
+              </th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th><span class="informative">[[ATK]]</span></th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <td><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th>Comments</th>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
         <h4 id="el-meta">`meta`</h4>
         <table class="data" aria-labelledby="el-meta">
           <tbody>


### PR DESCRIPTION
Closes #????

Three new menu-related html elements are being added in https://github.com/whatwg/html/pull/12011. This adds their (straightforward) mappings to html-aam.

Temporary Note: I included the below so that links in the preview will work and go to whatpr until the html PR is merged. Once the html PR is merged, I'll replace the whatpr links with the commented out real links.
```html
<!-- <a data-cite="html">`menubar`</a> -->
<a href="https://whatpr.org/html/12011/interactive-elements.html#the-menubar-element">`menubar`</a>
```

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests:
* [ ] Browser implementations (link to issue or commit):
   * WebKit:
   * Gecko:
   * Blink:
* [ ] ACT review?
* [ ] Does this need AT implementations?
* [ ] Related APG Issue/PR:
* [ ] MDN Issue/PR:
