### PR TITLE
Chore: Stop triggers for DPUB TR publication

### DIFF
--- a/.github/workflows/dpub-aam.yml
+++ b/.github/workflows/dpub-aam.yml
@@ -25,8 +25,8 @@ jobs:
           DESTINATION: dpub-aam/index.html
           GH_PAGES_BRANCH: gh-pages
           BUILD_FAIL_ON: nothing
-          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN_DPUB_AAM }}
-          W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-aria-admin/2018Sep/0011.html
-          W3C_BUILD_OVERRIDE: |
-            specStatus: WD
-            shortName: dpub-aam-1.2
+          # W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN_DPUB_AAM }}
+          # W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-aria-admin/2018Sep/0011.html
+          # W3C_BUILD_OVERRIDE: |
+            # specStatus: WD
+            # shortName: dpub-aam-1.2

--- a/.github/workflows/dpub-aria.yml
+++ b/.github/workflows/dpub-aria.yml
@@ -25,8 +25,8 @@ jobs:
           DESTINATION: dpub-aria/index.html
           GH_PAGES_BRANCH: gh-pages
           BUILD_FAIL_ON: nothing
-          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN_DPUB_ARIA }}
-          W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-aria-admin/2018Sep/0011.html
-          W3C_BUILD_OVERRIDE: |
-            specStatus: WD
-            shortName: dpub-aria-1.2
+          # W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN_DPUB_ARIA }}
+          # W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-aria-admin/2018Sep/0011.html
+          # W3C_BUILD_OVERRIDE: |
+            # specStatus: WD
+            # shortName: dpub-aria-1.2


### PR DESCRIPTION
This stops triggers for DPUB publications to TR. Currently the workflow failed because it couldn't publish to GitHub and TR. We're fine with this just being published on GitHub up until we decide we want to update the existing DPUB Recommendations.
