### PR TITLE
Editorial: Adds ids to existing security and privacy sections

### DIFF
--- a/.github/workflows/roleInfo.yml
+++ b/.github/workflows/roleInfo.yml
@@ -1,18 +1,27 @@
 name: roleInfo update
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - aria
+    types:
+      - completed
     branches:
-      - gh-pages
+      - main
+
+concurrency:
+  group: roleinfo-update
+  queue: max
 
 jobs:
   roleInfo:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     env:
       PUPPETEER_EXECUTABLE_PATH: '/usr/bin/google-chrome'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0  # Needed to compare with origin/main
@@ -22,13 +31,19 @@ jobs:
         with:
           node-version: "lts/*"
       - run: npm i linkedom prettier@3.6.0
-      - run: git checkout gh-pages index.html # checkout (respec'ed) aria spec from gh-pages (WARNING: changes get staged!)
+      - run: git checkout origin/gh-pages -- index.html # checkout (respec'ed) aria spec from gh-pages (WARNING: changes get staged!)
       - run: node ./common/script/buildRoleInfo.js  # build roleInfo.js
       - run: npx prettier --write --print-width 200 ./common/script/roleInfo.js
-      - run: git reset index.html # reset spec source (to avoid comittting, cf. warning above)
-      - run: git config user.name "github-actions[bot]"
-      - run: git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      - run: git add ./common/script/roleInfo.js
-      - run: |
-         git diff-index --quiet HEAD ./common/script/roleInfo.js || git commit -m'chore: update roleInfo.js'
-      - run: git push
+      - run: git checkout HEAD -- index.html # restore spec source cleanly
+      - name: Commit and push roleInfo
+        run: |
+          if git diff --quiet -- ./common/script/roleInfo.js; then
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add ./common/script/roleInfo.js
+          git commit -m "chore: update roleInfo.js"
+          git pull --rebase origin main
+          git push origin HEAD:main

--- a/common/script/aria.js
+++ b/common/script/aria.js
@@ -152,7 +152,9 @@ const renderIndexEntry = (indexTest, rdef) => {
   if (!isAbstract && roleFromNode) {
     const content = rdef.innerText;
     const isRequired = roleFromNode.closest("table").querySelector(".role-namerequired")?.innerText === "True";
-    if (roleFromNode.textContent.indexOf(indexTest) !== -1) return `<li><a href="#${content}" class="role-reference"><code>${content}</code></a>${isRequired ? " (name required)" : ""}</li>`; // TODO: `textContent.indexOf` feels brittle; right now it's either the exact string or proper list markup with LI with exact string
+    if (!roleFromNode.innerHTML.includes(indexTest)) return;  // NOTE: it's either the exact string or contains LI with exact string. TODO: feels brittle. e.g. adding data-${indexTest} for selector may be better.
+    const synonymRoles = [...container.querySelectorAll('[data-role-synonyms] rref')].map(node => node.outerHTML);
+    return `<li><a href="#${content}" class="role-reference"><code>${content}</code></a>${isRequired ? " (name required)" : ""}${synonymRoles.length > 0 ? ` (synonymous: ${synonymRoles.join(', ')})` : ''}</li>`;
   }
 };
 

--- a/common/script/aria.js
+++ b/common/script/aria.js
@@ -152,9 +152,9 @@ const renderIndexEntry = (indexTest, rdef) => {
   if (!isAbstract && roleFromNode) {
     const content = rdef.innerText;
     const isRequired = roleFromNode.closest("table").querySelector(".role-namerequired")?.innerText === "True";
-    if (!roleFromNode.innerHTML.includes(indexTest)) return;  // NOTE: it's either the exact string or contains LI with exact string. TODO: feels brittle. e.g. adding data-${indexTest} for selector may be better.
-    const synonymRoles = [...container.querySelectorAll('[data-role-synonyms] rref')].map(node => node.outerHTML);
-    return `<li><a href="#${content}" class="role-reference"><code>${content}</code></a>${isRequired ? " (name required)" : ""}${synonymRoles.length > 0 ? ` (synonymous: ${synonymRoles.join(', ')})` : ''}</li>`;
+    if (!roleFromNode.innerHTML.includes(indexTest)) return; // NOTE: it's either the exact string or contains LI with exact string. TODO: feels brittle. e.g. adding data-${indexTest} for selector may be better.
+    const synonymRoles = [...container.querySelectorAll("[data-role-synonyms] rref")].map((node) => node.outerHTML);
+    return `<li><a href="#${content}" class="role-reference"><code>${content}</code></a>${isRequired ? " (name required)" : ""}${synonymRoles.length > 0 ? ` (synonymous: ${synonymRoles.join(", ")})` : ""}</li>`;
   }
 };
 

--- a/common/script/buildRoleInfo.js
+++ b/common/script/buildRoleInfo.js
@@ -36,6 +36,9 @@ const generateRoleInfoEntry = (roleSection) => {
   value.fragID = key; //TODO: [minor] is this duplication really worth it? Role names should be valid IDREFS, no?
   value.parentRoles = [];
   roleSection.querySelectorAll(".role-parent .role-reference").forEach((node) => value.parentRoles.push(node.textContent));
+  let synonymRoles = [];
+  roleSection.querySelectorAll("[data-role-synonyms] .role-reference").forEach((node) => synonymRoles.push(node.textContent));
+  if (synonymRoles.length > 0) value.synonymRoles = synonymRoles;
   value.localprops = [];
 
   roleSection.querySelectorAll(":is(.role-required-properties, .role-properties, .role-disallowed) :is(.property-reference, .state-reference)").forEach((link) => {

--- a/common/script/roleInfo.js
+++ b/common/script/roleInfo.js
@@ -6543,6 +6543,7 @@
     name: "image",
     fragID: "image",
     parentRoles: ["section"],
+    synonymRoles: ["img"],
     localprops: [],
     allprops: [
       {
@@ -10444,6 +10445,7 @@
     name: "none",
     fragID: "none",
     parentRoles: ["structure"],
+    synonymRoles: ["presentation"],
     localprops: [
       {
         is: "property",
@@ -13428,20 +13430,6 @@
         disallowed: false,
         deprecated: false,
       },
-      {
-        is: "property",
-        name: "aria-valuemax",
-        required: false,
-        disallowed: false,
-        deprecated: false,
-      },
-      {
-        is: "property",
-        name: "aria-valuemin",
-        required: false,
-        disallowed: false,
-        deprecated: false,
-      },
     ],
     allprops: [
       {
@@ -13461,20 +13449,6 @@
       {
         is: "property",
         name: "aria-orientation",
-        required: false,
-        disallowed: false,
-        deprecated: false,
-      },
-      {
-        is: "property",
-        name: "aria-valuemax",
-        required: false,
-        disallowed: false,
-        deprecated: false,
-      },
-      {
-        is: "property",
-        name: "aria-valuemin",
         required: false,
         disallowed: false,
         deprecated: false,
@@ -13636,6 +13610,20 @@
       {
         is: "property",
         name: "aria-roledescription",
+        required: false,
+        disallowed: false,
+        deprecated: false,
+      },
+      {
+        is: "property",
+        name: "aria-valuemax",
+        required: false,
+        disallowed: false,
+        deprecated: false,
+      },
+      {
+        is: "property",
+        name: "aria-valuemin",
         required: false,
         disallowed: false,
         deprecated: false,
@@ -15246,20 +15234,6 @@
         disallowed: false,
         deprecated: false,
       },
-      {
-        is: "property",
-        name: "aria-valuemax",
-        required: false,
-        disallowed: false,
-        deprecated: false,
-      },
-      {
-        is: "property",
-        name: "aria-valuemin",
-        required: false,
-        disallowed: false,
-        deprecated: false,
-      },
     ],
     allprops: [
       {
@@ -15300,20 +15274,6 @@
       {
         is: "property",
         name: "aria-readonly",
-        required: false,
-        disallowed: false,
-        deprecated: false,
-      },
-      {
-        is: "property",
-        name: "aria-valuemax",
-        required: false,
-        disallowed: false,
-        deprecated: false,
-      },
-      {
-        is: "property",
-        name: "aria-valuemin",
         required: false,
         disallowed: false,
         deprecated: false,
@@ -15461,6 +15421,20 @@
       {
         is: "property",
         name: "aria-roledescription",
+        required: false,
+        disallowed: false,
+        deprecated: false,
+      },
+      {
+        is: "property",
+        name: "aria-valuemax",
+        required: false,
+        disallowed: false,
+        deprecated: false,
+      },
+      {
+        is: "property",
+        name: "aria-valuemin",
         required: false,
         disallowed: false,
         deprecated: false,

--- a/core-aam/index.html
+++ b/core-aam/index.html
@@ -12641,7 +12641,7 @@
         fallback nodes are not exposed to or detectable by web content and this behavior is not required.
       </p>
     </section>
-    <section>
+    <section id="privacy-considerations">
       <h2>Privacy considerations</h2>
       <p>
         In accordance with <a href="https://w3ctag.github.io/design-principles/#do-not-expose-use-of-assistive-tech">Web Platform Design Principles</a>, this specification provides no programmatic
@@ -12651,7 +12651,7 @@
         <a href="https://www.w3.org/TR/fingerprinting-guidance/#active-0">active fingerprinting</a> of users of Assistive Technologies.
       </p>
     </section>
-    <section>
+    <section id="security-considerations">
       <h2>Security considerations</h2>
       <p>This specification introduces no new security considerations.</p>
     </section>

--- a/dpub-aam/index.html
+++ b/dpub-aam/index.html
@@ -2612,12 +2612,12 @@
         <a class="core=mappings" data-cite="core-aam-1.1#mapping_events">Events</a> mappings.
       </p>
     </section>
-    <section class="informative">
+    <section class="informative" id="security-considerations">
       <h2>Security Considerations</h2>
 
       <p>This specification introduces no new security considerations.</p>
     </section>
-    <section class="informative">
+    <section class="informative" id="privacy-considerations">
       <h2>Privacy Considerations</h2>
 
       <p>

--- a/dpub-aria/index.html
+++ b/dpub-aria/index.html
@@ -4413,12 +4413,12 @@
         </div>
       </section>
     </section>
-    <section class="informative">
+    <section class="informative" id="security-considerations">
       <h2>Security Considerations</h2>
 
       <p>This specification introduces no new security considerations.</p>
     </section>
-    <section class="informative">
+    <section class="informative" id="privacy-considerations">
       <h2>Privacy Considerations</h2>
 
       <p>

--- a/graphics-aam/index.html
+++ b/graphics-aam/index.html
@@ -329,7 +329,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://w3c.github.io/core-aam/#roleMappingComputedRole">Computed Role</a></th>
+              <th>[[[core-aam#roleMappingComputedRole|Computed Role]]]</th>
               <td>
                 <code>graphics-document</code>
               </td>
@@ -371,7 +371,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://w3c.github.io/core-aam/#roleMappingComputedRole">Computed Role</a></th>
+              <th>[[[core-aam#roleMappingComputedRole|Computed Role]]]</th>
               <td>
                 <code>graphics-object</code>
               </td>
@@ -413,7 +413,7 @@
               </td>
             </tr>
             <tr>
-              <th><a href="https://w3c.github.io/core-aam/#roleMappingComputedRole">Computed Role</a></th>
+              <th>[[[core-aam#roleMappingComputedRole|Computed Role]]]</th>
               <td>
                 <code>graphics-symbol</code>
               </td>

--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -17038,7 +17038,7 @@
          frameset - https://html.spec.whatwg.org/multipage/obsolete.html#frames
 
   -->
-    <section>
+    <section id="privacy-considerations">
       <h2>Privacy considerations</h2>
       <p>
         In accordance with <a href="https://w3ctag.github.io/design-principles/#do-not-expose-use-of-assistive-tech">Web Platform Design Principles</a>, this specification provides no programmatic
@@ -17048,7 +17048,7 @@
         <a href="https://www.w3.org/TR/fingerprinting-guidance/#active-0">active fingerprinting</a> of users of Assistive Technologies.
       </p>
     </section>
-    <section>
+    <section id="security-considerations">
       <h2>Security considerations</h2>
       <p>This specification introduces no new security considerations.</p>
     </section>

--- a/index.html
+++ b/index.html
@@ -5010,6 +5010,10 @@
                 <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
                 <td class="role-presentational-inherited"> </td>
               </tr>
+              <tr>
+                <th scope="row">Synonym roles</th>
+                <td data-role-synonyms=""><rref>img</rref></td>
+              </tr>
             </tbody>
           </table>
         </div>
@@ -7120,6 +7124,10 @@
               <tr>
                 <th class="role-presentational-inherited-head" scope="row">Inherits Presentational:</th>
                 <td class="role-presentational-inherited"> </td>
+              </tr>
+              <tr>
+                <th scope="row">Synonym roles</th>
+                <td data-role-synonyms=""><rref>presentation</rref></td>
               </tr>
             </tbody>
           </table>

--- a/index.html
+++ b/index.html
@@ -17256,11 +17256,11 @@ el.getAttribute("aria-label"); // Returns "Publish"</pre
         </aside>
       </section>
     </section>
-    <section class="informative">
+    <section class="informative" id="security-considerations">
       <h2>Security Considerations</h2>
       <p>This specification introduces no new security considerations.</p>
     </section>
-    <section class="informative">
+    <section class="informative" id="privacy-considerations">
       <h2>Privacy Considerations</h2>
       <p>
         In accordance with <a data-cite="design-principles#do-not-expose-use-of-assistive-tech">Web Platform Design Principles</a>, this specification provides no programmatic interface to determine

--- a/pdf-aam/index.html
+++ b/pdf-aam/index.html
@@ -1082,11 +1082,11 @@
       </section>
     </section>
 
-    <section>
+    <section id="privacy-considerations">
       <h2>Privacy considerations</h2>
       <p>TBD. Should we duplicate or cross-reference this content from the corresponding Core-AAM section?</p>
     </section>
-    <section>
+    <section id="security-considerations">
       <h2>Security considerations</h2>
       <p>This specification introduces no new security considerations.</p>
     </section>


### PR DESCRIPTION
🚀 **Netlify Preview**:
🔄 **this PR updates the following sspecs**:
- [core-aam preview](https://deploy-preview-2878--wai-aria.netlify.app/core-aam/index.html) &mdash; [core-aam diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fcore-aam%2F&doc2=https%3A%2F%2Fdeploy-preview-2878--wai-aria.netlify.app%2Fcore-aam%2Findex.html)
- [dpub-aam preview](https://deploy-preview-2878--wai-aria.netlify.app/dpub-aam/index.html) &mdash; [dpub-aam diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fdpub-aam%2F&doc2=https%3A%2F%2Fdeploy-preview-2878--wai-aria.netlify.app%2Fdpub-aam%2Findex.html)
- [dpub-aria preview](https://deploy-preview-2878--wai-aria.netlify.app/dpub-aria/index.html) &mdash; [dpub-aria diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fdpub-aria%2F&doc2=https%3A%2F%2Fdeploy-preview-2878--wai-aria.netlify.app%2Fdpub-aria%2Findex.html)
- [html-aam preview](https://deploy-preview-2878--wai-aria.netlify.app/html-aam/index.html) &mdash; [html-aam diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fhtml-aam%2F&doc2=https%3A%2F%2Fdeploy-preview-2878--wai-aria.netlify.app%2Fhtml-aam%2Findex.html)
- [ARIA preview](https://deploy-preview-2878--wai-aria.netlify.app/index.html) &mdash; [ARIA diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Faria%2F&doc2=https%3A%2F%2Fdeploy-preview-2878--wai-aria.netlify.app%2Findex.html)
- [pdf-aam preview](https://deploy-preview-2878--wai-aria.netlify.app/pdf-aam/index.html) &mdash; [pdf-aam diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fpdf-aam%2F&doc2=https%3A%2F%2Fdeploy-preview-2878--wai-aria.netlify.app%2Fpdf-aam%2Findex.html)

I left untouched the ones that are either missing or combined.