### PR TITLE
Editorial: correct typo in required attribute comments

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -14158,7 +14158,7 @@
               <td>
                 <p>If the element includes both the `required` attribute and the `aria-required` attribute with a valid value, User Agents MUST expose only the `required` attribute value.</p>
                 <p>
-                  If an element is <a data-cite="html/input.html#concept-input-required">required</a>, user agents MUST NOT expose the element with an intitial invalid state (<a
+                  If an element is <a data-cite="html/input.html#concept-input-required">required</a>, user agents MUST NOT expose the element with an initial invalid state (<a
                     class="core-mapping"
                     href="#ariaInvalidTrue"
                     >`aria-invalid="true"`</a


### PR DESCRIPTION
Corrects a typo for the word “initial” in [the Comments for the `required` attribute in HTML-AAM](https://w3c.github.io/html-aam/#att-required).