### PR TITLE
Clarify case-insensitive treatment of ARIA roles

### DIFF
--- a/index.html
+++ b/index.html
@@ -870,7 +870,7 @@
           language semantics, there are no changes in the <abbr title="Document Object Model">DOM</abbr>, only in the <a class="termref">accessibility tree</a>.
         </p>
         <p>
-          User agents MUST use the first token in the sequence of tokens in the <a><code>role</code> attribute</a> value that matches the name of any non-abstract
+          User agents MUST use the first token in the sequence of tokens in the <a><code>role</code> attribute</a> value that is an [=ASCII case-insensitive=] match for the name of any non-abstract
           <abbr title="Accessible Internet Application">WAI-ARIA</abbr> <a>role</a>. Refer to the section on <a><code>role</code> attribute</a> implementation in
           <a href="#host_general_role">Host Languages</a> for further details.
         </p>

--- a/index.html
+++ b/index.html
@@ -16352,7 +16352,7 @@ button.ariaPressed; // null</pre
             attribute value illegal in the host-language syntax; and
           </li>
           <li>
-            The first name literal of a non-abstract <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role in the list of tokens in the <a><code>role</code> attribute</a> defines
+            The first [=ASCII case-insensitive=] name literal of a non-abstract <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> role in the list of tokens in the <a><code>role</code> attribute</a> defines
             the role according to which the user agent MUST process the element. User Agent processing for roles is defined in the
             <cite><a href="" class="core-mapping">Core Accessibility API Mappings</a></cite> [[CORE-AAM-1.2]].
           </li>


### PR DESCRIPTION
🚀 **Netlify Preview**:
🔄 **this PR updates the following sspecs**:
- [ARIA preview](https://deploy-preview-2838--wai-aria.netlify.app/index.html) &mdash; [ARIA diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Faria%2F&doc2=https%3A%2F%2Fdeploy-preview-2838--wai-aria.netlify.app%2Findex.html)

Closes #2548 

This PR updates the "WAI-ARIA Roles" section specifying treatment of ARIA roles should be case-insensitive (see WPT tests below).

* [x] "author MUST" tests: n/a
* [x] "user agent MUST" tests: https://github.com/web-platform-tests/wpt/pull/53966/
* [x] Browser implementations (link to issue or commit):
   * WebKit: n/a
   * Gecko: n/a
   * Blink: n/a
* [x] ACT review? No
* [x] Does this need AT implementations? No
* [x] Related APG Issue/PR: n/a
* [x] MDN Issue/PR: n/a