### PR TITLE
editorial: update Taxonomy of WAI-ARIA States and Properties

### DIFF
--- a/index.html
+++ b/index.html
@@ -12070,10 +12070,25 @@ button.ariaPressed; // null</pre
         <h2>Taxonomy of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> States and Properties</h2>
         <p>States and properties are categorized as follows:</p>
         <ol>
+          <li><a href="#attrs_naming">Naming Attributes</a></li>
           <li><a href="#attrs_widgets">Widget Attributes</a></li>
           <li><a href="#attrs_liveregions">Live Region Attributes</a></li>
           <li><a href="#attrs_relationships">Relationship Attributes</a></li>
         </ol>
+        <section id="attrs_naming">
+          <h3>Naming Attributes</h3>
+          <p>
+            This section contains [=attributes=] related to controlling specific names of elements and their roles.
+          </p>
+          <ul>
+            <li><pref>aria-braillelabel</pref></li>
+            <li><pref>aria-brailleroledescription</pref></li>
+            <li><pref>aria-description</pref></li>
+            <li><pref>aria-keyshortcuts</pref></li>
+            <li><pref>aria-label</pref></li>
+            <li><pref>aria-roledescription</pref></li>
+          </ul>
+        </section>
         <section id="attrs_widgets">
           <h3>Widget Attributes</h3>
           <p>
@@ -12089,7 +12104,6 @@ button.ariaPressed; // null</pre
             <li><pref>aria-haspopup</pref></li>
             <li><sref>aria-hidden</sref></li>
             <li><sref>aria-invalid</sref></li>
-            <li><pref>aria-label</pref></li>
             <li><pref>aria-level</pref></li>
             <li><pref>aria-modal</pref></li>
             <li><pref>aria-multiline</pref></li>
@@ -12136,6 +12150,7 @@ button.ariaPressed; // null</pre
             <li><pref>aria-colindextext</pref></li>
             <li><pref>aria-colspan</pref></li>
             <li><pref>aria-controls</pref></li>
+            <li><sref>aria-current</sref></li>
             <li><pref>aria-describedby</pref></li>
             <li><pref>aria-details</pref></li>
             <li><pref>aria-errormessage</pref></li>


### PR DESCRIPTION
🚀 **Netlify Preview**:
🔄 **this PR updates the following sspecs**:
- [ARIA preview](https://deploy-preview-2823--wai-aria.netlify.app/index.html) &mdash; [ARIA diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Faria%2F&doc2=https%3A%2F%2Fdeploy-preview-2823--wai-aria.netlify.app%2Findex.html)

Adds remaining states and properties, except aria-dropeffect and aria-grabbed as they are now deprecated.

Resolves #1823