### PR TITLE
errata: [htmlaam] popovertarget expanded state calculation shouldn't refer to command attribute.

### DIFF
--- a/html-aam/index.html
+++ b/html-aam/index.html
@@ -13742,7 +13742,7 @@
                     <a class="core-mapping" href="#ariaExpandedFalse">`aria-expanded=false`</a>
                   </p>
                   <p>
-                    If the associated element is an accessibility ancestor of the element with the `command` attribute or is not present in the DOM:
+                    If the associated element is an accessibility ancestor of the element with the `popovertarget` attribute or is not present in the DOM:
                     <a class="core-mapping" href="#ariaExpandedUndefined">`aria-expanded=undefined`</a>
                   </p>
                   <p>If the associated element is not a valid `popover` element: no `aria-expanded` mapping.</p>


### PR DESCRIPTION
Closes #????

Corrects the popovertarget expanded state section to refer to elements with the `popovertarget` attribute instead of `command` attribute.

And a few other todo items (delete this section after performing them):
* [ ] For every spec that this PR edits, please add the appropriate `spec:<spec_name>` label. If you don't have privileges to do this, editors will do it for you.
* [ ] If the change is [editorial](https://github.com/w3c/aria/blob/main/documentation/process.md#editorial-changes), please add "Editorial:" at the start of your PR name, and delete the "Test, Documentation and Implementation tracking" section below.

# Test, Documentation and Implementation tracking
Once this PR has been reviewed and has consensus from the working group, tests should be written and issues should be opened on browsers. Add N/A and check when not applicable.

* [ ] "author MUST" tests:
* [ ] "user agent MUST" tests:
* [ ] Browser implementations (link to issue or commit):
   * WebKit:
   * Gecko:
   * Blink:
* [ ] ACT review?
* [ ] Does this need AT implementations?
* [ ] Related APG Issue/PR:
* [ ] MDN Issue/PR:
