### PR TITLE
Editorial: clarify ARIA 1.2 historical references

### DIFF
--- a/common/script/aria.js
+++ b/common/script/aria.js
@@ -269,7 +269,7 @@ const buildInheritedStatesProperties = function (item) {
       const suffix = isState ? " (state)" : "";
       const tag = isState ? "sref" : "pref";
       const req = property.required ? " <strong>(required)</strong>" : "";
-      const dep = property.deprecated ? " <strong>(deprecated on this role in ARIA 1.2)</strong>" : "";
+      const dep = property.deprecated ? " <strong>(deprecated on this role since ARIA 1.2)</strong>" : "";
 
       return `<li><${tag}>${property.name}</${tag}>${suffix}${req}${dep}</li>\n`;
     })
@@ -358,7 +358,7 @@ const renderStateOrProperty = function (propList, descendantRoles, item) {
   // Current values for placeholderText:
   // * "All elements of the base markup"
   // * "Placeholder"
-  // * "Use as a global deprecated in ARIA 1.2"
+  // * "Global use deprecated since ARIA 1.2"
   // * "All elements of the base markup except for some roles or elements that prohibit its use"
   // TODO: Maybe use a data attribute instead?
 
@@ -378,7 +378,7 @@ const renderStateOrProperty = function (propList, descendantRoles, item) {
   }
 
   // Otherwise, i.e.,
-  // Cases: placeholderText "Placeholder" or "Use as a global deprecated in ARIA 1.2"
+  // Cases: placeholderText "Placeholder" or "Global use deprecated since ARIA 1.2"
 
   // populate placeholder
   placeholder.innerHTML = `<ul>\n${item.roles.map((role) => `<li><rref>${role}</rref></li>\n`).join("")}</ul>\n`;

--- a/common/script/ariaChild.js
+++ b/common/script/ariaChild.js
@@ -291,7 +291,7 @@ function ariaAttributeReferences() {
                   output += " (Except where prohibited)";
                 }
                 if (role.deprecated) {
-                  output += " (Global use deprecated in ARIA 1.2)";
+                  output += " (Global use deprecated since ARIA 1.2)";
                 }
                 output += "</li>\n";
                 prev = role.name;

--- a/common/script/ariaPreprocessing.js
+++ b/common/script/ariaPreprocessing.js
@@ -10,7 +10,7 @@ const buildGlobalStatesAndPropertiesLists = (globalStatesPlaceholder, roletypePr
   const applicabilityText = container.querySelector(".state-applicability, .property-applicability").innerText;
   const isDefault = applicabilityText === "All elements of the base markup";
   const isProhibited = applicabilityText === "All elements of the base markup except for some roles or elements that prohibit its use";
-  const isDeprecated = applicabilityText === "Use as a global deprecated in ARIA 1.2";
+  const isDeprecated = applicabilityText === "Global use deprecated since ARIA 1.2";
   // NOTE: the only other value for applicabilityText appears to be "Placeholder"
   if (!(isDefault || isProhibited || isDeprecated)) return;
   const isState = def.tagName === "SDEF";
@@ -20,7 +20,7 @@ const buildGlobalStatesAndPropertiesLists = (globalStatesPlaceholder, roletypePr
   }>${def.innerHTML}${isState ? " (state)" : ""}</${refTagName}>${
     // TODO: consider moving "(state)" out of sref/pref tag; then maybe remove title attr for sref (after checking resolveReferences interference)
     isProhibited ? " (Except where prohibited)" : ""
-  }${isDeprecated ? " (Global use deprecated in ARIA 1.2)" : ""}</li>\n`;
+  }${isDeprecated ? " (Global use deprecated since ARIA 1.2)" : ""}</li>\n`;
   globalStatesPlaceholder.insertAdjacentHTML("beforeend", htmlString);
   roletypePropsPlaceholder.insertAdjacentHTML("beforeend", htmlString);
 };

--- a/index.html
+++ b/index.html
@@ -259,9 +259,9 @@
         between roles, such as <a href="#baseConcept">baseConcepts</a> and more descriptive definitions, would not be available in <abbr title="Extensible Markup Language Schema Datatypes">XSD</abbr>.
       </p>
       <p>
-        <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 1.2 is a member of the
-        <a href="https://www.w3.org/WAI/intro/aria"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 1.2 suite</a> that defines how to expose semantics of WAI-ARIA and other web
-        content languages to <a>accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a
+        <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is a member of the
+        <a href="https://www.w3.org/WAI/intro/aria"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> suite</a> that defines how to expose semantics of WAI-ARIA and other web content
+        languages to <a>accessibility <abbr title="Application Programming Interfaces">APIs</abbr></a
         >.
       </p>
       <section class="section" id="intro_ria_accessibility">
@@ -2794,9 +2794,9 @@
               An <rref>input</rref> that controls another element, such as a <rref>listbox</rref> or <rref>grid</rref>, that can dynamically pop up to help the user set the value of the
               <rref>input</rref>.
             </p>
-            <p class="ednote" title="Major Changes to combobox role in ARIA 1.2">
-              The Guidance for <rref>combobox</rref> has changed significantly in ARIA 1.2 due to problems with implementation of the previous patterns. Authors and developers of User Agents,
-              Assistive Technologies, and Conformance Checkers are advised to review this section carefully to understand the changes. Explanation of the changes is available in the
+            <p class="ednote" title="Major Changes to combobox role starting with ARIA 1.2">
+              The Guidance for <rref>combobox</rref> has changed significantly starting with ARIA 1.2 due to problems with implementation of the previous patterns. Authors and developers of User
+              Agents, Assistive Technologies, and Conformance Checkers are advised to review this section carefully to understand the changes. Explanation of the changes is available in the
               <a href="https://github.com/w3c/aria/blob/main/documentation/archive/1.2/Resolving%20ARIA%201.1%20Combobox%20Issues.md">ARIA repository wiki</a>.
             </p>
             <p>
@@ -2850,7 +2850,7 @@
 				  &lt;/ul&gt;
 				</pre
             >
-            <p class="ednote" title="Validity changes combobox for ARIA 1.2">
+            <p class="ednote" title="Validity changes to combobox starting with ARIA 1.2">
               Please review the following carefully. As a result of these changes a combobox following the ARIA 1.1 combobox specification will no longer conform with the ARIA specification.
             </p>
             <div class="note">
@@ -3743,7 +3743,7 @@
         <div class="role" id="directory">
           <rdef>directory</rdef>
           <div class="role-description">
-            <p>[Deprecated in ARIA 1.2] A list of references to members of a group, such as a static table of contents.</p>
+            <p>[Deprecated since ARIA 1.2] A list of references to members of a group, such as a static table of contents.</p>
             <p class="note">
               As exposed by accessibility APIs, the <code>directory</code> <a>role</a> is essentially equivalent to the <code>list</code> <a>role</a>. So, using <code>directory</code> does not provide
               any additional benefits to assistive technology users. Authors are advised to treat <code>directory</code> as deprecated and to use <code>list</code>, or a host language's equivalent
@@ -13516,7 +13516,7 @@ button.ariaPressed; // null</pre
               While <sref>aria-disabled</sref> is currently supported on <rref>columnheader</rref>, <rref>rowheader</rref>, and <rref>row</rref>, in a future version the working group plans to
               prohibit its use on elements with any of those three roles except when they are in the context of a <rref>grid</rref> or <rref>treegrid</rref>.
             </p>
-            <p class="note">This state is being deprecated as a global state in ARIA 1.2. In future versions it will only be allowed on roles where it is specifically supported.</p>
+            <p class="note">This state has been deprecated as a global state since ARIA 1.2. In future versions it will only be allowed on roles where it is specifically supported.</p>
           </div>
           <table class="def">
             <caption>
@@ -13535,7 +13535,7 @@ button.ariaPressed; // null</pre
               </tr>
               <tr>
                 <th class="state-applicability-head" scope="row">Used in Roles:</th>
-                <td class="state-applicability">Use as a global deprecated in ARIA 1.2</td>
+                <td class="state-applicability">Global use deprecated since ARIA 1.2</td>
               </tr>
               <tr>
                 <th class="state-descendants-head" scope="row">Inherits into Roles:</th>
@@ -13709,7 +13709,7 @@ button.ariaPressed; // null</pre
               This example uses <code>role="alert"</code> (which includes an implicit value of <code>aria-live="assertive"</code>) to indicate that assistive technologies will immediately announce the
               error message rather than completing other queued announcements first. This increases the likelihood that users are aware of the error message before they move focus out of the input.
             </p>
-            <p class="note">This state has been deprecated as a global state in ARIA 1.2. It is only supported on <a href="#live_region_roles">live region roles</a>.</p>
+            <p class="note">This state has been deprecated as a global state since ARIA 1.2. It is only supported on <a href="#live_region_roles">live region roles</a>.</p>
           </div>
           <table class="def">
             <caption>
@@ -13724,7 +13724,7 @@ button.ariaPressed; // null</pre
             <tbody>
               <tr>
                 <th class="property-applicability-head" scope="row">Used in Roles:</th>
-                <td class="property-applicability">Use as a global deprecated in ARIA 1.2</td>
+                <td class="property-applicability">Global use deprecated since ARIA 1.2</td>
               </tr>
               <tr>
                 <th class="property-descendants-head" scope="row">Inherits into Roles:</th>
@@ -13975,7 +13975,7 @@ button.ariaPressed; // null</pre
               relevant to display to a sighted user by means of a different visual style, that functional difference is usually relevant to convey to users of assistive technology. If there is no
               visual indication that an element will trigger a popup, authors are advised to consider whether use of <code>aria-haspopup</code> is necessary, and avoid using it when it's not.
             </p>
-            <p class="note">This property is being deprecated as a global property in ARIA 1.2. In future versions it will only be allowed on roles where it is specifically supported.</p>
+            <p class="note">This property has been deprecated as a global property since ARIA 1.2. In future versions it will only be allowed on roles where it is specifically supported.</p>
           </div>
           <table class="def">
             <caption>
@@ -13996,7 +13996,7 @@ button.ariaPressed; // null</pre
               </tr>
               <tr>
                 <th class="property-applicability-head" scope="row">Used in Roles:</th>
-                <td class="property-applicability">Use as a global deprecated in ARIA 1.2</td>
+                <td class="property-applicability">Global use deprecated since ARIA 1.2</td>
               </tr>
               <tr>
                 <th class="property-descendants-head" scope="row">Inherits into Roles:</th>
@@ -14161,7 +14161,7 @@ button.ariaPressed; // null</pre
               the value <code>true</code> had been provided. If the attribute is not present, or its value is <code>false</code>, or its value is the empty string, the default value of
               <code>false</code> applies.
             </p>
-            <p class="note">This state is being deprecated as a global state in ARIA 1.2. In future versions it will only be allowed on roles where it is specifically supported.</p>
+            <p class="note">This state has been deprecated as a global state since ARIA 1.2. In future versions it will only be allowed on roles where it is specifically supported.</p>
           </div>
           <table class="def">
             <caption>
@@ -14180,7 +14180,7 @@ button.ariaPressed; // null</pre
               </tr>
               <tr>
                 <th class="state-applicability-head" scope="row">Used in Roles:</th>
-                <td class="state-applicability">Use as a global deprecated in ARIA 1.2</td>
+                <td class="state-applicability">Global use deprecated since ARIA 1.2</td>
               </tr>
               <tr>
                 <th class="state-descendants-head" scope="row">Inherits into Roles:</th>


### PR DESCRIPTION
Closes #2893

Clarifies ARIA 1.2 references that were carried into the ARIA 1.3 draft:

- removes the hard-coded 1.2 version from the suite membership statement;
- uses "starting with" for combobox changes and "since" for ongoing deprecations;
- keeps the source table labels and preprocessing/rendering strings synchronized so deprecated states and properties remain marked correctly.

Validation:

- Prettier 3.6.0 with the repository's 200-column setting;
- `node --check` for all three changed scripts;
- ReSpec 37.3.6 render completed successfully;
- rendered-output assertions confirmed all targeted old forms are absent, the replacements are present, and all eight `data-deprecated` markers are still generated.

ReSpec reported only the existing unused-definition warnings for "Expose" and "Target Element"; neither definition is changed by this PR.