### PR TITLE
editorial: link aria-posinset and aria-setsize to spec, wrap css references in code

### DIFF
--- a/index.html
+++ b/index.html
@@ -667,8 +667,8 @@
           <dd>
             <p>
               <a>Accessibility API</a> <a>state</a> that is controlled by the user agent, such as focus and selection. These are contrasted with &quot;unmanaged states&quot; that are typically
-              controlled by the author. Nevertheless, authors can override some managed states, such as aria-posinset and aria-setsize. Many managed states have corresponding CSS pseudo-classes, such
-              as :focus, and pseudo-elements, such as ::selection, that are also updated by the user agent.
+              controlled by the author. Nevertheless, authors can override some managed states, such as <pref>aria-posinset</pref> and <pref>aria-setsize</pref>. Many managed states have corresponding CSS pseudo-classes, such
+              as <code>:focus</code>, and pseudo-elements, such as <code>::selection</code>, that are also updated by the user agent.
             </p>
           </dd>
           <dt><dfn>Nemeth Braille</dfn></dt>


### PR DESCRIPTION
🚀 **Netlify Preview**:
🔄 **this PR updates the following sspecs**:
- [ARIA preview](https://deploy-preview-2853--wai-aria.netlify.app/index.html) &mdash; [ARIA diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Faria%2F&doc2=https%3A%2F%2Fdeploy-preview-2853--wai-aria.netlify.app%2Findex.html)

Closes #2545

Change `aria-posinset` and `aria-setsize` in the Managed State glossary entry to links in the spec, and wrap CSS references in `<code>`