### PR TITLE
Add aria-actions focus handling wording

### DIFF
--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -6461,7 +6461,12 @@
             </p>
           </section>
           <h4 id="ariaActions"><code>aria-actions</code></h4>
-          <table aria-labelledby="ariaActions">
+          <p>
+            After an action is invoked, browsers MUST NOT fire the API's <a href="#focus_state_event_table">focus event</a> when the referenced action node receives focus.
+            The browser MUST subsequently return DOM focus to the referencing node also without firing an API <a href="#focus_state_event_table">focus event</a>,
+            unless focus is moved to a different node by a programmatic focus change or a user interaction.
+          </p>
+          <table class="data" aria-labelledby="ariaActions">
             <tbody>
               <tr>
                 <th>ARIA Specification</th>

--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -6463,7 +6463,7 @@
           <h4 id="ariaActions"><code>aria-actions</code></h4>
           <p>
             After an action is invoked, browsers MUST NOT fire the API's <a href="#focus_state_event_table">focus event</a> when the referenced action node receives focus.
-            The browser MUST subsequently return DOM focus to the referencing node also without firing an API <a href="#focus_state_event_table">focus event</a>,
+            The browser MUST subsequently return DOM focus to the referencing node also without firing an API <a href="#focus_state_event_table">focus event</a>
             unless focus is moved to a different node by a programmatic focus change or a user interaction.
           </p>
           <table class="data" aria-labelledby="ariaActions">

--- a/index.html
+++ b/index.html
@@ -12197,8 +12197,21 @@ button.ariaPressed; // null</pre
               <li>User Agents SHOULD use the accessible names of elements referenced by <code>aria-actions</code> to determine the names of actions that are exposed in a platform accessibility API.</li>
               <li>User Agents MUST NOT expose <code>aria-actions</code> if the Author MUST's are not followed.</li>
             </ul>
+            <p>In order to allow users to invoke actions while remaining on the referencing element, browsers MUST do the following steps to manage focus once an action is invoke via the <code>aria-actions</code> API:</p>
+            <ol>
+              <li>
+                 If the referenced action node is focusable and receives focus as a result of an <code>aria-actions</code> invocation:
+                <ul>
+                  <li>Allow the DOM focus events to fire on the referenced action node as a result of invoking it.</li>
+                  <li>Do not fire the <a>desktop focus event</a>.</li>
+                </ul>
+              </li>
+              <li>If focus is moved either programmatically or via a user interaction, handle that focus change as normal, and do not perform any further <code>aria-actions</code> focus steps.</li>
+              <li>If focus has not moved, the browser MUST move DOM focus back to the referencing element, again without firing a <a>desktop focus event</a>.</li>
+              <li>If the referencing element can no longer be focused, the browser MAY keep focus on the referenced action element and fire a <a>desktop focus event</a>.</li>
+            </ol>
           </div>
-          <table class="property-features">
+          <table class="def">
             <caption>Characteristics:</caption>
             <thead>
               <tr>

--- a/index.html
+++ b/index.html
@@ -12197,17 +12197,18 @@ button.ariaPressed; // null</pre
               <li>User Agents SHOULD use the accessible names of elements referenced by <code>aria-actions</code> to determine the names of actions that are exposed in a platform accessibility API.</li>
               <li>User Agents MUST NOT expose <code>aria-actions</code> if the Author MUST's are not followed.</li>
             </ul>
-            <p>In order to allow users to invoke actions while remaining on the referencing element, browsers MUST do the following steps to manage focus once an action is invoke via the <code>aria-actions</code> API:</p>
+            <p>To prevent an unexpected focus change away from the referencing element after users invoke actions, browsers MUST perform the following steps to manage focus once an action is invoked via <code>aria-actions</code>:</p>
             <ol>
               <li>
-                 If the referenced action node is focusable and receives focus as a result of an <code>aria-actions</code> invocation:
+                 If the referenced action node is focusable and received focus as a result of an <code>aria-actions</code> invocation:
                 <ul>
                   <li>Allow the DOM focus events to fire on the referenced action node as a result of invoking it.</li>
                   <li>Do not fire the <a>desktop focus event</a>.</li>
                 </ul>
               </li>
+              <li>If the referenced action node is not focusable or did not receive focus, do not perform any further <code>aria-actions</code> focus steps.</li>
               <li>If focus is moved either programmatically or via a user interaction, handle that focus change as normal, and do not perform any further <code>aria-actions</code> focus steps.</li>
-              <li>If focus has not moved, the browser MUST move DOM focus back to the referencing element, again without firing a <a>desktop focus event</a>.</li>
+              <li>If focus has remained on the referenced action node, the browser MUST move DOM focus back to the referencing element, again without firing a <a>desktop focus event</a>.</li>
               <li>If the referencing element can no longer be focused, the browser MAY keep focus on the referenced action element and fire a <a>desktop focus event</a>.</li>
             </ol>
           </div>


### PR DESCRIPTION
🚀 **Netlify Preview**:
🔄 **this PR updates the following sspecs**:
- [core-aam preview](https://deploy-preview-2845--wai-aria.netlify.app/core-aam/index.html) &mdash; [core-aam diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fcore-aam%2F&doc2=https%3A%2F%2Fdeploy-preview-2845--wai-aria.netlify.app%2Fcore-aam%2Findex.html)
- [ARIA preview](https://deploy-preview-2845--wai-aria.netlify.app/index.html) &mdash; [ARIA diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Faria%2F&doc2=https%3A%2F%2Fdeploy-preview-2845--wai-aria.netlify.app%2Findex.html)

Closes #2691

This is a PR into the aria-actions branch, not into main. It's split out into its own PR for ease of reviewing this specific update.

I tried to put our agreed-on focus bounce behavior into spec language. In plain language, what happens is:

The browser (not ATs) allow DOM focus to move to the action following the click event, but don't fire API focus events, so screen reader cursors will stay on the referencing element. After a short delay (maybe one tick, maybe a small timeout), browsers will move focus back to the referencing element unless focus has moved somewhere else in the meantime. The API focus event still won't be called, so from a screen reader user's perspective, there have been no focus changes at all. But from a page javascript perspective, the normal events have fired.

I didn't include any wording about what happens if a page author does `preventDefault` on the click or on the first focus event, since that seems too far into the weeds of DOM behavior for ARIA (and more of a JS/eventing concern). Let me know if anyone feels that should be here, though.