### PR TITLE
[graphics-aam] Fix broken links to "Computed Role" in core-aam

### DIFF
--- a/graphics-aam/index.html
+++ b/graphics-aam/index.html
@@ -329,7 +329,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://w3c.github.io/core-aam/#roleMappingComputedRole">Computed Role</a></th>
+              <th>[[[core-aam#roleMappingComputedRole|Computed Role]]]</th>
               <td>
                 <code>graphics-document</code>
               </td>
@@ -371,7 +371,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://w3c.github.io/core-aam/#roleMappingComputedRole">Computed Role</a></th>
+              <th>[[[core-aam#roleMappingComputedRole|Computed Role]]]</th>
               <td>
                 <code>graphics-object</code>
               </td>
@@ -413,7 +413,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://w3c.github.io/core-aam/#roleMappingComputedRole">Computed Role</a></th>
+              <th>[[[core-aam#roleMappingComputedRole|Computed Role]]]</th>
               <td>
                 <code>graphics-symbol</code>
               </td>


### PR DESCRIPTION
The spec still used the previous URL for the "Computed Role" links and the anchors are lost during redirection.

This update fixes the link using the more idiomatic cross-spec section link shorthand that ReSpec supports:
https://respec.org/docs/#cross-spec-section-links

(Note that creates link to the current specification under /TR, which is 1.1, but then the links will auto-update themselves once the group decides to make 1.2 the current specification).