### PR TITLE
[html-aam] Add HTML spec link for child <summary> behavior with parent <details>

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -6864,7 +6864,7 @@
               <th>Comments</th>
               <td>
                 If a `summary` element is not a child of a `details` element, or it is not the first `summary` element of a parent `details`, then user agents MUST expose the `summary` element with a
-                `generic` role.
+                `generic` role (see <a data-cite="HTML/media.html#attr-media-controls">HTML `summary` element</a>).
               </td>
             </tr>
           </tbody>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -6864,7 +6864,7 @@
               <th>Comments</th>
               <td>
                 If a `summary` element is not a child of a `details` element, or it is not the first `summary` element of a parent `details`, then user agents MUST expose the `summary` element with a
-                `generic` role (see <a data-cite="HTML/#the-summary-element">HTML `summary` element</a>).
+                `generic` role (see <a data-cite="HTML/interactive-elements.html#the-summary-element">HTML `summary` element</a>).
               </td>
             </tr>
           </tbody>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -6864,7 +6864,7 @@
               <th>Comments</th>
               <td>
                 If a `summary` element is not a child of a `details` element, or it is not the first `summary` element of a parent `details`, then user agents MUST expose the `summary` element with a
-                `generic` role (see <a data-cite="HTML/media.html#attr-media-controls">HTML `summary` element</a>).
+                `generic` role (see <a data-cite="HTML/#the-summary-element">HTML `summary` element</a>).
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
🚀 **Netlify Preview**:
🔄 **this PR updates the following sspecs**:
- [html-aam preview](https://deploy-preview-2840--wai-aria.netlify.app/html-aam/index.html) &mdash; [html-aam diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fhtml-aam%2F&doc2=https%3A%2F%2Fdeploy-preview-2840--wai-aria.netlify.app%2Fhtml-aam%2Findex.html)

As part https://github.com/web-platform-tests/wpt/pull/43859 (Update html-aam/roles-contextual.html with `<summary>` tests): 

@cookiecrook suggested clarifying the `<summary>` algorithm in HTML-AAM when it has a parent `<details>` per https://github.com/web-platform-tests/wpt/pull/43859#issuecomment-1879559495.