### PR TITLE
[html-aam] Add img w/controls attr mapping

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -3271,32 +3271,55 @@
                 <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
               </th>
               <td>
-                <div class="general">Use WAI-ARIA mapping</div>
+                <div class="role"><span class="type">Role:</span> `ROLE_SYSTEM_GROUPING`</div>
               </td>
             </tr>
             <tr>
               <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
               <td>
-                <div class="general">Use WAI-ARIA mapping</div>
+                <div class="ctrltype"><span class="type">Control Type:</span> `Group`</div>
+                <div class="ctrltype"><span class="type">Localized Control Type:</span> `"group"`</div>
+                <div class="general">
+                  <b>Note:</b> If the <a data-cite="HTML/media.html#attr-media-controls">`controls`</a> attribute is present, UI controls (e.g., play, volume) are exposed as children of the
+                  <a data-cite="HTML">`video`</a> element in the <a class="termref">accessibility tree</a>, and mapped as appropriate for the type of control (e.g.,
+                  <a class="core-mapping" href="#role-map-button">`button`</a> or <a class="core-mapping" href="#role-map-slider">`slider`</a>).
+                </div>
+                <div class="general">
+                  User agents MAY include the following in the <a class="termref">accessibility tree</a> and mark them as hidden or off-screen:
+                  <ul>
+                    <li>Loading messages or error messages</li>
+                    <li>UI controls that are not currently displayed</li>
+                  </ul>
+                </div>
               </td>
             </tr>
             <tr>
               <th><span class="informative">[[ATK]]</span></th>
               <td>
-                <div class="general">Use WAI-ARIA mapping</div>
+                <div class="role"><span class="type">Role:</span> `ATK_ROLE_VIDEO`</div>
               </td>
             </tr>
             <tr>
               <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
               <td>
-                <div class="general">Use WAI-ARIA mapping</div>
+                <div class="role"><span class="type">AXRole:</span> `AXGroup`</div>
+                <div class="subrole"><span class="type">AXSubrole:</span> `AXVideo`</div>
+                <div class="roledesc"><span class="type">AXRoleDescription:</span> `"video playback"`</div>
+                <div class="general">
+                  <b>Note:</b> If the <a data-cite="HTML/media.html#attr-media-controls">`controls`</a> attribute is present, UI controls (e.g., play, volume) are exposed as descendants of an
+                  <a class="termref">accessible object</a> with a role of <a class="core-mapping" href="#role-map-toolbar">`toolbar`</a>, and mapped as appropriate for the type of control (e.g.,
+                  <a class="core-mapping" href="#role-map-button">`button`</a> or <a class="core-mapping" href="#role-map-slider">`slider`</a>).
+                </div>
               </td>
             </tr>
             <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
             <tr>
               <th>Comments</th>
-              <td>If the `alt` attribute value, when trimmed of whitespace, is the empty string, i.e., `alt`="", `alt`=" ", or `alt` with no value in the markup, 
-                user agents MUST expose the `img` (with a `controls` attribute) with its implicit `image` role.
+              <td>
+                <p>See the <a href="el-img-with-controls-attr">`controls` (for `img`)</a> attribute mapping.</p>
+                <p class="note">
+                  <strong>Note:</strong> The mappings for an `img` (with `controls` attribute) are the same as `img`. However, when used on an `img` element, the `controls` attribute should produce a parent container with `role="group"` that contains both the image and associated controls.
+                </p>
               </td>
             </tr>
           </tbody>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -3280,8 +3280,8 @@
                 <div class="ctrltype"><span class="type">Control Type:</span> `Group`</div>
                 <div class="ctrltype"><span class="type">Localized Control Type:</span> `"group"`</div>
                 <div class="general">
-                  <b>Note:</b> If the <a data-cite="HTML/media.html#attr-media-controls">`controls`</a> attribute is present, UI controls (e.g., play, volume) are exposed as children of the
-                  <a data-cite="HTML">`video`</a> element in the <a class="termref">accessibility tree</a>, and mapped as appropriate for the type of control (e.g.,
+                  <b>Note:</b> If the <a data-cite="html/embedded-content.html#attr-img-controls">`controls`</a> attribute is present, UI controls (e.g., play, volume) are exposed as children of the
+                  parent `role="group"` element in the <a class="termref">accessibility tree</a>, and mapped as appropriate for the type of control (e.g.,
                   <a class="core-mapping" href="#role-map-button">`button`</a> or <a class="core-mapping" href="#role-map-slider">`slider`</a>).
                 </div>
                 <div class="general">
@@ -3306,7 +3306,7 @@
                 <div class="subrole"><span class="type">AXSubrole:</span> `AXVideo`</div>
                 <div class="roledesc"><span class="type">AXRoleDescription:</span> `"video playback"`</div>
                 <div class="general">
-                  <b>Note:</b> If the <a data-cite="HTML/media.html#attr-media-controls">`controls`</a> attribute is present, UI controls (e.g., play, volume) are exposed as descendants of an
+                  <b>Note:</b> If the <a data-cite="html/embedded-content.html#attr-img-controls">`controls`</a> attribute is present, UI controls (e.g., play, volume) are exposed as descendants of an
                   <a class="termref">accessible object</a> with a role of <a class="core-mapping" href="#role-map-toolbar">`toolbar`</a>, and mapped as appropriate for the type of control (e.g.,
                   <a class="core-mapping" href="#role-map-button">`button`</a> or <a class="core-mapping" href="#role-map-slider">`slider`</a>).
                 </div>
@@ -3316,7 +3316,7 @@
             <tr>
               <th>Comments</th>
               <td>
-                <p>See the <a href="el-img-with-controls-attr">`controls` (for `img`)</a> attribute mapping.</p>
+                <p>See the <a href="att-controls-img">`controls` (for `img`)</a> attribute mapping.</p>
                 <p class="note">
                   <strong>Note:</strong> The mappings for an `img` (with `controls` attribute) are the same as `img`. However, when used on an `img` element, the `controls` attribute should produce a parent container with `role="group"` that contains both the image and associated controls.
                 </p>
@@ -9791,7 +9791,7 @@
             <tr>
               <th>Element(s)</th>
               <td>
-                <a data-cite="html/embedded-content.html#attr-img-crossorigin">`img`</a>
+                <a data-cite="html/embedded-content.html#attr-img-controls">`img`</a>
               </td>
             </tr>
             <tr>
@@ -9826,7 +9826,9 @@
             </tr>
             <tr>
               <th>Comments</th>
-              <td></td>
+              <td>
+                <p>See the <a href="el-img-with-controls-attr">`img` (with `controls`)</a> element mapping.</p>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -9709,7 +9709,7 @@
             </tr>
           </tbody>
         </table>
-        <h4 id="att-controls">`controls`</h4>
+        <h4 id="att-controls">`controls` (for `audio` and `video`)</h4>
         <table class="data" aria-labelledby="att-controls">
           <tbody>
             <tr>
@@ -9719,7 +9719,56 @@
             <tr>
               <th>Element(s)</th>
               <td>
-                <a data-cite="html/media.html#attr-media-controls">`audio` and `video`</a>; <a data-cite="html/embedded-content.html#attr-img-crossorigin">`img`</a>
+                <a data-cite="html/media.html#attr-media-controls">`audio` and `video`</a>
+              </td>
+            </tr>
+            <tr>
+              <th>[[WAI-ARIA-1.2]]</th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
+              </th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
+            </tr>
+            <tr>
+              <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
+            </tr>
+            <tr>
+              <th><span class="informative">[[ATK]]</span></th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
+            </tr>
+            <tr>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <td>Controls exposed as `AXToolbar`</td>
+            </tr>
+            <tr>
+              <th>Comments</th>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+        <h4 id="att-controls-img">`controls` (for `img`)</h4>
+        <table class="data" aria-labelledby="att-controls-img">
+          <tbody>
+            <tr>
+              <th>HTML Specification</th>
+              <td>`controls`</td>
+            </tr>
+            <tr>
+              <th>Element(s)</th>
+              <td>
+                <a data-cite="html/embedded-content.html#attr-img-crossorigin">`img`</a>
               </td>
             </tr>
             <tr>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -3243,6 +3243,64 @@
             </tr>
           </tbody>
         </table>
+        <h4 id="el-img-with-controls-attr">
+          `img`
+          <span class="el-context">(with `controls` attribute)</span>
+        </h4>
+        <table class="data" aria-labelledby="el-img-with-controls-attr">
+          <tbody>
+            <tr>
+              <th>HTML Specification</th>
+              <td>
+                <a data-cite="HTML">`img`</a>
+              </td>
+            </tr>
+            <tr>
+              <th>[[wai-aria-1.2]]</th>
+              <td>
+                <a class="core-mapping" href="#role-map-image">`image`</a>
+                or <a class="core-mapping" href="#role-map-img">`img`</a> role
+              </td>
+            </tr>
+            <tr>
+              <th><a data-cite="core-aam-1.2/#roleMappingComputedRole">Computed Role</a></th>
+              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
+            </tr>
+            <tr>
+              <th>
+                <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
+              </th>
+              <td>
+                <div class="general">Use WAI-ARIA mapping</div>
+              </td>
+            </tr>
+            <tr>
+              <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+              <td>
+                <div class="general">Use WAI-ARIA mapping</div>
+              </td>
+            </tr>
+            <tr>
+              <th><span class="informative">[[ATK]]</span></th>
+              <td>
+                <div class="general">Use WAI-ARIA mapping</div>
+              </td>
+            </tr>
+            <tr>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <td>
+                <div class="general">Use WAI-ARIA mapping</div>
+              </td>
+            </tr>
+            <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+            <tr>
+              <th>Comments</th>
+              <td>If the `alt` attribute value, when trimmed of whitespace, is the empty string, i.e., `alt`="", `alt`=" ", or `alt` with no value in the markup, 
+                user agents MUST expose the `img` (with a `controls` attribute) with its implicit `image` role.
+              </td>
+            </tr>
+          </tbody>
+        </table>
         <h4 id="el-input-button">`input` <span class="el-context">(`type` attribute in the Button state)</span></h4>
         <table class="data" aria-labelledby="el-input-button">
           <tbody>
@@ -9661,7 +9719,7 @@
             <tr>
               <th>Element(s)</th>
               <td>
-                <a data-cite="html/media.html#attr-media-controls">`audio` and `video`</a>
+                <a data-cite="html/media.html#attr-media-controls">`audio` and `video`</a>; <a data-cite="html/embedded-content.html#attr-img-crossorigin">`img`</a>
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
🚀 **Netlify Preview**:
🔄 **this PR updates the following sspecs**:
- [html-aam preview](https://deploy-preview-2815--wai-aria.netlify.app/html-aam/index.html) &mdash; [html-aam diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fhtml-aam%2F&doc2=https%3A%2F%2Fdeploy-preview-2815--wai-aria.netlify.app%2Fhtml-aam%2Findex.html)

Closes https://github.com/w3c/html-aam/issues/601

This PR makes two changes:
- Adds new mapping table for `img` element with a `controls` attribute, with a callout that empty `alt` should be ignored
- Adds `img` element to `controls` attribute mapping (along with existing `audio` and `video`) 

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests:
* [ ] Browser implementations (link to issue or commit):
   * WebKit:
   * Gecko:
   * Blink:
* [ ] ACT review?
* [ ] Does this need AT implementations?
* [ ] Related APG Issue/PR:
* [ ] MDN Issue/PR: