### PR TITLE
Editorial: PDF-AAM import export 7 - table elements

### DIFF
--- a/pdf-aam/index.html
+++ b/pdf-aam/index.html
@@ -1071,342 +1071,342 @@
             </tbody>
           </table>
 
-			<h4 id="pdf-table">`Table`</h4>
-			<table class="data" aria-labelledby="pdf-table">
-			  <tbody>
-				<tr>
-				  <th>PDF Specification</th>
-				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
-				</tr>
-				<tr>
-				  <th>ARIA Specification</th>
-				  <td><a class="core-mapping" href="#role-map-table">Role: `table`</a></td>
-				</tr>
-				<tr>
-				  <th>Analogous HTML Element</th>
-				  <td><a class="html-mapping" href="#el-table">Role: `table`</a></td>
-				</tr>
-				<tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
-			  </tbody>
-			</table>
+          <h4 id="pdf-table">`Table`</h4>
+          <table class="data" aria-labelledby="pdf-table">
+            <tbody>
+              <tr>
+                <th>PDF Specification</th>
+                <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+              </tr>
+              <tr>
+                <th>ARIA Specification</th>
+                <td><a class="core-mapping" href="#role-map-table">Role: `table`</a></td>
+              </tr>
+              <tr>
+                <th>Analogous HTML Element</th>
+                <td><a class="html-mapping" href="#el-table">Role: `table`</a></td>
+              </tr>
+              <tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
+            </tbody>
+          </table>
 
-			<h4 id="pdf-tr">`TR`</h4>
-			<table class="data" aria-labelledby="pdf-tr">
-			  <tbody>
-				<tr>
-				  <th>PDF Specification</th>
-				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
-				</tr>
-				<tr>
-				  <th>ARIA Specification</th>
-				  <td><a class="core-mapping" href="#role-map-row">Role: `row not inside treegrid`</a></td>
-				</tr>
-				<tr>
-				  <th>Analogous HTML Element</th>
-				  <td><a class="html-mapping" href="#el-tr">Role: `tr`</a></td>
-				</tr>
-				<tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
-			  </tbody>
-			</table>
+          <h4 id="pdf-tr">`TR`</h4>
+          <table class="data" aria-labelledby="pdf-tr">
+            <tbody>
+              <tr>
+                <th>PDF Specification</th>
+                <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+              </tr>
+              <tr>
+                <th>ARIA Specification</th>
+                <td><a class="core-mapping" href="#role-map-row">Role: `row not inside treegrid`</a></td>
+              </tr>
+              <tr>
+                <th>Analogous HTML Element</th>
+                <td><a class="html-mapping" href="#el-tr">Role: `tr`</a></td>
+              </tr>
+              <tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
+            </tbody>
+          </table>
 
-			<h4 id="pdf-th-scope-column">`TH` <span class="el-context">(`Scope` = `Column` and `Headers` array not set)</span></h4>
-			<table class="data" aria-labelledby="pdf-th-scope-column">
-			  <tbody>
-				<tr>
-				  <th>PDF Specification</th>
-				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
-				</tr>
-				<tr>
-				  <th>ARIA Specification</th>
-				  <td><a class="core-mapping" href="#role-map-columnheader">Role: `columnheader`</a></td>
-				</tr>
-				<tr>
-				  <th>Analogous HTML Element</th>
-				  <td><a class="html-mapping" href="#el-th-columnheader">Role: `th` <span class="el-context">(is a column header or column group header)</span></a></td>
-				</tr>
-				<tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
-			  </tbody>
-			</table>
+          <h4 id="pdf-th-scope-column">`TH` <span class="el-context">(`Scope` = `Column` and `Headers` array not set)</span></h4>
+          <table class="data" aria-labelledby="pdf-th-scope-column">
+            <tbody>
+              <tr>
+                <th>PDF Specification</th>
+                <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+              </tr>
+              <tr>
+                <th>ARIA Specification</th>
+                <td><a class="core-mapping" href="#role-map-columnheader">Role: `columnheader`</a></td>
+              </tr>
+              <tr>
+                <th>Analogous HTML Element</th>
+                <td><a class="html-mapping" href="#el-th-columnheader">Role: `th` <span class="el-context">(is a column header or column group header)</span></a></td>
+              </tr>
+              <tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
+            </tbody>
+          </table>
 
-			<h4 id="pdf-th-scope-row">`TH` <span class="el-context">(`Scope` = `Row` and `Headers` array not set)</span></h4>
-			<table class="data" aria-labelledby="pdf-th-scope-row">
-			  <tbody>
-				<tr>
-				  <th>PDF Specification</th>
-				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
-				</tr>
-				<tr>
-				  <th>ARIA Specification</th>
-				  <td><a class="core-mapping" href="#role-map-rowheader">Role: `rowheader`</a></td>
-				</tr>
-				<tr>
-				  <th>Analogous HTML Element</th>
-				  <td><a class="html-mapping" href="#el-th-rowheader">Role: `th` <span class="el-context"> (is a row header or row group header)</span></a></td>
-				</tr>
-				<tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
-			  </tbody>
-			</table>
+          <h4 id="pdf-th-scope-row">`TH` <span class="el-context">(`Scope` = `Row` and `Headers` array not set)</span></h4>
+          <table class="data" aria-labelledby="pdf-th-scope-row">
+            <tbody>
+              <tr>
+                <th>PDF Specification</th>
+                <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+              </tr>
+              <tr>
+                <th>ARIA Specification</th>
+                <td><a class="core-mapping" href="#role-map-rowheader">Role: `rowheader`</a></td>
+              </tr>
+              <tr>
+                <th>Analogous HTML Element</th>
+                <td><a class="html-mapping" href="#el-th-rowheader">Role: `th` <span class="el-context"> (is a row header or row group header)</span></a></td>
+              </tr>
+              <tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
+            </tbody>
+          </table>
 
-			<h4 id="pdf-th-scope-both">`TH` <span class="el-context">(`Scope` = `Both` and `Headers` array not set)</span></h4>
-			<table class="data" aria-labelledby="pdf-th-scope-both">
-			  <tbody>
-				<tr>
-				  <th>PDF Specification</th>
-				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
-				</tr>
-				<tr>
-				  <th>ARIA Specification</th>
-				  <td>TBD</td>
-				</tr>
-				<tr>
-				  <th>Analogous HTML Element</th>
-				  <td>TBD</td>
-				</tr>
-				<tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="Notes">Notes:</abbr></th><td>Expose the TH to both row and column navigation for cells within the scope</td></tr>
-			  </tbody>
-			</table>
+          <h4 id="pdf-th-scope-both">`TH` <span class="el-context">(`Scope` = `Both` and `Headers` array not set)</span></h4>
+          <table class="data" aria-labelledby="pdf-th-scope-both">
+            <tbody>
+              <tr>
+                <th>PDF Specification</th>
+                <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+              </tr>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>TBD</td>
+              </tr>
+              <tr>
+                <th>Analogous HTML Element</th>
+                <td>TBD</td>
+              </tr>
+              <tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Notes">Notes:</abbr></th><td>Expose the TH to both row and column navigation for cells within the scope</td></tr>
+            </tbody>
+          </table>
 
-			<h4 id="pdf-th-headers-set">`TH` <span class="el-context">(`Scope` is not set and `Headers` array is set)</span></h4>
-			<table class="data" aria-labelledby="pdf-th-headers-set">
-			  <tbody>
-				<tr>
-				  <th>PDF Specification</th>
-				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
-				</tr>
-				<tr>
-				  <th>ARIA Specification</th>
-				  <td><a class="core-mapping" href="#role-map-cell">Role: `cell`</a></td>
-				</tr>
-				<tr>
-				  <th>Analogous HTML Element</th>
-				  <td><a class="html-mapping" href="#el-th">Role: `th`</a></td>
-				</tr>
-				<tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="Notes">Notes:</abbr></th><td><span class="property">Note from PDFa: HTML uses `Headers` array / IDs for `TH` and `TD`</span></td></tr>
-			  </tbody>
-			</table>
+          <h4 id="pdf-th-headers-set">`TH` <span class="el-context">(`Scope` is not set and `Headers` array is set)</span></h4>
+          <table class="data" aria-labelledby="pdf-th-headers-set">
+            <tbody>
+              <tr>
+                <th>PDF Specification</th>
+                <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+              </tr>
+              <tr>
+                <th>ARIA Specification</th>
+                <td><a class="core-mapping" href="#role-map-cell">Role: `cell`</a></td>
+              </tr>
+              <tr>
+                <th>Analogous HTML Element</th>
+                <td><a class="html-mapping" href="#el-th">Role: `th`</a></td>
+              </tr>
+              <tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Notes">Notes:</abbr></th><td><span class="property">Note from PDFa: HTML uses `Headers` array / IDs for `TH` and `TD`</span></td></tr>
+            </tbody>
+          </table>
 
-			<h4 id="pdf-th-scope-both-headers-set">`TH` <span class="el-context">(`Scope` = `Both` and `Headers` array is set)</span></h4>
-			<table class="data" aria-labelledby="pdf-th-scope-both-headers-set">
-			  <tbody>
-				<tr>
-				  <th>PDF Specification</th>
-				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
-				</tr>
-				<tr>
-				  <th>ARIA Specification</th>
-				  <td>TBD</td>
-				</tr>
-				<tr>
-				  <th>Analogous HTML Element</th>
-				  <td>Use WAI-ARIA mapping</td>
-				</tr>
-				<tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
-			  </tbody>
-			</table>
+          <h4 id="pdf-th-scope-both-headers-set">`TH` <span class="el-context">(`Scope` = `Both` and `Headers` array is set)</span></h4>
+          <table class="data" aria-labelledby="pdf-th-scope-both-headers-set">
+            <tbody>
+              <tr>
+                <th>PDF Specification</th>
+                <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+              </tr>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>TBD</td>
+              </tr>
+              <tr>
+                <th>Analogous HTML Element</th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
+            </tbody>
+          </table>
 
-			<h4 id="pdf-td">`TD`</h4>
-			<table class="data" aria-labelledby="pdf-td">
-			  <tbody>
-				<tr>
-				  <th>PDF Specification</th>
-				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
-				</tr>
-				<tr>
-				  <th>ARIA Specification</th>
-				  <td><a class="core-mapping" href="#role-map-cell">Role: `cell`</a></td>
-				</tr>
-				<tr>
-				  <th>Analogous HTML Element</th>
-				  <td><a class="html-mapping" href="#el-td">Role: `td`</a></td>
-				</tr>
-				<tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-				<tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
-			  </tbody>
-			</table>
+          <h4 id="pdf-td">`TD`</h4>
+          <table class="data" aria-labelledby="pdf-td">
+            <tbody>
+              <tr>
+                <th>PDF Specification</th>
+                <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+              </tr>
+              <tr>
+                <th>ARIA Specification</th>
+                <td><a class="core-mapping" href="#role-map-cell">Role: `cell`</a></td>
+              </tr>
+              <tr>
+                <th>Analogous HTML Element</th>
+                <td><a class="html-mapping" href="#el-td">Role: `td`</a></td>
+              </tr>
+              <tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
+            </tbody>
+          </table>
 
-			<h4 id="pdf-thead">`THead`</h4>
-			<table class="data" aria-labelledby="pdf-thead">
-			  <tbody>
-				<tr>
-				  <th>PDF Specification</th>
-				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
-				</tr>
-				<tr>
-				  <th>ARIA Specification</th>
-				  <td><a class="core-mapping" href="#role-map-rowgroup">Role: `rowgroup`</a></td>
-				</tr>
-				<tr>
-				  <th>Analogous HTML Element</th>
-				  <td><a class="html-mapping" href="#el-thead">Role: `thead`</a></td>
-				</tr>
-				<tr>
-				  <th>MSAA + IAccessible2</th>
-				  <td>Use WAI-ARIA mapping</td>
-				</tr>
-				<tr>
-				  <th><abbr title="User Interface Automation">UIA</abbr></th>
-				  <td>Use WAI-ARIA mapping</td>
-				</tr>
-				<tr>
-				  <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-				  <td>Use WAI-ARIA mapping</td>
-				</tr>
-				<tr>
-				  <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-				  <td>Use WAI-ARIA mapping</td>
-				</tr>
-				<tr>
-				  <th><abbr title="Notes">Notes:</abbr></th>
-				  <td></td>
-				</tr>
-			  </tbody>
-			</table>
+          <h4 id="pdf-thead">`THead`</h4>
+          <table class="data" aria-labelledby="pdf-thead">
+            <tbody>
+              <tr>
+                <th>PDF Specification</th>
+                <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+              </tr>
+              <tr>
+                <th>ARIA Specification</th>
+                <td><a class="core-mapping" href="#role-map-rowgroup">Role: `rowgroup`</a></td>
+              </tr>
+              <tr>
+                <th>Analogous HTML Element</th>
+                <td><a class="html-mapping" href="#el-thead">Role: `thead`</a></td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="Notes">Notes:</abbr></th>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
 
-			<h4 id="pdf-tbody">`TBody`</h4>
-			<table class="data" aria-labelledby="pdf-tbody">
-			  <tbody>
-				<tr>
-				  <th>PDF Specification</th>
-				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
-				</tr>
-				<tr>
-				  <th>ARIA Specification</th>
-				  <td><a class="core-mapping" href="#role-map-rowgroup">Role: `rowgroup`</a></td>
-				</tr>
-				<tr>
-				  <th>Analogous HTML Element</th>
-				  <td><a class="html-mapping" href="#el-tbody">Role: `tbody`</a></td>
-				</tr>
-				<tr>
-				  <th>MSAA + IAccessible2</th>
-				  <td>Use WAI-ARIA mapping</td>
-				</tr>
-				<tr>
-				  <th><abbr title="User Interface Automation">UIA</abbr></th>
-				  <td>Use WAI-ARIA mapping</td>
-				</tr>
-				<tr>
-				  <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-				  <td>Use WAI-ARIA mapping</td>
-				</tr>
-				<tr>
-				  <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-				  <td>Use WAI-ARIA mapping</td>
-				</tr>
-				<tr>
-				  <th><abbr title="Notes">Notes:</abbr></th>
-				  <td></td>
-				</tr>
-			  </tbody>
-			</table>
+          <h4 id="pdf-tbody">`TBody`</h4>
+          <table class="data" aria-labelledby="pdf-tbody">
+            <tbody>
+              <tr>
+                <th>PDF Specification</th>
+                <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+              </tr>
+              <tr>
+                <th>ARIA Specification</th>
+                <td><a class="core-mapping" href="#role-map-rowgroup">Role: `rowgroup`</a></td>
+              </tr>
+              <tr>
+                <th>Analogous HTML Element</th>
+                <td><a class="html-mapping" href="#el-tbody">Role: `tbody`</a></td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="Notes">Notes:</abbr></th>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
 
-			<h4 id="pdf-tfoot">`TFoot`</h4>
-			<table class="data" aria-labelledby="pdf-tfoot">
-			  <tbody>
-				<tr>
-				  <th>PDF Specification</th>
-				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
-				</tr>
-				<tr>
-				  <th>ARIA Specification</th>
-				  <td><a class="core-mapping" href="#role-map-rowgroup">Role: `rowgroup`</a></td>
-				</tr>
-				<tr>
-				  <th>Analogous HTML Element</th>
-				  <td><a class="html-mapping" href="#el-tfoot">Role: `tfoot`</a></td>
-				</tr>
-				<tr>
-				  <th>MSAA + IAccessible2</th>
-				  <td>Use WAI-ARIA mapping</td>
-				</tr>
-				<tr>
-				  <th><abbr title="User Interface Automation">UIA</abbr></th>
-				  <td>Use WAI-ARIA mapping</td>
-				</tr>
-				<tr>
-				  <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-				  <td>Use WAI-ARIA mapping</td>
-				</tr>
-				<tr>
-				  <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-				  <td>Use WAI-ARIA mapping</td>
-				</tr>
-				<tr>
-				  <th><abbr title="Notes">Notes:</abbr></th>
-				  <td></td>
-				</tr>
-			  </tbody>
-			</table>
+          <h4 id="pdf-tfoot">`TFoot`</h4>
+          <table class="data" aria-labelledby="pdf-tfoot">
+            <tbody>
+              <tr>
+                <th>PDF Specification</th>
+                <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+              </tr>
+              <tr>
+                <th>ARIA Specification</th>
+                <td><a class="core-mapping" href="#role-map-rowgroup">Role: `rowgroup`</a></td>
+              </tr>
+              <tr>
+                <th>Analogous HTML Element</th>
+                <td><a class="html-mapping" href="#el-tfoot">Role: `tfoot`</a></td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="Notes">Notes:</abbr></th>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
 
 
-			<h4 id="pdf-caption-table">`Caption` <span class="el-context">(child of `Table`)</span></h4>
-			<table class="data" aria-labelledby="pdf-caption-table">
-			  <tbody>
-				<tr>
-				  <th>PDF Specification</th>
-				  <td>ISO 32000-2:2020, 14.8.4.8.4 Caption structure type, Table 372</td>
-				</tr>
-				<tr>
-				  <th>ARIA Specification</th>
-				  <td><a class="core-mapping" href="#role-map-caption">Role: `caption`</a></td>
-				</tr>
-				<tr>
-				  <th>Analogous HTML Element</th>
-				  <td>Use WAI-ARIA mapping</td>
-				</tr>
-				<tr>
-				  <th>MSAA + IAccessible2</th>
-				  <td>Use WAI-ARIA mapping</td>
-				</tr>
-				<tr>
-				  <th><abbr title="User Interface Automation">UIA</abbr></th>
-				  <td>Use WAI-ARIA mapping</td>
-				</tr>
-				<tr>
-				  <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-				  <td>Use WAI-ARIA mapping</td>
-				</tr>
-				<tr>
-				  <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-				  <td>Use WAI-ARIA mapping</td>
-				</tr>
-				<tr>
-				  <th><abbr title="Notes">Notes:</abbr></th>
-				  <td><span class="property">Note from PDFa: If a descendant of a `Table`, the first instance of a `Caption` will provide the `Table` its accessible name.</span></td>
-				</tr>
-			  </tbody>
-			</table>
+          <h4 id="pdf-caption-table">`Caption` <span class="el-context">(child of `Table`)</span></h4>
+          <table class="data" aria-labelledby="pdf-caption-table">
+            <tbody>
+              <tr>
+                <th>PDF Specification</th>
+                <td>ISO 32000-2:2020, 14.8.4.8.4 Caption structure type, Table 372</td>
+              </tr>
+              <tr>
+                <th>ARIA Specification</th>
+                <td><a class="core-mapping" href="#role-map-caption">Role: `caption`</a></td>
+              </tr>
+              <tr>
+                <th>Analogous HTML Element</th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="Notes">Notes:</abbr></th>
+                <td><span class="property">Note from PDFa: If a descendant of a `Table`, the first instance of a `Caption` will provide the `Table` its accessible name.</span></td>
+              </tr>
+            </tbody>
+          </table>
 
 
         </section>

--- a/pdf-aam/index.html
+++ b/pdf-aam/index.html
@@ -412,6 +412,44 @@
             </tbody>
           </table>
 
+          <h4 id="pdf-caption-table">`Caption` <span class="el-context">(child of `Table`)</span></h4>
+          <table class="data" aria-labelledby="pdf-caption-table">
+            <tbody>
+              <tr>
+                <th>PDF Specification</th>
+                <td>ISO 32000-2:2020, 14.8.4.8.4 Caption structure type, Table 372</td>
+              </tr>
+              <tr>
+                <th>ARIA Specification</th>
+                <td><a class="core-mapping" href="#role-map-caption">Role: `caption`</a></td>
+              </tr>
+              <tr>
+                <th>Analogous HTML Element</th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="Notes">Notes:</abbr></th>
+                <td><span class="property">Note from PDFa: If a descendant of a `Table`, the first instance of a `Caption` will provide the `Table` its accessible name.</span></td>
+              </tr>
+            </tbody>
+          </table>
+
           <h4 id="role-div-has-attributes"><code> Div (has attributes)</code></h4>
           <table class="data" aria-labelledby="role-div-has-attributes">
             <tbody>
@@ -701,40 +739,42 @@
             </tbody>
           </table>
 
-          <h4 id="role-lbl"><code> Lbl</code> (Not associated with a Form element)</h4>
-          <table class="data" aria-labelledby="role-lbl">
+          <h4 id="role-lbl-forms"><code> Lbl</code> (associated with a Form element)</h4>
+          <table class="data" aria-labelledby="role-lbl-forms">
             <tbody>
               <tr>
                 <th>ARIA Specification</th>
-                <td>
-                  <a class="core-mapping" href="#role-map-generic">Role: <code>generic</code></a>
-                </td>
+                <td>No corresponding role</td>
               </tr>
               <tr>
                 <th>Analogous HTML Element</th>
-                <td>Use WAI-ARIA mapping</td>
+                <td>
+                  <a class="html-mapping" href="#el-label">Role: <code>label</code></a>
+                </td>
               </tr>
               <tr>
                 <th>MSAA + IAccessible2</th>
-                <td>Use WAI-ARIA mapping</td>
+                <td>Use HTML-AAM mapping</td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
-                <td>Use WAI-ARIA mapping</td>
+                <td>Use HTML-AAM mapping</td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-                <td>Use WAI-ARIA mapping</td>
+                <td>Use HTML-AAM mapping</td>
               </tr>
               <tr>
                 <th>
                   <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
                 </th>
-                <td>Use WAI-ARIA mapping</td>
+                <td>Use HTML-AAM mapping</td>
               </tr>
               <tr>
                 <th><abbr title="Notes">Notes:</abbr></th>
-                <td>Label types, especially for lists in UA-2, will receive further guidance at a future time.</td>
+                <td>
+                  <span class="property"><code></code></span>
+                </td>
               </tr>
             </tbody>
           </table>
@@ -781,42 +821,40 @@
             </tbody>
           </table>
 
-          <h4 id="role-lbl-forms"><code> Lbl</code> (associated with a Form element)</h4>
-          <table class="data" aria-labelledby="role-lbl-forms">
+          <h4 id="role-lbl"><code> Lbl</code> (Not associated with a Form element)</h4>
+          <table class="data" aria-labelledby="role-lbl">
             <tbody>
               <tr>
                 <th>ARIA Specification</th>
-                <td>No corresponding role</td>
-              </tr>
-              <tr>
-                <th>Analogous HTML Element</th>
                 <td>
-                  <a class="html-mapping" href="#el-label">Role: <code>label</code></a>
+                  <a class="core-mapping" href="#role-map-generic">Role: <code>generic</code></a>
                 </td>
               </tr>
               <tr>
+                <th>Analogous HTML Element</th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
                 <th>MSAA + IAccessible2</th>
-                <td>Use HTML-AAM mapping</td>
+                <td>Use WAI-ARIA mapping</td>
               </tr>
               <tr>
                 <th><abbr title="User Interface Automation">UIA</abbr></th>
-                <td>Use HTML-AAM mapping</td>
+                <td>Use WAI-ARIA mapping</td>
               </tr>
               <tr>
                 <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-                <td>Use HTML-AAM mapping</td>
+                <td>Use WAI-ARIA mapping</td>
               </tr>
               <tr>
                 <th>
                   <abbr title="macOS Accessibility Protocol">AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup>
                 </th>
-                <td>Use HTML-AAM mapping</td>
+                <td>Use WAI-ARIA mapping</td>
               </tr>
               <tr>
                 <th><abbr title="Notes">Notes:</abbr></th>
-                <td>
-                  <span class="property"><code></code></span>
-                </td>
+                <td>Label types, especially for lists in UA-2, will receive further guidance at a future time.</td>
               </tr>
             </tbody>
           </table>
@@ -1094,8 +1132,8 @@
             </tbody>
           </table>
 
-          <h4 id="pdf-tr">`TR`</h4>
-          <table class="data" aria-labelledby="pdf-tr">
+          <h4 id="pdf-tbody">`TBody`</h4>
+          <table class="data" aria-labelledby="pdf-tbody">
             <tbody>
               <tr>
                 <th>PDF Specification</th>
@@ -1103,17 +1141,139 @@
               </tr>
               <tr>
                 <th>ARIA Specification</th>
-                <td><a class="core-mapping" href="#role-map-row">Role: `row not inside treegrid`</a></td>
+                <td><a class="core-mapping" href="#role-map-rowgroup">Role: `rowgroup`</a></td>
               </tr>
               <tr>
                 <th>Analogous HTML Element</th>
-                <td><a class="html-mapping" href="#el-tr">Role: `tr`</a></td>
+                <td><a class="html-mapping" href="#el-tbody">Role: `tbody`</a></td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="Notes">Notes:</abbr></th>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+
+          <h4 id="pdf-td">`TD`</h4>
+          <table class="data" aria-labelledby="pdf-td">
+            <tbody>
+              <tr>
+                <th>PDF Specification</th>
+                <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+              </tr>
+              <tr>
+                <th>ARIA Specification</th>
+                <td><a class="core-mapping" href="#role-map-cell">Role: `cell`</a></td>
+              </tr>
+              <tr>
+                <th>Analogous HTML Element</th>
+                <td><a class="html-mapping" href="#el-td">Role: `td`</a></td>
               </tr>
               <tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
               <tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
               <tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
               <tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
               <tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
+            </tbody>
+          </table>
+
+          <h4 id="pdf-tfoot">`TFoot`</h4>
+          <table class="data" aria-labelledby="pdf-tfoot">
+            <tbody>
+              <tr>
+                <th>PDF Specification</th>
+                <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+              </tr>
+              <tr>
+                <th>ARIA Specification</th>
+                <td><a class="core-mapping" href="#role-map-rowgroup">Role: `rowgroup`</a></td>
+              </tr>
+              <tr>
+                <th>Analogous HTML Element</th>
+                <td><a class="html-mapping" href="#el-tfoot">Role: `tfoot`</a></td>
+              </tr>
+              <tr>
+                <th>MSAA + IAccessible2</th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="User Interface Automation">UIA</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr>
+                <th><abbr title="Notes">Notes:</abbr></th>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+
+          <h4 id="pdf-th-scope-both-headers-set">`TH` <span class="el-context">(`Scope` = `Both` and `Headers` array is set)</span></h4>
+          <table class="data" aria-labelledby="pdf-th-scope-both-headers-set">
+            <tbody>
+              <tr>
+                <th>PDF Specification</th>
+                <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+              </tr>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>TBD</td>
+              </tr>
+              <tr>
+                <th>Analogous HTML Element</th>
+                <td>Use WAI-ARIA mapping</td>
+              </tr>
+              <tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
+            </tbody>
+          </table>
+
+          <h4 id="pdf-th-scope-both">`TH` <span class="el-context">(`Scope` = `Both` and `Headers` array not set)</span></h4>
+          <table class="data" aria-labelledby="pdf-th-scope-both">
+            <tbody>
+              <tr>
+                <th>PDF Specification</th>
+                <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+              </tr>
+              <tr>
+                <th>ARIA Specification</th>
+                <td>TBD</td>
+              </tr>
+              <tr>
+                <th>Analogous HTML Element</th>
+                <td>TBD</td>
+              </tr>
+              <tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Notes">Notes:</abbr></th><td>Expose the TH to both row and column navigation for cells within the scope</td></tr>
             </tbody>
           </table>
 
@@ -1163,29 +1323,6 @@
             </tbody>
           </table>
 
-          <h4 id="pdf-th-scope-both">`TH` <span class="el-context">(`Scope` = `Both` and `Headers` array not set)</span></h4>
-          <table class="data" aria-labelledby="pdf-th-scope-both">
-            <tbody>
-              <tr>
-                <th>PDF Specification</th>
-                <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
-              </tr>
-              <tr>
-                <th>ARIA Specification</th>
-                <td>TBD</td>
-              </tr>
-              <tr>
-                <th>Analogous HTML Element</th>
-                <td>TBD</td>
-              </tr>
-              <tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
-              <tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-              <tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-              <tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-              <tr><th><abbr title="Notes">Notes:</abbr></th><td>Expose the TH to both row and column navigation for cells within the scope</td></tr>
-            </tbody>
-          </table>
-
           <h4 id="pdf-th-headers-set">`TH` <span class="el-context">(`Scope` is not set and `Headers` array is set)</span></h4>
           <table class="data" aria-labelledby="pdf-th-headers-set">
             <tbody>
@@ -1206,52 +1343,6 @@
               <tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
               <tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
               <tr><th><abbr title="Notes">Notes:</abbr></th><td><span class="property">Note from PDFa: HTML uses `Headers` array / IDs for `TH` and `TD`</span></td></tr>
-            </tbody>
-          </table>
-
-          <h4 id="pdf-th-scope-both-headers-set">`TH` <span class="el-context">(`Scope` = `Both` and `Headers` array is set)</span></h4>
-          <table class="data" aria-labelledby="pdf-th-scope-both-headers-set">
-            <tbody>
-              <tr>
-                <th>PDF Specification</th>
-                <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
-              </tr>
-              <tr>
-                <th>ARIA Specification</th>
-                <td>TBD</td>
-              </tr>
-              <tr>
-                <th>Analogous HTML Element</th>
-                <td>Use WAI-ARIA mapping</td>
-              </tr>
-              <tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
-              <tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-              <tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-              <tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-              <tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
-            </tbody>
-          </table>
-
-          <h4 id="pdf-td">`TD`</h4>
-          <table class="data" aria-labelledby="pdf-td">
-            <tbody>
-              <tr>
-                <th>PDF Specification</th>
-                <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
-              </tr>
-              <tr>
-                <th>ARIA Specification</th>
-                <td><a class="core-mapping" href="#role-map-cell">Role: `cell`</a></td>
-              </tr>
-              <tr>
-                <th>Analogous HTML Element</th>
-                <td><a class="html-mapping" href="#el-td">Role: `td`</a></td>
-              </tr>
-              <tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
-              <tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-              <tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-              <tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
-              <tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
             </tbody>
           </table>
 
@@ -1293,8 +1384,8 @@
             </tbody>
           </table>
 
-          <h4 id="pdf-tbody">`TBody`</h4>
-          <table class="data" aria-labelledby="pdf-tbody">
+          <h4 id="pdf-tr">`TR`</h4>
+          <table class="data" aria-labelledby="pdf-tr">
             <tbody>
               <tr>
                 <th>PDF Specification</th>
@@ -1302,109 +1393,17 @@
               </tr>
               <tr>
                 <th>ARIA Specification</th>
-                <td><a class="core-mapping" href="#role-map-rowgroup">Role: `rowgroup`</a></td>
+                <td><a class="core-mapping" href="#role-map-row">Role: `row not inside treegrid`</a></td>
               </tr>
               <tr>
                 <th>Analogous HTML Element</th>
-                <td><a class="html-mapping" href="#el-tbody">Role: `tbody`</a></td>
+                <td><a class="html-mapping" href="#el-tr">Role: `tr`</a></td>
               </tr>
-              <tr>
-                <th>MSAA + IAccessible2</th>
-                <td>Use WAI-ARIA mapping</td>
-              </tr>
-              <tr>
-                <th><abbr title="User Interface Automation">UIA</abbr></th>
-                <td>Use WAI-ARIA mapping</td>
-              </tr>
-              <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-                <td>Use WAI-ARIA mapping</td>
-              </tr>
-              <tr>
-                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-                <td>Use WAI-ARIA mapping</td>
-              </tr>
-              <tr>
-                <th><abbr title="Notes">Notes:</abbr></th>
-                <td></td>
-              </tr>
-            </tbody>
-          </table>
-
-          <h4 id="pdf-tfoot">`TFoot`</h4>
-          <table class="data" aria-labelledby="pdf-tfoot">
-            <tbody>
-              <tr>
-                <th>PDF Specification</th>
-                <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
-              </tr>
-              <tr>
-                <th>ARIA Specification</th>
-                <td><a class="core-mapping" href="#role-map-rowgroup">Role: `rowgroup`</a></td>
-              </tr>
-              <tr>
-                <th>Analogous HTML Element</th>
-                <td><a class="html-mapping" href="#el-tfoot">Role: `tfoot`</a></td>
-              </tr>
-              <tr>
-                <th>MSAA + IAccessible2</th>
-                <td>Use WAI-ARIA mapping</td>
-              </tr>
-              <tr>
-                <th><abbr title="User Interface Automation">UIA</abbr></th>
-                <td>Use WAI-ARIA mapping</td>
-              </tr>
-              <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-                <td>Use WAI-ARIA mapping</td>
-              </tr>
-              <tr>
-                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-                <td>Use WAI-ARIA mapping</td>
-              </tr>
-              <tr>
-                <th><abbr title="Notes">Notes:</abbr></th>
-                <td></td>
-              </tr>
-            </tbody>
-          </table>
-
-
-          <h4 id="pdf-caption-table">`Caption` <span class="el-context">(child of `Table`)</span></h4>
-          <table class="data" aria-labelledby="pdf-caption-table">
-            <tbody>
-              <tr>
-                <th>PDF Specification</th>
-                <td>ISO 32000-2:2020, 14.8.4.8.4 Caption structure type, Table 372</td>
-              </tr>
-              <tr>
-                <th>ARIA Specification</th>
-                <td><a class="core-mapping" href="#role-map-caption">Role: `caption`</a></td>
-              </tr>
-              <tr>
-                <th>Analogous HTML Element</th>
-                <td>Use WAI-ARIA mapping</td>
-              </tr>
-              <tr>
-                <th>MSAA + IAccessible2</th>
-                <td>Use WAI-ARIA mapping</td>
-              </tr>
-              <tr>
-                <th><abbr title="User Interface Automation">UIA</abbr></th>
-                <td>Use WAI-ARIA mapping</td>
-              </tr>
-              <tr>
-                <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
-                <td>Use WAI-ARIA mapping</td>
-              </tr>
-              <tr>
-                <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
-                <td>Use WAI-ARIA mapping</td>
-              </tr>
-              <tr>
-                <th><abbr title="Notes">Notes:</abbr></th>
-                <td><span class="property">Note from PDFa: If a descendant of a `Table`, the first instance of a `Caption` will provide the `Table` its accessible name.</span></td>
-              </tr>
+              <tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+              <tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
             </tbody>
           </table>
 

--- a/pdf-aam/index.html
+++ b/pdf-aam/index.html
@@ -1070,6 +1070,345 @@
               </tr>
             </tbody>
           </table>
+
+			<h4 id="pdf-table">`Table`</h4>
+			<table class="data" aria-labelledby="pdf-table">
+			  <tbody>
+				<tr>
+				  <th>PDF Specification</th>
+				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+				</tr>
+				<tr>
+				  <th>ARIA Specification</th>
+				  <td><a class="core-mapping" href="#role-map-table">Role: `table`</a></td>
+				</tr>
+				<tr>
+				  <th>Analogous HTML Element</th>
+				  <td><a class="html-mapping" href="#el-table">Role: `table`</a></td>
+				</tr>
+				<tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
+			  </tbody>
+			</table>
+
+			<h4 id="pdf-tr">`TR`</h4>
+			<table class="data" aria-labelledby="pdf-tr">
+			  <tbody>
+				<tr>
+				  <th>PDF Specification</th>
+				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+				</tr>
+				<tr>
+				  <th>ARIA Specification</th>
+				  <td><a class="core-mapping" href="#role-map-row">Role: `row not inside treegrid`</a></td>
+				</tr>
+				<tr>
+				  <th>Analogous HTML Element</th>
+				  <td><a class="html-mapping" href="#el-tr">Role: `tr`</a></td>
+				</tr>
+				<tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
+			  </tbody>
+			</table>
+
+			<h4 id="pdf-th-scope-column">`TH` <span class="el-context">(`Scope` = `Column` and `Headers` array not set)</span></h4>
+			<table class="data" aria-labelledby="pdf-th-scope-column">
+			  <tbody>
+				<tr>
+				  <th>PDF Specification</th>
+				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+				</tr>
+				<tr>
+				  <th>ARIA Specification</th>
+				  <td><a class="core-mapping" href="#role-map-columnheader">Role: `columnheader`</a></td>
+				</tr>
+				<tr>
+				  <th>Analogous HTML Element</th>
+				  <td><a class="html-mapping" href="#el-th-columnheader">Role: `th` <span class="el-context">(is a column header or column group header)</span></a></td>
+				</tr>
+				<tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
+			  </tbody>
+			</table>
+
+			<h4 id="pdf-th-scope-row">`TH` <span class="el-context">(`Scope` = `Row` and `Headers` array not set)</span></h4>
+			<table class="data" aria-labelledby="pdf-th-scope-row">
+			  <tbody>
+				<tr>
+				  <th>PDF Specification</th>
+				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+				</tr>
+				<tr>
+				  <th>ARIA Specification</th>
+				  <td><a class="core-mapping" href="#role-map-rowheader">Role: `rowheader`</a></td>
+				</tr>
+				<tr>
+				  <th>Analogous HTML Element</th>
+				  <td><a class="html-mapping" href="#el-th-rowheader">Role: `th` <span class="el-context"> (is a row header or row group header)</span></a></td>
+				</tr>
+				<tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
+			  </tbody>
+			</table>
+
+			<h4 id="pdf-th-scope-both">`TH` <span class="el-context">(`Scope` = `Both` and `Headers` array not set)</span></h4>
+			<table class="data" aria-labelledby="pdf-th-scope-both">
+			  <tbody>
+				<tr>
+				  <th>PDF Specification</th>
+				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+				</tr>
+				<tr>
+				  <th>ARIA Specification</th>
+				  <td>TBD</td>
+				</tr>
+				<tr>
+				  <th>Analogous HTML Element</th>
+				  <td>TBD</td>
+				</tr>
+				<tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="Notes">Notes:</abbr></th><td>Expose the TH to both row and column navigation for cells within the scope</td></tr>
+			  </tbody>
+			</table>
+
+			<h4 id="pdf-th-headers-set">`TH` <span class="el-context">(`Scope` is not set and `Headers` array is set)</span></h4>
+			<table class="data" aria-labelledby="pdf-th-headers-set">
+			  <tbody>
+				<tr>
+				  <th>PDF Specification</th>
+				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+				</tr>
+				<tr>
+				  <th>ARIA Specification</th>
+				  <td><a class="core-mapping" href="#role-map-cell">Role: `cell`</a></td>
+				</tr>
+				<tr>
+				  <th>Analogous HTML Element</th>
+				  <td><a class="html-mapping" href="#el-th">Role: `th`</a></td>
+				</tr>
+				<tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="Notes">Notes:</abbr></th><td><span class="property">Note from PDFa: HTML uses `Headers` array / IDs for `TH` and `TD`</span></td></tr>
+			  </tbody>
+			</table>
+
+			<h4 id="pdf-th-scope-both-headers-set">`TH` <span class="el-context">(`Scope` = `Both` and `Headers` array is set)</span></h4>
+			<table class="data" aria-labelledby="pdf-th-scope-both-headers-set">
+			  <tbody>
+				<tr>
+				  <th>PDF Specification</th>
+				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+				</tr>
+				<tr>
+				  <th>ARIA Specification</th>
+				  <td>TBD</td>
+				</tr>
+				<tr>
+				  <th>Analogous HTML Element</th>
+				  <td>Use WAI-ARIA mapping</td>
+				</tr>
+				<tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
+			  </tbody>
+			</table>
+
+			<h4 id="pdf-td">`TD`</h4>
+			<table class="data" aria-labelledby="pdf-td">
+			  <tbody>
+				<tr>
+				  <th>PDF Specification</th>
+				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+				</tr>
+				<tr>
+				  <th>ARIA Specification</th>
+				  <td><a class="core-mapping" href="#role-map-cell">Role: `cell`</a></td>
+				</tr>
+				<tr>
+				  <th>Analogous HTML Element</th>
+				  <td><a class="html-mapping" href="#el-td">Role: `td`</a></td>
+				</tr>
+				<tr><th>MSAA + IAccessible2</th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="User Interface Automation">UIA</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="macOS Accessibility Protocol">AX API</abbr></th><td>Use WAI-ARIA mapping</td></tr>
+				<tr><th><abbr title="Notes">Notes:</abbr></th><td></td></tr>
+			  </tbody>
+			</table>
+
+			<h4 id="pdf-thead">`THead`</h4>
+			<table class="data" aria-labelledby="pdf-thead">
+			  <tbody>
+				<tr>
+				  <th>PDF Specification</th>
+				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+				</tr>
+				<tr>
+				  <th>ARIA Specification</th>
+				  <td><a class="core-mapping" href="#role-map-rowgroup">Role: `rowgroup`</a></td>
+				</tr>
+				<tr>
+				  <th>Analogous HTML Element</th>
+				  <td><a class="html-mapping" href="#el-thead">Role: `thead`</a></td>
+				</tr>
+				<tr>
+				  <th>MSAA + IAccessible2</th>
+				  <td>Use WAI-ARIA mapping</td>
+				</tr>
+				<tr>
+				  <th><abbr title="User Interface Automation">UIA</abbr></th>
+				  <td>Use WAI-ARIA mapping</td>
+				</tr>
+				<tr>
+				  <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+				  <td>Use WAI-ARIA mapping</td>
+				</tr>
+				<tr>
+				  <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+				  <td>Use WAI-ARIA mapping</td>
+				</tr>
+				<tr>
+				  <th><abbr title="Notes">Notes:</abbr></th>
+				  <td></td>
+				</tr>
+			  </tbody>
+			</table>
+
+			<h4 id="pdf-tbody">`TBody`</h4>
+			<table class="data" aria-labelledby="pdf-tbody">
+			  <tbody>
+				<tr>
+				  <th>PDF Specification</th>
+				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+				</tr>
+				<tr>
+				  <th>ARIA Specification</th>
+				  <td><a class="core-mapping" href="#role-map-rowgroup">Role: `rowgroup`</a></td>
+				</tr>
+				<tr>
+				  <th>Analogous HTML Element</th>
+				  <td><a class="html-mapping" href="#el-tbody">Role: `tbody`</a></td>
+				</tr>
+				<tr>
+				  <th>MSAA + IAccessible2</th>
+				  <td>Use WAI-ARIA mapping</td>
+				</tr>
+				<tr>
+				  <th><abbr title="User Interface Automation">UIA</abbr></th>
+				  <td>Use WAI-ARIA mapping</td>
+				</tr>
+				<tr>
+				  <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+				  <td>Use WAI-ARIA mapping</td>
+				</tr>
+				<tr>
+				  <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+				  <td>Use WAI-ARIA mapping</td>
+				</tr>
+				<tr>
+				  <th><abbr title="Notes">Notes:</abbr></th>
+				  <td></td>
+				</tr>
+			  </tbody>
+			</table>
+
+			<h4 id="pdf-tfoot">`TFoot`</h4>
+			<table class="data" aria-labelledby="pdf-tfoot">
+			  <tbody>
+				<tr>
+				  <th>PDF Specification</th>
+				  <td>ISO 32000-2:2020, 14.8.4.8.3 Table structure types, Table 371</td>
+				</tr>
+				<tr>
+				  <th>ARIA Specification</th>
+				  <td><a class="core-mapping" href="#role-map-rowgroup">Role: `rowgroup`</a></td>
+				</tr>
+				<tr>
+				  <th>Analogous HTML Element</th>
+				  <td><a class="html-mapping" href="#el-tfoot">Role: `tfoot`</a></td>
+				</tr>
+				<tr>
+				  <th>MSAA + IAccessible2</th>
+				  <td>Use WAI-ARIA mapping</td>
+				</tr>
+				<tr>
+				  <th><abbr title="User Interface Automation">UIA</abbr></th>
+				  <td>Use WAI-ARIA mapping</td>
+				</tr>
+				<tr>
+				  <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+				  <td>Use WAI-ARIA mapping</td>
+				</tr>
+				<tr>
+				  <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+				  <td>Use WAI-ARIA mapping</td>
+				</tr>
+				<tr>
+				  <th><abbr title="Notes">Notes:</abbr></th>
+				  <td></td>
+				</tr>
+			  </tbody>
+			</table>
+
+
+			<h4 id="pdf-caption-table">`Caption` <span class="el-context">(child of `Table`)</span></h4>
+			<table class="data" aria-labelledby="pdf-caption-table">
+			  <tbody>
+				<tr>
+				  <th>PDF Specification</th>
+				  <td>ISO 32000-2:2020, 14.8.4.8.4 Caption structure type, Table 372</td>
+				</tr>
+				<tr>
+				  <th>ARIA Specification</th>
+				  <td><a class="core-mapping" href="#role-map-caption">Role: `caption`</a></td>
+				</tr>
+				<tr>
+				  <th>Analogous HTML Element</th>
+				  <td>Use WAI-ARIA mapping</td>
+				</tr>
+				<tr>
+				  <th>MSAA + IAccessible2</th>
+				  <td>Use WAI-ARIA mapping</td>
+				</tr>
+				<tr>
+				  <th><abbr title="User Interface Automation">UIA</abbr></th>
+				  <td>Use WAI-ARIA mapping</td>
+				</tr>
+				<tr>
+				  <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr></th>
+				  <td>Use WAI-ARIA mapping</td>
+				</tr>
+				<tr>
+				  <th><abbr title="macOS Accessibility Protocol">AX API</abbr></th>
+				  <td>Use WAI-ARIA mapping</td>
+				</tr>
+				<tr>
+				  <th><abbr title="Notes">Notes:</abbr></th>
+				  <td><span class="property">Note from PDFa: If a descendant of a `Table`, the first instance of a `Caption` will provide the `Table` its accessible name.</span></td>
+				</tr>
+			  </tbody>
+			</table>
+
+
         </section>
       </section>
       <section id="mapping_additional">


### PR DESCRIPTION
🚀 **Netlify Preview**:
🔄 **this PR updates the following sspecs**:
- [pdf-aam preview](https://deploy-preview-2868--wai-aria.netlify.app/pdf-aam/index.html) &mdash; [pdf-aam diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fpdf-aam%2F&doc2=https%3A%2F%2Fdeploy-preview-2868--wai-aria.netlify.app%2Fpdf-aam%2Findex.html)

Closes PDF-AAM PR#41

This is purely an addition for new mapping tables. Primarily concerning PDF tables and their respective elements.