### PR TITLE
Accessibility mapping of <a> element

### DIFF
--- a/mathml-aam/index.html
+++ b/mathml-aam/index.html
@@ -194,7 +194,7 @@
             <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                    <div class="general">Use WAI-ARIA mapping, but replace the <code>AXSubrole</code> with <code>AXMathRow</code>.</div>
+                    <div class="general">Use WAI-ARIA mapping, but override the <code>AXSubrole</code> with <code>AXMathRow</code>.</div>
                 </td>
             </tr>
             </tbody>

--- a/mathml-aam/index.html
+++ b/mathml-aam/index.html
@@ -160,6 +160,49 @@
 
       <section>
         <h3>MathML Element Mappings</h3>
+        <h4 id="el-a">`a`</h4>
+                <table class="data" aria-labelledby="el-a">
+                  <tbody>
+                    <tr>
+                      <th>MathML Specification</th>
+                      <td>
+                        <a data-cite="MathML3/chapter5.html#mixing.elements.a">`a`</a>
+                      </td>
+                    </tr>
+                    <tr>
+                      <th>[[wai-aria-1.1]]</th>
+                      <td>`link` role</td>
+                    </tr>
+                    <tr>
+                      <th>MSAA + IAccessible2</th>
+                      <td>
+                        <span class="role">Role: <code>ROLE_SYSTEM_LINK</code></span><br />
+                        <span class="state">IA2 State: <code>IA2_STATE_LINKED</code></span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <th><abbr title="User Interface Automation">UIA</abbr></th>
+                      <td>
+                        <span class="controltype">ControlType: <code>Hyperlink</code></span><br />
+                        <span class="localizedtype">LocalizedControlType: <code>"link"</code></span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+                      <td>
+                        <span class="role">Role: <code>ATK_ROLE_LINK</code></span><br />
+                        <span class="objattr">Object Attribute: <code>tag:a</code></span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                      <td>
+                        <span class="role">AXRole: <code>AXLink</code></span><br />
+                        <span class="subrole">AXSubrole: <code>AXMathRow</code></span>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
         <h4 id="el-annotation">`annotation`</h4>
         <table class="data" aria-labelledby="el-annotation">
           <tbody>

--- a/mathml-aam/index.html
+++ b/mathml-aam/index.html
@@ -171,7 +171,7 @@
             </tr>
             <tr>
                 <th>[[wai-aria-1.1]]</th>
-                <td><a class="core-mapping" href="#role-map-link">`link`</a> role if the element has a valid <code>href</code> attribute. For elements that are not links, use the mapping for <a href="#el-mrow"><code>mrow</code></a>.</td>
+                <td><a class="core-mapping" href="#role-map-link">`link`</a> role if the element has a valid <code>href</code> attribute. For elements that do not have a valid <code>href</code>, use the mapping for <a href="#el-mrow"><code>mrow</code></a>.</td>
             </tr>
             <tr>
                 <th>MSAA + IAccessible2</th>

--- a/mathml-aam/index.html
+++ b/mathml-aam/index.html
@@ -171,28 +171,30 @@
             </tr>
             <tr>
                 <th>[[wai-aria-1.1]]</th>
-                <td>No corresponding role</td>
+                <td><a class="core-mapping" href="#role-map-link">`link`</a> role if the element has a valid <code>href</code> attribute. For elements that are not links, use the mapping for <a href="#el-mrow"><code>mrow</code></a>.</td>
             </tr>
             <tr>
                 <th>MSAA + IAccessible2</th>
-                <td>TBD</td>
+                <td>
+                    TBD
+                </td>
             </tr>
             <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
-                <td>TBD</td>
+                <td>
+                    TBD
+                </td>
             </tr>
             <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
                 <td>
-                <span class="role">Role: <code>ATK_ROLE_LINK</code></span><br />
-                <span class="objattr">Object Attribute: <code>tag:a</code></span>
+                    <div class="general">Use WAI-ARIA mapping</div>
                 </td>
             </tr>
             <tr>
                 <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
                 <td>
-                <span class="role">AXRole: <code>AXLink</code></span><br />
-                <span class="subrole">AXSubrole: <code>AXMathRow</code></span>
+                    <div class="general">Use WAI-ARIA mapping, but replace the <code>AXSubrole</code> with <code>AXMathRow</code>.</div>
                 </td>
             </tr>
             </tbody>

--- a/mathml-aam/index.html
+++ b/mathml-aam/index.html
@@ -161,48 +161,42 @@
       <section>
         <h3>MathML Element Mappings</h3>
         <h4 id="el-a">`a`</h4>
-                <table class="data" aria-labelledby="el-a">
-                  <tbody>
-                    <tr>
-                      <th>MathML Specification</th>
-                      <td>
-                        <a data-cite="MathML3/chapter5.html#mixing.elements.a">`a`</a>
-                      </td>
-                    </tr>
-                    <tr>
-                      <th>[[wai-aria-1.1]]</th>
-                      <td>`link` role</td>
-                    </tr>
-                    <tr>
-                      <th>MSAA + IAccessible2</th>
-                      <td>
-                        <span class="role">Role: <code>ROLE_SYSTEM_LINK</code></span><br />
-                        <span class="state">IA2 State: <code>IA2_STATE_LINKED</code></span>
-                      </td>
-                    </tr>
-                    <tr>
-                      <th><abbr title="User Interface Automation">UIA</abbr></th>
-                      <td>
-                        <span class="controltype">ControlType: <code>Hyperlink</code></span><br />
-                        <span class="localizedtype">LocalizedControlType: <code>"link"</code></span>
-                      </td>
-                    </tr>
-                    <tr>
-                      <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
-                      <td>
-                        <span class="role">Role: <code>ATK_ROLE_LINK</code></span><br />
-                        <span class="objattr">Object Attribute: <code>tag:a</code></span>
-                      </td>
-                    </tr>
-                    <tr>
-                      <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-                      <td>
-                        <span class="role">AXRole: <code>AXLink</code></span><br />
-                        <span class="subrole">AXSubrole: <code>AXMathRow</code></span>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
+        <table class="data" aria-labelledby="el-a">
+            <tbody>
+            <tr>
+                <th>MathML Specification</th>
+                <td>
+                <a data-cite="MathML3/chapter5.html#mixing.elements.a">`a`</a>
+                </td>
+            </tr>
+            <tr>
+                <th>[[wai-aria-1.1]]</th>
+                <td>No corresponding role</td>
+            </tr>
+            <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>TBD</td>
+            </tr>
+            <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>TBD</td>
+            </tr>
+            <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+                <td>
+                <span class="role">Role: <code>ATK_ROLE_LINK</code></span><br />
+                <span class="objattr">Object Attribute: <code>tag:a</code></span>
+                </td>
+            </tr>
+            <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>
+                <span class="role">AXRole: <code>AXLink</code></span><br />
+                <span class="subrole">AXSubrole: <code>AXMathRow</code></span>
+                </td>
+            </tr>
+            </tbody>
+        </table>
         <h4 id="el-annotation">`annotation`</h4>
         <table class="data" aria-labelledby="el-annotation">
           <tbody>


### PR DESCRIPTION
Closes https://github.com/w3c/mathml-aam/issues/39

This change map mathml a element to link role in atspi and axapi.
Leave TBD for MSAA and UIA api.
See the mathml-aam issue in detail.

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [x] "author MUST" tests: N/A
* [ ] "user agent MUST" tests: https://github.com/web-platform-tests/wpt/pull/61018
* [x] Browser implementations (link to issue or commit):
   * WebKit: will file an issue later
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2054819
   * Blink: https://issues.chromium.org/issues/510487697
* [x] ACT review? N/A
* [x] Does this need AT implementations? N/A
* [x] Related APG Issue/PR: N/A
* [x] MDN Issue/PR: N/A

I got 503 when accessing webkit bug tracker, so for now I can't file the issue. :-)