### PR TITLE
editorial: remove elements no longer in SVG 2 Editor's Draft

### DIFF
--- a/svg-aam/index.html
+++ b/svg-aam/index.html
@@ -181,16 +181,22 @@
       <p>Relative to the last published working draft (10 May 2018), the following changes have been made:</p>
       <ul>
         <li>
-          Removal of a number of SVG elements that are either deprecated or no longer present in the last SVG Candidate Recommendation. These include:
+          Removal of a number of SVG elements that are either deprecated or no longer present in the SVG 2 Editor's Draft. These include:
           <ul>
-            <li>Discard</li>
-            <li>SolidColor</li>
-            <li>MeshPatch</li>
-            <li>Mesh</li>
-            <li>HatchPath</li>
-            <li>MeshRow</li>
-            <li>Hatch</li>
-            <li>Cursor</li>
+            <li>audio</li>
+            <li>canvas</li>
+            <li>cursor</li>
+            <li>discard</li>
+            <li>hatch</li>
+            <li>hatchpath</li>
+            <li>iframe</li>
+            <li>mesh</li>
+            <li>meshpatch</li>
+            <li>meshrow</li>
+            <li>solidcolor</li>
+            <li>source</li>
+            <li>track</li>
+            <li>video</li>
           </ul>
         </li>
       </ul>
@@ -253,7 +259,7 @@
         </p>
         <p>
           SVG 2 now incorporates keyboard navigation based on the established model from HTML 5. The <a class="termref" data-lt="user agent">user agent</a> provides sequential focus navigation to
-          <abbr title="Scalable Vector Graphics">SVG</abbr> elements that are interactive by default (links and audio/video elements with controls), or that the author has indicated may receive focus
+          <abbr title="Scalable Vector Graphics">SVG</abbr> elements that are interactive by default (links), or that the author has indicated may receive focus
           (through the use of <code>tabindex</code> attribute). Focus may also be set or removed programmatically by scripts, so that authors may implement more complex keyboard focus patterns.
         </p>
         <p>
@@ -649,24 +655,14 @@
             <li>the <code>use</code> element</li>
             <li>the grouping (<code>g</code>) element</li>
             <li>the <code>image</code> element</li>
-            <li>the <code>mesh</code> element</li>
             <li>
               text formatting elements (<code>textPath</code>,
               <code>tspan</code>)
             </li>
             <li>the <code>foreignObject</code> element</li>
-            <!--
-        <li>
-          the <code>canvas</code> element
-        </li>
-        <li>
-          the <code>iframe</code> element
-        </li>
-        -->
           </ul>
           <p>
             Although these elements are omitted from the accessibility tree, their child content
-            <!-- (or the embedded document, for an <code>iframe</code>) -->
             is still processed, as if it was a direct child of the nearest ancestor node in the DOM tree that is included in the accessibility tree. In other words, the markup elements are treated as
             if they had a role of <code>none</code> or <code>presentation</code>.
           </p>
@@ -961,61 +957,6 @@
             <tr>
               <th>Allowed <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Roles and Platform <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Role Mappings</th>
               <td>no role may be applied</td>
-            </tr>
-          </tbody>
-        </table>
-        <h4 id="role-map-audio"><code>audio</code></h4>
-        <table class="data" aria-labelledby="role-map-audio">
-          <tbody>
-            <tr>
-              <th>SVG Specification</th>
-              <td>
-                <a class="element-reference" href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element"><code>audio</code></a>
-              </td>
-            </tr>
-            <tr>
-              <th>
-                Default Platform
-                <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Role Mappings
-              </th>
-              <td>
-                Follow the recommendations for <a class="html-mapping" href="#el-audio">the HTML audio element</a>
-                in the HTML Accessibility API Mappings specification [[HTML-AAM]].
-              </td>
-            </tr>
-            <tr>
-              <th>Allowed <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Roles and Platform <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Role Mappings</th>
-              <td>
-                <a class="core-mapping" href="#role-map-application"><code title="attr-aria-role-application">application</code></a> role
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <h4 id="role-map-canvas"><code>canvas</code></h4>
-        <table class="data" aria-labelledby="role-map-canvas">
-          <tbody>
-            <tr>
-              <th>SVG Specification</th>
-              <td>
-                <a class="element-reference" href="https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-element"><code>canvas</code></a>
-              </td>
-            </tr>
-            <tr>
-              <th>
-                Default Platform
-                <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Role Mappings
-              </th>
-              <td>
-                Follow the recommendations for <a class="html-mapping" href="#el-canvas">the HTML canvas element</a>
-                in the HTML Accessibility API Mappings specification [[HTML-AAM]].
-              </td>
-            </tr>
-            <tr>
-              <th>Allowed <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Roles and Platform <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Role Mappings</th>
-              <td>
-                any role; see the <a class="core-mapping" href="#mapping_role_table"><code>Core Accessibility API Role Mappings</code></a> and the
-                <a class="graphics-mapping" href="#mapping_role_table"><code>Graphics Accessibility API Role Mappings</code></a>
-              </td>
             </tr>
           </tbody>
         </table>
@@ -1772,35 +1713,6 @@
             </tr>
           </tbody>
         </table>
-        <h4 id="role-map-iframe"><code>iframe</code></h4>
-        <table class="data" aria-labelledby="role-map-iframe">
-          <tbody>
-            <tr>
-              <th>SVG Specification</th>
-              <td>
-                <a class="element-reference" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element"><code>iframe</code></a>
-              </td>
-            </tr>
-            <tr>
-              <th>
-                Default Platform
-                <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Role Mappings
-              </th>
-              <td>
-                Follow the recommendations for <a class="html-mapping" href="#el-iframe">the HTML iframe element</a>
-                in the HTML Accessibility API Mappings specification [[HTML-AAM]].
-              </td>
-            </tr>
-            <tr>
-              <th>Allowed <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Roles and Platform <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Role Mappings</th>
-              <td>
-                <a class="core-mapping" href="#role-map-application"><code title="attr-aria-role-application">application</code></a
-                >, <a class="core-mapping" href="#role-map-document"><code title="attr-aria-role-document">document</code></a
-                >, <a class="core-mapping" href="#role-map-img"><code title="attr-aria-role-img">img</code></a>
-              </td>
-            </tr>
-          </tbody>
-        </table>
         <h4 id="role-map-image"><code>image</code></h4>
         <table class="data" aria-labelledby="role-map-image">
           <tbody>
@@ -2167,31 +2079,6 @@
             </tr>
           </tbody>
         </table>
-        <h4 id="role-map-source"><code>source</code></h4>
-        <table class="data" aria-labelledby="role-map-source">
-          <tbody>
-            <tr>
-              <th>SVG Specification</th>
-              <td>
-                <a class="element-reference" href="https://html.spec.whatwg.org/multipage/embedded-content-0.html#the-source-element"><code>source</code></a>
-              </td>
-            </tr>
-            <tr>
-              <th>
-                Default Platform
-                <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Role Mappings
-              </th>
-              <td>
-                Follow the recommendations for <a class="html-mapping" href="#el-source">the HTML source element</a>
-                in the HTML Accessibility API Mappings specification [[HTML-AAM]].
-              </td>
-            </tr>
-            <tr>
-              <th>Allowed <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Roles and Platform <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Role Mappings</th>
-              <td>no role may be applied</td>
-            </tr>
-          </tbody>
-        </table>
         <h4 id="role-map-stop"><code>stop</code></h4>
         <table class="data" aria-labelledby="role-map-stop">
           <tbody>
@@ -2433,31 +2320,6 @@
             </tr>
           </tbody>
         </table>
-        <h4 id="role-map-track"><code>track</code></h4>
-        <table class="data" aria-labelledby="role-map-track">
-          <tbody>
-            <tr>
-              <th>SVG Specification</th>
-              <td>
-                <a class="element-reference" href="https://html.spec.whatwg.org/multipage/media.html#the-track-element"><code>track</code></a>
-              </td>
-            </tr>
-            <tr>
-              <th>
-                Default Platform
-                <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Role Mappings
-              </th>
-              <td>
-                Follow the recommendations for <a class="html-mapping" href="#el-track">the HTML track element</a>
-                in the HTML Accessibility API Mappings specification [[HTML-AAM]].
-              </td>
-            </tr>
-            <tr>
-              <th>Allowed <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Roles and Platform <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Role Mappings</th>
-              <td>no role may be applied</td>
-            </tr>
-          </tbody>
-        </table>
         <h4 id="role-map-tspan"><code>tspan</code></h4>
         <table class="data" aria-labelledby="role-map-tspan">
           <tbody>
@@ -2524,33 +2386,6 @@
             </tr>
           </tbody>
         </table>
-        <h4 id="role-map-video"><code>video</code></h4>
-        <table class="data" aria-labelledby="role-map-video">
-          <tbody>
-            <tr>
-              <th>SVG Specification</th>
-              <td>
-                <a class="element-reference" href="https://html.spec.whatwg.org/multipage/media.html#the-video-element"><code>video</code></a>
-              </td>
-            </tr>
-            <tr>
-              <th>
-                Default Platform
-                <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Role Mappings
-              </th>
-              <td>
-                Follow the recommendations for <a class="html-mapping" href="#el-video">the HTML video element</a>
-                in the HTML Accessibility API Mappings specification [[HTML-AAM]].
-              </td>
-            </tr>
-            <tr>
-              <th>Allowed <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Roles and Platform <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Role Mappings</th>
-              <td>
-                <a class="core-mapping" href="#role-map-application"><code title="attr-aria-role-application">application</code></a> role
-              </td>
-            </tr>
-          </tbody>
-        </table>
         <h4 id="role-map-view"><code>view</code></h4>
         <table class="data" aria-labelledby="role-map-view">
           <tbody>
@@ -2603,14 +2438,8 @@
       <p>In addition, the following attributes on SVG elements require special processing:</p>
       <ul>
         <li>
-          <code>controls</code>
-          on a <a class="element-reference" href="http://www.w3.org/TR/SVG2/embedded.html#HTMLElements"><code>audio</code></a> or
-          <a class="element-reference" href="http://www.w3.org/TR/SVG2/embedded.html#HTMLElements"><code>video</code></a> element is interpretted as defined in the
-          <a class="html-mapping" href="#html-attribute-state-and-property-mappings">HTML Attribute State and Property Mappings</a> [[HTML-AAM]].
-        </li>
-        <li>
           <code>tabindex</code>
-          on a rendered element (whether visible or not) is interpretted as defined in the
+          on a rendered element (whether visible or not) is interpreted as defined in the
           <a class="html-mapping" href="#html-attribute-state-and-property-mappings">HTML Attribute State and Property Mappings</a> [[HTML-AAM]].
         </li>
         <li>


### PR DESCRIPTION
This removes mappings for elements that are no longer in the SVG 2 Editors Draft due to lack of implementations - the elements in question were never implemented by any browser. Also fixes one typo (interpretted -> interpreted)


