### PR TITLE
editorial: add related concepts to aria-colspan and aria-rowspan

### DIFF
--- a/index.html
+++ b/index.html
@@ -13074,7 +13074,7 @@ button.ariaPressed; // null</pre
             <tbody>
               <tr>
                 <th class="property-related-head" scope="row">Related Concepts:</th>
-                <td class="property-related"> </td>
+                <td class="property-related"><a href="#aria-rowspan">aria-rowspan</a>, <a href="https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-colspan">colspan</a> in HTML</td>
               </tr>
               <tr>
                 <th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -15716,7 +15716,7 @@ button.ariaPressed; // null</pre
             <tbody>
               <tr>
                 <th class="property-related-head" scope="row">Related Concepts:</th>
-                <td class="property-related"> </td>
+                <td class="property-related"><a href="#aria-colspan">aria-colspan</a>, <a href="https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-rowspan">rowspan</a> in HTML</td>
               </tr>
               <tr>
                 <th class="property-applicability-head" scope="row">Used in Roles:</th>

--- a/index.html
+++ b/index.html
@@ -13074,7 +13074,7 @@ button.ariaPressed; // null</pre
             <tbody>
               <tr>
                 <th class="property-related-head" scope="row">Related Concepts:</th>
-                <td class="property-related"><a href="#aria-rowspan">aria-rowspan</a>, <a href="https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-colspan">colspan</a> in HTML</td>
+                <td class="property-related"><a href="https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-colspan">colspan</a> in HTML</td>
               </tr>
               <tr>
                 <th class="property-applicability-head" scope="row">Used in Roles:</th>
@@ -15716,7 +15716,7 @@ button.ariaPressed; // null</pre
             <tbody>
               <tr>
                 <th class="property-related-head" scope="row">Related Concepts:</th>
-                <td class="property-related"><a href="#aria-colspan">aria-colspan</a>, <a href="https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-rowspan">rowspan</a> in HTML</td>
+                <td class="property-related"><a href="https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-rowspan">rowspan</a> in HTML</td>
               </tr>
               <tr>
                 <th class="property-applicability-head" scope="row">Used in Roles:</th>


### PR DESCRIPTION
🚀 **Netlify Preview**:
🔄 **this PR updates the following sspecs**:
- [ARIA preview](https://deploy-preview-2846--wai-aria.netlify.app/index.html) &mdash; [ARIA diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Faria%2F&doc2=https%3A%2F%2Fdeploy-preview-2846--wai-aria.netlify.app%2Findex.html)

Closes #2565

Adds related concepts of `aria-rowspan` & HTML `colspan` under `aria-colspan` property
Adds related concepts of `aria-colspan` & HTML `rowspan` under `aria-rowspan` property