### PR TITLE
editorial: add note to clarify association between definition and term

### DIFF
--- a/index.html
+++ b/index.html
@@ -3432,7 +3432,7 @@
             <p>A definition of a term or concept. See related <rref>term</rref>.</p>
             <p>Authors MUST identify the <a>element</a> being defined and assign that element a role of <rref>term</rref>.</p>
             <div class="note">
-              <p>The relationship between a <rref>term</rref> and its <code>definition</code> is conveyed on the <rref>term</rref> element using <pref>aria-details</pref> and referencing the <code>definition</code> element; see the <rref>term</rref> role for more information.</p>
+              <p>The relationship between a <rref>term</rref> and its <code>definition</code> is conveyed on the <rref>term</rref> element; see the <rref>term</rref> role for more information.</p>
             </div>
           </div>
           <table class="def">

--- a/index.html
+++ b/index.html
@@ -3431,10 +3431,9 @@
           <div class="role-description">
             <p>A definition of a term or concept. See related <rref>term</rref>.</p>
             <p>Authors MUST identify the <a>element</a> being defined and assign that element a role of <rref>term</rref>.</p>
-            <p>
-              Authors SHOULD NOT use the <code>definition</code> role on interactive elements such as form controls because doing so could prevent users of assistive technologies from interacting with
-              those elements.
-            </p>
+            <div class="note">
+              <p>The relationship between a <rref>term</rref> and its <code>definition</code> is conveyed on the <rref>term</rref> element using <pref>aria-details</pref> and referencing the <code>definition</code> element; see the <rref>term</rref> role for more information.</p>
+            </div>
           </div>
           <table class="def">
             <caption>


### PR DESCRIPTION
🚀 **Netlify Preview**:
🔄 **this PR updates the following sspecs**:
- [ARIA preview](https://deploy-preview-2821--wai-aria.netlify.app/index.html) &mdash; [ARIA diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Faria%2F&doc2=https%3A%2F%2Fdeploy-preview-2821--wai-aria.netlify.app%2Findex.html)

Closes #2762 

Add a note to clarify association between `definition` and `term`; remove SHOULD NOT constraint

+@pkra