### PR TITLE
Add browser requirements that support synthetic activation by AT

### DIFF
--- a/index.html
+++ b/index.html
@@ -10270,7 +10270,9 @@ button.ariaPressed; // null</pre>
 					<li>Authors MUST NOT define an empty string value (<code>aria-actions=""</code>) on elements that do not have actions.</li>
 					<li>Authors SHOULD ensure that related actions elements are visible and activatable when the current element has DOM focus.</li>
 					<li>Authors SHOULD ensure the referencing element has <code>aria-actions=""</code> defined when not focused, if the related action elements do not exist in the DOM until the referencing element receives focus. This allows assistive technologies to surface the existence of actions outside of user interactions that trigger DOM focus.</li>
-					<li>User Agents SHOULD use the accessible names of elements referenced by <code>aria-actions</code> to determine the names of actions that are exposed in a platform accessibility API.</li>
+					<li>User Agents MUST use the accessible names of elements referenced by <code>aria-actions</code> to determine the names of actions that are exposed in a platform accessibility API.</li>
+					<li>User Agents MUST expose actions in the order that references are listed.</li>
+					<li>User Agents MUST expose an activation path to assistive technologies that performs the activation behavior of an element referenced by aria-actions without executing the default focus-transfer behavior associated with pointer activation.</li>
 					<li>User Agents MUST NOT expose <code>aria-actions</code> if the Author MUST's are not followed.</li>
 				</ul>
 			</div>


### PR DESCRIPTION
Closes #2691 

Note: Base branch is not main; it is the compare branch for #1805 (secondary-actions).

* Require browsers to use author-provided names
* Add browser requirement about sequencing actions
* Add browser requirement to prevent default focus-transfer behavior when an action is synthetically activated by an AT
