### PR TITLE
Editorial: Align "suggestion" role with "Allowed Accessibility Child Roles" model

### DIFF
--- a/index.html
+++ b/index.html
@@ -9909,8 +9909,9 @@
             <p>A single proposed change to content.</p>
             <p>For example, in an editing system that supports multiple users, one user can suggest a change, and another user would be responsible for accepting or rejecting the suggestion.</p>
             <p>
-              Authors MUST ensure that a <code>suggestion</code> contains either one <rref>insertion</rref> child or one <rref>deletion</rref> child or ensure that it contains two children where one
-              is an <rref>insertion</rref> and the other is a <rref>deletion</rref>. Authors MUST ensure a <code>suggestion</code> does not contain any other children.
+              Authors MUST ensure that a <code>suggestion</code> has either exactly one <rref>insertion</rref> <a>accessibility child</a> or exactly one <rref>deletion</rref> <a>accessibility child</a>, 
+			  or exactly two <a>accessibility children</a> where one is an <rref>insertion</rref> and the other is a <rref>deletion</rref>. Authors MUST NOT include any additional 
+			  <a>accessibility children</a> in a <code>suggestion</code>.
             </p>
             <p>
               Authors MAY use <pref>aria-details</pref> or <pref>aria-description</pref> to associate the <code>suggestion</code> with related information such as comments, authoring info, and time


### PR DESCRIPTION
🚀 **Netlify Preview**:
🔄 **this PR updates the following sspecs**:
- [ARIA preview](https://deploy-preview-2835--wai-aria.netlify.app/index.html) &mdash; [ARIA diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Faria%2F&doc2=https%3A%2F%2Fdeploy-preview-2835--wai-aria.netlify.app%2Findex.html)

Closes #2834

We moved from "Required Owned Elements" to "Allowed Accessibility Child Roles", updating all related roles accordingly. However, the definition for `suggestion` still appears somewhat outdated and inconsistent with the updated model
In particular:
- it refers to "children" rather than "accessibility children". This seems to unnecessarily restrict valid accessibility tree structures including "generic/role none" intervening. For example, it would appear to prevent patterns such as:
  ```
  <p>
    The best pet is a
    <span role="suggestion">
      <div>
        <span role="deletion">cat</span>
        <span role="insertion">dog</span>
      </div>
    </span>
  </p>
  ```
- it uses "contains"; my assumption is that this is intended to mean "contains in the descendant accessibility tree", rather than being strictly limited to DOM-wrapped children. This interpretation would already account for cases involving aria-owns and generic intervening elements, provided that the notion of "accessibility children" is applied consistently
- it must not be empty. I assume this is intentional, although it is not consistent with other patterns for "allowed accessibility child roles" such as menu, menubar, tree, treegrid, ...

If these three interpretations reflect the intended behavior, I have prepared this PR that aligns `suggestion` with the updated "accessibility children" model. This change should not affect the intended semantics, but it may impact how authors and tooling interpret or validate permitted structures.

----

And a few other todo items (delete this section after performing them):
* [ ] For every spec that this PR edits, please add the appropriate `spec:<spec_name>` label. If you don't have privileges to do this, editors will do it for you.
* [ ] If the change is [editorial](https://github.com/w3c/aria/blob/main/documentation/process.md#editorial-changes), please add "Editorial:" at the start of your PR name, and delete the "Test, Documentation and Implementation tracking" section below.

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests:
* [ ] Browser implementations (link to issue or commit):
   * WebKit:
   * Gecko:
   * Blink:
* [ ] ACT review?
* [ ] Does this need AT implementations?
* [ ] Related APG Issue/PR:
* [ ] MDN Issue/PR: