### PR TITLE
Editorial: Remove ATK prefix from role names for ATK/AT-SPI

### DIFF
--- a/mathml-aam/index.html
+++ b/mathml-aam/index.html
@@ -182,7 +182,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_STATIC</code></span
                 ><br />
@@ -221,7 +221,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
@@ -260,7 +260,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
@@ -303,7 +303,7 @@
               </td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <div class="general">Use WAI-ARIA mapping</div>
               </td>
@@ -338,7 +338,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
@@ -377,7 +377,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_MATH_FRACTION</code></span
                 ><br />
@@ -421,7 +421,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_STATIC</code></span
                 ><br />
@@ -460,7 +460,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
@@ -517,7 +517,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_STATIC</code></span
                 ><br />
@@ -556,7 +556,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_STATIC</code></span
                 ><br />
@@ -595,7 +595,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
@@ -636,7 +636,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
@@ -675,7 +675,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
@@ -714,7 +714,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
@@ -749,7 +749,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_MATH_ROOT</code></span
                 ><br />
@@ -793,7 +793,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
@@ -832,7 +832,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_STATIC</code></span
                 ><br />
@@ -871,7 +871,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>Not mapped</td>
             </tr>
             <tr>
@@ -902,7 +902,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_MATH_ROOT</code></span
                 ><br />
@@ -943,7 +943,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
@@ -982,7 +982,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
@@ -1026,7 +1026,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
@@ -1070,7 +1070,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
@@ -1114,7 +1114,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_TABLE</code></span
                 ><br />
@@ -1155,7 +1155,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_TABLE_CELL</code></span
                 ><br />
@@ -1196,7 +1196,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_STATIC</code></span
                 ><br />
@@ -1235,7 +1235,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_TABLE_ROW</code></span
                 ><br />
@@ -1274,7 +1274,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
@@ -1318,7 +1318,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
@@ -1363,7 +1363,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
@@ -1402,7 +1402,7 @@
               <td>TBD</td>
             </tr>
             <tr>
-              <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
+              <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
               <td>
                 <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />

--- a/mathml-aam/index.html
+++ b/mathml-aam/index.html
@@ -184,7 +184,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_STATIC</code></span
+                <span class="role">Role: <code>ROLE_STATIC</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:annotation</code></span>
               </td>
@@ -223,7 +223,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_SECTION</code></span
+                <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:annotation-xml</code></span>
               </td>
@@ -262,7 +262,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_SECTION</code></span
+                <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:maction</code></span>
               </td>
@@ -340,7 +340,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_SECTION</code></span
+                <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:merror</code></span>
               </td>
@@ -379,7 +379,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_MATH_FRACTION</code></span
+                <span class="role">Role: <code>ROLE_MATH_FRACTION</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:mfrac</code></span>
               </td>
@@ -423,7 +423,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_STATIC</code></span
+                <span class="role">Role: <code>ROLE_STATIC</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:mi</code></span>
               </td>
@@ -462,7 +462,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_SECTION</code></span
+                <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:mmultiscripts</code></span>
               </td>
@@ -519,7 +519,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_STATIC</code></span
+                <span class="role">Role: <code>ROLE_STATIC</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:ms</code></span>
               </td>
@@ -558,7 +558,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_STATIC</code></span
+                <span class="role">Role: <code>ROLE_STATIC</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:mo</code></span>
               </td>
@@ -597,7 +597,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_SECTION</code></span
+                <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:mover</code></span>
               </td>
@@ -638,7 +638,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_SECTION</code></span
+                <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:mpadded</code></span>
               </td>
@@ -677,7 +677,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_SECTION</code></span
+                <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:mphantom</code></span>
               </td>
@@ -716,7 +716,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_SECTION</code></span
+                <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:mprescripts</code></span>
               </td>
@@ -751,7 +751,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_MATH_ROOT</code></span
+                <span class="role">Role: <code>ROLE_MATH_ROOT</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:mroot</code></span>
               </td>
@@ -795,7 +795,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_SECTION</code></span
+                <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:mrow</code></span>
               </td>
@@ -834,7 +834,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_STATIC</code></span
+                <span class="role">Role: <code>ROLE_STATIC</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:ms</code></span>
               </td>
@@ -904,7 +904,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_MATH_ROOT</code></span
+                <span class="role">Role: <code>ROLE_MATH_ROOT</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:mroot</code></span>
               </td>
@@ -945,7 +945,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_SECTION</code></span
+                <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:mstyle</code></span>
               </td>
@@ -984,7 +984,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_SECTION</code></span
+                <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:msub</code></span>
               </td>
@@ -1028,7 +1028,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_SECTION</code></span
+                <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:msubsup</code></span>
               </td>
@@ -1072,7 +1072,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_SECTION</code></span
+                <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:msup</code></span>
               </td>
@@ -1116,7 +1116,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_TABLE</code></span
+                <span class="role">Role: <code>ROLE_TABLE</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:mtable</code></span
                 ><br />
@@ -1157,7 +1157,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_TABLE_CELL</code></span
+                <span class="role">Role: <code>ROLE_TABLE_CELL</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:mtd</code></span
                 ><br />
@@ -1198,7 +1198,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_STATIC</code></span
+                <span class="role">Role: <code>ROLE_STATIC</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:mtext</code></span>
               </td>
@@ -1237,7 +1237,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_TABLE_ROW</code></span
+                <span class="role">Role: <code>ROLE_TABLE_ROW</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:mtr</code></span>
               </td>
@@ -1276,7 +1276,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_SECTION</code></span
+                <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:munder</code></span>
               </td>
@@ -1320,7 +1320,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_SECTION</code></span
+                <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:munderover</code></span>
               </td>
@@ -1365,7 +1365,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_SECTION</code></span
+                <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:none</code></span>
               </td>
@@ -1404,7 +1404,7 @@
             <tr>
               <th><abbr title="Accessibility Toolkit">ATK</abbr></th>
               <td>
-                <span class="role">Role: <code>ATK_ROLE_SECTION</code></span
+                <span class="role">Role: <code>ROLE_SECTION</code></span
                 ><br />
                 <span class="objattr">Object Attribute: <code>tag:semantics</code></span>
               </td>


### PR DESCRIPTION
Closes https://github.com/w3c/mathml-aam/issues/42

Remove the `ATK_` prefix from `ATK/AT-SPI` role names for mathml-aam.

Rename section header from `ATK` to `ATK/AT-SPI` in mathml-aam.

This change is purely editorial and contains no behavior change.