### PR TITLE
Editorial: Correct typos for UIA CheckBox, ComboBox, and GetCurrentPropertyValue

### DIFF
--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -338,7 +338,7 @@
           </ul>
           <p>
             Properties for specific UIA control patterns are queried the same way using relevant control pattern interfaces. Taking Toggle Pattern as an example, to query the ToggleState property
-            clients can use IUIAutomationTogglePattern::CurrentToggleState or IUIAutomationTogglePattern::GetCurrentPropertyValue(UIA_ToggleToggleStatePropertyId) to get the current value.
+            clients can use IUIAutomationTogglePattern::CurrentToggleState or IUIAutomationElement::GetCurrentPropertyValue(UIA_ToggleToggleStatePropertyId) to get the current value.
           </p>
           <p>
             The property mappings in this specification provide the <code>{PropertyName}</code> and do not specify all specific ways to access the property value. Automation clients can access current
@@ -1281,7 +1281,7 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Checkbox</code></span
+                  <span class="property">Control Type: <code>CheckBox</code></span
                   ><br />
                   <span class="seealso">See also: <code>aria-checked</code> in the <a href="#mapping_state-property_table">State and Property Mapping Tables</a></span>
                 </td>
@@ -1464,7 +1464,7 @@
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
                 <td>
-                  <span class="property">Control Type: <code>Combobox</code></span>
+                  <span class="property">Control Type: <code>ComboBox</code></span>
                 </td>
               </tr>
               <tr>


### PR DESCRIPTION
🚀 **Netlify Preview**:
🔄 **this PR updates the following sspecs**:
- [core-aam preview](https://deploy-preview-2833--wai-aria.netlify.app/core-aam/index.html) &mdash; [core-aam diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fcore-aam%2F&doc2=https%3A%2F%2Fdeploy-preview-2833--wai-aria.netlify.app%2Fcore-aam%2Findex.html)

Fixing a few editorial-level mistakes in the Core-AAM that I and others noticed while writing the UIA Wrapper for WPTs.

### Description of Changes
This PR makes the following minor corrections:
* **Toggle Pattern Example:** Corrects the method reference from `IUIAutomationTogglePattern::GetCurrentPropertyValue` to `IUIAutomationElement::GetCurrentPropertyValue` (as `GetCurrentPropertyValue` is a method of the element interface, not the pattern).
* **Role Mappings (Casing):** Fixes the capitalization for UIA Control Types to match their correct PascalCase definitions:
  * `Checkbox` -> `CheckBox`
  * `Combobox` -> `ComboBox`


Closes #????

Describe Change Here!

And a few other todo items (delete this section after performing them):
* [x] For every spec that this PR edits, please add the appropriate `spec:<spec_name>` label. If you don't have privileges to do this, editors will do it for you.
* [x] If the change is editorial, please add "Editorial:" at the start of your PR name, and delete the "Test, Documentation and Implementation tracking" section below.