### PR TITLE
Fix tag attributes for msqrt and mn

### DIFF
--- a/mathml-aam/index.html
+++ b/mathml-aam/index.html
@@ -521,7 +521,7 @@
               <td>
                 <span class="role">Role: <code>ATK_ROLE_STATIC</code></span
                 ><br />
-                <span class="objattr">Object Attribute: <code>tag:ms</code></span>
+                <span class="objattr">Object Attribute: <code>tag:mn</code></span>
               </td>
             </tr>
             <tr>
@@ -906,7 +906,7 @@
               <td>
                 <span class="role">Role: <code>ATK_ROLE_MATH_ROOT</code></span
                 ><br />
-                <span class="objattr">Object Attribute: <code>tag:mroot</code></span>
+                <span class="objattr">Object Attribute: <code>tag:msqrt</code></span>
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
Closes https://github.com/w3c/mathml-aam/issues/40

Correcting the tag attribute for `<mn>` and `<msqrt>`.
The tag name attribute should be the same as the html name.

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [x] "author MUST" tests: N/A
* [ ] "user agent MUST" tests: https://github.com/web-platform-tests/wpt/pull/61018
* [x] Browser implementations (link to issue or commit):
   * WebKit: https://searchfox.org/wubkat/rev/d221d71a6a560cb45bb3e9b23e526b6bcfa9e4b3/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp#866
   * Gecko: https://searchfox.org/firefox-main/rev/7fa9b602777418732e08b26d1ef6c9945c4bbd72/accessible/generic/LocalAccessible.cpp#1253
   * Blink: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/accessibility/ax_object.cc;l=1558;drc=0976730981877ed30e1cb06c63ad7d60c030c7f4
* [x] ACT review? N/A
* [x] Does this need AT implementations? No
* [x] Related APG Issue/PR: N/A
* [x] MDN Issue/PR: N/A




