### PR TITLE
editorial: add references to expose & target element

### DIFF
--- a/index.html
+++ b/index.html
@@ -592,7 +592,7 @@
               commonly known as notifications.
             </p>
           </dd>
-          <dt><dfn>Expose</dfn></dt>
+          <dt><dfn data-local-lt="exposed|exposes">Expose</dfn></dt>
           <!--Not used-->
           <dd>
             <p>Translated to platform-specific <a class="termref">accessibility APIs</a> as defined in the <a href="" class="core-mapping">Core Accessibility API Mappings</a>.</p>
@@ -755,8 +755,8 @@
           <dt><dfn>Target Element</dfn></dt>
           <dd>
             <p>
-              An element specified in a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> relation. For example, in <code> &lt;div aria-controls=”elem1”&gt;</code>, where
-              <code>“elem1”</code> is the ID for the target element.
+              An element specified in a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> relation. For example, given <code> &lt;div aria-controls=”elem1”&gt;</code>, the element with ID
+              <code>“elem1”</code> is the target element.
             </p>
           </dd>
           <dt><dfn data-lt="unicode braille">Unicode Braille Patterns</dfn></dt>
@@ -805,7 +805,7 @@
         <p>
           A conforming <a>user agent</a> which implements a document object model that does not conform to the W3C DOM specification MUST include the <a><code>role</code> attribute</a> and its
           <a href="#roles_categorization">WAI-ARIA role values</a>, as well as the <a href="#states_and_properties">WAI-ARIA States and Properties</a> in the DOM as specified by the author, even
-          though processing might affect how the elements are exposed to accessibility APIs. Doing so ensures that each <a><code>role</code> attribute</a> and all
+          though processing might affect how the elements are <a>exposed</a> to accessibility APIs. Doing so ensures that each <a><code>role</code> attribute</a> and all
           <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> states and properties, including their values, are in the document in an unmodified form so other tools, such as assistive
           technologies, can access them. A conforming W3C <abbr title="Document Object Model">DOM</abbr> meets this criterion.
         </p>
@@ -1027,7 +1027,7 @@
                   semantics determine the focusable state.
                 </li>
                 <li>
-                  Focused, whenever the element is the target of the <pref>aria-activedescendant</pref> attribute and the element with the <pref>aria-activedescendant</pref> attribute has
+                  Focused, whenever the element is the <a>target</a> of the <pref>aria-activedescendant</pref> attribute and the element with the <pref>aria-activedescendant</pref> attribute has
                   <abbr title="Document Object Model">DOM</abbr> focus.
                 </li>
               </ol>
@@ -1156,7 +1156,7 @@
           <p>
             <a>States</a> and [=ARIA/properties=] specifically applicable to the <a>role</a> and child roles. Authors MAY provide <span>values</span> for supported states and properties, but need not
             in cases where default values are sufficient. [=user agents=] MUST map all supported states and properties for the role to an accessibility API. If the state or property is undefined and
-            it has a default value for the role, [=user agents=] SHOULD expose the default value.
+            it has a default value for the role, [=user agents=] SHOULD <a>expose</a> the default value.
           </p>
           <p class="note">A host language attribute with the appropriate <a href="#implicit_semantics">implicit WAI-ARIA semantic</a> fulfills this requirement.</p>
         </section>
@@ -1287,7 +1287,7 @@
         <section id="childrenArePresentational">
           <h3>Children Presentational</h3>
           <p>
-            Indicates whether DOM descendants are presentational. [=user agents=] SHOULD NOT expose descendants of this <a>element</a> through the platform
+            Indicates whether DOM descendants are presentational. [=user agents=] SHOULD NOT <a>expose</a> descendants of this <a>element</a> through the platform
             <a>accessibility <abbr title="Application Programming Interface">API</abbr></a
             >. If [=user agents=] do not hide the descendant nodes, some information might be read twice.
           </p>
@@ -2691,7 +2691,7 @@
             <p>
               While the <code>columnheader</code> role can be used in both interactive grids and non-interactive tables, the use of <pref>aria-readonly</pref> and <pref>aria-required</pref> is only
               applicable to interactive elements. Therefore, authors SHOULD NOT use <pref>aria-required</pref> or <pref>aria-readonly</pref> in a <code>columnheader</code> that descends from a
-              <rref>table</rref>, and user agents SHOULD NOT expose either property to <a>assistive technologies</a> unless the <code>columnheader</code> descends from a <rref>grid</rref>.
+              <rref>table</rref>, and user agents SHOULD NOT <a>expose</a> either property to <a>assistive technologies</a> unless the <code>columnheader</code> descends from a <rref>grid</rref>.
             </p>
             <p class="note">
               Because cells are organized into rows, there is not a single container element for the column. The column is the set of <rref>gridcell</rref> elements in a particular position within
@@ -2825,7 +2825,7 @@
               popup while focus remains on the <code>combobox</code> element.
             </p>
             <p>
-              User agents MUST expose the value of elements with role <code>combobox</code> to <a>assistive technologies</a>. The value of a <code>combobox</code> is represented by one of the
+              User agents MUST <a>expose</a> the value of elements with role <code>combobox</code> to <a>assistive technologies</a>. The value of a <code>combobox</code> is represented by one of the
               following:
             </p>
             <ul>
@@ -3085,7 +3085,7 @@
             </ol>
             <p>
               If the author has not explicitly declared <pref>aria-level</pref>, <pref>aria-posinset</pref>, or <pref>aria-setsize</pref> for a <code>comment</code> element, user agents MUST
-              automatically compute the missing values and expose them to assistive technologies.
+              automatically compute the missing values and <a>expose</a> them to assistive technologies.
             </p>
           </div>
           <table class="def">
@@ -3649,7 +3649,7 @@
             <aside class="example">
               <p>
                 In the following example, the first text field will receive initial focus when the dialog is rendered. As this means focus will be set "after" the preceding content that provides
-                instructions for the form fields, an <code>aria-describedby</code> attribute is used to expose this content as a description for the <code>dialog</code>.
+                instructions for the form fields, an <code>aria-describedby</code> attribute is used to <a>expose</a> this content as a description for the <code>dialog</code>.
               </p>
               <pre class="example highlight html">
 &lt;div role="dialog" aria-labelledby="h" aria-describedby="d" aria-modal="true" ...>
@@ -3745,7 +3745,7 @@
           <div class="role-description">
             <p>[Deprecated in ARIA 1.2] A list of references to members of a group, such as a static table of contents.</p>
             <p class="note">
-              As exposed by accessibility APIs, the <code>directory</code> <a>role</a> is essentially equivalent to the <code>list</code> <a>role</a>. So, using <code>directory</code> does not provide
+              As <a>exposed</a> by accessibility APIs, the <code>directory</code> <a>role</a> is essentially equivalent to the <code>list</code> <a>role</a>. So, using <code>directory</code> does not provide
               any additional benefits to assistive technology users. Authors are advised to treat <code>directory</code> as deprecated and to use <code>list</code>, or a host language's equivalent
               semantics instead.
             </p>
@@ -4353,7 +4353,7 @@
               as <pref>aria-live</pref> attributes.
             </p>
             <p>
-              However, unlike elements with role <code>presentation</code>, user agents expose <code>generic</code> elements in <a>accessibility APIs</a> when permitted accessibility attributes have
+              However, unlike elements with role <code>presentation</code>, user agents <a>expose</a> <code>generic</code> elements in <a>accessibility APIs</a> when permitted accessibility attributes have
               been specified. User agents MAY otherwise ignore <code>generic</code> elements if such permitted attributes have not been specified.
             </p>
           </div>
@@ -4493,7 +4493,7 @@
             <!-- make sure the following para remains synced with its counterpart in #treegrid -->
             <p>
               If <pref>aria-readonly</pref> is set on an element with role <code>grid</code>, [=user agents=] MUST propagate the value to all <rref>gridcell</rref> elements that are
-              <a>accessibility descendants</a> of that <code>grid</code> and expose the value in the accessibility API. An author MAY override the propagated value of <pref>aria-readonly</pref> for an
+              <a>accessibility descendants</a> of that <code>grid</code> and <a>expose</a> the value in the accessibility API. An author MAY override the propagated value of <pref>aria-readonly</pref> for an
               individual <rref>gridcell</rref> element.
             </p>
             <p>
@@ -6940,7 +6940,7 @@
               <li>A layout table and/or any of its associated rows, cells, etc.</li>
             </ul>
             <p>
-              For any element with a role of <rref>none</rref>/<rref>presentation</rref> and which is not <a>focusable</a>, the user agent MUST NOT expose the implicit native semantics of the element
+              For any element with a role of <rref>none</rref>/<rref>presentation</rref> and which is not <a>focusable</a>, the user agent MUST NOT <a>expose</a> the implicit native semantics of the element
               (the role and its states and properties) to accessibility <abbr title="Application Programming Interfaces">APIs</abbr>. However, the user agent MUST expose content and descendant
               elements that do not have an explicit or inherited role of <rref>none</rref>/<rref>presentation</rref>. Thus, the <rref>none</rref>/<rref>presentation</rref> role causes a given element
               to be treated as having no role or to be removed from the <a>accessibility tree</a>, but does not cause the content contained within the element to be removed from the accessibility
@@ -8167,7 +8167,7 @@
               While the row role can be used in a <rref>table</rref>, <rref>grid</rref>, or <rref>treegrid</rref>, the semantics of <sref>aria-expanded</sref>, <pref>aria-posinset</pref>,
               <pref>aria-setsize</pref>, and <pref>aria-level</pref> are only applicable to the hierarchical structure of an interactive tree grid. Therefore, authors MUST NOT apply
               <sref>aria-expanded</sref>, <pref>aria-posinset</pref>, <pref>aria-setsize</pref>, and <pref>aria-level</pref> to a <rref>row</rref> that descends from a <rref>table</rref> or
-              <rref>grid</rref>, and user agents SHOULD NOT expose any of these four properties to assistive technologies unless the <rref>row</rref> descends from a <rref>treegrid</rref>.
+              <rref>grid</rref>, and user agents SHOULD NOT <a>expose</a> any of these four properties to assistive technologies unless the <rref>row</rref> descends from a <rref>treegrid</rref>.
             </p>
             <p>
               Authors MUST ensure [=elements=] with <a>role</a> <code>row</code> are <a>accessibility children</a> of an element with the role <rref>table</rref>, <rref>grid</rref>,
@@ -8404,7 +8404,7 @@
             <p>
               While the <code>rowheader</code> role can be used in both interactive grids and non-interactive tables, the use of <sref>aria-expanded</sref>, <pref>aria-readonly</pref>, and
               <pref>aria-required</pref> is only applicable to interactive elements. Therefore, authors SHOULD NOT use <sref>aria-expanded</sref>, <pref>aria-readonly</pref>, or
-              <pref>aria-required</pref> in a <code>rowheader</code> that descends from a <rref>table</rref>, and user agents SHOULD NOT expose these properties to <a>assistive technologies</a> unless
+              <pref>aria-required</pref> in a <code>rowheader</code> that descends from a <rref>table</rref>, and user agents SHOULD NOT <a>expose</a> these properties to <a>assistive technologies</a> unless
               the <code>rowheader</code> descends from a <rref>grid</rref> or <rref>treegrid</rref>.
             </p>
             <p class="note" title="Usage of aria-disabled">
@@ -10778,6 +10778,7 @@
 					<p>It is not necessary to use the fallback role if the implicit role for the element provides sufficient fallback. In this example, an ARIA 1.0-capable browser would not recognize the "text" role token, and fall back to the default image role.</p>
 					<pre class="example highlight html">
 						&lt;p&gt;I &lt;img src="icon.gif" alt="love" role="text"&gt; New York.︎&lt;/p&gt;
+
 						&lt;p&gt;My &lt;img src="icon.gif" alt="heart" role="text"&gt; bleeds.︎&lt;/p&gt;
 					</pre>
 				</div>
@@ -10889,7 +10890,7 @@
               field.
             </p>
             <p>
-              Authors MUST limit the children of a textbox to non-interactive, entirely presentational elements such as icons used to visually convey information that is already exposed in an
+              Authors MUST limit the children of a textbox to non-interactive, entirely presentational elements such as icons used to visually convey information that is already <a>exposed</a> in an
               accessible manner. Examples include:
             </p>
             <ul>
@@ -11471,7 +11472,7 @@
             <!-- make sure the following para remains synced with its counterpart in #grid -->
             <p>
               If <pref>aria-readonly</pref> is set on an <a>element</a> with <a>role</a> <code>treegrid</code>, [=user agents=] MUST propagate the value to all <rref>gridcell</rref> elements that are
-              <a>accessibility descendants</a> of the <code>treegrid</code> and expose the value in the accessibility API. An author MAY override the propagated value of <pref>aria-readonly</pref> for
+              <a>accessibility descendants</a> of the <code>treegrid</code> and <a>expose</a> the value in the accessibility API. An author MAY override the propagated value of <pref>aria-readonly</pref> for
               an individual <rref>gridcell</rref> element.
             </p>
             <p>
@@ -11965,7 +11966,7 @@
         <section id="os-aapi-attribute-mapping">
           <h3>Operating System Accessibility API mapping of multi-value ARIA attributes</h3>
           <p>
-            Unlike IDL reflection, operating system accessibility API mappings of ARIA attributes can have defaults. Any default values from the ARIA values tables are exposed to the operating system
+            Unlike IDL reflection, operating system accessibility API mappings of ARIA attributes can have defaults. Any default values from the ARIA values tables are <a>exposed</a> to the operating system
             accessibility API as described in [[[#supportedState]]], and in [[[CORE-AAM]]].
           </p>
         </section>
@@ -12489,7 +12490,7 @@ button.ariaPressed; // null</pre
               <a>Assistive technologies</a> SHOULD use the value of <code>aria-braillelabel</code> when presenting the accessible name of an element in Braille, but SHOULD NOT change other
               functionality. For example, an assistive technology that provides aural rendering SHOULD use the accessible name.
             </p>
-            <p><a>Assistive technologies</a> SHOULD expose the <code>aria-braillelabel</code> property as follows:</p>
+            <p><a>Assistive technologies</a> SHOULD <a>expose</a> the <code>aria-braillelabel</code> property as follows:</p>
             <ol>
               <li>
                 If the value of <code>aria-braillelabel</code> does not contain characters in <a>Unicode Braille Patterns</a>, translate the value according to the user's preferred translation table.
@@ -12581,7 +12582,7 @@ button.ariaPressed; // null</pre
               <a>Assistive Technologies</a> will pass such content directly to the user without applying user specific braille translations; in general, authors are
               <strong>strongly discouraged</strong> from using Unicode Braille Patterns in <code>aria-brailleroledescription</code>.
             </p>
-            <p>User agents MUST NOT expose the <code>aria-brailleroledescription</code> property if any of the following conditions exist:</p>
+            <p>User agents MUST NOT <a>expose</a> the <code>aria-brailleroledescription</code> property if any of the following conditions exist:</p>
             <ol>
               <li>
                 The value of <code>aria-brailleroledescription</code> is empty or contains only whitespace characters, which includes standard [=ascii whitespace|whitespace=] and the empty Braille
@@ -13081,7 +13082,7 @@ button.ariaPressed; // null</pre
             <p>
               This <a>attribute</a> is intended for cells and gridcells which are not contained in a native table. When defining the column span of cells or gridcells in a native table, authors SHOULD
               use the host language's attribute instead of <pref>aria-colspan</pref>. If <pref>aria-colspan</pref> is used on an element for which the host language provides an equivalent attribute,
-              [=user agents=] MUST ignore the value of <pref>aria-colspan</pref> and instead expose the value of the host language's attribute to <a>assistive technologies</a>.
+              [=user agents=] MUST ignore the value of <pref>aria-colspan</pref> and instead <a>expose</a> the value of the host language's attribute to <a>assistive technologies</a>.
             </p>
             <p>
               Authors MUST set the <span>value</span> of <pref>aria-colspan</pref> to an integer greater than or equal to 1 and less than the value which would cause the cell or gridcell to overlap
@@ -13189,7 +13190,7 @@ button.ariaPressed; // null</pre
             <p>
               The <sref>aria-current</sref> <a>attribute</a> is a token type. Any value not included in the list of allowed values SHOULD be treated by <a>assistive technologies</a> as if the value
               <code>true</code> had been provided. If the attribute is not present or its value is the empty string or <code>undefined</code>, the default value of <code>false</code> applies and the
-              <sref>aria-current</sref> <a>state</a> MUST NOT be exposed by user agents or assistive technologies.
+              <sref>aria-current</sref> <a>state</a> MUST NOT be <a>exposed</a> by user agents or assistive technologies.
             </p>
             <p>The <sref>aria-current</sref> attribute is used when an element within a set of related elements is visually styled to indicate it is the current item in the set. For example:</p>
             <ul>
@@ -13424,7 +13425,7 @@ button.ariaPressed; // null</pre
             </p>
             <p>
               The <code>aria-details</code> property supports referring to multiple elements. For example, a paragraph in a document editor might reference multiple comments that are not related to
-              each other. If a user agent relies on an accessibility API that does not support exposing multiple descriptive relations, the user agent SHOULD expose the relationship to the first
+              each other. If a user agent relies on an accessibility API that does not support exposing multiple descriptive relations, the user agent SHOULD <a>expose</a> the relationship to the first
               element referenced by <code>aria-details</code>.
             </p>
             <p>
@@ -13682,7 +13683,7 @@ button.ariaPressed; // null</pre
               Similarly, when <code>aria-errormessage</code> is not pertinent, authors MUST either ensure the content is [=element/hidden from all users=] or remove the
               <code>aria-errormessage</code> attribute or its value.
             </p>
-            <p>User agents MUST NOT expose <code>aria-errormessage</code> for an object with an <sref>aria-invalid</sref> value of <code>false</code>.</p>
+            <p>User agents MUST NOT <a>expose</a> <code>aria-errormessage</code> for an object with an <sref>aria-invalid</sref> value of <code>false</code>.</p>
             <p>
               Authors MAY call attention to a new error message with a live region by modifying inserting the error message into the contents of a existing, rendered element with a
               <a href="#live_region_roles">live region role</a>, such as <rref>alert</rref>. A live region notification is appropriate when an error message is displayed to users after they have
@@ -13967,7 +13968,7 @@ button.ariaPressed; // null</pre
               the empty string, as if the value <code>false</code> had been provided. To provide backward compatibility with ARIA 1.0 content, user agents MUST treat an
               <code>aria-haspopup</code> value of <code>true</code> as equivalent to a value of <code>menu</code>.
             </p>
-            <p><a>Assistive technologies</a> and user agents SHOULD NOT expose the <code>aria-haspopup</code> property if it has a value of <code>false</code>.</p>
+            <p><a>Assistive technologies</a> and user agents SHOULD NOT <a>expose</a> the <code>aria-haspopup</code> property if it has a value of <code>false</code>.</p>
             <p class="note">A <rref>tooltip</rref> is not considered to be a popup in this context.</p>
             <p class="note">
               <code>aria-haspopup</code> is most relevant to use when there is a visual indicator in the element that triggers the popup. For example, many controls styled with a downward pointing
@@ -14064,7 +14065,7 @@ button.ariaPressed; // null</pre
               of the primary document in view. For instance, the <code>html</code> or <code>body</code> elements in an HTML document. Authors MAY, with caution, use <code>aria-hidden</code> to hide
               visibly rendered content from assistive technologies <em>only</em> if the act of hiding this content is intended to improve the experience for users of assistive technologies by removing
               redundant or extraneous content. Authors using <code>aria-hidden</code> to hide visible content from screen readers MUST ensure that identical or equivalent meaning and functionality is
-              exposed to assistive technologies.
+              <a>exposed</a> to assistive technologies.
             </p>
             <p class="note">
               Authors are advised to use extreme caution and consider a wide range of disabilities when hiding visibly rendered content from assistive technologies. For example, a sighted,
@@ -14282,7 +14283,7 @@ button.ariaPressed; // null</pre
               users.
             </p>
             <p>
-              Authors SHOULD provide a way to expose keyboard shortcuts so that all users can discover them, such as through the use of a tooltip. Authors MUST ensure that
+              Authors SHOULD provide a way to <a>expose</a> keyboard shortcuts so that all users can discover them, such as through the use of a tooltip. Authors MUST ensure that
               <code>aria-keyshortcuts</code> applied to disabled elements are unavailable.
             </p>
             <p>
@@ -14864,7 +14865,7 @@ button.ariaPressed; // null</pre
             </p>
             <p>
               The value of the <pref>aria-owns</pref> <a>attribute</a> is a space-separated ID reference list that references one or more elements in the document by ID. The reason for adding
-              <pref>aria-owns</pref> is to expose a parent/child contextual relationship to <a>assistive technologies</a> that is otherwise impossible to infer from the
+              <pref>aria-owns</pref> is to <a>expose</a> a parent/child contextual relationship to <a>assistive technologies</a> that is otherwise impossible to infer from the
               <abbr title="Document Object Model">DOM</abbr>.
             </p>
             <p>
@@ -15419,7 +15420,7 @@ button.ariaPressed; // null</pre
               Additionally, authors MUST NOT specify <code>aria-roledescription</code> on an element which has an explicit or implicit WAI-ARIA role where <code>aria-roledescription</code> is
               <a href="#prohibitedattributes">prohibited</a>.
             </p>
-            <p>User agents MUST NOT expose the <code>aria-roledescription</code> property if any of the following conditions exist:</p>
+            <p>User agents MUST NOT <a>expose</a> the <code>aria-roledescription</code> property if any of the following conditions exist:</p>
             <ol>
               <li>
                 The element to which <code>aria-roledescription</code> is applied has an explicit or implicit WAI-ARIA role where <code>aria-roledescription</code> is
@@ -15723,7 +15724,7 @@ button.ariaPressed; // null</pre
             <p>
               This <a>attribute</a> is intended for cells and gridcells which are not contained in a native table. When defining the row span of cells or gridcells in a native table, authors SHOULD
               use the host language's attribute instead of <pref>aria-rowspan</pref>. If <pref>aria-rowspan</pref> is used on an element for which the host language provides an equivalent attribute,
-              [=user agents=] MUST ignore the value of <pref>aria-rowspan</pref> and instead expose the value of the host language's attribute to <a>assistive technologies</a>.
+              [=user agents=] MUST ignore the value of <pref>aria-rowspan</pref> and instead <a>expose</a> the value of the host language's attribute to <a>assistive technologies</a>.
             </p>
             <p>
               Authors MUST set the <span>value</span> of <pref>aria-rowspan</pref> to an integer greater than or equal to 0 and less than the value which would cause the cell or gridcell to overlap
@@ -16163,7 +16164,7 @@ button.ariaPressed; // null</pre
       <h1><dfn class="export">Accessibility Tree</dfn></h1>
       <p>
         The <a class="termref">accessibility tree</a> and the DOM tree are parallel structures. The <a class="termref">accessibility tree</a> includes the user interface objects of the
-        <a>user agent</a> and the objects of the document. <a>Accessible objects</a> are created in the accessibility tree for every DOM element that should be exposed to an
+        <a>user agent</a> and the objects of the document. <a>Accessible objects</a> are created in the accessibility tree for every DOM element that should be <a>exposed</a> to an
         <a>assistive technology</a>, either because it might fire an accessibility <a>event</a> or because it has a [=ARIA/property=], <a>relationship</a> or feature which needs to be exposed.
       </p>
       <section id="tree_exclusion">
@@ -16225,7 +16226,7 @@ button.ariaPressed; // null</pre
             Elements that are not [=element/hidden=] and can fire an <a>accessibility <abbr title="Application Program Interface">API</abbr></a> <a>event</a>, including:
             <ul>
               <li>Elements that are currently focused, even if the element or one of its ancestor elements has its <sref>aria-hidden</sref> attribute set to <code>true</code>.</li>
-              <li>Elements that are a valid target of an <pref>aria-activedescendant</pref> attribute.</li>
+              <li>Elements that are a valid <a>target</a> of an <pref>aria-activedescendant</pref> attribute.</li>
             </ul>
           </li>
           <li>
@@ -16459,7 +16460,7 @@ button.ariaPressed; // null</pre
           these semantics are not available, and are generally used on elements that have no native semantics of their own. They can also be used on elements that have similar but non-identical
           semantics (for example, a nested list could be used to represent a tree structure). This method can be part of a fallback strategy for older browsers that have no
           <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> implementation, or because native presentation of the repurposed element reduces the amount of style and/or script needed.
-          Except for the cases outlined below, user agents MUST always use the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics to define how it exposes the element to
+          Except for the cases outlined below, user agents MUST always use the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics to define how it <a>exposes</a> the element to
           accessibility APIs, rather than using the host language semantics.
         </p>
         <p>
@@ -16601,7 +16602,7 @@ button.ariaPressed; // null</pre
         </p>
         <p>
           If the <a><code>role</code> attribute</a> contains no tokens matching the name of a non-abstract <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> role, the user agent MUST
-          treat the element as if no <a>role</a> had been provided. For example, <code>&lt;table&nbsp;role=&quot;foo&quot;&gt;</code> should be exposed in the same way as
+          treat the element as if no <a>role</a> had been provided. For example, <code>&lt;table&nbsp;role=&quot;foo&quot;&gt;</code> should be <a>exposed</a> in the same way as
           <code>&lt;table&gt;</code> and <code>&lt;input&nbsp;type=&quot;text&quot;&nbsp;role=&quot;structure&quot;&gt;</code> in the same way as <code>&lt;input&nbsp;type=&quot;text&quot;&gt;</code>.
         </p>
         <p>
@@ -16644,7 +16645,7 @@ button.ariaPressed; // null</pre
           </li>
         </ul>
         <p>
-          If a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> property contains an unknown or disallowed value, the user agent SHOULD expose to platform
+          If a <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> property contains an unknown or disallowed value, the user agent SHOULD <a>expose</a> to platform
           <a>accessibility APIs</a> as follows:
         </p>
         <ul>
@@ -16757,7 +16758,7 @@ button.ariaPressed; // null</pre
       <section id="conflict_resolution_presentation_none">
         <h3>Presentational Roles Conflict Resolution</h3>
         <p>There are a number of ways presentational role conflicts are resolved.</p>
-        <p>User agents MUST NOT expose [=elements=] having explicit or inherited presentational role in the accessibility tree, with these exceptions:</p>
+        <p>User agents MUST NOT <a>expose</a> [=elements=] having explicit or inherited presentational role in the accessibility tree, with these exceptions:</p>
         <ul>
           <li>
             If an element is <a>focusable</a>, user agents MUST ignore the <rref>none</rref>/<rref>presentation</rref> role and expose the element with its implicit role, in order to ensure that the


### PR DESCRIPTION
🚀 **Netlify Preview**:
🔄 **this PR updates the following sspecs**:
- [ARIA preview](https://deploy-preview-2894--wai-aria.netlify.app/index.html) &mdash; [ARIA diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Faria%2F&doc2=https%3A%2F%2Fdeploy-preview-2894--wai-aria.netlify.app%2Findex.html)

Closes #2084

I mostly linked the first mention of "expose" in sections. 
There are relatively few matches for "target" and I ignored deprecated sections.